### PR TITLE
Updates the chunking algorithm for http source to account for Unicode

### DIFF
--- a/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/JsonCodec.java
+++ b/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/JsonCodec.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.HttpData;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class JsonCodec implements Codec<List<List<String>>> {
                 size = OVERHEAD_CHARACTERS.length();
             }
             innerJsonList.add(recordString);
-            size += recordString.length() + COMMA_OVERHEAD_LENGTH;
+            size += recordString.getBytes(Charset.defaultCharset()).length + COMMA_OVERHEAD_LENGTH;
         }
         if (size > OVERHEAD_CHARACTERS.length()) {
             jsonList.add(innerJsonList);

--- a/data-prepper-plugins/http-source-common/src/test/java/org/opensearch/dataprepper/http/codec/JsonCodecTest.java
+++ b/data-prepper-plugins/http-source-common/src/test/java/org/opensearch/dataprepper/http/codec/JsonCodecTest.java
@@ -7,16 +7,31 @@ package org.opensearch.dataprepper.http.codec;
 
 import com.linecorp.armeria.common.HttpData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class JsonCodecTest {
     private final HttpData goodTestData = HttpData.ofUtf8("[{\"a\":\"b\"}, {\"c\":\"d\"}]");
     private final HttpData goodLargeTestData = HttpData.ofUtf8("[{\"a1\":\"b1\"}, {\"a2\":\"b2\"}, {\"a3\":\"b3\"}, {\"a4\":\"b4\"}, {\"a5\":\"b5\"}]");
+    private final HttpData goodLargeTestDataUnicode = HttpData.ofUtf8("[{\"ὊὊὊ1\":\"ὊὊὊ1\"}, {\"ὊὊὊ2\":\"ὊὊὊ2\"}, {\"a3\":\"b3\"}, {\"ὊὊὊ4\":\"ὊὊὊ4\"}]");
     private final HttpData badTestDataJsonLine = HttpData.ofUtf8("{\"a\":\"b\"}");
     private final HttpData badTestDataMultiJsonLines = HttpData.ofUtf8("{\"a\":\"b\"}{\"c\":\"d\"}");
     private final HttpData badTestDataNonJson = HttpData.ofUtf8("non json content");
@@ -51,6 +66,25 @@ class JsonCodecTest {
         assertEquals("{\"a5\":\"b5\"}", res.get(2).get(0));
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(JsonArrayWithKnownFirstArgumentsProvider.class)
+    public void parse_should_return_lists_smaller_than_provided_length(
+            final String inputJsonArray, final String knownFirstPart) throws IOException {
+        final int knownSingleBodySize = knownFirstPart.getBytes(Charset.defaultCharset()).length;
+        final int maxSize = (knownSingleBodySize * 2) + 3;
+        final List<List<String>> chunkedBodies = objectUnderTest.parse(HttpData.ofUtf8(inputJsonArray),
+                maxSize);
+
+        assertThat(chunkedBodies, notNullValue());
+        assertThat(chunkedBodies.size(), greaterThanOrEqualTo(1));
+        final String firstReconstructed = chunkedBodies.get(0).stream().collect(Collectors.joining(",", "[", "]"));
+        assertThat(firstReconstructed.getBytes(Charset.defaultCharset()).length,
+                lessThanOrEqualTo(maxSize));
+
+        assertThat(chunkedBodies.get(0).size(), greaterThanOrEqualTo(1));
+        assertThat(chunkedBodies.get(0).get(0), equalTo(knownFirstPart));
+    }
+
     @Test
     public void testParseJsonLineFailure() {
         assertThrows(IOException.class, () -> objectUnderTest.parse(badTestDataJsonLine));
@@ -64,5 +98,19 @@ class JsonCodecTest {
     @Test
     public void testParseNonJsonFailure() {
         assertThrows(IOException.class, () -> objectUnderTest.parse(badTestDataNonJson));
+    }
+
+    static class JsonArrayWithKnownFirstArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    arguments(
+                            "[{\"ὊὊὊ1\":\"ὊὊὊ1\"}, {\"ὊὊὊ2\":\"ὊὊὊ2\"}, {\"a3\":\"b3\"}, {\"ὊὊὊ4\":\"ὊὊὊ4\"}]",
+                            "{\"ὊὊὊ1\":\"ὊὊὊ1\"}"),
+                    arguments(
+                            "[{\"aaa1\":\"aaa1\"}, {\"aaa2\":\"aaa2\"}, {\"a3\":\"b3\"}, {\"bbb4\":\"bbb4\"}]",
+                            "{\"aaa1\":\"aaa1\"}")
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description

The `JsonCodec` has code to split input requests to keep under a certain size. However, this chunking currently counts character length, not byte size. This PR corrects that behavior by comparing the byte size.

I added a unit test to verify this:

Before changing the code, I was able to verify that this failed with Unicode input.

```
JsonCodecTest > parse_should_return_lists_smaller_than_provided_length(String, String) > [1] [{"ὊὊὊ1":"ὊὊὊ1"}, {"ὊὊὊ2":"ὊὊὊ2"}, {"a3":"b3"}, {"ὊὊὊ4":"ὊὊὊ4"}], {"ὊὊὊ1":"ὊὊὊ1"} FAILED
    java.lang.AssertionError at JsonCodecTest.java:81
```
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
