### PR TITLE
Add an option to count unique values of specified key(s) to CountAggregateAction

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -54,7 +54,7 @@ public class CountAggregateAction implements AggregateAction {
     public final String outputFormat;
     private long startTimeNanos;
     private final String metricName;
-    private final IdentificationKeysHasher identificationKeysHasher;
+    private final IdentificationKeysHasher uniqueKeysHasher;
 
     @DataPrepperPluginConstructor
     public CountAggregateAction(final CountAggregateActionConfig countAggregateActionConfig) {
@@ -64,9 +64,9 @@ public class CountAggregateAction implements AggregateAction {
         this.outputFormat = countAggregateActionConfig.getOutputFormat();
         this.metricName = countAggregateActionConfig.getMetricName();
         if (countAggregateActionConfig.getUniqueKeys() != null) {
-            this.identificationKeysHasher = new IdentificationKeysHasher(countAggregateActionConfig.getUniqueKeys());
+            this.uniqueKeysHasher = new IdentificationKeysHasher(countAggregateActionConfig.getUniqueKeys());
         } else {
-            this.identificationKeysHasher = null;
+            this.uniqueKeysHasher = null;
         }
     }
 
@@ -104,11 +104,11 @@ public class CountAggregateAction implements AggregateAction {
         }
         if (groupState.get(countKey) == null) {
             groupState.putAll(aggregateActionInput.getIdentificationKeys());
-            if (identificationKeysHasher != null) {
-                Set<IdentificationKeysHasher.IdentificationKeysMap> identificationKeysMapSet = new HashSet<>();
+            if (uniqueKeysHasher != null) {
+                Set<IdentificationKeysHasher.IdentificationKeysMap> uniqueKeysMapSet = new HashSet<>();
             
-                identificationKeysMapSet.add(identificationKeysHasher.createIdentificationKeysMapFromEvent(event));
-                groupState.put(UNIQUE_KEYS_SETKEY, identificationKeysMapSet);
+                uniqueKeysMapSet.add(uniqueKeysHasher.createIdentificationKeysMapFromEvent(event));
+                groupState.put(UNIQUE_KEYS_SETKEY, uniqueKeysMapSet);
             } 
             groupState.put(countKey, 1);
             groupState.put(exemplarKey, createExemplar(event));
@@ -117,10 +117,10 @@ public class CountAggregateAction implements AggregateAction {
         } else {
             Integer v = (Integer)groupState.get(countKey) + 1;
             
-            if (identificationKeysHasher != null) {
-                Set<IdentificationKeysHasher.IdentificationKeysMap> identificationKeysMapSet = (Set<IdentificationKeysHasher.IdentificationKeysMap>) groupState.get(UNIQUE_KEYS_SETKEY);
-                identificationKeysMapSet.add(identificationKeysHasher.createIdentificationKeysMapFromEvent(event));
-                v = identificationKeysMapSet.size();
+            if (uniqueKeysHasher != null) {
+                Set<IdentificationKeysHasher.IdentificationKeysMap> uniqueKeysMapSet = (Set<IdentificationKeysHasher.IdentificationKeysMap>) groupState.get(UNIQUE_KEYS_SETKEY);
+                uniqueKeysMapSet.add(uniqueKeysHasher.createIdentificationKeysMapFromEvent(event));
+                v = uniqueKeysMapSet.size();
             }
             groupState.put(countKey, v);
             Instant groupStartTime = (Instant)groupState.get(startTimeKey);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -22,13 +22,17 @@ import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor
 import static org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor.getTimeNanos;
 import org.opensearch.dataprepper.plugins.processor.aggregate.GroupState;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
 import java.time.Instant;
-import java.util.List;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
+
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * An AggregateAction that combines multiple Events into a single Event. This action will count the number of events with same keys and will create a combined event
@@ -38,6 +42,7 @@ import java.util.HashMap;
 @DataPrepperPlugin(name = "count", pluginType = AggregateAction.class, pluginConfigurationType = CountAggregateActionConfig.class)
 public class CountAggregateAction implements AggregateAction {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    private static final String UNIQUE_KEYS_SETKEY = "__unique_keys";
     private static final String exemplarKey = "__exemplar";
     static final String EVENT_TYPE = "event";
     static final String SUM_METRIC_DESCRIPTION = "Number of events";
@@ -49,6 +54,7 @@ public class CountAggregateAction implements AggregateAction {
     public final String outputFormat;
     private long startTimeNanos;
     private final String metricName;
+    private final IdentificationKeysHasher identificationKeysHasher;
 
     @DataPrepperPluginConstructor
     public CountAggregateAction(final CountAggregateActionConfig countAggregateActionConfig) {
@@ -57,6 +63,11 @@ public class CountAggregateAction implements AggregateAction {
         this.endTimeKey = countAggregateActionConfig.getEndTimeKey();
         this.outputFormat = countAggregateActionConfig.getOutputFormat();
         this.metricName = countAggregateActionConfig.getMetricName();
+        if (countAggregateActionConfig.getUniqueKeys() != null) {
+            this.identificationKeysHasher = new IdentificationKeysHasher(countAggregateActionConfig.getUniqueKeys());
+        } else {
+            this.identificationKeysHasher = null;
+        }
     }
 
     public Exemplar createExemplar(final Event event) {
@@ -93,12 +104,24 @@ public class CountAggregateAction implements AggregateAction {
         }
         if (groupState.get(countKey) == null) {
             groupState.putAll(aggregateActionInput.getIdentificationKeys());
+            if (identificationKeysHasher != null) {
+                Set<IdentificationKeysHasher.IdentificationKeysMap> identificationKeysMapSet = new HashSet<>();
+            
+                identificationKeysMapSet.add(identificationKeysHasher.createIdentificationKeysMapFromEvent(event));
+                groupState.put(UNIQUE_KEYS_SETKEY, identificationKeysMapSet);
+            } 
             groupState.put(countKey, 1);
             groupState.put(exemplarKey, createExemplar(event));
             groupState.put(startTimeKey, eventStartTime);
             groupState.put(endTimeKey, eventEndTime);
         } else {
             Integer v = (Integer)groupState.get(countKey) + 1;
+            
+            if (identificationKeysHasher != null) {
+                Set<IdentificationKeysHasher.IdentificationKeysMap> identificationKeysMapSet = (Set<IdentificationKeysHasher.IdentificationKeysMap>) groupState.get(UNIQUE_KEYS_SETKEY);
+                identificationKeysMapSet.add(identificationKeysHasher.createIdentificationKeysMapFromEvent(event));
+                v = identificationKeysMapSet.size();
+            }
             groupState.put(countKey, v);
             Instant groupStartTime = (Instant)groupState.get(startTimeKey);
             Instant groupEndTime = (Instant)groupState.get(endTimeKey);
@@ -117,6 +140,7 @@ public class CountAggregateAction implements AggregateAction {
         Instant startTime = (Instant)groupState.get(startTimeKey);
         Instant endTime = (Instant)groupState.get(endTimeKey);
         groupState.remove(endTimeKey);
+        groupState.remove(UNIQUE_KEYS_SETKEY);
         if (outputFormat.equals(OutputFormat.RAW.toString())) {
             groupState.put(startTimeKey, startTime.atZone(ZoneId.of(ZoneId.systemDefault().toString())).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
             event = JacksonEvent.builder()

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
@@ -5,8 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 
-import java.util.Set;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CountAggregateActionConfig {
@@ -22,6 +23,9 @@ public class CountAggregateActionConfig {
     @JsonProperty("metric_name")
     String metricName = SUM_METRIC_NAME;
 
+    @JsonProperty("unique_keys")
+    List<String> uniqueKeys = null;
+
     @JsonProperty("start_time_key")
     String startTimeKey = DEFAULT_START_TIME_KEY;
 
@@ -33,6 +37,10 @@ public class CountAggregateActionConfig {
 
     public String getMetricName() {
         return metricName;
+    }
+
+    public List<String> getUniqueKeys() {
+        return uniqueKeys;
     }
 
     public String getCountKey() {

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfigTests.java
@@ -13,6 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.opensearch.dataprepper.plugins.processor.aggregate.actions.CountAggregateActionConfig.DEFAULT_COUNT_KEY;
 import static org.opensearch.dataprepper.plugins.processor.aggregate.actions.CountAggregateActionConfig.DEFAULT_START_TIME_KEY;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -39,6 +41,7 @@ public class CountAggregateActionConfigTests {
         assertThat(countAggregateActionConfig.getStartTimeKey(), equalTo(DEFAULT_START_TIME_KEY));
         assertThat(countAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
         assertThat(countAggregateActionConfig.getMetricName(), equalTo(CountAggregateActionConfig.SUM_METRIC_NAME));
+        assertThat(countAggregateActionConfig.getUniqueKeys(), equalTo(null));
     }
 
     @Test
@@ -55,6 +58,11 @@ public class CountAggregateActionConfigTests {
         final String testName = UUID.randomUUID().toString();
         setField(CountAggregateActionConfig.class, countAggregateActionConfig, "metricName", testName);
         assertThat(countAggregateActionConfig.getMetricName(), equalTo(testName));
+        final List<String> uniqueKeys = new ArrayList<>();
+        uniqueKeys.add(UUID.randomUUID().toString());
+        uniqueKeys.add(UUID.randomUUID().toString());
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "uniqueKeys", uniqueKeys);
+        assertThat(countAggregateActionConfig.getUniqueKeys(), equalTo(uniqueKeys));
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -153,6 +153,7 @@ public class CountAggregateActionTest {
     void testCountAggregateOTelFormatWithStartAndEndTimesInTheEvent(int testCount) {
         CountAggregateActionConfig mockConfig = mock(CountAggregateActionConfig.class);
         when(mockConfig.getCountKey()).thenReturn(CountAggregateActionConfig.DEFAULT_COUNT_KEY);
+        when(mockConfig.getUniqueKeys()).thenReturn(null);
         final String testName = UUID.randomUUID().toString();
         when(mockConfig.getMetricName()).thenReturn(testName);
         String startTimeKey = UUID.randomUUID().toString();
@@ -232,5 +233,60 @@ public class CountAggregateActionTest {
         attributes = (Map<String, Object>)exemplar.get("attributes");
         assertThat(attributes.get(key2), equalTo(value2));
         assertTrue(attributes.containsKey(dataKey2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 10, 20})
+    void testCountAggregateOTelFormatUniqueKeys(int testCount) throws NoSuchFieldException, IllegalAccessException {
+        CountAggregateActionConfig countAggregateActionConfig = new CountAggregateActionConfig();
+        final String testName = UUID.randomUUID().toString();
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "metricName", testName);
+        final String key1 = "key-"+UUID.randomUUID().toString();
+        final String value1 = UUID.randomUUID().toString();
+        final String dataKey1 = "datakey-"+UUID.randomUUID().toString();
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "uniqueKeys", List.of(dataKey1));
+        countAggregateAction = createObjectUnderTest(countAggregateActionConfig);
+        Map<Object, Object> eventMap = Collections.singletonMap(key1, value1);
+        Event testEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+        final String dataKey1_1 = UUID.randomUUID().toString();
+        final String dataKey1_2 = UUID.randomUUID().toString();
+        final String dataKey1_3 = UUID.randomUUID().toString();
+        final String[] dataKeysList = {dataKey1_1, dataKey1_2, dataKey1_3};
+        for (int i = 0; i < testCount; i++) { 
+            testEvent.put(dataKey1, dataKeysList[i % 3]);
+            AggregateActionResponse aggregateActionResponse = countAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+        }
+
+        AggregateActionOutput actionOutput = countAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+        Map<String, Object> expectedEventMap = new HashMap<>();
+        double expectedCount = (testCount >= 3) ? 3 : testCount;
+        expectedEventMap.put("value", expectedCount);
+        expectedEventMap.put("description", "Number of events");
+        expectedEventMap.put("isMonotonic", true);
+        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
+        expectedEventMap.put("unit", "1");
+        expectedEventMap.put("name", testName);
+        System.out.println("===EXP==="+expectedEventMap);
+        System.out.println("===RES==="+result.get(0).toMap());
+        expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));
+        assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
+        JacksonMetric metric = (JacksonMetric) result.get(0);
+        assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
+        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey("time"));
+        List<Map<String, Object>> exemplars = (List <Map<String, Object>>)result.get(0).toMap().get("exemplars");
+        assertThat(exemplars.size(), equalTo(1));
+        Map<String, Object> exemplar = exemplars.get(0);
+        Map<String, Object> attributes = (Map<String, Object>)exemplar.get("attributes");
+        assertThat(attributes.get(key1), equalTo(value1));
+        assertTrue(attributes.containsKey(dataKey1));
+
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -273,8 +273,6 @@ public class CountAggregateActionTest {
         expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
         expectedEventMap.put("unit", "1");
         expectedEventMap.put("name", testName);
-        System.out.println("===EXP==="+expectedEventMap);
-        System.out.println("===RES==="+result.get(0).toMap());
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
         JacksonMetric metric = (JacksonMetric) result.get(0);


### PR DESCRIPTION
### Description
Add an option to count unique values of specified key(s) to CountAggregateAction

Resolves #4644
 
### Issues Resolved
Resolves #4644 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
