### PR TITLE
MAINT: add json property description into obfuscate processor

### DIFF
--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.obfuscation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
@@ -17,6 +18,7 @@ import java.util.List;
 public class ObfuscationProcessorConfig {
 
     @JsonProperty("source")
+    @JsonPropertyDescription("The source field to obfuscate.")
     @NotEmpty
     @NotNull
     private String source;
@@ -25,18 +27,29 @@ public class ObfuscationProcessorConfig {
     private List<String> patterns;
     
     @JsonProperty("target")
+    @JsonPropertyDescription("The new field in which to store the obfuscated value. " +
+            "This leaves the original source field unchanged. " +
+            "When no `target` is provided, the source field updates with the obfuscated value.")
     private String target;
 
     @JsonProperty("action")
+    @JsonPropertyDescription("The obfuscation action. As of Data Prepper 2.3, only the `mask` action is supported.")
     private PluginModel action;
 
     @JsonProperty("obfuscate_when")
+    @JsonPropertyDescription("Specifies under what condition the Obfuscate processor should perform matching. " +
+            "Default is no condition.")
     private String obfuscateWhen;
 
     @JsonProperty("tags_on_match_failure")
+    @JsonPropertyDescription("The tag to add to an event if the obfuscate processor fails to match the pattern.")
     private List<String> tagsOnMatchFailure;
 
     @JsonProperty("single_word_only")
+    @JsonPropertyDescription("When set to `true`, a word boundary `\b` is added to the pattern, " +
+            "which causes obfuscation to be applied only to words that are standalone in the input text. " +
+            "By default, it is false, meaning obfuscation patterns are applied to all occurrences. " +
+            "Can be used for Data Prepper 2.8 or greater.")
     private boolean singleWordOnly = false;
 
     public ObfuscationProcessorConfig() {


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/obfuscate/#configuration) into @JsonPropertyDescription so that a complete json schema can be generated:

```
{
  "$schema" : "https://json-schema.org/draft/2020-12/schema",
  "type" : "object",
  "properties" : {
    "action" : {
      "type" : "object",
      "properties" : {
        "pluginName" : {
          "type" : "string"
        }
      },
      "description" : "The obfuscation action. As of Data Prepper 2.3, only the `mask` action is supported."
    },
    "obfuscate_when" : {
      "type" : "string",
      "description" : "Specifies under what condition the Obfuscate processor should perform matching. Default is no condition."
    },
    "patterns" : {
      "type" : "array",
      "items" : {
        "type" : "string"
      }
    },
    "single_word_only" : {
      "type" : "boolean",
      "description" : "When set to `true`, a word boundary `\b` is added to the pattern, which causes obfuscation to be applied only to words that are standalone in the input text. By default, it is false, meaning obfuscation patterns are applied to all occurrences. Can be used for Data Prepper 2.8 or greater."
    },
    "source" : {
      "type" : "string",
      "description" : "The source field to obfuscate.",
      "minLength" : 1
    },
    "tags_on_match_failure" : {
      "description" : "The tag to add to an event if the obfuscate processor fails to match the pattern.",
      "type" : "array",
      "items" : {
        "type" : "string"
      }
    },
    "target" : {
      "type" : "string",
      "description" : "The new field in which to store the obfuscated value. This leaves the original source field unchanged. When no `target` is provided, the source field updates with the obfuscated value."
    }
  },
  "required" : [ "source" ]
}
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
