### PR TITLE
add remove_brackets option to flatten-processor (#4616)

### DIFF
--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessor.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessor.java
@@ -119,14 +119,15 @@ public class FlattenProcessor extends AbstractProcessor<Record<Event>, Record<Ev
         final Map<String, Object> resultMap = new HashMap<>();
 
         for (final Map.Entry<String, Object> entry : inputMap.entrySet()) {
-            final String keyWithoutIndices = removeListIndices(entry.getKey());
+            final String keyWithoutIndices = removeListIndices(entry.getKey(), config.isRemoveBrackets());
             addFieldsToMapWithMerge(keyWithoutIndices, entry.getValue(), resultMap);
         }
         return resultMap;
     }
 
-    private String removeListIndices(final String key) {
-        return key.replaceAll("\\[\\d+\\]", "[]");
+    private String removeListIndices(final String key, final boolean removeBrackets) {
+        final String replacement = removeBrackets ? "" : "[]";
+        return key.replaceAll("\\[\\d+\\]", replacement);
     }
 
     private void addFieldsToMapWithMerge(String key, Object value, Map<String, Object> map) {

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -6,6 +6,8 @@
 package org.opensearch.dataprepper.plugins.processor.flatten;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.ArrayList;
@@ -28,6 +30,9 @@ public class FlattenProcessorConfig {
 
     @JsonProperty("remove_list_indices")
     private boolean removeListIndices = false;
+
+    @JsonProperty("remove_brackets")
+    private boolean removeBrackets = false;
 
     @JsonProperty("exclude_keys")
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
@@ -54,6 +59,10 @@ public class FlattenProcessorConfig {
         return removeListIndices;
     }
 
+    public boolean isRemoveBrackets() {
+        return removeBrackets;
+    }
+
     public List<String> getExcludeKeys() {
         return excludeKeys;
     }
@@ -64,5 +73,10 @@ public class FlattenProcessorConfig {
 
     public List<String> getTagsOnFailure() {
         return tagsOnFailure;
+    }
+
+    @AssertTrue(message = "remove_brackets can not be true if remove_list_indices is false.")
+    boolean removeBracketsNotTrueWhenRemoveListIndicesFalse() {
+        return (!removeBrackets || removeListIndices);
     }
 }

--- a/data-prepper-plugins/flatten-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfigTest.java
+++ b/data-prepper-plugins/flatten-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfigTest.java
@@ -20,7 +20,7 @@ class FlattenProcessorConfigTest {
         assertThat(FlattenProcessorConfig.getSource(), equalTo(null));
         assertThat(FlattenProcessorConfig.getTarget(), equalTo(null));
         assertThat(FlattenProcessorConfig.isRemoveListIndices(), equalTo(false));
-        assertThat(FlattenProcessorConfig.isRemoveListIndices(), equalTo(false));
+        assertThat(FlattenProcessorConfig.isRemoveBrackets(), equalTo(false));
         assertThat(FlattenProcessorConfig.getFlattenWhen(), equalTo(null));
         assertThat(FlattenProcessorConfig.getTagsOnFailure(), equalTo(null));
         assertThat(FlattenProcessorConfig.getExcludeKeys(), equalTo(List.of()));


### PR DESCRIPTION
### Description
adds a new option `remove_brackets` to the flatten processor.

```json
{
  "key1": {
    "key2": [
      {
        "key3": "value1",
        "key4": "value2"
      },
      {
        "key3": "value3",
        "key4": "value4"
      }
    ]
  }
}
```
 
transforms to

```json
{
  "key1.key2.key3": ["value1", "value3"],
  "key1.key2.key4": ["value2", "value4"]
}
```

### Issues Resolved
Resolves #4616
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
