### PR TITLE
Introducing delete input configuration option for some parsers

### DIFF
--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/AbstractParseProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/AbstractParseProcessor.java
@@ -36,6 +36,7 @@ public abstract class AbstractParseProcessor extends AbstractProcessor<Record<Ev
     private final String parseWhen;
     private final List<String> tagsOnFailure;
     private final boolean overwriteIfDestinationExists;
+    private final boolean deleteSourceRequested;
 
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -50,6 +51,7 @@ public abstract class AbstractParseProcessor extends AbstractProcessor<Record<Ev
         parseWhen = commonParseConfig.getParseWhen();
         tagsOnFailure = commonParseConfig.getTagsOnFailure();
         overwriteIfDestinationExists = commonParseConfig.getOverwriteIfDestinationExists();
+        deleteSourceRequested = commonParseConfig.isDeleteSourceRequested();
         this.expressionEvaluator = expressionEvaluator;
     }
 
@@ -92,6 +94,10 @@ public abstract class AbstractParseProcessor extends AbstractProcessor<Record<Ev
                     writeToRoot(event, parsedValue);
                 } else if (overwriteIfDestinationExists || !event.containsKey(destination)) {
                     event.put(destination, parsedValue);
+                }
+
+                if(deleteSourceRequested) {
+                    event.delete(this.source);
                 }
             } catch (Exception e) {
                 LOG.error(EVENT, "An exception occurred while using the {} processor on Event [{}]", getProcessorName(), record.getData(), e);

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/CommonParseConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/CommonParseConfig.java
@@ -54,4 +54,12 @@ public interface CommonParseConfig {
      * Defaults to true.
      */
     boolean getOverwriteIfDestinationExists();
+
+    /**
+     * An optional setting used to request dropping the original raw message after successfully parsing the input event.
+     * Defaults to false.
+     */
+    default boolean isDeleteSourceRequested() {
+        return false;
+    }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/CommonParseConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/CommonParseConfig.java
@@ -27,7 +27,6 @@ public interface CommonParseConfig {
      * An optional setting used to specify a JSON Pointer. Pointer points to the JSON key that will be parsed into the destination.
      * There is no pointer by default, meaning that the entirety of source will be parsed. If the target key would overwrite an existing
      * key in the Event then the absolute path of the target key will be placed into destination
-     *
      * Note: (should this be configurable/what about double conflicts?)
      * @return String representing JSON Pointer
      */
@@ -59,7 +58,5 @@ public interface CommonParseConfig {
      * An optional setting used to request dropping the original raw message after successfully parsing the input event.
      * Defaults to false.
      */
-    default boolean isDeleteSourceRequested() {
-        return false;
-    }
+    boolean isDeleteSourceRequested();
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -35,6 +35,9 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     @JsonProperty("overwrite_if_destination_exists")
     private boolean overwriteIfDestinationExists = true;
 
+    @JsonProperty
+    private boolean deleteSource = false;
+
     @Override
     public String getSource() {
         return source;
@@ -73,6 +76,6 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
 
     @Override
     public boolean isDeleteSourceRequested() {
-        return false;
+        return deleteSource;
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -68,6 +68,11 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
         if (Objects.isNull(destination)) return true;
 
         final String trimmedDestination = destination.trim();
-        return trimmedDestination.length() != 0 && !(trimmedDestination.equals("/"));
+        return !trimmedDestination.isEmpty() && !(trimmedDestination.equals("/"));
+    }
+
+    @Override
+    public boolean isDeleteSourceRequested() {
+        return false;
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
@@ -35,6 +35,9 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     @JsonProperty("overwrite_if_destination_exists")
     private boolean overwriteIfDestinationExists = true;
 
+    @JsonProperty
+    private boolean deleteSource = false;
+
     @Override
     public String getSource() {
         return source;
@@ -63,11 +66,16 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
         return overwriteIfDestinationExists;
     }
 
+    @Override
+    public boolean isDeleteSourceRequested() {
+        return deleteSource;
+    }
+
     @AssertTrue(message = "destination cannot be empty, whitespace, or a front slash (/)")
     boolean isValidDestination() {
         if (Objects.isNull(destination)) return true;
 
         final String trimmedDestination = destination.trim();
-        return trimmedDestination.length() != 0 && !(trimmedDestination.equals("/"));
+        return !trimmedDestination.isEmpty() && !(trimmedDestination.equals("/"));
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -30,6 +30,9 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
     @JsonProperty("overwrite_if_destination_exists")
     private boolean overwriteIfDestinationExists = true;
 
+    @JsonProperty
+    private boolean deleteSource = false;
+
     @Override
     public String getSource() {
         return source;
@@ -70,6 +73,6 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
 
     @Override
     public boolean isDeleteSourceRequested() {
-        return false;
+        return deleteSource;
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -65,6 +65,11 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
         if (Objects.isNull(destination)) return true;
 
         final String trimmedDestination = destination.trim();
-        return trimmedDestination.length() != 0 && !(trimmedDestination.equals("/"));
+        return !trimmedDestination.isEmpty() && !(trimmedDestination.equals("/"));
+    }
+
+    @Override
+    public boolean isDeleteSourceRequested() {
+        return false;
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfigTest.java
@@ -57,6 +57,9 @@ public class ParseIonProcessorConfigTest {
             setField(ParseIonProcessorConfig.class, config, "tagsOnFailure", tagsList);
 
             assertThat(config.getTagsOnFailure(), equalTo(tagsList));
+
+            setField(ParseIonProcessorConfig.class, config, "deleteSource", true);
+            assertThat(config.isDeleteSourceRequested(), equalTo(true));
         }
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorTest.java
@@ -47,6 +47,22 @@ class ParseIonProcessorTest extends ParseJsonProcessorTest {
         final String serializedMessage = "{bareKey: 1, symbol: SYMBOL, timestamp: 2023-11-30T21:05:23.383Z, attribute: dollars::100.0 }";
         final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
 
+        assertThat(parsedEvent.containsKey(processorConfig.getSource()), equalTo(true));
+        assertThat(parsedEvent.get("bareKey", Integer.class), equalTo(1));
+        assertThat(parsedEvent.get("symbol", String.class), equalTo("SYMBOL"));
+        assertThat(parsedEvent.get("timestamp", String.class), equalTo("2023-11-30T21:05:23.383Z"));
+        assertThat(parsedEvent.get("attribute", Double.class), equalTo(100.0));
+    }
+
+    @Test
+    void test_when_deleteSourceFlagEnabled() {
+        when(processorConfig.isDeleteSourceRequested()).thenReturn(true);
+        parseJsonProcessor = new ParseIonProcessor(pluginMetrics, ionProcessorConfig, expressionEvaluator);
+
+        final String serializedMessage = "{bareKey: 1, symbol: SYMBOL, timestamp: 2023-11-30T21:05:23.383Z, attribute: dollars::100.0 }";
+        final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
+
+        assertThat(parsedEvent.containsKey(processorConfig.getSource()), equalTo(false));
         assertThat(parsedEvent.get("bareKey", Integer.class), equalTo(1));
         assertThat(parsedEvent.get("symbol", String.class), equalTo("SYMBOL"));
         assertThat(parsedEvent.get("timestamp", String.class), equalTo("2023-11-30T21:05:23.383Z"));

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorTest.java
@@ -48,6 +48,7 @@ class ParseIonProcessorTest extends ParseJsonProcessorTest {
         final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
 
         assertThat(parsedEvent.containsKey(processorConfig.getSource()), equalTo(true));
+        assertThat(parsedEvent.get(processorConfig.getSource(), Object.class), equalTo(serializedMessage));
         assertThat(parsedEvent.get("bareKey", Integer.class), equalTo(1));
         assertThat(parsedEvent.get("symbol", String.class), equalTo("SYMBOL"));
         assertThat(parsedEvent.get("timestamp", String.class), equalTo("2023-11-30T21:05:23.383Z"));

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfigTest.java
@@ -29,6 +29,7 @@ public class ParseJsonProcessorConfigTest {
         assertThat(objectUnderTest.getPointer(), equalTo(null));
         assertThat(objectUnderTest.getTagsOnFailure(), equalTo(null));
         assertThat(objectUnderTest.getOverwriteIfDestinationExists(), equalTo(true));
+        assertThat(objectUnderTest.isDeleteSourceRequested(), equalTo(false));
     }
 
     @Nested
@@ -57,6 +58,9 @@ public class ParseJsonProcessorConfigTest {
             setField(ParseJsonProcessorConfig.class, config, "tagsOnFailure", tagsList);
 
             assertThat(config.getTagsOnFailure(), equalTo(tagsList));
+
+            setField(ParseJsonProcessorConfig.class, config, "deleteSource", true);
+            assertThat(config.isDeleteSourceRequested(), equalTo(true));
         }
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
@@ -195,6 +195,22 @@ public class ParseJsonProcessorTest {
     }
 
     @Test
+    void test_when_deleteSourceFlagEnabled() {
+        when(processorConfig.isDeleteSourceRequested()).thenReturn(true);
+        parseJsonProcessor = new ParseJsonProcessor(pluginMetrics, jsonProcessorConfig, expressionEvaluator);
+
+        final String key = "key";
+        final ArrayList<String> value = new ArrayList<>(List.of("Element0","Element1","Element2"));
+        final String jsonArray = "{\"key\":[\"Element0\",\"Element1\",\"Element2\"]}";
+        final Event parsedEvent = createAndParseMessageEvent(jsonArray);
+
+        assertThat(parsedEvent.containsKey(processorConfig.getSource()), equalTo(false));
+        assertThat(parsedEvent.get(key, ArrayList.class), equalTo(value));
+        final String pointerToFirstElement = key + "/0";
+        assertThat(parsedEvent.get(pointerToFirstElement, String.class), equalTo(value.get(0)));
+    }
+
+    @Test
     void test_when_nestedJSONArrayOfJSON_then_parsedIntoArrayAndIndicesAccessible() {
         parseJsonProcessor = createObjectUnderTest();
 
@@ -373,23 +389,21 @@ public class ParseJsonProcessorTest {
 
     /**
      * Naive serialization that converts every = to : and wraps every word with double quotes (no error handling or input validation).
-     * @param messageMap
-     * @return
+     * @param messageMap source key value map
+     * @return serialized string representation of the map
      */
     private String convertMapToJSONString(final Map<String, Object> messageMap) {
         final String replaceEquals = messageMap.toString().replace("=",":");
-        final String addQuotes = replaceEquals.replaceAll("(\\w+)", "\"$1\""); // wrap every word in quotes
-        return addQuotes;
+        return replaceEquals.replaceAll("(\\w+)", "\"$1\"");
     }
 
     /**
      * Creates a Map that maps a single key to a value nested numberOfLayers layers deep.
-     * @param numberOfLayers
-     * @return
+     * @param numberOfLayers indicates the depth of layers count
+     * @return a Map representing the nested structure
      */
     private Map<String, Object> constructArbitrarilyDeepJsonMap(final int numberOfLayers) {
-        final Map<String, Object> result = Collections.singletonMap(DEEPLY_NESTED_KEY_NAME,deepJsonMapHelper(0,numberOfLayers));
-        return result;
+        return Collections.singletonMap(DEEPLY_NESTED_KEY_NAME,deepJsonMapHelper(0,numberOfLayers));
     }
 
     private Object deepJsonMapHelper(final int currentLayer, final int numberOfLayers) {

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfigTest.java
@@ -52,6 +52,9 @@ public class ParseXmlProcessorConfigTest {
             setField(ParseXmlProcessorConfig.class, config, "tagsOnFailure", tagsList);
 
             assertThat(config.getTagsOnFailure(), equalTo(tagsList));
+
+            setField(ParseXmlProcessorConfig.class, config, "deleteSource", true);
+            assertThat(config.isDeleteSourceRequested(), equalTo(true));
         }
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorTest.java
@@ -61,6 +61,22 @@ public class ParseXmlProcessorTest {
     }
 
     @Test
+    void test_when_deleteSourceFlagEnabled() {
+
+        final String tagOnFailure = UUID.randomUUID().toString();
+        when(processorConfig.getTagsOnFailure()).thenReturn(List.of(tagOnFailure));
+        when(processorConfig.isDeleteSourceRequested()).thenReturn(true);
+
+        parseXmlProcessor = createObjectUnderTest();
+
+        final String serializedMessage = "<Person><name>John Doe</name><age>30</age></Person>";
+        final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
+        assertThat(parsedEvent.containsKey(processorConfig.getSource()), equalTo(false));
+        assertThat(parsedEvent.get("name", String.class), equalTo("John Doe"));
+        assertThat(parsedEvent.get("age", String.class), equalTo("30"));
+    }
+
+    @Test
     void test_when_using_invalid_xml_tags_correctly() {
 
         final String tagOnFailure = UUID.randomUUID().toString();


### PR DESCRIPTION
### Description
Introducing delete input configuration option for some parsers

Read about this fix [here](https://github.com/opensearch-project/data-prepper/issues/3968)

Example pipeline yaml configuration will be 
```
simple-sample-pipeline:
  source:
    file:
      path: /tmp/input-file
      record_type: event
  processor:
    - parse_json:
        delete_source: false
    - convert_entry_type:
        key: "my_number_ending_in_0"
        type: "big_decimal"
        scale: 1
  sink:
    - stdout:
  ```
 
### Issues Resolved
Resolves #3968 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
