### PR TITLE
Fixes the loading of peer-forwarders when using multiple workers

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -67,13 +67,10 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
                     "Peer Forwarder Plugin: %s cannot have empty identification keys." + pluginId);
         }
 
+        final PeerForwarder peerForwarder = peerForwarderProvider.register(pipelineName, firstInnerProcessor, pluginId, identificationKeys, pipelineWorkerThreads);
 
-        return processors.stream()
-               .map(processor -> {
-                    PeerForwarder peerForwarder = peerForwarderProvider.register(pipelineName, processor, pluginId, identificationKeys, pipelineWorkerThreads);
-                    return new PeerForwardingProcessorDecorator(peerForwarder, processor);
-                })
-                 .collect(Collectors.toList());
+        return processors.stream().map(processor -> new PeerForwardingProcessorDecorator(peerForwarder, processor))
+                .collect(Collectors.toList());
     }
 
     private PeerForwardingProcessorDecorator(final PeerForwarder peerForwarder, final Processor innerProcessor) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,18 +51,6 @@ class PeerForwardingProcessingDecoratorTest {
 
     @Mock
     private Processor processor;
-
-    @Mock
-    private Processor processor1;
-
-    @Mock
-    private Processor processor2;
-
-    @Mock(extraInterfaces = Processor.class)
-    private RequiresPeerForwarding requiresPeerForwarding1;
-
-    @Mock(extraInterfaces = Processor.class)
-    private RequiresPeerForwarding requiresPeerForwarding2;
 
     @Mock(extraInterfaces = Processor.class)
     private RequiresPeerForwarding requiresPeerForwarding;
@@ -82,13 +71,13 @@ class PeerForwardingProcessingDecoratorTest {
         pluginId = UUID.randomUUID().toString();
     }
 
-    private List<Processor> createObjectUnderTesDecoratedProcessors(final List<Processor> processors) {
+    private List<Processor> createObjectUnderTestDecoratedProcessors(final List<Processor> processors) {
         return PeerForwardingProcessorDecorator.decorateProcessors(processors, peerForwarderProvider, pipelineName, pluginId, PIPELINE_WORKER_THREADS);
     }
 
     @Test
     void PeerForwardingProcessingDecorator_should_not_have_any_interactions_if_its_not_an_instance_of_RequiresPeerForwarding() {
-        assertThrows(UnsupportedPeerForwarderPluginException.class, () -> createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor)));
+        assertThrows(UnsupportedPeerForwarderPluginException.class, () -> createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor)));
 
         verifyNoInteractions(peerForwarderProvider);
     }
@@ -97,7 +86,7 @@ class PeerForwardingProcessingDecoratorTest {
     void PeerForwardingProcessingDecorator_execute_with_empty_identification_keys_should_throw() {
         when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(Collections.emptySet());
 
-        assertThrows(EmptyPeerForwarderPluginIdentificationKeysException.class, () -> createObjectUnderTesDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding)));
+        assertThrows(EmptyPeerForwarderPluginIdentificationKeysException.class, () -> createObjectUnderTestDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding)));
     }
 
     @Test
@@ -109,12 +98,12 @@ class PeerForwardingProcessingDecoratorTest {
         when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(Set.of(UUID.randomUUID().toString()));
         when(requiresPeerForwardingCopy.getIdentificationKeys()).thenReturn(Set.of(UUID.randomUUID().toString()));
 
-        assertThrows(RuntimeException.class, () -> createObjectUnderTesDecoratedProcessors(List.of(((Processor) requiresPeerForwarding), (Processor) requiresPeerForwardingCopy)));
+        assertThrows(RuntimeException.class, () -> createObjectUnderTestDecoratedProcessors(List.of(((Processor) requiresPeerForwarding), (Processor) requiresPeerForwardingCopy)));
     }
 
     @Test
     void decorateProcessors_with_empty_processors_should_return_empty_list_of_processors() {
-        final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.emptyList());
+        final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.emptyList());
         assertThat(processors.size(), equalTo(0));
     }
 
