### PR TITLE
Enhanced Kafka source logging through the use of MDC and thread naming

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaMdc.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaMdc.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.kafka.common;public class KafkaMdc {
+package org.opensearch.dataprepper.plugins.kafka.common;
+
+public class KafkaMdc {
     public static final String MDC_KAFKA_PLUGIN_KEY = "kafkaPluginType";
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/thread/KafkaPluginThreadFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/thread/KafkaPluginThreadFactory.java
@@ -25,7 +25,16 @@ public class KafkaPluginThreadFactory implements ThreadFactory {
             final ThreadFactory delegateThreadFactory,
             final String kafkaPluginType) {
         this.delegateThreadFactory = delegateThreadFactory;
-        this.threadPrefix = "kafka-" + kafkaPluginType + "-";
+        this.threadPrefix = createPluginPart(kafkaPluginType);
+        this.kafkaPluginType = kafkaPluginType;
+    }
+
+    KafkaPluginThreadFactory(
+            final ThreadFactory delegateThreadFactory,
+            final String kafkaPluginType,
+            final String kafkaTopic) {
+        this.delegateThreadFactory = delegateThreadFactory;
+        this.threadPrefix = normalizeName(kafkaTopic) + "-" + createPluginPart(kafkaPluginType);
         this.kafkaPluginType = kafkaPluginType;
     }
 
@@ -37,6 +46,28 @@ public class KafkaPluginThreadFactory implements ThreadFactory {
      */
     public static KafkaPluginThreadFactory defaultExecutorThreadFactory(final String kafkaPluginType) {
         return new KafkaPluginThreadFactory(Executors.defaultThreadFactory(), kafkaPluginType);
+    }
+
+    /**
+     * Creates an instance specifically for use with {@link Executors}.
+     *
+     * @param kafkaPluginType The name of the plugin type. e.g. sink, source, buffer
+     * @return An instance of the {@link KafkaPluginThreadFactory}.
+     */
+    public static KafkaPluginThreadFactory defaultExecutorThreadFactory(
+            final String kafkaPluginType,
+            final String kafkaTopic) {
+        return new KafkaPluginThreadFactory(Executors.defaultThreadFactory(), kafkaPluginType, kafkaTopic);
+    }
+
+    private static String createPluginPart(final String kafkaPluginType) {
+        return "kafka-" + kafkaPluginType + "-";
+    }
+
+    private static String normalizeName(final String kafkaTopic) {
+        final String limitedName = kafkaTopic.length() > 20 ? kafkaTopic.substring(0, 20) : kafkaTopic;
+        return limitedName
+                .toLowerCase().replaceAll("[^a-z0-9]", "-");
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -29,6 +29,8 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.plugins.kafka.common.KafkaMdc;
+import org.opensearch.dataprepper.plugins.kafka.common.thread.KafkaPluginThreadFactory;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConsumerConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.OAuthConfig;
@@ -46,6 +48,7 @@ import org.opensearch.dataprepper.plugins.kafka.util.KafkaTopicConsumerMetrics;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,10 +76,10 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 public class KafkaSource implements Source<Record<Event>> {
     private static final String NO_RESOLVABLE_URLS_ERROR_MESSAGE = "No resolvable bootstrap urls given in bootstrap.servers";
     private static final long RETRY_SLEEP_INTERVAL = 30000;
+    private static final String MDC_KAFKA_PLUGIN_VALUE = "source";
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
     private final KafkaSourceConfig sourceConfig;
     private final AtomicBoolean shutdownInProgress;
-    private ExecutorService executorService;
     private final PluginMetrics pluginMetrics;
     private KafkaCustomConsumer consumer;
     private KafkaConsumer kafkaConsumer;
@@ -112,59 +115,65 @@ public class KafkaSource implements Source<Record<Event>> {
 
     @Override
     public void start(Buffer<Record<Event>> buffer) {
-        Properties authProperties = new Properties();
-        KafkaSecurityConfigurer.setDynamicSaslClientCallbackHandler(authProperties, sourceConfig, pluginConfigObservable);
-        KafkaSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
-        sourceConfig.getTopics().forEach(topic -> {
-            consumerGroupID = topic.getGroupId();
-            KafkaTopicConsumerMetrics topicMetrics = new KafkaTopicConsumerMetrics(topic.getName(), pluginMetrics, true);
-            Properties consumerProperties = getConsumerProperties(topic, authProperties);
-            MessageFormat schema = MessageFormat.getByMessageFormatByName(schemaType);
-            try {
-                int numWorkers = topic.getWorkers();
-                executorService = Executors.newFixedThreadPool(numWorkers);
-                allTopicExecutorServices.add(executorService);
+        try {
+            setMdc();
+            Properties authProperties = new Properties();
+            KafkaSecurityConfigurer.setDynamicSaslClientCallbackHandler(authProperties, sourceConfig, pluginConfigObservable);
+            KafkaSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
+            sourceConfig.getTopics().forEach(topic -> {
+                consumerGroupID = topic.getGroupId();
+                KafkaTopicConsumerMetrics topicMetrics = new KafkaTopicConsumerMetrics(topic.getName(), pluginMetrics, true);
+                Properties consumerProperties = getConsumerProperties(topic, authProperties);
+                MessageFormat schema = MessageFormat.getByMessageFormatByName(schemaType);
+                try {
+                    int numWorkers = topic.getWorkers();
+                    final ExecutorService executorService = Executors.newFixedThreadPool(
+                            numWorkers, KafkaPluginThreadFactory.defaultExecutorThreadFactory(MDC_KAFKA_PLUGIN_VALUE, topic.getName()));
+                    allTopicExecutorServices.add(executorService);
 
-                IntStream.range(0, numWorkers).forEach(index -> {
-                    while (true) {
-                        try {
-                            kafkaConsumer = createKafkaConsumer(schema, consumerProperties);
-                            break;
-                        } catch (ConfigException ce) {
-                            if (ce.getMessage().contains(NO_RESOLVABLE_URLS_ERROR_MESSAGE)) {
-                                LOG.warn("Exception while creating Kafka consumer: ", ce);
-                                LOG.warn("Bootstrap URL could not be resolved. Retrying in {} ms...", RETRY_SLEEP_INTERVAL);
-                                try {
-                                    sleep(RETRY_SLEEP_INTERVAL);
-                                } catch (InterruptedException ie) {
-                                    Thread.currentThread().interrupt();
-                                    throw new RuntimeException(ie);
+                    IntStream.range(0, numWorkers).forEach(index -> {
+                        while (true) {
+                            try {
+                                kafkaConsumer = createKafkaConsumer(schema, consumerProperties);
+                                break;
+                            } catch (ConfigException ce) {
+                                if (ce.getMessage().contains(NO_RESOLVABLE_URLS_ERROR_MESSAGE)) {
+                                    LOG.warn("Exception while creating Kafka consumer: ", ce);
+                                    LOG.warn("Bootstrap URL could not be resolved. Retrying in {} ms...", RETRY_SLEEP_INTERVAL);
+                                    try {
+                                        sleep(RETRY_SLEEP_INTERVAL);
+                                    } catch (InterruptedException ie) {
+                                        Thread.currentThread().interrupt();
+                                        throw new RuntimeException(ie);
+                                    }
+                                } else {
+                                    throw ce;
                                 }
-                            } else {
-                                throw ce;
                             }
+
                         }
+                        consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
+                                acknowledgementSetManager, null, topicMetrics, PauseConsumePredicate.noPause());
+                        allTopicConsumers.add(consumer);
 
+                        executorService.submit(consumer);
+                    });
+                } catch (Exception e) {
+                    if (e instanceof BrokerNotAvailableException || e instanceof TimeoutException) {
+                        LOG.error("The kafka broker is not available...");
+                    } else {
+                        LOG.error("Failed to setup the Kafka Source Plugin.", e);
                     }
-                    consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
-                            acknowledgementSetManager, null, topicMetrics, PauseConsumePredicate.noPause());
-                    allTopicConsumers.add(consumer);
-
-                    executorService.submit(consumer);
-                });
-            } catch (Exception e) {
-                if (e instanceof BrokerNotAvailableException || e instanceof TimeoutException) {
-                    LOG.error("The kafka broker is not available...");
-                } else {
-                    LOG.error("Failed to setup the Kafka Source Plugin.", e);
+                    throw new RuntimeException(e);
                 }
-                throw new RuntimeException(e);
-            }
-            LOG.info("Started Kafka source for topic " + topic.getName());
-        });
+                LOG.info("Started Kafka source for topic " + topic.getName());
+            });
+        } finally {
+            removeMdc();
+        }
     }
 
-    public KafkaConsumer<?, ?> createKafkaConsumer(final MessageFormat schema, final Properties consumerProperties) {
+    KafkaConsumer<?, ?> createKafkaConsumer(final MessageFormat schema, final Properties consumerProperties) {
         switch (schema) {
             case JSON:
                 return new KafkaConsumer<String, JsonNode>(consumerProperties);
@@ -183,19 +192,24 @@ public class KafkaSource implements Source<Record<Event>> {
 
     @Override
     public void stop() {
-        shutdownInProgress.set(true);
-        final long shutdownWaitTime = calculateLongestThreadWaitingTime();
+        try {
+            setMdc();
+            shutdownInProgress.set(true);
+            final long shutdownWaitTime = calculateLongestThreadWaitingTime();
 
-        LOG.info("Shutting down {} Executor services", allTopicExecutorServices.size());
-        allTopicExecutorServices.forEach(executor -> stopExecutor(executor, shutdownWaitTime));
+            LOG.info("Shutting down {} Executor services", allTopicExecutorServices.size());
+            allTopicExecutorServices.forEach(executor -> stopExecutor(executor, shutdownWaitTime));
 
-        LOG.info("Closing {} consumers", allTopicConsumers.size());
-        allTopicConsumers.forEach(consumer -> consumer.closeConsumer());
+            LOG.info("Closing {} consumers", allTopicConsumers.size());
+            allTopicConsumers.forEach(consumer -> consumer.closeConsumer());
 
-        LOG.info("Kafka source shutdown successfully...");
+            LOG.info("Kafka source shutdown successfully...");
+        } finally {
+            removeMdc();
+        }
     }
 
-    public void stopExecutor(final ExecutorService executorService, final long shutdownWaitTime) {
+    private void stopExecutor(final ExecutorService executorService, final long shutdownWaitTime) {
         executorService.shutdown();
         try {
             if (!executorService.awaitTermination(shutdownWaitTime, TimeUnit.SECONDS)) {
@@ -346,7 +360,7 @@ public class KafkaSource implements Source<Record<Event>> {
         }
     }
 
-    protected void sleep(final long millis) throws InterruptedException {
+    void sleep(final long millis) throws InterruptedException {
         Thread.sleep(millis);
     }
 
@@ -365,5 +379,13 @@ public class KafkaSource implements Source<Record<Event>> {
                 sourceConfig.setEncryptionConfig(kafkaClusterConfigSupplier.getEncryptionConfig());
             }
         }
+    }
+
+    private static void setMdc() {
+        MDC.put(KafkaMdc.MDC_KAFKA_PLUGIN_KEY, MDC_KAFKA_PLUGIN_VALUE);
+    }
+
+    private static void removeMdc() {
+        MDC.remove(KafkaMdc.MDC_KAFKA_PLUGIN_KEY);
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/thread/KafkaPluginThreadFactoryTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/thread/KafkaPluginThreadFactoryTest.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.plugins.kafka.common.thread;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -37,10 +39,12 @@ class KafkaPluginThreadFactoryTest {
     @Mock
     private Runnable runnable;
     private String pluginType;
+    private String topic;
 
     @BeforeEach
     void setUp() {
         pluginType = UUID.randomUUID().toString();
+        topic = UUID.randomUUID().toString();
 
         when(delegateThreadFactory.newThread(any(Runnable.class))).thenReturn(innerThread);
     }
@@ -50,9 +54,18 @@ class KafkaPluginThreadFactoryTest {
         return new KafkaPluginThreadFactory(delegateThreadFactory, pluginType);
     }
 
+    private KafkaPluginThreadFactory createObjectUnderTestWithTopic() {
+        return new KafkaPluginThreadFactory(delegateThreadFactory, pluginType, topic);
+    }
+
     @Test
     void newThread_creates_thread_from_delegate() {
         assertThat(createObjectUnderTest().newThread(runnable), equalTo(innerThread));
+    }
+
+    @Test
+    void newThread_with_topic_creates_thread_from_delegate() {
+        assertThat(createObjectUnderTestWithTopic().newThread(runnable), equalTo(innerThread));
     }
 
     @Test
@@ -67,6 +80,30 @@ class KafkaPluginThreadFactoryTest {
         final Thread thread2 = objectUnderTest.newThread(runnable);
         assertThat(thread2, notNullValue());
         verify(thread2).setName(String.format("kafka-%s-2", pluginType));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "abcd12,abcd12",
+            "aBCd12,abcd12",
+            "abcd-12,abcd-12",
+            "has space,has-space",
+            "has!character,has-character",
+            "this-is-somewhat-too-long,this-is-somewhat-too"
+    })
+    void newThread_with_topic_creates_thread_with_name(
+            final String topicName,
+            final String expectedPrefix) {
+        this.topic = topicName;
+        final KafkaPluginThreadFactory objectUnderTest = createObjectUnderTestWithTopic();
+
+        final Thread thread1 = objectUnderTest.newThread(runnable);
+        assertThat(thread1, notNullValue());
+        verify(thread1).setName(String.format("%s-kafka-%s-1", expectedPrefix, pluginType));
+
+        final Thread thread2 = objectUnderTest.newThread(runnable);
+        assertThat(thread2, notNullValue());
+        verify(thread2).setName(String.format("%s-kafka-%s-2", expectedPrefix, pluginType));
     }
 
     @Test
@@ -86,8 +123,44 @@ class KafkaPluginThreadFactoryTest {
     }
 
     @Test
+    void newThread_with_topic_creates_thread_with_wrapping_runnable() {
+        createObjectUnderTestWithTopic().newThread(runnable);
+
+        final ArgumentCaptor<Runnable> actualRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(delegateThreadFactory).newThread(actualRunnableCaptor.capture());
+
+        final Runnable actualRunnable = actualRunnableCaptor.getValue();
+
+        assertThat(actualRunnable, not(equalTo(runnable)));
+
+        verifyNoInteractions(runnable);
+        actualRunnable.run();
+        verify(runnable).run();
+    }
+
+    @Test
     void newThread_creates_thread_that_calls_MDC_on_run() {
         createObjectUnderTest().newThread(runnable);
+
+        final ArgumentCaptor<Runnable> actualRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(delegateThreadFactory).newThread(actualRunnableCaptor.capture());
+
+        final Runnable actualRunnable = actualRunnableCaptor.getValue();
+
+        final String[] actualKafkaPluginType = new String[1];
+        doAnswer(a -> {
+            actualKafkaPluginType[0] = MDC.get(KafkaMdc.MDC_KAFKA_PLUGIN_KEY);
+            return null;
+        }).when(runnable).run();
+
+        actualRunnable.run();
+
+        assertThat(actualKafkaPluginType[0], equalTo(pluginType));
+    }
+
+    @Test
+    void newThread_with_topic_creates_thread_that_calls_MDC_on_run() {
+        createObjectUnderTestWithTopic().newThread(runnable);
 
         final ArgumentCaptor<Runnable> actualRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
         verify(delegateThreadFactory).newThread(actualRunnableCaptor.capture());

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
@@ -6,11 +6,14 @@
 package org.opensearch.dataprepper.plugins.kafka.source;
 
 import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -21,6 +24,7 @@ import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kafka.common.KafkaMdc;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConsumerConfig;
@@ -29,6 +33,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.extension.KafkaClusterConfigSupplier;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
+import org.slf4j.MDC;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -41,6 +46,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -229,5 +235,39 @@ class KafkaSourceTest {
         verify(sourceConfig, never()).setAuthConfig(any());
         verify(sourceConfig, never()).setAwsConfig(any());
         verify(sourceConfig, never()).setEncryptionConfig(any());
+    }
+
+    @Nested
+    class MdcTests {
+        private MockedStatic<MDC> mdcMockedStatic;
+
+        @BeforeEach
+        void setUp() {
+            mdcMockedStatic = mockStatic(MDC.class);
+        }
+
+        @AfterEach
+        void tearDown() {
+            mdcMockedStatic.close();
+        }
+
+        @Test
+        void start_sets_and_removes_MDC() {
+            when(topic1.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
+            when(topic2.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
+
+            createObjectUnderTest().start(buffer);
+
+            mdcMockedStatic.verify(() -> MDC.put(KafkaMdc.MDC_KAFKA_PLUGIN_KEY, "source"));
+            mdcMockedStatic.verify(() -> MDC.remove(KafkaMdc.MDC_KAFKA_PLUGIN_KEY));
+        }
+
+        @Test
+        void stop_sets_and_removes_MDC() {
+            createObjectUnderTest().stop();
+
+            mdcMockedStatic.verify(() -> MDC.put(KafkaMdc.MDC_KAFKA_PLUGIN_KEY, "source"));
+            mdcMockedStatic.verify(() -> MDC.remove(KafkaMdc.MDC_KAFKA_PLUGIN_KEY));
+        }
     }
 }


### PR DESCRIPTION
### Description

This PR continues the work done in #4131 by adding similar support for the Kafka source.

This adds logging MDC to the `kafka` source to disambiguate it against the `kafka` buffer Entry points into the `Sink` interface set the MDC value. Also, the threads which the `kafka` source directly creates will have MDC and also have a useful thread name.

This MDC is now available for both Data Prepper loggers and Apache Kafka loggers.

#### Results

First, I updated the logging pattern to include the MDC key:

```
appender.console.layout.pattern = %d{ISO8601} [%t] [%X{kafkaPluginType}] %-5p %40C - %m%n
```

Then I ran. The logs look like:

```
2024-06-25T17:44:34,212 [logs-kafka-source-1] [source] INFO  org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=consumer-data-prepper-1, groupId=data-prepper] Subscribed to topic(s): logs
2024-06-25T17:44:34,215 [logs-pipeline-sink-worker-2-thread-1] [source] INFO  org.apache.kafka.common.utils.AppInfoParser$AppInfo - Kafka version: 7.6.0-ccs
2024-06-25T17:44:34,215 [logs-pipeline-sink-worker-2-thread-1] [source] INFO  org.apache.kafka.common.utils.AppInfoParser$AppInfo - Kafka commitId: 1991cb733c81d679
2024-06-25T17:44:34,215 [logs-pipeline-sink-worker-2-thread-1] [source] INFO  org.apache.kafka.common.utils.AppInfoParser$AppInfo - Kafka startTimeMs: 1719355474215
2024-06-25T17:44:34,215 [logs-kafka-source-2] [source] INFO  org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=consumer-data-prepper-2, groupId=data-prepper] Subscribed to topic(s): logs
2024-06-25T17:44:34,216 [logs-pipeline-sink-worker-2-thread-1] [source] INFO  org.opensearch.dataprepper.plugins.kafka.source.KafkaSource - Started Kafka source for topic logs
2024-06-25T17:44:34,216 [logs-pipeline-sink-worker-2-thread-1] [] INFO  org.opensearch.dataprepper.pipeline.Pipeline - Pipeline [logs-pipeline] - Submitting request to initiate the pipeline processing
2024-06-25T17:44:34,349 [logs-kafka-source-2] [source] INFO         org.apache.kafka.clients.Metadata - [Consumer clientId=consumer-data-prepper-2, groupId=data-prepper] Cluster ID: _yZHgyDeT6ynMobR262CaA
2024-06-25T17:44:34,349 [logs-kafka-source-1] [source] INFO         org.apache.kafka.clients.Metadata - [Consumer clientId=consumer-data-prepper-1, groupId=data-prepper] Cluster ID: _yZHgyDeT6ynMobR262CaA
2024-06-25T17:44:34,349 [logs-kafka-source-1] [source] INFO  org.apache.kafka.clients.consumer.internals.AbstractCoordinator$FindCoordinatorResponseHandler - [Consumer clientId=consumer-data-prepper-1, groupId=data-prepper] Discovered group coordinator localhost:9092 (id: 2147483647 rack: null)
2024-06-25T17:44:34,349 [logs-kafka-source-2] [source] INFO  org.apache.kafka.clients.consumer.internals.AbstractCoordinator$FindCoordinatorResponseHandler - [Consumer clientId=consumer-data-prepper-2, groupId=data-prepper] Discovered group coordinator localhost:9092 (id: 2147483647 rack: null)
2024-06-25T17:44:34,350 [logs-kafka-source-1] [source] INFO  org.apache.kafka.clients.consumer.internals.AbstractCoordinator - [Consumer clientId=consumer-data-prepper-1, groupId=data-prepper] (Re-)joining group
2024-06-25T17:44:34,350 [logs-kafka-source-2] [source] INFO  org.apache.kafka.clients.consumer.internals.AbstractCoordinator - [Consumer clientId=consumer-data-prepper-2, groupId=data-prepper] (Re-)joining group
2024-06-25T17:44:34,362 [logs-kafka-source-2] [source] INFO  org.apache.kafka.clients.consumer.internals.AbstractCoordinator - [Consumer clientId=consumer-data-prepper-2, groupId=data-prepper] Request joining group due to: need to re-join with the given member-id: consumer-data-prepper-2-ae860ae1-e687-4e2c-9bad-c5b56ab911a2
```
 
### Issues Resolved

Resolves #4126


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
