### PR TITLE
Export to S3 in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -69,8 +69,8 @@ public class RdsService {
     public void shutdown() {
         if (executor != null) {
             LOG.info("shutdown RDS schedulers");
-            exportScheduler.shutDown();
-            leaderScheduler.shutDown();
+            exportScheduler.shutdown();
+            leaderScheduler.shutdown();
             executor.shutdownNow();
         }
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -29,6 +29,8 @@ public class RdsService {
     private final PluginMetrics pluginMetrics;
     private final RdsSourceConfig sourceConfig;
     private ExecutorService executor;
+    private LeaderScheduler leaderScheduler;
+    private ExportScheduler exportScheduler;
 
     public RdsService(final EnhancedSourceCoordinator sourceCoordinator,
                       final RdsSourceConfig sourceConfig,
@@ -51,8 +53,10 @@ public class RdsService {
     public void start(Buffer<Record<Event>> buffer) {
         LOG.info("Start running RDS service");
         final List<Runnable> runnableList = new ArrayList<>();
-        runnableList.add(new LeaderScheduler(sourceCoordinator, sourceConfig));
-        runnableList.add(new ExportScheduler(sourceCoordinator, rdsClient, pluginMetrics));
+        leaderScheduler = new LeaderScheduler(sourceCoordinator, sourceConfig);
+        exportScheduler = new ExportScheduler(sourceCoordinator, rdsClient, pluginMetrics);
+        runnableList.add(leaderScheduler);
+        runnableList.add(exportScheduler);
 
         executor = Executors.newFixedThreadPool(runnableList.size());
         runnableList.forEach(executor::submit);
@@ -65,6 +69,8 @@ public class RdsService {
     public void shutdown() {
         if (executor != null) {
             LOG.info("shutdown RDS schedulers");
+            exportScheduler.shutDown();
+            leaderScheduler.shutDown();
             executor.shutdownNow();
         }
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -17,6 +17,8 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreI
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.UsesEnhancedSourceCoordination;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.PartitionFactory;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +49,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
     @Override
     public void start(Buffer<Record<Event>> buffer) {
         Objects.requireNonNull(sourceCoordinator);
+        sourceCoordinator.createPartition(new LeaderPartition());
 
         rdsService = new RdsService(sourceCoordinator, sourceConfig, clientFactory, pluginMetrics);
 
@@ -70,6 +73,6 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
 
     @Override
     public Function<SourcePartitionStoreItem, EnhancedSourcePartition> getPartitionFactory() {
-        return null;
+        return new PartitionFactory();
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
@@ -8,8 +8,8 @@ package org.opensearch.dataprepper.plugins.source.rds.coordination;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
-import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
 
 import java.util.function.Function;
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
+
+import java.util.function.Function;
+
+/**
+ * Partition factory to map a {@link SourcePartitionStoreItem} to a {@link EnhancedSourcePartition}.
+ */
+public class PartitionFactory implements Function<SourcePartitionStoreItem, EnhancedSourcePartition> {
+
+    @Override
+    public EnhancedSourcePartition apply(SourcePartitionStoreItem partitionStoreItem) {
+        String sourceIdentifier = partitionStoreItem.getSourceIdentifier();
+        String partitionType = sourceIdentifier.substring(sourceIdentifier.lastIndexOf('|') + 1);
+
+        if (LeaderPartition.PARTITION_TYPE.equals(partitionType)) {
+            return new LeaderPartition(partitionStoreItem);
+        }  if (ExportPartition.PARTITION_TYPE.equals(partitionType)) {
+            return new ExportPartition(partitionStoreItem);
+        } else {
+            // Unable to acquire other partitions.
+            return new GlobalState(partitionStoreItem);
+        }
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/ExportPartition.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/ExportPartition.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.partition;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * An ExportPartition represents an export job needs to be run for tables.
+ * Each export job has an export time associate with it.
+ * Each job maintains the state such as total files/records etc. independently.
+ * The source identifier contains keyword 'EXPORT'
+ */
+public class ExportPartition extends EnhancedSourcePartition<ExportProgressState> {
+    public static final String PARTITION_TYPE = "EXPORT";
+
+    private static final String DB_CLUSTER = "cluster";
+    private static final String DB_INSTANCE = "instance";
+
+    private final String dbIdentifier;
+
+    private final boolean isCluster;
+
+    private final ExportProgressState progressState;
+
+    public ExportPartition(String dbIdentifier, boolean isCluster, ExportProgressState progressState) {
+        this.dbIdentifier = dbIdentifier;
+        this.isCluster = isCluster;
+        this.progressState = progressState;
+    }
+
+    public ExportPartition(SourcePartitionStoreItem sourcePartitionStoreItem) {
+        setSourcePartitionStoreItem(sourcePartitionStoreItem);
+        String [] keySplits = sourcePartitionStoreItem.getSourcePartitionKey().split("\\|");
+        dbIdentifier = keySplits[0];
+        isCluster = DB_CLUSTER.equals(keySplits[1]);
+        progressState = convertStringToPartitionProgressState(ExportProgressState.class, sourcePartitionStoreItem.getPartitionProgressState());
+    }
+
+    @Override
+    public String getPartitionType() {
+        return PARTITION_TYPE;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        final String dbType = isCluster ? DB_CLUSTER : DB_INSTANCE;
+        return dbIdentifier + "|" + dbType;
+    }
+
+    @Override
+    public Optional<ExportProgressState> getProgressState() {
+        if (progressState != null) {
+            return Optional.of(progressState);
+        }
+        return Optional.empty();
+    }
+
+    public String getDbIdentifier() {
+        return dbIdentifier;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/ExportPartition.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/ExportPartition.java
@@ -9,7 +9,6 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreI
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
 
-import java.time.Instant;
 import java.util.Optional;
 
 /**

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/GlobalState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/GlobalState.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.partition;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class GlobalState extends EnhancedSourcePartition<Map<String, Object>> {
+
+    private final String stateName;
+
+    private Map<String, Object> state;
+
+    public GlobalState(String stateName, Map<String, Object> state) {
+        this.stateName = stateName;
+        this.state = state;
+    }
+
+    public GlobalState(SourcePartitionStoreItem sourcePartitionStoreItem) {
+        setSourcePartitionStoreItem(sourcePartitionStoreItem);
+        stateName = sourcePartitionStoreItem.getSourcePartitionKey();
+        state = convertStringToPartitionProgressState(null, sourcePartitionStoreItem.getPartitionProgressState());
+    }
+
+    @Override
+    public String getPartitionType() {
+        return null;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return stateName;
+    }
+
+    @Override
+    public Optional<Map<String, Object>> getProgressState() {
+        if (state != null) {
+            return Optional.of(state);
+        }
+        return Optional.empty();
+    }
+
+    public void setProgressState(Map<String, Object> state) {
+        this.state = state;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/LeaderPartition.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/LeaderPartition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.partition;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.LeaderProgressState;
+
+import java.util.Optional;
+
+/**
+ * <p>A LeaderPartition is for some tasks that should be done in a single node only. </p>
+ * <p>Hence whatever node owns the lease of this partition will be acted as a 'leader'. </p>
+ * <p>In this DynamoDB source design, a leader node will be responsible for:</p>
+ * <ul>
+ * <li>Initialization process (create EXPORT and STREAM partitions)</li>
+ * <li>Triggering RDS export task</li>
+ * <li>Reading stream data</li>
+ * </ul>
+ */
+public class LeaderPartition extends EnhancedSourcePartition<LeaderProgressState> {
+    public static final String PARTITION_TYPE = "LEADER";
+
+    // identifier for the partition
+    private static final String DEFAULT_PARTITION_KEY = "GLOBAL";
+
+    private final LeaderProgressState state;
+
+    public LeaderPartition() {
+        this.state = new LeaderProgressState();
+    }
+
+    public LeaderPartition(SourcePartitionStoreItem partitionStoreItem) {
+        setSourcePartitionStoreItem(partitionStoreItem);
+        this.state = convertStringToPartitionProgressState(LeaderProgressState.class, partitionStoreItem.getPartitionProgressState());
+    }
+
+    @Override
+    public String getPartitionType() {
+        return PARTITION_TYPE;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return DEFAULT_PARTITION_KEY;
+    }
+
+    @Override
+    public Optional<LeaderProgressState> getProgressState() {
+        return Optional.of(state);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/ExportProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/ExportProgressState.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Progress state for an EXPORT partition
+ */
+public class ExportProgressState {
+
+    @JsonProperty("snapshotId")
+    private String snapshotId;
+
+    @JsonProperty("exportTaskId")
+    private String exportTaskId;
+
+    @JsonProperty("iamRoleArn")
+    private String iamRoleArn;
+
+    @JsonProperty("bucket")
+    private String bucket;
+
+    @JsonProperty("prefix")
+    private String prefix;
+
+    @JsonProperty("tables")
+    private List<String> tables;
+
+    @JsonProperty("kmsKeyId")
+    private String kmsKeyId;
+
+    @JsonProperty("exportTime")
+    private String exportTime;
+
+    @JsonProperty("status")
+    private String status;
+
+    public String getSnapshotId() {
+        return snapshotId;
+    }
+
+    public void setSnapshotId(String snapshotId) {
+        this.snapshotId = snapshotId;
+    }
+
+    public String getExportTaskId() {
+        return exportTaskId;
+    }
+
+    public void setExportTaskId(String exportTaskId) {
+        this.exportTaskId = exportTaskId;
+    }
+
+    public String getIamRoleArn() {
+        return iamRoleArn;
+    }
+
+    public void setIamRoleArn(String iamRoleArn) {
+        this.iamRoleArn = iamRoleArn;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public List<String> getTables() {
+        return tables;
+    }
+
+    public void setTables(List<String> tables) {
+        this.tables = tables;
+    }
+
+    public String getKmsKeyId() {
+        return kmsKeyId;
+    }
+
+    public void setKmsKeyId(String kmsKeyId) {
+        this.kmsKeyId = kmsKeyId;
+    }
+
+    public String getExportTime() {
+        return exportTime;
+    }
+
+    public void setExportTime(String exportTime) {
+        this.exportTime = exportTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/LeaderProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/LeaderProgressState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Progress state for a LEADER partition
+ */
+public class LeaderProgressState {
+
+    @JsonProperty("initialized")
+    private boolean initialized = false;
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public void setInitialized(boolean initialized) {
+        this.initialized = initialized;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -122,8 +122,10 @@ public class ExportScheduler implements Runnable {
         }
 
         final String snapshotId = snapshotInfo.getSnapshotId();
+        final CheckSnapshotStatusRunner checkSnapshotStatusRunner = new CheckSnapshotStatusRunner(
+                snapshotId, snapshotManager, DEFAULT_SNAPSHOT_STATUS_CHECK_TIMEOUT);
         try {
-            checkSnapshotStatus(snapshotId, DEFAULT_SNAPSHOT_STATUS_CHECK_TIMEOUT);
+            checkSnapshotStatusRunner.run();
         } catch (Exception e) {
             LOG.warn("Check snapshot status for {} failed", snapshotId, e);
             sourceCoordinator.giveUpPartition(exportPartition);
@@ -155,28 +157,41 @@ public class ExportScheduler implements Runnable {
         sourceCoordinator.closePartition(exportPartition, DEFAULT_CLOSE_DURATION, DEFAULT_MAX_CLOSE_COUNT);
     }
 
-    private String checkSnapshotStatus(String snapshotId, Duration timeout) {
-        final Instant endTime = Instant.now().plus(timeout);
+    private static class CheckSnapshotStatusRunner implements Runnable {
+        private final String snapshotId;
+        private final SnapshotManager snapshotManager;
+        private final Duration timeout;
 
-        LOG.debug("Start checking status of snapshot {}", snapshotId);
-        while (Instant.now().isBefore(endTime)) {
-            SnapshotInfo snapshotInfo = snapshotManager.checkSnapshotStatus(snapshotId);
-            String status = snapshotInfo.getStatus();
-            // Valid snapshot statuses are: available, copying, creating
-            // The status should never be "copying" here
-            if (SnapshotStatus.AVAILABLE.getStatusName().equals(status)) {
-                LOG.info("Snapshot {} is available.", snapshotId);
-                return status;
-            }
-
-            LOG.debug("Snapshot {} is still creating. Wait and check later", snapshotId);
-            try {
-                Thread.sleep(DEFAULT_CHECK_STATUS_INTERVAL_MILLS);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+        public CheckSnapshotStatusRunner(final String snapshotId, final SnapshotManager snapshotManager, final Duration timeout) {
+            this.snapshotId = snapshotId;
+            this.snapshotManager = snapshotManager;
+            this.timeout = timeout;
         }
-        throw new RuntimeException("Snapshot status check timed out.");
+
+        @Override
+        public void run() {
+            final Instant endTime = Instant.now().plus(timeout);
+
+            LOG.debug("Start checking status of snapshot {}", snapshotId);
+            while (Instant.now().isBefore(endTime)) {
+                SnapshotInfo snapshotInfo = snapshotManager.checkSnapshotStatus(snapshotId);
+                String status = snapshotInfo.getStatus();
+                // Valid snapshot statuses are: available, copying, creating
+                // The status should never be "copying" here
+                if (SnapshotStatus.AVAILABLE.getStatusName().equals(status)) {
+                    LOG.info("Snapshot {} is available.", snapshotId);
+                    return;
+                }
+
+                LOG.debug("Snapshot {} is still creating. Wait and check later", snapshotId);
+                try {
+                    Thread.sleep(DEFAULT_CHECK_STATUS_INTERVAL_MILLS);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            throw new RuntimeException("Snapshot status check timed out.");
+        }
     }
 
     private String checkExportStatus(ExportPartition exportPartition) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -7,13 +7,20 @@ package org.opensearch.dataprepper.plugins.source.rds.export;
 
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
 
 import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.BiConsumer;
 
 public class ExportScheduler implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ExportScheduler.class);
@@ -32,6 +39,9 @@ public class ExportScheduler implements Runnable {
 
     private final ExecutorService executor;
 
+    private final ExportTaskManager exportTaskManager;
+    private final SnapshotManager snapshotManager;
+
     public ExportScheduler(final EnhancedSourceCoordinator sourceCoordinator,
                            final RdsClient rdsClient,
                            final PluginMetrics pluginMetrics) {
@@ -39,10 +49,173 @@ public class ExportScheduler implements Runnable {
         this.sourceCoordinator = sourceCoordinator;
         this.rdsClient = rdsClient;
         this.executor = Executors.newCachedThreadPool();
+        this.exportTaskManager = new ExportTaskManager(rdsClient);
+        this.snapshotManager = new SnapshotManager(rdsClient);
     }
 
     @Override
     public void run() {
+        LOG.debug("Start running Export Scheduler");
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                final Optional<EnhancedSourcePartition> sourcePartition = sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE);
+                
+                if (sourcePartition.isPresent()) {
+                    ExportPartition exportPartition = (ExportPartition) sourcePartition.get();
+                    LOG.debug("Acquired an export partition: " + exportPartition.getPartitionKey());
 
+                    String exportTaskId = getOrCreateExportTaskId(exportPartition);
+
+                    if (exportTaskId == null) {
+                        LOG.error("The export to S3 failed, it will be retried");
+                        closeExportPartitionWithError(exportPartition);
+                    } else {
+                        CompletableFuture<String> checkStatus = CompletableFuture.supplyAsync(() -> checkExportStatus(exportPartition), executor);
+                        checkStatus.whenComplete(completeExport(exportPartition));
+                    }
+                }
+
+                try {
+                    Thread.sleep(DEFAULT_TAKE_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException e) {
+                    LOG.info("The ExportScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            } catch (final Exception e) {
+                LOG.error("Received an exception during export, backing off and retrying", e);
+                try {
+                    Thread.sleep(DEFAULT_TAKE_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException ex) {
+                    LOG.info("The ExportScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            }
+        }
+        LOG.warn("Export scheduler interrupted, looks like shutdown has triggered");
+        executor.shutdownNow();
+    }
+
+    private String getOrCreateExportTaskId(ExportPartition exportPartition) {
+        ExportProgressState progressState = exportPartition.getProgressState().get();
+
+        if (progressState.getExportTaskId() != null) {
+            LOG.info("Export task has already created for db {}", exportPartition.getDbIdentifier());
+            return progressState.getExportTaskId();
+        }
+
+        LOG.info("Creating a new snapshot for db {}", exportPartition.getDbIdentifier());
+        SnapshotInfo snapshotInfo = snapshotManager.createSnapshot(exportPartition.getDbIdentifier());
+        if (snapshotInfo != null) {
+            LOG.info("Snapshot id is {}", snapshotInfo.getSnapshotId());
+            progressState.setSnapshotId(snapshotInfo.getSnapshotId());
+            sourceCoordinator.saveProgressStateForPartition(exportPartition, null);
+        } else {
+            LOG.error("The snapshot failed to create, it will be retried");
+            closeExportPartitionWithError(exportPartition);
+            return null;
+        }
+
+        final String snapshotId = snapshotInfo.getSnapshotId();
+        try {
+            checkSnapshotStatus(snapshotId);
+        } catch (Exception e) {
+            LOG.warn("Check snapshot status for {} failed", snapshotId, e);
+            sourceCoordinator.giveUpPartition(exportPartition);
+        }
+
+        LOG.info("Creating an export task for db {} from snapshot {}", exportPartition.getDbIdentifier(), snapshotId);
+        String exportTaskId = exportTaskManager.startExportTask(
+                snapshotInfo.getSnapshotArn(), progressState.getIamRoleArn(), progressState.getBucket(),
+                progressState.getPrefix(), progressState.getKmsKeyId(), progressState.getTables());
+
+        if (exportTaskId != null) {
+            LOG.info("Export task id is {}", exportTaskId);
+            progressState.setExportTaskId(exportTaskId);
+            sourceCoordinator.saveProgressStateForPartition(exportPartition, null);
+        } else {
+            LOG.error("The export task failed to create, it will be retried");
+            closeExportPartitionWithError(exportPartition);
+        }
+
+        return exportTaskId;
+    }
+
+    private void closeExportPartitionWithError(ExportPartition exportPartition) {
+        ExportProgressState exportProgressState = exportPartition.getProgressState().get();
+        // Clear current task id, so that a new export can be submitted.
+        exportProgressState.setExportTaskId(null);
+        sourceCoordinator.closePartition(exportPartition, DEFAULT_CLOSE_DURATION, DEFAULT_MAX_CLOSE_COUNT);
+    }
+
+    private String checkSnapshotStatus(String snapshotId) {
+        LOG.debug("Start checking status of snapshot {}", snapshotId);
+        while (true) {
+            SnapshotInfo snapshotInfo = snapshotManager.checkSnapshotStatus(snapshotId);
+            String status = snapshotInfo.getStatus();
+            // Valid snapshot statuses are: available, copying, creating
+            // The status should never be "copying" here
+            if ("available".equals(status)) {
+                LOG.info("Snapshot {} is available.", snapshotId);
+                return status;
+            }
+
+            LOG.debug("Snapshot {} is still creating. Wait and check later", snapshotId);
+            try {
+                Thread.sleep(DEFAULT_CHECK_STATUS_INTERVAL_MILLS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private String checkExportStatus(ExportPartition exportPartition) {
+        long lastCheckpointTime = System.currentTimeMillis();
+        String exportTaskId = exportPartition.getProgressState().get().getExportTaskId();
+
+        LOG.debug("Start checking the status of export " + exportTaskId);
+        while (true) {
+            if (System.currentTimeMillis() - lastCheckpointTime > DEFAULT_CHECKPOINT_INTERVAL_MILLS) {
+                sourceCoordinator.saveProgressStateForPartition(exportPartition, null);
+                lastCheckpointTime = System.currentTimeMillis();
+            }
+
+            // Valid statuses are: CANCELED, CANCELING, COMPLETE, FAILED, IN_PROGRESS, STARTING
+            String status = exportTaskManager.checkExportStatus(exportTaskId);
+            LOG.debug("Current export status is {}.", status);
+            if ("COMPLETE".equals(status) || "FAILED".equals(status) || "CANCELED".equals(status)) {
+                LOG.info("Export {} is completed with final status {}", exportTaskId, status);
+                return status;
+            }
+            LOG.debug("Export {} is still running in progress. Wait and check later", exportTaskId);
+            try {
+                Thread.sleep(DEFAULT_CHECK_STATUS_INTERVAL_MILLS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private BiConsumer<String, Throwable> completeExport(ExportPartition exportPartition) {
+        return (status, ex) -> {
+            if (ex != null) {
+                LOG.warn("Check export status for {} failed", exportPartition.getPartitionKey(), ex);
+                sourceCoordinator.giveUpPartition(exportPartition);
+            } else {
+                if (!"COMPLETE".equals(status)) {
+                    LOG.error("Export failed with status {}", status);
+                    closeExportPartitionWithError(exportPartition);
+                    return;
+                }
+                LOG.info("Export for {} completed successfully", exportPartition.getPartitionKey());
+
+                completeExportPartition(exportPartition);
+            }
+        };
+    }
+
+    private void completeExportPartition(ExportPartition exportPartition) {
+        ExportProgressState progressState = exportPartition.getProgressState().get();
+        progressState.setStatus("Completed");
+        sourceCoordinator.completePartition(exportPartition);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportTaskManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportTaskManager.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeExportTasksRequest;
+import software.amazon.awssdk.services.rds.model.DescribeExportTasksResponse;
+import software.amazon.awssdk.services.rds.model.StartExportTaskRequest;
+import software.amazon.awssdk.services.rds.model.StartExportTaskResponse;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public class ExportTaskManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExportTaskManager.class);
+
+    // Export identifier cannot be longer than 60 characters
+    private static final int EXPORT_TASK_ID_MAX_LENGTH = 60;
+
+    private final RdsClient rdsClient;
+
+    public ExportTaskManager(final RdsClient rdsClient) {
+        this.rdsClient = rdsClient;
+    }
+
+    public String startExportTask(String snapshotArn, String iamRoleArn, String bucket, String prefix, String kmsKeyId, Collection<String> includeTables) {
+        final String exportTaskId = generateExportTaskId(snapshotArn);
+        StartExportTaskRequest.Builder requestBuilder = StartExportTaskRequest.builder()
+                .exportTaskIdentifier(exportTaskId)
+                .sourceArn(snapshotArn)
+                .iamRoleArn(iamRoleArn)
+                .s3BucketName(bucket)
+                .s3Prefix(prefix)
+                .kmsKeyId(kmsKeyId);
+
+        if (includeTables != null && !includeTables.isEmpty()) {
+            requestBuilder.exportOnly(includeTables);
+        }
+
+        try {
+            StartExportTaskResponse response = rdsClient.startExportTask(requestBuilder.build());
+            LOG.info("Export task submitted with id {} and status {}", exportTaskId, response.status());
+            return exportTaskId;
+
+        } catch (Exception e) {
+            LOG.error("Failed to start an export task", e);
+            return null;
+        }
+    }
+
+    public String checkExportStatus(String exportTaskId) {
+        DescribeExportTasksRequest request = DescribeExportTasksRequest.builder()
+                .exportTaskIdentifier(exportTaskId)
+                .build();
+
+        DescribeExportTasksResponse response = rdsClient.describeExportTasks(request);
+
+        return response.exportTasks().get(0).status();
+    }
+
+    private String generateExportTaskId(String snapshotArn) {
+        String snapshotId = Arn.fromString(snapshotArn).resource().resource();
+        return truncateString(snapshotId, EXPORT_TASK_ID_MAX_LENGTH - 16) + "-export-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private String truncateString(String originalString, int maxLength) {
+        if (originalString.length() <= maxLength) {
+            return originalString;
+        }
+        return originalString.substring(0, maxLength);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManager.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class SnapshotManager {
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotManager.class);
+
+    private final RdsClient rdsClient;
+
+    public SnapshotManager(final RdsClient rdsClient) {
+        this.rdsClient = rdsClient;
+    }
+
+    public SnapshotInfo createSnapshot(String dbInstanceId) {
+        final String snapshotId = generateSnapshotId(dbInstanceId);
+        CreateDbSnapshotRequest request = CreateDbSnapshotRequest.builder()
+                .dbInstanceIdentifier(dbInstanceId)
+                .dbSnapshotIdentifier(snapshotId)
+                .build();
+
+        try {
+            CreateDbSnapshotResponse response = rdsClient.createDBSnapshot(request);
+            String snapshotArn = response.dbSnapshot().dbSnapshotArn();
+            String status = response.dbSnapshot().status();
+            Instant createTime = response.dbSnapshot().snapshotCreateTime();
+            LOG.info("Creating snapshot with id {} and status {}", snapshotId, status);
+
+            return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+        } catch (Exception e) {
+            LOG.error("Failed to create snapshot for {}", dbInstanceId, e);
+            return null;
+        }
+    }
+
+    public SnapshotInfo checkSnapshotStatus(String snapshotId) {
+        DescribeDbSnapshotsRequest request = DescribeDbSnapshotsRequest.builder()
+                .dbSnapshotIdentifier(snapshotId)
+                .build();
+
+        DescribeDbSnapshotsResponse response = rdsClient.describeDBSnapshots(request);
+        String snapshotArn = response.dbSnapshots().get(0).dbSnapshotArn();
+        String status = response.dbSnapshots().get(0).status();
+        Instant createTime = response.dbSnapshots().get(0).snapshotCreateTime();
+
+        return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+    }
+
+    private String generateSnapshotId(String dbClusterId) {
+        return dbClusterId + "-snapshot-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -6,11 +6,19 @@
 package org.opensearch.dataprepper.plugins.source.rds.leader;
 
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.LeaderProgressState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 
 public class LeaderScheduler implements Runnable {
 
@@ -20,6 +28,8 @@ public class LeaderScheduler implements Runnable {
     private final EnhancedSourceCoordinator sourceCoordinator;
     private final RdsSourceConfig sourceConfig;
 
+    private LeaderPartition leaderPartition;
+
     public LeaderScheduler(final EnhancedSourceCoordinator sourceCoordinator, final RdsSourceConfig sourceConfig) {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
@@ -27,6 +37,80 @@ public class LeaderScheduler implements Runnable {
 
     @Override
     public void run() {
+        LOG.info("Starting Leader Scheduler for initialization.");
 
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                // Try to acquire the lease if not owned
+                if (leaderPartition == null) {
+                    final Optional<EnhancedSourcePartition> sourcePartition = sourceCoordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE);
+                    if (sourcePartition.isPresent()) {
+                        LOG.info("Running as a LEADER node.");
+                        leaderPartition = (LeaderPartition) sourcePartition.get();
+                    }
+                }
+
+                // Once owned, run Normal LEADER node process
+                if (leaderPartition != null) {
+                    LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
+                    if (!leaderProgressState.isInitialized()) {
+                        init();
+                    }
+                }
+            } catch (final Exception e) {
+                LOG.error("Exception occurred in primary leader scheduling loop", e);
+            } finally {
+                if (leaderPartition != null) {
+                    // Extend the timeout
+                    // will always be a leader until shutdown
+                    sourceCoordinator.saveProgressStateForPartition(leaderPartition, Duration.ofMinutes(DEFAULT_EXTEND_LEASE_MINUTES));
+                }
+
+                try {
+                    Thread.sleep(DEFAULT_LEASE_INTERVAL.toMillis());
+                } catch (final InterruptedException e) {
+                    LOG.info("InterruptedException occurred while waiting in leader scheduling loop.");
+                    break;
+                }
+            }
+        }
+
+        // Should stop
+        LOG.warn("Quitting Leader Scheduler");
+        if (leaderPartition != null) {
+            sourceCoordinator.giveUpPartition(leaderPartition);
+        }
     }
+
+    private void init() {
+        LOG.info("Initializing RDS source service...");
+
+        // Create a Global state in the coordination table for the configuration.
+        // Global State here is designed to be able to read whenever needed
+        // So that the jobs can refer to the configuration.
+        sourceCoordinator.createPartition(new GlobalState(sourceConfig.getDbIdentifier(), null));
+
+        if (sourceConfig.isExportEnabled()) {
+            Instant startTime = Instant.now();
+            LOG.debug("Export is enabled. Creating export partition in the source coordination store.");
+            createExportPartition(sourceConfig, startTime);
+        }
+
+        LOG.debug("Update initialization state");
+        LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
+        leaderProgressState.setInitialized(true);
+    }
+
+    private void createExportPartition(RdsSourceConfig sourceConfig, Instant exportTime) {
+        ExportProgressState progressState = new ExportProgressState();
+        progressState.setIamRoleArn(sourceConfig.getAwsAuthenticationConfig().getAwsStsRoleArn());
+        progressState.setBucket(sourceConfig.getS3Bucket());
+        progressState.setPrefix(sourceConfig.getS3Prefix());
+        progressState.setTables(sourceConfig.getTableNames());
+        progressState.setKmsKeyId(sourceConfig.getExport().getKmsKeyId());
+        progressState.setExportTime(exportTime.toString());
+        ExportPartition exportPartition = new ExportPartition(sourceConfig.getDbIdentifier(), sourceConfig.isCluster(), progressState);
+        sourceCoordinator.createPartition(exportPartition);
+    }
+
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -29,7 +29,7 @@ public class LeaderScheduler implements Runnable {
     private final RdsSourceConfig sourceConfig;
 
     private LeaderPartition leaderPartition;
-    private volatile boolean shutDownRequested = false;
+    private volatile boolean shutdownRequested = false;
 
     public LeaderScheduler(final EnhancedSourceCoordinator sourceCoordinator, final RdsSourceConfig sourceConfig) {
         this.sourceCoordinator = sourceCoordinator;
@@ -40,7 +40,7 @@ public class LeaderScheduler implements Runnable {
     public void run() {
         LOG.info("Starting Leader Scheduler for initialization.");
 
-        while (!shutDownRequested && !Thread.currentThread().isInterrupted()) {
+        while (!shutdownRequested && !Thread.currentThread().isInterrupted()) {
             try {
                 // Try to acquire the lease if not owned
                 if (leaderPartition == null) {
@@ -83,8 +83,8 @@ public class LeaderScheduler implements Runnable {
         }
     }
 
-    public void shutDown() {
-        shutDownRequested = true;
+    public void shutdown() {
+        shutdownRequested = true;
     }
 
     private void init() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -29,6 +29,7 @@ public class LeaderScheduler implements Runnable {
     private final RdsSourceConfig sourceConfig;
 
     private LeaderPartition leaderPartition;
+    private volatile boolean shutDownRequested = false;
 
     public LeaderScheduler(final EnhancedSourceCoordinator sourceCoordinator, final RdsSourceConfig sourceConfig) {
         this.sourceCoordinator = sourceCoordinator;
@@ -39,7 +40,7 @@ public class LeaderScheduler implements Runnable {
     public void run() {
         LOG.info("Starting Leader Scheduler for initialization.");
 
-        while (!Thread.currentThread().isInterrupted()) {
+        while (!shutDownRequested && !Thread.currentThread().isInterrupted()) {
             try {
                 // Try to acquire the lease if not owned
                 if (leaderPartition == null) {
@@ -80,6 +81,10 @@ public class LeaderScheduler implements Runnable {
         if (leaderPartition != null) {
             sourceCoordinator.giveUpPartition(leaderPartition);
         }
+    }
+
+    public void shutDown() {
+        shutDownRequested = true;
     }
 
     private void init() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatus.java
@@ -5,7 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.model;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public enum ExportStatus {
     CANCELED,
@@ -15,5 +18,19 @@ public enum ExportStatus {
     IN_PROGRESS,
     STARTING;
 
-    public static final Set<String> TERMINAL_STATUS_NAMES = Set.of(CANCELED.name(), COMPLETE.name(), FAILED.name());
+    private static final Map<String, ExportStatus> TYPES_MAP = Arrays.stream(ExportStatus.values())
+            .collect(Collectors.toMap(
+                    Enum::name,
+                    value -> value
+            ));
+    private static final Set<ExportStatus> TERMINAL_STATUSES = Set.of(CANCELED, COMPLETE, FAILED);
+
+    public static ExportStatus fromString(final String name) {
+        return TYPES_MAP.get(name);
+    }
+
+    public static boolean isTerminal(final String name) {
+        ExportStatus status = fromString(name);
+        return status != null && TERMINAL_STATUSES.contains(status);
+    }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatus.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.util.Set;
+
+public enum ExportStatus {
+    CANCELED,
+    CANCELING,
+    COMPLETE,
+    FAILED,
+    IN_PROGRESS,
+    STARTING;
+
+    public static final Set<String> TERMINAL_STATUS_NAMES = Set.of(CANCELED.name(), COMPLETE.name(), FAILED.name());
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/SnapshotInfo.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/SnapshotInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.time.Instant;
+
+public class SnapshotInfo {
+
+    private final String snapshotId;
+    private final String snapshotArn;
+    private final Instant createTime;
+    private String status;
+
+    public SnapshotInfo(String snapshotId, String snapshotArn, Instant createTime, String status) {
+        this.snapshotId = snapshotId;
+        this.snapshotArn = snapshotArn;
+        this.createTime = createTime;
+        this.status = status;
+    }
+
+    public String getSnapshotId() {
+        return snapshotId;
+    }
+
+    public String getSnapshotArn() {
+        return snapshotArn;
+    }
+
+    public Instant getCreateTime() {
+        return createTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/SnapshotStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/SnapshotStatus.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+public enum SnapshotStatus {
+    AVAILABLE("available"),
+    COPYING("copying"),
+    CREATING("creating");
+
+    private final String statusName;
+
+    SnapshotStatus(final String statusName) {
+        this.statusName = statusName;
+    }
+
+    public String getStatusName() {
+        return statusName;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -56,7 +56,6 @@ class RdsServiceTest {
     @BeforeEach
     void setUp() {
         when(clientFactory.buildRdsClient()).thenReturn(rdsClient);
-
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactoryTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PartitionFactoryTest {
+
+    @Mock
+    private SourcePartitionStoreItem partitionStoreItem;
+
+    @Test
+    void given_leader_partition_item_then_create_leader_partition() {
+        PartitionFactory objectUnderTest = createObjectUnderTest();
+        when(partitionStoreItem.getSourceIdentifier()).thenReturn(UUID.randomUUID() + "|" + LeaderPartition.PARTITION_TYPE);
+        when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
+
+        assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(LeaderPartition.class));
+    }
+
+    @Test
+    void given_export_partition_item_then_create_export_partition() {
+        PartitionFactory objectUnderTest = createObjectUnderTest();
+        when(partitionStoreItem.getSourceIdentifier()).thenReturn(UUID.randomUUID() + "|" + ExportPartition.PARTITION_TYPE);
+        when(partitionStoreItem.getSourcePartitionKey()).thenReturn(UUID.randomUUID() + "|" + UUID.randomUUID());
+        when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
+
+        assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(ExportPartition.class));
+    }
+
+    @Test
+    void given_store_item_of_undefined_type_then_create_global_state() {
+        PartitionFactory objectUnderTest = createObjectUnderTest();
+        when(partitionStoreItem.getSourceIdentifier()).thenReturn(UUID.randomUUID() + "|" + UUID.randomUUID());
+        when(partitionStoreItem.getSourcePartitionKey()).thenReturn(UUID.randomUUID().toString());
+        when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
+
+        assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(GlobalState.class));
+    }
+
+    private PartitionFactory createObjectUnderTest() {
+        return new PartitionFactory();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -160,7 +160,7 @@ class ExportSchedulerTest {
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(exportScheduler);
-        exportScheduler.shutDown();
+        exportScheduler.shutdown();
         verifyNoMoreInteractions(sourceCoordinator, rdsClient);
         executorService.shutdownNow();
     }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBSnapshot;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.DescribeExportTasksRequest;
+import software.amazon.awssdk.services.rds.model.DescribeExportTasksResponse;
+import software.amazon.awssdk.services.rds.model.StartExportTaskRequest;
+import software.amazon.awssdk.services.rds.model.StartExportTaskResponse;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class ExportSchedulerTest {
+
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @Mock
+    private RdsClient rdsClient;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private ExportPartition exportPartition;
+
+    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    private ExportProgressState exportProgressState;
+
+    private ExportScheduler exportScheduler;
+
+    @BeforeEach
+    void setUp() {
+        exportScheduler = createObjectUnderTest();
+    }
+
+    @Test
+    void test_given_no_export_partition_then_not_export() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(exportScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(ExportPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verifyNoInteractions(rdsClient);
+    }
+
+    @Test
+    void test_given_export_partition_and_task_id_then_complete_export() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.of(exportPartition));
+        when(exportPartition.getPartitionKey()).thenReturn(UUID.randomUUID().toString());
+        when(exportProgressState.getExportTaskId()).thenReturn(UUID.randomUUID().toString());
+        when(exportPartition.getProgressState()).thenReturn(Optional.of(exportProgressState));
+
+        DescribeExportTasksResponse describeExportTasksResponse = mock(DescribeExportTasksResponse.class, Mockito.RETURNS_DEEP_STUBS);
+        when(describeExportTasksResponse.exportTasks().get(0).status()).thenReturn("COMPLETE");
+        when(rdsClient.describeExportTasks(any(DescribeExportTasksRequest.class))).thenReturn(describeExportTasksResponse);
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(exportScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(ExportPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verify(sourceCoordinator).completePartition(exportPartition);
+        verify(rdsClient, never()).startExportTask(any(StartExportTaskRequest.class));
+        verify(rdsClient, never()).createDBSnapshot(any(CreateDbSnapshotRequest.class));
+    }
+
+
+    @Test
+    void test_given_export_partition_and_no_task_id_then_start_and_complete_export() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.of(exportPartition));
+        when(exportPartition.getPartitionKey()).thenReturn(UUID.randomUUID().toString());
+        when(exportProgressState.getExportTaskId()).thenReturn(null).thenReturn(UUID.randomUUID().toString());
+        when(exportPartition.getProgressState()).thenReturn(Optional.of(exportProgressState));
+        final String dbIdentifier = UUID.randomUUID().toString();
+        when(exportPartition.getDbIdentifier()).thenReturn(dbIdentifier);
+
+        // Mock snapshot response
+        CreateDbSnapshotResponse createDbSnapshotResponse = mock(CreateDbSnapshotResponse.class);
+        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
+        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
+        when(dbSnapshot.status()).thenReturn("creating").thenReturn("available");
+        when(dbSnapshot.snapshotCreateTime()).thenReturn(Instant.now());
+        when(createDbSnapshotResponse.dbSnapshot()).thenReturn(dbSnapshot);
+        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenReturn(createDbSnapshotResponse);
+
+        DescribeDbSnapshotsResponse describeDbSnapshotsResponse = DescribeDbSnapshotsResponse.builder()
+                .dbSnapshots(dbSnapshot)
+                .build();
+        when(rdsClient.describeDBSnapshots(any(DescribeDbSnapshotsRequest.class))).thenReturn(describeDbSnapshotsResponse);
+
+        // Mock export response
+        StartExportTaskResponse startExportTaskResponse = mock(StartExportTaskResponse.class);
+        when(startExportTaskResponse.status()).thenReturn("STARTING");
+        when(rdsClient.startExportTask(any(StartExportTaskRequest.class))).thenReturn(startExportTaskResponse);
+
+        DescribeExportTasksResponse describeExportTasksResponse = mock(DescribeExportTasksResponse.class, Mockito.RETURNS_DEEP_STUBS);
+        when(describeExportTasksResponse.exportTasks().get(0).status()).thenReturn("COMPLETE");
+        when(rdsClient.describeExportTasks(any(DescribeExportTasksRequest.class))).thenReturn(describeExportTasksResponse);
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(exportScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(ExportPartition.PARTITION_TYPE));
+        Thread.sleep(200);
+        executorService.shutdownNow();
+
+        verify(rdsClient).createDBSnapshot(any(CreateDbSnapshotRequest.class));
+        verify(rdsClient).startExportTask(any(StartExportTaskRequest.class));
+        verify(sourceCoordinator).completePartition(exportPartition);
+    }
+
+    private ExportScheduler createObjectUnderTest() {
+        return new ExportScheduler(sourceCoordinator, rdsClient, pluginMetrics);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportTaskManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportTaskManagerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeExportTasksRequest;
+import software.amazon.awssdk.services.rds.model.DescribeExportTasksResponse;
+import software.amazon.awssdk.services.rds.model.ExportTask;
+import software.amazon.awssdk.services.rds.model.StartExportTaskRequest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class ExportTaskManagerTest {
+
+    @Mock
+    private RdsClient rdsClient;
+
+    private ExportTaskManager exportTaskManager;
+
+    @BeforeEach
+    void setUp() {
+        exportTaskManager = createObjectUnderTest();
+    }
+
+    @Test
+    void test_start_export_task_without_specifying_tables() {
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
+        final String iamRoleArn = "arn:aws:iam:us-east-1:123456789012:role:my-role";
+        final String bucket = "bucket";
+        final String prefix = "prefix";
+        final String kmsKey = UUID.randomUUID().toString();
+        final List<String> exportOnly = List.of();
+
+        exportTaskManager.startExportTask(snapshotArn, iamRoleArn, bucket, prefix, kmsKey, exportOnly);
+
+
+        final ArgumentCaptor<StartExportTaskRequest> exportTaskRequestArgumentCaptor =
+                ArgumentCaptor.forClass(StartExportTaskRequest.class);
+
+        verify(rdsClient).startExportTask(exportTaskRequestArgumentCaptor.capture());
+
+        final StartExportTaskRequest actualRequest = exportTaskRequestArgumentCaptor.getValue();
+        assertRequestParameters(actualRequest, snapshotArn, iamRoleArn, bucket, prefix, kmsKey, exportOnly);
+    }
+
+    @Test
+    void test_start_export_task_without_specifying_tables1() {
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
+        final String iamRoleArn = "arn:aws:iam:us-east-1:123456789012:role:my-role";
+        final String bucket = "bucket";
+        final String prefix = "prefix";
+        final String kmsKey = UUID.randomUUID().toString();
+        final List<String> exportOnly = List.of("my_db.cars", "my_db.houses");
+
+        exportTaskManager.startExportTask(snapshotArn, iamRoleArn, bucket, prefix, kmsKey, exportOnly);
+
+        final ArgumentCaptor<StartExportTaskRequest> exportTaskRequestArgumentCaptor =
+                ArgumentCaptor.forClass(StartExportTaskRequest.class);
+
+        verify(rdsClient).startExportTask(exportTaskRequestArgumentCaptor.capture());
+
+        final StartExportTaskRequest actualRequest = exportTaskRequestArgumentCaptor.getValue();
+        assertRequestParameters(actualRequest, snapshotArn, iamRoleArn, bucket, prefix, kmsKey, exportOnly);
+    }
+
+    @Test
+    void test_check_export_status() {
+        final String exportTaskId = UUID.randomUUID().toString();
+        DescribeExportTasksResponse describeExportTasksResponse = mock(DescribeExportTasksResponse.class);
+        when(describeExportTasksResponse.exportTasks()).thenReturn(List.of(ExportTask.builder().status("COMPLETE").build()));
+        when(rdsClient.describeExportTasks(any(DescribeExportTasksRequest.class))).thenReturn(describeExportTasksResponse);
+
+        exportTaskManager.checkExportStatus(exportTaskId);
+
+        final ArgumentCaptor<DescribeExportTasksRequest> exportTaskRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DescribeExportTasksRequest.class);
+
+        verify(rdsClient).describeExportTasks(exportTaskRequestArgumentCaptor.capture());
+
+        final DescribeExportTasksRequest actualRequest = exportTaskRequestArgumentCaptor.getValue();
+        assertThat(actualRequest.exportTaskIdentifier(), equalTo(exportTaskId));
+    }
+
+    private ExportTaskManager createObjectUnderTest() {
+        return new ExportTaskManager(rdsClient);
+    }
+
+    private void assertRequestParameters(final StartExportTaskRequest request,
+                                         final String sourceArn,
+                                         final String iamRoleArn,
+                                         final String bucket,
+                                         final String prefix,
+                                         final String kmsKey,
+                                         final List<String> exportOnly) {
+        assertThat(request.sourceArn(), equalTo(sourceArn));
+        assertThat(request.iamRoleArn(), equalTo(iamRoleArn));
+        assertThat(request.s3BucketName(), equalTo(bucket));
+        assertThat(request.s3Prefix(), equalTo(prefix));
+        assertThat(request.kmsKeyId(), equalTo(kmsKey));
+        assertThat(request.exportOnly(), equalTo(exportOnly));
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManagerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBSnapshot;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SnapshotManagerTest {
+
+    @Mock
+    private RdsClient rdsClient;
+
+    private SnapshotManager snapshotManager;
+
+    @BeforeEach
+    void setUp() {
+        snapshotManager = createObjectUnderTest();
+    }
+
+    @Test
+    void test_create_snapshot_with_success() {
+        String dbInstanceId = UUID.randomUUID().toString();
+        CreateDbSnapshotResponse createDbSnapshotResponse = mock(CreateDbSnapshotResponse.class);
+        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
+        final String status = "creating";
+        final Instant createTime = Instant.now();
+        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
+        when(dbSnapshot.status()).thenReturn(status);
+        when(dbSnapshot.snapshotCreateTime()).thenReturn(createTime);
+        when(createDbSnapshotResponse.dbSnapshot()).thenReturn(dbSnapshot);
+        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenReturn(createDbSnapshotResponse);
+
+        SnapshotInfo snapshotInfo = snapshotManager.createSnapshot(dbInstanceId);
+
+        ArgumentCaptor<CreateDbSnapshotRequest> argumentCaptor = ArgumentCaptor.forClass(CreateDbSnapshotRequest.class);
+        verify(rdsClient).createDBSnapshot(argumentCaptor.capture());
+
+        CreateDbSnapshotRequest request = argumentCaptor.getValue();
+        assertThat(request.dbInstanceIdentifier(), equalTo(dbInstanceId));
+
+        assertThat(snapshotInfo, notNullValue());
+        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
+        assertThat(snapshotInfo.getStatus(), equalTo(status));
+        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+    }
+
+    @Test
+    void test_create_snapshot_throws_exception_then_returns_null() {
+        String dbInstanceId = UUID.randomUUID().toString();
+        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenThrow(new RuntimeException("Error"));
+
+        SnapshotInfo snapshotInfo = snapshotManager.createSnapshot(dbInstanceId);
+
+        assertThat(snapshotInfo, equalTo(null));
+    }
+
+    @Test
+    void test_check_snapshot_status_returns_correct_result() {
+        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
+        final String status = "creating";
+        final Instant createTime = Instant.now();
+        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
+        when(dbSnapshot.status()).thenReturn(status);
+        when(dbSnapshot.snapshotCreateTime()).thenReturn(createTime);
+        DescribeDbSnapshotsResponse describeDbSnapshotsResponse = mock(DescribeDbSnapshotsResponse.class);
+        when(describeDbSnapshotsResponse.dbSnapshots()).thenReturn(List.of(dbSnapshot));
+
+        final String snapshotId = UUID.randomUUID().toString();
+        DescribeDbSnapshotsRequest describeDbSnapshotsRequest = DescribeDbSnapshotsRequest.builder()
+                .dbSnapshotIdentifier(snapshotId)
+                .build();
+        when(rdsClient.describeDBSnapshots(describeDbSnapshotsRequest)).thenReturn(describeDbSnapshotsResponse);
+
+        SnapshotInfo snapshotInfo = snapshotManager.checkSnapshotStatus(snapshotId);
+
+        assertThat(snapshotInfo, notNullValue());
+        assertThat(snapshotInfo.getSnapshotId(), equalTo(snapshotId));
+        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
+        assertThat(snapshotInfo.getStatus(), equalTo(status));
+        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+    }
+
+    private SnapshotManager createObjectUnderTest() {
+        return new SnapshotManager(rdsClient);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
@@ -124,7 +124,7 @@ class LeaderSchedulerTest {
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(leaderScheduler);
-        leaderScheduler.shutDown();
+        leaderScheduler.shutdown();
         verifyNoMoreInteractions(sourceCoordinator);
         executorService.shutdownNow();
     }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.leader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.ExportConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.LeaderProgressState;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class LeaderSchedulerTest {
+
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private LeaderPartition leaderPartition;
+
+    @Mock
+    private LeaderProgressState leaderProgressState;
+
+    private LeaderScheduler leaderScheduler;
+
+    @BeforeEach
+    void setUp() {
+        leaderScheduler = createObjectUnderTest();
+
+        AwsAuthenticationConfig awsAuthenticationConfig = mock(AwsAuthenticationConfig.class);
+        lenient().when(awsAuthenticationConfig.getAwsStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+        lenient().when(sourceConfig.getAwsAuthenticationConfig()).thenReturn(awsAuthenticationConfig);
+        ExportConfig exportConfig = mock(ExportConfig.class);
+        lenient().when(exportConfig.getKmsKeyId()).thenReturn(UUID.randomUUID().toString());
+        lenient().when(sourceConfig.getExport()).thenReturn(exportConfig);
+    }
+
+    @Test
+    void non_leader_node_should_not_perform_init() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(leaderScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(LeaderPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verify(sourceCoordinator, never()).createPartition(any(GlobalState.class));
+        verify(sourceCoordinator, never()).createPartition(any(ExportPartition.class));
+    }
+
+    @Test
+    void leader_node_should_perform_init_if_not_initialized() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).thenReturn(Optional.of(leaderPartition));
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        when(leaderProgressState.isInitialized()).thenReturn(false);
+        when(sourceConfig.isExportEnabled()).thenReturn(true);
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(leaderScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(LeaderPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verify(sourceCoordinator).createPartition(any(GlobalState.class));
+        verify(sourceCoordinator).createPartition(any(ExportPartition.class));
+        verify(sourceCoordinator).saveProgressStateForPartition(eq(leaderPartition), any(Duration.class));
+    }
+
+    @Test
+    void leader_node_should_skip_init_if_initialized() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).thenReturn(Optional.of(leaderPartition));
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        when(leaderProgressState.isInitialized()).thenReturn(true);
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(leaderScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(LeaderPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verify(sourceCoordinator, never()).createPartition(any(GlobalState.class));
+        verify(sourceCoordinator, never()).createPartition(any(ExportPartition.class));
+        verify(sourceCoordinator).saveProgressStateForPartition(eq(leaderPartition), any(Duration.class));
+    }
+
+    private LeaderScheduler createObjectUnderTest() {
+        return new LeaderScheduler(sourceCoordinator, sourceConfig);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -115,6 +116,17 @@ class LeaderSchedulerTest {
         verify(sourceCoordinator, never()).createPartition(any(GlobalState.class));
         verify(sourceCoordinator, never()).createPartition(any(ExportPartition.class));
         verify(sourceCoordinator).saveProgressStateForPartition(eq(leaderPartition), any(Duration.class));
+    }
+
+    @Test
+    void test_shutDown() {
+        lenient().when(sourceCoordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(leaderScheduler);
+        leaderScheduler.shutDown();
+        verifyNoMoreInteractions(sourceCoordinator);
+        executorService.shutdownNow();
     }
 
     private LeaderScheduler createObjectUnderTest() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatusTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatusTest.java
@@ -27,8 +27,8 @@ class ExportStatusTest {
 
     @ParameterizedTest
     @ArgumentsSource(ProvideTerminalStatusTestData.class)
-    void test_is_terminal_returns_expected_result(final String status, final boolean expected_result) {
-        assertThat(ExportStatus.isTerminal(status), equalTo(expected_result));
+    void test_is_terminal_returns_expected_result(final String status, final boolean expectedResult) {
+        assertThat(ExportStatus.isTerminal(status), equalTo(expectedResult));
     }
 
     static class ProvideTerminalStatusTestData implements ArgumentsProvider {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatusTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatusTest.java
@@ -27,8 +27,8 @@ class ExportStatusTest {
 
     @ParameterizedTest
     @ArgumentsSource(ProvideTerminalStatusTestData.class)
-    void test_is_terminal_returns_expected_result(final String status, final boolean expectedResult) {
-        assertThat(ExportStatus.isTerminal(status), equalTo(expectedResult));
+    void test_is_terminal_returns_expected_result(final String status, final boolean expected_result) {
+        assertThat(ExportStatus.isTerminal(status), equalTo(expected_result));
     }
 
     static class ProvideTerminalStatusTestData implements ArgumentsProvider {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatusTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportStatusTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ExportStatusTest {
+
+    @ParameterizedTest
+    @EnumSource(ExportStatus.class)
+    void fromString_returns_expected_value(final ExportStatus status) {
+        assertThat(ExportStatus.fromString(status.name()), equalTo(status));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProvideTerminalStatusTestData.class)
+    void test_is_terminal_returns_expected_result(final String status, final boolean expected_result) {
+        assertThat(ExportStatus.isTerminal(status), equalTo(expected_result));
+    }
+
+    static class ProvideTerminalStatusTestData implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("COMPLETE", true),
+                    Arguments.of("CANCELED", true),
+                    Arguments.of("FAILED", true),
+                    Arguments.of("CANCELING", false),
+                    Arguments.of("IN_PROGRESS", false),
+                    Arguments.of("STARTING", false),
+                    Arguments.of("INVALID_STATUS", false),
+                    Arguments.of(null, false)
+            );
+        }
+    }
+}

--- a/shared-config/log4j2.properties
+++ b/shared-config/log4j2.properties
@@ -27,7 +27,7 @@ logger.parser.name = org.opensearch.dataprepper.parser
 logger.parser.level = info
 
 logger.plugins.name = org.opensearch.dataprepper.plugins
-logger.plugins.level = info
+logger.plugins.level = debug
 
 logger.springframework.name = org.springframework
 logger.springframework.level = info

--- a/shared-config/log4j2.properties
+++ b/shared-config/log4j2.properties
@@ -27,7 +27,7 @@ logger.parser.name = org.opensearch.dataprepper.parser
 logger.parser.level = info
 
 logger.plugins.name = org.opensearch.dataprepper.plugins
-logger.plugins.level = debug
+logger.plugins.level = info
 
 logger.springframework.name = org.springframework
 logger.springframework.level = info


### PR DESCRIPTION
### Description
Adds the basic ability to export tables from RDS to S3. Follows a similar pattern to DynamoDB/DocumentDB source that the leader node creates ExportPartition in coordination store and the node that picks up the ExportPartition will call RDS APIs to take snapshot and export it to S3.

There will be a follow-up PR to process the S3 files in the rds source. This PR only targets RDS instances, will add support for RDS/Aurora clusters in separate PRs (the RDS APIs for instances and clusters are different). 

#### Testing
Created RDS MySQL instance as source and created a DDB table as coordination store and tested with the following pipeline config and verified that the data is exported to S3.
```
rds-mysql-pipeline:
  source:
    rds:
      db_identifier: "mysql-instance"
      table_names:
        - "my_db.cars"
        - "my_db.houses"
      s3_bucket: "rds-data-oeyh"
      s3_region: "us-east-1"
      s3_prefix: "rds-source-test"
      export:
        kms_key_id: xxxxxx
      aws:
        sts_role_arn: "arn:aws:iam::xxxxxxxxxxxxx:role/rdsSourcePipelineRole"
        region: "us-east-1"
  sink:
    - stdout:
```
 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