@@ -136,9 +125,22 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_should_have_interaction_with_getIdentificationKeys() {
-            createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
             verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
             verify(peerForwarderProvider).register(pipelineName, processor, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
+            verifyNoMoreInteractions(peerForwarderProvider);
+        }
+
+        @Test
+        void PeerForwardingProcessingDecorator_should_have_interaction_with_getIdentificationKeys_when_list_of_processors() {
+            when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(identificationKeys);
+            when(requiresPeerForwardingCopy.getIdentificationKeys()).thenReturn(identificationKeys);
+
+            createObjectUnderTestDecoratedProcessors(List.of((Processor) requiresPeerForwarding, (Processor) requiresPeerForwardingCopy));
+
+            verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
+            verify(peerForwarderProvider).register(pipelineName, processor, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
+            verifyNoMoreInteractions(peerForwarderProvider);
         }
 
         @Test
@@ -148,16 +150,15 @@ class PeerForwardingProcessingDecoratorTest {
             processorList.add((Processor) requiresPeerForwardingCopy);
 
             LocalPeerForwarder localPeerForwarder = mock(LocalPeerForwarder.class);
-            lenient().when(peerForwarderProvider.register(pipelineName, (Processor) requiresPeerForwarding, pluginId, identificationKeys, PIPELINE_WORKER_THREADS)).thenReturn(localPeerForwarder);
-            lenient().when(peerForwarderProvider.register(pipelineName, (Processor) requiresPeerForwardingCopy, pluginId, identificationKeys, PIPELINE_WORKER_THREADS)).thenReturn(localPeerForwarder);
+            when(peerForwarderProvider.register(pipelineName, (Processor) requiresPeerForwarding, pluginId, identificationKeys, PIPELINE_WORKER_THREADS)).thenReturn(localPeerForwarder);
             Event event = mock(Event.class);
             when(record.getData()).thenReturn(event);
             List<Record<Event>> testData = Collections.singletonList(record);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(false);
             when(requiresPeerForwardingCopy.isApplicableEventForPeerForwarding(event)).thenReturn(false);
 
-            processor1 = (Processor)requiresPeerForwarding;
-            processor2 = (Processor)requiresPeerForwardingCopy;
+            Processor processor1 = (Processor)requiresPeerForwarding;
+            Processor processor2 = (Processor)requiresPeerForwardingCopy;
             when(processor1.execute(testData)).thenReturn(testData);
             when(processor2.execute(testData)).thenReturn(testData);
 
@@ -167,9 +168,10 @@ class PeerForwardingProcessingDecoratorTest {
             when(requiresPeerForwarding.isForLocalProcessingOnly(any())).thenReturn(true);
             when(requiresPeerForwardingCopy.isForLocalProcessingOnly(any())).thenReturn(true);
 
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(processorList);
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(processorList);
             assertThat(processors.size(), equalTo(2));
             verify(peerForwarderProvider, times(1)).register(pipelineName, processor, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
+            verifyNoMoreInteractions(peerForwarderProvider);
             Collection<Record<Event>> result = processors.get(0).execute(testData);
             assertThat(result.size(), equalTo(testData.size()));
             assertThat(result, equalTo(testData));
@@ -189,7 +191,7 @@ class PeerForwardingProcessingDecoratorTest {
 
             when(processor.execute(testData)).thenReturn(testData);
 
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
             assertThat(processors.size(), equalTo(1));
             final Collection<Record<Event>> records = processors.get(0).execute(testData);
 
@@ -215,7 +217,7 @@ class PeerForwardingProcessingDecoratorTest {
 
             when(((Processor) requiresPeerForwarding).execute(anyCollection())).thenReturn(expectedRecordsToProcessLocally);
 
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding));
             assertThat(processors.size(), equalTo(1));
             final Collection<Record<Event>> records = processors.get(0).execute(forwardTestData);
 
@@ -232,7 +234,7 @@ class PeerForwardingProcessingDecoratorTest {
             Event event = mock(Event.class);
             when(record.getData()).thenReturn(event);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(true);
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
             Collection<Record<Event>> testData = Collections.singletonList(record);
 
             assertThat(processors.size(), equalTo(1));
@@ -248,7 +250,7 @@ class PeerForwardingProcessingDecoratorTest {
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(false);
             when(requiresPeerForwarding.isForLocalProcessingOnly(any())).thenReturn(true);
 
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
             Collection<Record<Event>> testData = Collections.singletonList(record);
 
             assertThat(processors.size(), equalTo(1));
@@ -272,7 +274,7 @@ class PeerForwardingProcessingDecoratorTest {
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event2)).thenReturn(false);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event3)).thenReturn(false);
             when(requiresPeerForwarding.isForLocalProcessingOnly(any())).thenReturn(true);
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
             when(record1.getData()).thenReturn(event1);
             when(record2.getData()).thenReturn(event2);
             when(record3.getData()).thenReturn(event3);
@@ -303,7 +305,7 @@ class PeerForwardingProcessingDecoratorTest {
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event2)).thenReturn(false);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event3)).thenReturn(true);
             when(requiresPeerForwarding.isForLocalProcessingOnly(any())).thenReturn(false);
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
             when(record1.getData()).thenReturn(event1);
             when(record2.getData()).thenReturn(event2);
             when(record3.getData()).thenReturn(event3);
@@ -322,7 +324,7 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_prepareForShutdown_will_call_inner_processors_prepareForShutdown() {
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
 
             assertThat(processors.size(), equalTo(1));
             processors.get(0).prepareForShutdown();
@@ -331,7 +333,7 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_isReadyForShutdown_will_call_inner_processors_isReadyForShutdown() {
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
 
             assertThat(processors.size(), equalTo(1));
             processors.get(0).isReadyForShutdown();
@@ -340,7 +342,7 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_shutdown_will_call_inner_processors_shutdown() {
-            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessors(Collections.singletonList(processor));
 
             assertThat(processors.size(), equalTo(1));
             processors.get(0).shutdown();


### PR DESCRIPTION
### Description

Running a trace analytics pipeline with the `service_map` processor was not working when the pipeline has multiple workers. This PR fixes that bug.

The approach here is to revert the following change to go back to what we had before.

https://github.com/opensearch-project/data-prepper/pull/4574/files#diff-82ab126c928e8f6c33e33fcdca6015c436d7df3870b9b420880f669cce2c8681R71-R76

However, now the `register` API takes in a processor. Upon inspection of the code, the `List<Processor>` in the decorate method are all the same plugin - it is just that we may have multiple instances due to the `@SingleThread` annotation. This results in multiple instances of the same thing. 

This code already gets the first instance as an exemplar. See this line:

https://github.com/opensearch-project/data-prepper/blob/ab9700a70e4ff512ad456f6b9895d66c2d3e9bdc/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java#L45

So we follow that approach here as well.
 
### Issues Resolved

Resolves #4660
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
