### PR TITLE
Mockito 5

### DIFF
--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
@@ -6,20 +6,28 @@
 package org.opensearch.dataprepper.metrics;
 
 import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class MetricsTestUtil {
 
     public static synchronized void initMetrics() {
-        Metrics.globalRegistry.getRegistries().forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
-        Metrics.globalRegistry.getMeters().forEach(meter -> Metrics.globalRegistry.remove(meter));
+        final Set<MeterRegistry> registries = new HashSet<>(Metrics.globalRegistry.getRegistries());
+        registries.forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
+
+        final List<Meter> meters = new ArrayList<>(Metrics.globalRegistry.getMeters());
+        meters.forEach(meter -> Metrics.globalRegistry.remove(meter));
+
         Metrics.addRegistry(new SimpleMeterRegistry());
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
@@ -23,16 +23,20 @@ public class MetricsTestUtil {
 
     public static synchronized void initMetrics() {
         final Set<MeterRegistry> registries = new HashSet<>(Metrics.globalRegistry.getRegistries());
-        registries.forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
+        registries.forEach(Metrics.globalRegistry::remove);
 
         final List<Meter> meters = new ArrayList<>(Metrics.globalRegistry.getMeters());
-        meters.forEach(meter -> Metrics.globalRegistry.remove(meter));
+        meters.forEach(Metrics.globalRegistry::remove);
 
         Metrics.addRegistry(new SimpleMeterRegistry());
     }
 
     public static synchronized List<Measurement> getMeasurementList(final String meterName) {
-        return StreamSupport.stream(getRegistry().find(meterName).meter().measure().spliterator(), false)
+        final Meter meter = getRegistry().find(meterName).meter();
+        if(meter == null)
+            throw new RuntimeException("No metrics meter is available for " + meterName);
+
+        return StreamSupport.stream(meter.measure().spliterator(), false)
                 .collect(Collectors.toList());
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
@@ -17,13 +17,13 @@ import java.util.stream.StreamSupport;
 
 public class MetricsTestUtil {
 
-    public static void initMetrics() {
+    public static synchronized void initMetrics() {
         Metrics.globalRegistry.getRegistries().forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
         Metrics.globalRegistry.getMeters().forEach(meter -> Metrics.globalRegistry.remove(meter));
         Metrics.addRegistry(new SimpleMeterRegistry());
     }
 
-    public static List<Measurement> getMeasurementList(final String meterName) {
+    public static synchronized List<Measurement> getMeasurementList(final String meterName) {
         return StreamSupport.stream(getRegistry().find(meterName).meter().measure().spliterator(), false)
                 .collect(Collectors.toList());
     }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     implementation 'software.amazon.awssdk:servicediscovery'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation testLibs.junit.vintage
-    testImplementation testLibs.mockito.inline
     testImplementation libs.commons.lang3
     testImplementation project(':data-prepper-test-event')
     testImplementation project(':data-prepper-test-common')

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/DnsPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/DnsPeerListProviderTest.java
@@ -7,30 +7,33 @@ package org.opensearch.dataprepper.peerforwarder.discovery;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
-import io.micrometer.core.instrument.Measurement;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.opensearch.dataprepper.metrics.MetricNames;
-import org.opensearch.dataprepper.metrics.MetricsTestUtil;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.HashRing;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.ToDoubleFunction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.peerforwarder.discovery.PeerListProvider.PEER_ENDPOINTS;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DnsPeerListProviderTest {
 
     private static final String ENDPOINT_1 = "10.1.1.1";
@@ -39,8 +42,6 @@ public class DnsPeerListProviderTest {
             Endpoint.of(ENDPOINT_1),
             Endpoint.of(ENDPOINT_2)
     );
-    private static final String COMPONENT_SCOPE = "testComponentScope";
-    private static final String COMPONENT_ID = "testComponentId";
 
     @Mock
     private DnsAddressEndpointGroup dnsAddressEndpointGroup;
@@ -48,34 +49,33 @@ public class DnsPeerListProviderTest {
     @Mock
     private HashRing hashRing;
 
+    @Mock
     private PluginMetrics pluginMetrics;
 
     private CompletableFuture completableFuture;
 
     private DnsPeerListProvider dnsPeerListProvider;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        MetricsTestUtil.initMetrics();
         completableFuture = CompletableFuture.completedFuture(null);
         when(dnsAddressEndpointGroup.whenReady()).thenReturn(completableFuture);
 
-        pluginMetrics = PluginMetrics.fromNames(COMPONENT_ID, COMPONENT_SCOPE);
         dnsPeerListProvider = new DnsPeerListProvider(dnsAddressEndpointGroup, pluginMetrics);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testDefaultListProviderWithNullHostname() {
-        new DnsPeerListProvider(null, pluginMetrics);
+        assertThrows(NullPointerException.class, () -> new DnsPeerListProvider(null, pluginMetrics));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testConstructWithInterruptedException() throws Exception {
         CompletableFuture mockFuture = mock(CompletableFuture.class);
         when(mockFuture.get()).thenThrow(new InterruptedException());
         when(dnsAddressEndpointGroup.whenReady()).thenReturn(mockFuture);
 
-        new DnsPeerListProvider(dnsAddressEndpointGroup, pluginMetrics);
+        assertThrows(RuntimeException.class, () -> new DnsPeerListProvider(dnsAddressEndpointGroup, pluginMetrics));
     }
 
     @Test
@@ -90,17 +90,27 @@ public class DnsPeerListProviderTest {
     }
 
     @Test
-    public void testActivePeerCounter() {
+    public void testActivePeerCounter_with_list() {
         when(dnsAddressEndpointGroup.endpoints()).thenReturn(ENDPOINT_LIST);
 
-        final List<Measurement> endpointsMeasures = MetricsTestUtil.getMeasurementList(new StringJoiner(MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID)
-                .add(PeerListProvider.PEER_ENDPOINTS).toString());
-        assertEquals(1, endpointsMeasures.size());
-        final Measurement endpointsMeasure = endpointsMeasures.get(0);
-        assertEquals(2.0, endpointsMeasure.getValue(), 0);
+        final ArgumentCaptor<ToDoubleFunction<DnsAddressEndpointGroup>> gaugeFunctionCaptor = ArgumentCaptor.forClass(ToDoubleFunction.class);
+        verify(pluginMetrics).gauge(eq(PEER_ENDPOINTS), eq(dnsAddressEndpointGroup), gaugeFunctionCaptor.capture());
 
+        final ToDoubleFunction<DnsAddressEndpointGroup> gaugeFunction = gaugeFunctionCaptor.getValue();
+
+        assertThat(gaugeFunction.applyAsDouble(dnsAddressEndpointGroup), equalTo(2.0));
+    }
+
+    @Test
+    public void testActivePeerCounter_with_single() {
         when(dnsAddressEndpointGroup.endpoints()).thenReturn(Collections.singletonList(Endpoint.of(ENDPOINT_1)));
-        assertEquals(1.0, endpointsMeasure.getValue(), 0);
+
+        final ArgumentCaptor<ToDoubleFunction<DnsAddressEndpointGroup>> gaugeFunctionCaptor = ArgumentCaptor.forClass(ToDoubleFunction.class);
+        verify(pluginMetrics).gauge(eq(PEER_ENDPOINTS), eq(dnsAddressEndpointGroup), gaugeFunctionCaptor.capture());
+
+        final ToDoubleFunction<DnsAddressEndpointGroup> gaugeFunction = gaugeFunctionCaptor.getValue();
+
+        assertThat(gaugeFunction.applyAsDouble(dnsAddressEndpointGroup), equalTo(1.0));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderTest.java
@@ -5,56 +5,58 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
-import io.micrometer.core.instrument.Measurement;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.opensearch.dataprepper.metrics.MetricNames;
-import org.opensearch.dataprepper.metrics.MetricsTestUtil;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.HashRing;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.StringJoiner;
+import java.util.function.ToDoubleFunction;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.opensearch.dataprepper.peerforwarder.discovery.PeerListProvider.PEER_ENDPOINTS;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class StaticPeerListProviderTest {
 
     private static final String ENDPOINT_1 = "10.10.0.1";
     private static final String ENDPOINT_2 = "10.10.0.2";
     private static final List<String> ENDPOINT_LIST = Arrays.asList(ENDPOINT_1, ENDPOINT_2);
-    private static final String COMPONENT_SCOPE = "testComponentScope";
-    private static final String COMPONENT_ID = "testComponentId";
 
     @Mock
     private HashRing hashRing;
 
+    @Mock
     private PluginMetrics pluginMetrics;
 
     private StaticPeerListProvider staticPeerListProvider;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        MetricsTestUtil.initMetrics();
-        pluginMetrics = PluginMetrics.fromNames(COMPONENT_ID, COMPONENT_SCOPE);
         staticPeerListProvider = new StaticPeerListProvider(ENDPOINT_LIST, pluginMetrics);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testListProviderWithEmptyList() {
-        new StaticPeerListProvider(Collections.emptyList(), pluginMetrics);
+        assertThrows(RuntimeException.class, () -> new StaticPeerListProvider(Collections.emptyList(), pluginMetrics));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testListProviderWithNullList() {
-        new StaticPeerListProvider(null, pluginMetrics);
+        assertThrows(RuntimeException.class, () -> new StaticPeerListProvider(null, pluginMetrics));
     }
 
     @Test
@@ -65,11 +67,12 @@ public class StaticPeerListProviderTest {
 
     @Test
     public void testActivePeerCounter() {
-        final List<Measurement> endpointsMeasures = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(PeerListProvider.PEER_ENDPOINTS).toString());
-        assertEquals(1, endpointsMeasures.size());
-        final Measurement endpointsMeasure = endpointsMeasures.get(0);
-        assertEquals(2.0, endpointsMeasure.getValue(), 0);
+        final ArgumentCaptor<ToDoubleFunction<List<String>>> gaugeFunctionCaptor = ArgumentCaptor.forClass(ToDoubleFunction.class);
+        verify(pluginMetrics).gauge(eq(PEER_ENDPOINTS), any(List.class), gaugeFunctionCaptor.capture());
+
+        final ToDoubleFunction<List<String>> gaugeFunction = gaugeFunctionCaptor.getValue();
+
+        assertThat(gaugeFunction.applyAsDouble(ENDPOINT_LIST), equalTo(2.0));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/common/FutureHelperTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/common/FutureHelperTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/CloudWatchMeterRegistryProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/CloudWatchMeterRegistryProviderTest.java
@@ -9,7 +9,7 @@ import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/data-prepper-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-expression/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-expression/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/data-prepper-logstash-configuration/build.gradle
+++ b/data-prepper-logstash-configuration/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation libs.commons.lang3
     testImplementation testLibs.slf4j.simple
-    testImplementation testLibs.mockito.inline
 }
 
 generateGrammarSource {

--- a/data-prepper-pipeline-parser/build.gradle
+++ b/data-prepper-pipeline-parser/build.gradle
@@ -30,12 +30,7 @@ dependencies {
     testImplementation testLibs.bundles.junit
     testImplementation testLibs.bundles.mockito
     testImplementation testLibs.hamcrest
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
     testImplementation 'org.assertj:assertj-core:3.20.2'
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 }

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EventKeyDeserializerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EventKeyDeserializerTest.java
@@ -30,8 +30,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EventKeyDeserializerTest {

--- a/data-prepper-plugin-framework/build.gradle
+++ b/data-prepper-plugin-framework/build.gradle
@@ -24,5 +24,4 @@ dependencies {
     }
     implementation libs.reflections.core
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    testImplementation testLibs.mockito.inline
 }

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     implementation libs.opentelemetry.proto
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/armeria-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/armeria-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/data-prepper-plugins/aws-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/aws-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
     testImplementation project(path: ':data-prepper-test-common')
-    testImplementation testLibs.mockito.inline
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }

--- a/data-prepper-plugins/cloudwatch-metrics-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/cloudwatch-metrics-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation project(':data-prepper-test-event')
     testImplementation libs.commons.io
-    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/decompress-processor/build.gradle
+++ b/data-prepper-plugins/decompress-processor/build.gradle
@@ -9,5 +9,4 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation testLibs.mockito.inline
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
     implementation 'software.amazon.awssdk:sts'
-    testImplementation testLibs.mockito.inline
 }
 
 test {

--- a/data-prepper-plugins/dynamodb-source/build.gradle
+++ b/data-prepper-plugins/dynamodb-source/build.gradle
@@ -25,6 +25,5 @@ dependencies {
     implementation project(path: ':data-prepper-plugins:buffer-common')
 
 
-    testImplementation testLibs.mockito.inline
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 }

--- a/data-prepper-plugins/geoip-processor/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/geoip-processor/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/grok-processor/build.gradle
+++ b/data-prepper-plugins/grok-processor/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.krakens:java-grok:0.1.9"
     implementation 'io.micrometer:micrometer-core'
-    testImplementation testLibs.mockito.inline
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/http-common/build.gradle
+++ b/data-prepper-plugins/http-common/build.gradle
@@ -6,7 +6,6 @@
 dependencies {
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     testImplementation testLibs.bundles.junit
-    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/http-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/http-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/http-source-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/http-source-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/http-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/http-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
 
-    testImplementation testLibs.mockito.inline
     testImplementation 'org.yaml:snakeyaml:2.2'
     testImplementation testLibs.spring.test
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
@@ -62,12 +61,10 @@ dependencies {
     testImplementation project(':data-prepper-core')
     testImplementation project(':data-prepper-plugin-framework')
     testImplementation project(':data-prepper-pipeline-parser')
-    testImplementation testLibs.mockito.inline
     testImplementation 'org.apache.kafka:kafka_2.13:3.6.1'
     testImplementation 'org.apache.kafka:kafka_2.13:3.6.1:test'
     testImplementation 'org.apache.curator:curator-test:5.5.0'
     testImplementation('com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39')
-    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testImplementation project(':data-prepper-plugins:otel-metrics-source')
     testImplementation project(':data-prepper-plugins:otel-proto-common')
     testImplementation libs.opentelemetry.proto

--- a/data-prepper-plugins/lambda/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/lambda/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/mongodb/build.gradle
+++ b/data-prepper-plugins/mongodb/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation project(path: ':data-prepper-plugins:common')
 
 
-    testImplementation testLibs.mockito.inline
     testImplementation testLibs.bundles.junit
     testImplementation testLibs.slf4j.simple
     testImplementation project(path: ':data-prepper-test-common')

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     testImplementation 'net.bytebuddy:byte-buddy:1.14.12'
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.14.12'
     testImplementation testLibs.slf4j.simple
-    testImplementation testLibs.mockito.inline
 }
 
 sourceSets {

--- a/data-prepper-plugins/opensearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/opensearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/otel-logs-source/build.gradle
+++ b/data-prepper-plugins/otel-logs-source/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation libs.bouncycastle.bcprov
     implementation libs.bouncycastle.bcpkix
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation testLibs.mockito.inline
     testImplementation libs.commons.io
 }
 

--- a/data-prepper-plugins/otel-logs-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/otel-logs-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.guava.core
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation libs.bouncycastle.bcprov
     implementation libs.bouncycastle.bcpkix
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation testLibs.mockito.inline
     testImplementation libs.commons.io
 }
 

--- a/data-prepper-plugins/otel-metrics-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/otel-metrics-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/otel-trace-group-processor/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/otel-trace-group-processor/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.caffeine
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation libs.bouncycastle.bcprov
     implementation libs.bouncycastle.bcpkix
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation testLibs.mockito.inline
     testImplementation testLibs.slf4j.simple
     testImplementation libs.commons.io
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/otel-trace-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/prometheus-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/prometheus-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    testImplementation testLibs.mockito.inline
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 }

--- a/data-prepper-plugins/s3-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/s3-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/s3-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/s3-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -19,7 +19,6 @@ dependencies {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
     implementation libs.protobuf.core
-    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/sns-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/sns-sink/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/data-prepper-plugins/sqs-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/sqs-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,3 +1,0 @@
-# To enable mocking of final classes with vanilla Mockito
-# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
-mock-maker-inline

--- a/settings.gradle
+++ b/settings.gradle
@@ -74,7 +74,7 @@ dependencyResolutionManagement {
         }
         testLibs {
             version('junit', '5.8.2')
-            version('mockito', '3.11.2')
+            version('mockito', '5.12.0')
             version('hamcrest', '2.2')
             version('awaitility', '4.2.0')
             version('spring', '5.3.28')


### PR DESCRIPTION
### Description

Use Mockito 5.

* Update Mockito to 5.12.0
* Removes use of the `mockito-inline` project as this is now the default
* Use the new package for the JUnit 4 runner
* Remove all `org.mockito.plugins.MockMaker` files since inline is now the default
* Removes PowerMock as this is not necessary anymore.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
