### PR TITLE
Removes Zookeeper from Data Prepper

### DIFF
--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -15,15 +15,19 @@ dependencies {
     runtimeOnly(libs.hadoop.common) {
         exclude group: 'org.eclipse.jetty'
         exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
     }
     runtimeOnly(libs.hadoop.mapreduce) {
+        exclude group: 'org.eclipse.jetty'
         exclude group: 'org.apache.hadoop', module: 'hadoop-hdfs-client'
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
     }
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-test-event')
     testImplementation(libs.hadoop.common) {
         exclude group: 'org.eclipse.jetty'
         exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
     }
 
     constraints {

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.hadoop.common) {
         exclude group: 'org.eclipse.jetty'
         exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
     }
     implementation libs.parquet.avro
     implementation 'software.amazon.awssdk:apache-client'

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -45,7 +45,11 @@ dependencies {
     testImplementation project(':data-prepper-plugins:parquet-codecs')
     testImplementation project(':data-prepper-test-event')
     testImplementation libs.avro.core
-    testImplementation libs.hadoop.common
+    testImplementation(libs.hadoop.common)  {
+        exclude group: 'org.eclipse.jetty'
+        exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
+    }
     testImplementation libs.parquet.avro
     testImplementation libs.parquet.column
     testImplementation libs.parquet.hadoop


### PR DESCRIPTION
### Description

Excludes the Zookeeper dependency from Hadoop. This removes it from Data Prepper entirely. Also, exclude Jetty from Hadoop as a transitive dependency. We still rely on Jetty for other projects, but it is no longer being pulled from Hadoop.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
