### PR TITLE
Load exported S3 files in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(path: ':data-prepper-plugins:buffer-common')
     implementation project(path: ':data-prepper-plugins:http-common')
     implementation project(path: ':data-prepper-plugins:common')
+    implementation project(path: ':data-prepper-plugins:parquet-codecs')
 
     implementation 'io.micrometer:micrometer-core'
 

--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -24,4 +24,5 @@ dependencies {
     testImplementation testLibs.mockito.inline
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    testImplementation project(path: ':data-prepper-test-event')
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/ClientFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/ClientFactory.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class ClientFactory {
     private final AwsCredentialsProvider awsCredentialsProvider;
@@ -28,6 +29,13 @@ public class ClientFactory {
 
     public RdsClient buildRdsClient() {
         return RdsClient.builder()
+                .region(awsAuthenticationConfig.getAwsRegion())
+                .credentialsProvider(awsCredentialsProvider)
+                .build();
+    }
+
+    public S3Client buildS3Client() {
+        return S3Client.builder()
                 .region(awsAuthenticationConfig.getAwsRegion())
                 .credentialsProvider(awsCredentialsProvider)
                 .build();

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -8,13 +8,16 @@ package org.opensearch.dataprepper.plugins.source.rds;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.export.DataFileScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.leader.LeaderScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,22 +28,28 @@ public class RdsService {
     private static final Logger LOG = LoggerFactory.getLogger(RdsService.class);
 
     private final RdsClient rdsClient;
+    private final S3Client s3Client;
     private final EnhancedSourceCoordinator sourceCoordinator;
+    private final EventFactory eventFactory;
     private final PluginMetrics pluginMetrics;
     private final RdsSourceConfig sourceConfig;
     private ExecutorService executor;
     private LeaderScheduler leaderScheduler;
     private ExportScheduler exportScheduler;
+    private DataFileScheduler dataFileScheduler;
 
     public RdsService(final EnhancedSourceCoordinator sourceCoordinator,
                       final RdsSourceConfig sourceConfig,
+                      final EventFactory eventFactory,
                       final ClientFactory clientFactory,
                       final PluginMetrics pluginMetrics) {
         this.sourceCoordinator = sourceCoordinator;
+        this.eventFactory = eventFactory;
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
 
         rdsClient = clientFactory.buildRdsClient();
+        s3Client = clientFactory.buildS3Client();
     }
 
     /**
@@ -54,9 +63,11 @@ public class RdsService {
         LOG.info("Start running RDS service");
         final List<Runnable> runnableList = new ArrayList<>();
         leaderScheduler = new LeaderScheduler(sourceCoordinator, sourceConfig);
-        exportScheduler = new ExportScheduler(sourceCoordinator, rdsClient, pluginMetrics);
+        exportScheduler = new ExportScheduler(sourceCoordinator, rdsClient, s3Client, pluginMetrics);
+        dataFileScheduler = new DataFileScheduler(sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer);
         runnableList.add(leaderScheduler);
         runnableList.add(exportScheduler);
+        runnableList.add(dataFileScheduler);
 
         executor = Executors.newFixedThreadPool(runnableList.size());
         runnableList.forEach(executor::submit);
@@ -71,6 +82,7 @@ public class RdsService {
             LOG.info("shutdown RDS schedulers");
             exportScheduler.shutdown();
             leaderScheduler.shutdown();
+            dataFileScheduler.shutdown();
             executor.shutdownNow();
         }
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
@@ -33,15 +34,18 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
     private final ClientFactory clientFactory;
     private final PluginMetrics pluginMetrics;
     private final RdsSourceConfig sourceConfig;
+    private final EventFactory eventFactory;
     private EnhancedSourceCoordinator sourceCoordinator;
     private RdsService rdsService;
 
     @DataPrepperPluginConstructor
     public RdsSource(final PluginMetrics pluginMetrics,
                      final RdsSourceConfig sourceConfig,
+                     final EventFactory eventFactory,
                      final AwsCredentialsSupplier awsCredentialsSupplier) {
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
+        this.eventFactory = eventFactory;
 
         clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig.getAwsAuthenticationConfig());
     }
@@ -51,7 +55,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
         Objects.requireNonNull(sourceCoordinator);
         sourceCoordinator.createPartition(new LeaderPartition());
 
-        rdsService = new RdsService(sourceCoordinator, sourceConfig, clientFactory, pluginMetrics);
+        rdsService = new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics);
 
         LOG.info("Start RDS service");
         rdsService.start(buffer);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverter.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.plugins.source.rds.converter;
 
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventMetadata;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,14 +22,9 @@ public class ExportRecordConverter {
     static final String EXPORT_EVENT_TYPE = "EXPORT";
 
     public Event convert(Record<Event> record, String tableName, String primaryKeyName) {
-
-        final Event event = JacksonEvent.builder()
-                .withEventType(EXPORT_EVENT_TYPE)
-                .withData(record.getData().toMap())
-                .build();
+        Event event = record.getData();
 
         EventMetadata eventMetadata = event.getMetadata();
-
         eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
         eventMetadata.setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, EXPORT_EVENT_TYPE);
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+
+public class ExportRecordConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExportRecordConverter.class);
+
+    static final String EXPORT_EVENT_TYPE = "EXPORT";
+
+    public Event convert(Record<Event> record, String tableName, String primaryKeyName) {
+
+        final Event event = JacksonEvent.builder()
+                .withEventType(EXPORT_EVENT_TYPE)
+                .withData(record.getData().toMap())
+                .build();
+
+        EventMetadata eventMetadata = event.getMetadata();
+
+        eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
+        eventMetadata.setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, EXPORT_EVENT_TYPE);
+
+        final Object primaryKeyValue = record.getData().get(primaryKeyName, Object.class);
+        eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, primaryKeyValue);
+
+        return event;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+public class MetadataKeyAttributes {
+    static final String PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE = "primary_key";
+
+    static final String EVENT_VERSION_FROM_TIMESTAMP = "document_version";
+
+    static final String EVENT_TIMESTAMP_METADATA_ATTRIBUTE = "event_timestamp";
+
+    static final String EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE = "opensearch_action";
+
+    static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
+
+    static final String INGESTION_EVENT_TYPE_ATTRIBUTE = "ingestion_type";
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.source.rds.coordination;
 
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
@@ -25,8 +26,10 @@ public class PartitionFactory implements Function<SourcePartitionStoreItem, Enha
 
         if (LeaderPartition.PARTITION_TYPE.equals(partitionType)) {
             return new LeaderPartition(partitionStoreItem);
-        }  if (ExportPartition.PARTITION_TYPE.equals(partitionType)) {
+        } else if (ExportPartition.PARTITION_TYPE.equals(partitionType)) {
             return new ExportPartition(partitionStoreItem);
+        } else if (DataFilePartition.PARTITION_TYPE.equals(partitionType)) {
+            return new DataFilePartition(partitionStoreItem);
         } else {
             // Unable to acquire other partitions.
             return new GlobalState(partitionStoreItem);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/DataFilePartition.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/DataFilePartition.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.partition;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.DataFileProgressState;
+
+import java.util.Optional;
+
+/**
+ * An DataFilePartition represents an export data file needs to be loaded.
+ * The source identifier contains keyword 'DATAFILE'
+ */
+public class DataFilePartition extends EnhancedSourcePartition<DataFileProgressState> {
+
+    public static final String PARTITION_TYPE = "DATAFILE";
+
+    private final String exportTaskId;
+    private final String bucket;
+    private final String key;
+    private final DataFileProgressState state;
+
+    public DataFilePartition(final SourcePartitionStoreItem sourcePartitionStoreItem) {
+
+        setSourcePartitionStoreItem(sourcePartitionStoreItem);
+        String[] keySplits = sourcePartitionStoreItem.getSourcePartitionKey().split("\\|");
+        exportTaskId = keySplits[0];
+        bucket = keySplits[1];
+        key = keySplits[2];
+        state = convertStringToPartitionProgressState(DataFileProgressState.class, sourcePartitionStoreItem.getPartitionProgressState());
+
+    }
+
+    public DataFilePartition(final String exportTaskId,
+                             final String bucket,
+                             final String key,
+                             final Optional<DataFileProgressState> state) {
+        this.exportTaskId = exportTaskId;
+        this.bucket = bucket;
+        this.key = key;
+        this.state = state.orElse(null);
+    }
+
+    @Override
+    public String getPartitionType() {
+        return PARTITION_TYPE;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return exportTaskId + "|" + bucket + "|" + key;
+    }
+
+    @Override
+    public Optional<DataFileProgressState> getProgressState() {
+        if (state != null) {
+            return Optional.of(state);
+        }
+        return Optional.empty();
+    }
+
+    public String getExportTaskId() {
+        return exportTaskId;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DataFileProgressState {
+
+    @JsonProperty("totalRecords")
+    private int total;
+
+    @JsonProperty("loadedRecords")
+    private int loaded;
+
+    @JsonProperty("exportStartTime")
+    private long startTime;
+
+    @JsonProperty("sourceTable")
+    private String sourceTable;
+
+    public int getTotal() {
+        return total;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    public int getLoaded() {
+        return loaded;
+    }
+
+    public void setLoaded(int loaded) {
+        this.loaded = loaded;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(long startTime) {
+        this.startTime = startTime;
+    }
+
+    public String getSourceTable() {
+        return sourceTable;
+    }
+
+    public void setSourceTable(String sourceTable) {
+        this.sourceTable = sourceTable;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
@@ -9,40 +9,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DataFileProgressState {
 
+    @JsonProperty("isLoaded")
+    private boolean isLoaded = false;
+
     @JsonProperty("totalRecords")
-    private int total;
-
-    @JsonProperty("loadedRecords")
-    private int loaded;
-
-    @JsonProperty("exportStartTime")
-    private long startTime;
+    private int totalRecords;
 
     @JsonProperty("sourceTable")
     private String sourceTable;
 
-    public int getTotal() {
-        return total;
+    public int getTotalRecords() {
+        return totalRecords;
     }
 
-    public void setTotal(int total) {
-        this.total = total;
+    public void setTotalRecords(int totalRecords) {
+        this.totalRecords = totalRecords;
     }
 
-    public int getLoaded() {
-        return loaded;
+    public boolean getLoaded() {
+        return isLoaded;
     }
 
-    public void setLoaded(int loaded) {
-        this.loaded = loaded;
-    }
-
-    public long getStartTime() {
-        return startTime;
-    }
-
-    public void setStartTime(long startTime) {
-        this.startTime = startTime;
+    public void setLoaded(boolean loaded) {
+        this.isLoaded = loaded;
     }
 
     public String getSourceTable() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.codec.parquet.ParquetInputCodec;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.io.InputStream;
+import java.time.Duration;
+
+public class DataFileLoader implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataFileLoader.class);
+
+    /**
+     * A flag to interrupt the process
+     */
+    private static volatile boolean shouldStop = false;
+
+    /**
+     * Number of lines to be read in a batch
+     */
+    private static final int DEFAULT_BATCH_SIZE = 1000;
+
+    /**
+     * Default regular checkpoint interval
+     */
+    private static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 2 * 60_000;
+
+    static final Duration BUFFER_TIMEOUT = Duration.ofSeconds(60);
+    static final int DEFAULT_BUFFER_BATCH_SIZE = 1_000;
+
+    private final DataFilePartition dataFilePartition;
+    private final String bucket;
+    private final String objectKey;
+    private final S3ObjectReader objectReader;
+    private final InputCodec codec;
+    private final BufferAccumulator<Record<Event>> bufferAccumulator;
+
+    public DataFileLoader(final DataFilePartition dataFilePartition,
+                          final S3Client s3Client,
+                          final EventFactory eventFactory,
+                          final Buffer<Record<Event>> buffer) {
+        this.dataFilePartition = dataFilePartition;
+        bucket = dataFilePartition.getBucket();
+        objectKey = dataFilePartition.getKey();
+        objectReader = new S3ObjectReader(s3Client);
+        codec = new ParquetInputCodec(eventFactory);
+        bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
+    }
+
+    @Override
+    public void run() {
+        LOG.info("Start loading s3://{}/{}", bucket, objectKey);
+
+        try (InputStream inputStream = objectReader.readFile(bucket, objectKey)) {
+
+            codec.parse(inputStream, record -> {
+                try {
+                    bufferAccumulator.add(record);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            LOG.info("Completed loading object s3://{}/{} to buffer", bucket, objectKey);
+        } catch (Exception e) {
+            LOG.error("Failed to load object s3://{}/{} to buffer", bucket, objectKey, e);
+            throw new RuntimeException(e);
+        }
+
+        try {
+            bufferAccumulator.flush();
+        } catch (Exception e) {
+            LOG.error("Failed to write events to buffer", e);
+        }
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -23,22 +23,6 @@ import java.time.Duration;
 public class DataFileLoader implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataFileLoader.class);
-
-    /**
-     * A flag to interrupt the process
-     */
-    private static volatile boolean shouldStop = false;
-
-    /**
-     * Number of lines to be read in a batch
-     */
-    private static final int DEFAULT_BATCH_SIZE = 1000;
-
-    /**
-     * Default regular checkpoint interval
-     */
-    private static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 2 * 60_000;
-
     static final Duration BUFFER_TIMEOUT = Duration.ofSeconds(60);
     static final int DEFAULT_BUFFER_BATCH_SIZE = 1_000;
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DataFileScheduler implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataFileScheduler.class);
+
+    private final AtomicInteger numOfWorkers = new AtomicInteger(0);
+
+    /**
+     * Maximum concurrent data loader per node
+     */
+    private static final int MAX_JOB_COUNT = 1;
+
+    /**
+     * Default interval to acquire a lease from coordination store
+     */
+    private static final int DEFAULT_LEASE_INTERVAL_MILLIS = 2_000;
+
+
+    private final EnhancedSourceCoordinator sourceCoordinator;
+    private final ExecutorService executor;
+    private final RdsSourceConfig sourceConfig;
+    private final S3Client s3Client;
+    private final EventFactory eventFactory;
+    private final Buffer<Record<Event>> buffer;
+
+    private volatile boolean shutdownRequested = false;
+
+    public DataFileScheduler(final EnhancedSourceCoordinator sourceCoordinator,
+                             final RdsSourceConfig sourceConfig,
+                             final S3Client s3Client,
+                             final EventFactory eventFactory,
+                             final Buffer<Record<Event>> buffer) {
+        this.sourceCoordinator = sourceCoordinator;
+        this.sourceConfig = sourceConfig;
+        this.s3Client = s3Client;
+        this.eventFactory = eventFactory;
+        this.buffer = buffer;
+        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT);
+    }
+
+    @Override
+    public void run() {
+        LOG.debug("Starting Data File Scheduler to process S3 data files for export");
+
+        while (!shutdownRequested && !Thread.currentThread().isInterrupted()) {
+            try {
+                if (numOfWorkers.get() < MAX_JOB_COUNT) {
+                    final Optional<EnhancedSourcePartition> sourcePartition = sourceCoordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE);
+
+                    if (sourcePartition.isPresent()) {
+                        LOG.debug("Acquired data file partition");
+                        DataFilePartition dataFilePartition = (DataFilePartition) sourcePartition.get();
+                        LOG.debug("Start processing data file partition");
+                        processDataFilePartition(dataFilePartition);
+                    }
+                }
+                try {
+                    Thread.sleep(DEFAULT_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException e) {
+                    LOG.info("The DataFileScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            } catch (final Exception e) {
+                LOG.error("Received an exception while processing an S3 data file, backing off and retrying", e);
+                try {
+                    Thread.sleep(DEFAULT_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException ex) {
+                    LOG.info("The DataFileScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            }
+        }
+        LOG.warn("Data file scheduler is interrupted, stopping all data file loaders...");
+        // Cannot call executor.shutdownNow() here
+        // Otherwise the final checkpoint will fail due to SDK interruption.
+        executor.shutdown();
+    }
+
+    public void shutdown() {
+        shutdownRequested = true;
+    }
+
+    private void processDataFilePartition(DataFilePartition dataFilePartition) {
+        Runnable loader = new DataFileLoader(dataFilePartition, s3Client, eventFactory, buffer);
+        CompletableFuture runLoader = CompletableFuture.runAsync(loader, executor);
+
+        runLoader.whenComplete((v, ex) -> {
+            if (ex == null) {
+                // TODO: update global state
+                sourceCoordinator.completePartition(dataFilePartition);
+            } else {
+                LOG.error("There was an exception while processing an S3 data file: {}", ex);
+                sourceCoordinator.giveUpPartition(dataFilePartition);
+            }
+            numOfWorkers.decrementAndGet();
+        });
+        numOfWorkers.incrementAndGet();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -44,7 +44,7 @@ public class ExportScheduler implements Runnable {
     private static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 5 * 60_000;
     private static final int DEFAULT_CHECK_STATUS_INTERVAL_MILLS = 30 * 1000;
     private static final Duration DEFAULT_SNAPSHOT_STATUS_CHECK_TIMEOUT = Duration.ofMinutes(60);
-    private static final String PARQUET_SUFFIX = ".parquet";
+    static final String PARQUET_SUFFIX = ".parquet";
 
     private final RdsClient rdsClient;
     private final S3Client s3Client;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Expo
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.DataFileProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.ExportObjectKey;
 import org.opensearch.dataprepper.plugins.source.rds.model.ExportStatus;
 import org.opensearch.dataprepper.plugins.source.rds.model.LoadStatus;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
@@ -295,8 +296,8 @@ public class ExportScheduler implements Runnable {
         AtomicInteger totalFiles = new AtomicInteger();
         for (final String objectKey : dataFileObjectKeys) {
             DataFileProgressState progressState = new DataFileProgressState();
-            // objectKey has this structure: "{prefix}/{export task ID}/{database name}/{table name}/...", table name is the 4th part
-            String table = objectKey.split("/")[3];
+            ExportObjectKey exportObjectKey = ExportObjectKey.fromString(objectKey);
+            String table = exportObjectKey.getTableName();
             progressState.setSourceTable(table);
 
             DataFilePartition dataFilePartition = new DataFilePartition(exportTaskId, bucket, objectKey, Optional.of(progressState));

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/S3ObjectReader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/S3ObjectReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.InputStream;
+
+public class S3ObjectReader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3ObjectReader.class);
+
+    private final S3Client s3Client;
+
+    public S3ObjectReader(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    public InputStream readFile(String bucketName, String s3Key) {
+        LOG.debug("Read file from s3://" + bucketName + "/" + s3Key);
+
+        GetObjectRequest objectRequest = GetObjectRequest
+                .builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .build();
+
+        ResponseInputStream<GetObjectResponse> object = s3Client.getObject(objectRequest);
+
+        return object;
+    }
+
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/S3ObjectReader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/S3ObjectReader.java
@@ -7,10 +7,8 @@ package org.opensearch.dataprepper.plugins.source.rds.export;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.InputStream;
 
@@ -25,17 +23,14 @@ public class S3ObjectReader {
     }
 
     public InputStream readFile(String bucketName, String s3Key) {
-        LOG.debug("Read file from s3://" + bucketName + "/" + s3Key);
+        LOG.debug("Read file from s3://{}/{}", bucketName, s3Key);
 
-        GetObjectRequest objectRequest = GetObjectRequest
-                .builder()
+        GetObjectRequest objectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(s3Key)
                 .build();
 
-        ResponseInputStream<GetObjectResponse> object = s3Client.getObject(objectRequest);
-
-        return object;
+        return s3Client.getObject(objectRequest);
     }
 
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKey.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKey.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+/**
+ * Represents the object key for an object exported to S3 by RDS.
+ * The object key has this structure: "{prefix}/{export task ID}/{database name}/{table name}/{numbered folder}/{file name}"
+ */
+public class ExportObjectKey {
+
+    private final String prefix;
+    private final String exportTaskId;
+    private final String databaseName;
+    private final String tableName;
+    private final String numberedFolder;
+    private final String fileName;
+
+    ExportObjectKey(final String prefix, final String exportTaskId, final String databaseName, final String tableName, final String numberedFolder, final String fileName) {
+        this.prefix = prefix;
+        this.exportTaskId = exportTaskId;
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+        this.numberedFolder = numberedFolder;
+        this.fileName = fileName;
+    }
+
+    public static ExportObjectKey fromString(final String objectKeyString) {
+
+        final String[] parts = objectKeyString.split("/");
+        if (parts.length != 6) {
+            throw new IllegalArgumentException("Export object key is not valid: " + objectKeyString);
+        }
+        final String prefix = parts[0];
+        final String exportTaskId = parts[1];
+        final String databaseName = parts[2];
+        final String tableName = parts[3];
+        final String numberedFolder = parts[4];
+        final String fileName = parts[5];
+        return new ExportObjectKey(prefix, exportTaskId, databaseName, tableName, numberedFolder, fileName);
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getExportTaskId() {
+        return exportTaskId;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getNumberedFolder() {
+        return numberedFolder;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/LoadStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/LoadStatus.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.util.Map;
+
+public class LoadStatus {
+
+    private static final String TOTAL_FILES = "totalFiles";
+    private static final String LOADED_FILES = "loadedFiles";
+
+    private int totalFiles;
+
+    private int loadedFiles;
+
+    public LoadStatus(int totalFiles, int loadedFiles) {
+        this.totalFiles = totalFiles;
+        this.loadedFiles = loadedFiles;
+    }
+
+    public int getTotalFiles() {
+        return totalFiles;
+    }
+
+    public void setTotalFiles(int totalFiles) {
+        this.totalFiles = totalFiles;
+    }
+
+    public int getLoadedFiles() {
+        return loadedFiles;
+    }
+
+    public void setLoadedFiles(int loadedFiles) {
+        this.loadedFiles = loadedFiles;
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                TOTAL_FILES, totalFiles,
+                LOADED_FILES, loadedFiles
+        );
+    }
+
+    public static LoadStatus fromMap(Map<String, Object> map) {
+        return new LoadStatus(
+                ((Number) map.get(TOTAL_FILES)).intValue(),
+                ((Number) map.get(LOADED_FILES)).intValue()
+        );
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler;
@@ -46,6 +47,9 @@ class RdsServiceTest {
 
     @Mock
     private ExecutorService executor;
+
+    @Mock
+    private EventFactory eventFactory;
 
     @Mock
     private ClientFactory clientFactory;
@@ -83,6 +87,6 @@ class RdsServiceTest {
     }
 
     private RdsService createObjectUnderTest() {
-        return new RdsService(sourceCoordinator, sourceConfig, clientFactory, pluginMetrics);
+        return new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.export.DataFileScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.leader.LeaderScheduler;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -63,8 +64,9 @@ class RdsServiceTest {
     }
 
     @Test
-    void test_normal_service_start() {
+    void test_normal_service_start_when_export_is_enabled() {
         RdsService rdsService = createObjectUnderTest();
+        when(sourceConfig.isExportEnabled()).thenReturn(true);
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
             executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt())).thenReturn(executor);
             rdsService.start(buffer);
@@ -72,6 +74,7 @@ class RdsServiceTest {
 
         verify(executor).submit(any(LeaderScheduler.class));
         verify(executor).submit(any(ExportScheduler.class));
+        verify(executor).submit(any(DataFileScheduler.class));
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,6 +27,9 @@ class RdsSourceTest {
 
     @Mock
     private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private EventFactory eventFactory;
 
     @Mock
     AwsCredentialsSupplier awsCredentialsSupplier;
@@ -45,6 +49,6 @@ class RdsSourceTest {
     }
 
     private RdsSource createObjectUnderTest() {
-        return new RdsSource(pluginMetrics, sourceConfig, awsCredentialsSupplier);
+        return new RdsSource(pluginMetrics, sourceConfig, eventFactory, awsCredentialsSupplier);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
@@ -8,8 +8,9 @@ package org.opensearch.dataprepper.plugins.source.rds.converter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Map;
@@ -17,6 +18,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter.EXPORT_EVENT_TYPE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
@@ -30,7 +32,7 @@ class ExportRecordConverterTest {
         final String tableName = UUID.randomUUID().toString();
         final String primaryKeyName = UUID.randomUUID().toString();
         final String primaryKeyValue = UUID.randomUUID().toString();
-        final Event testEvent = JacksonEvent.builder()
+        final Event testEvent = TestEventFactory.getTestEventFactory().eventBuilder(EventBuilder.class)
                 .withEventType("EVENT")
                 .withData(Map.of(primaryKeyName, primaryKeyValue))
                 .build();
@@ -41,9 +43,9 @@ class ExportRecordConverterTest {
         Event actualEvent = exportRecordConverter.convert(testRecord, tableName, primaryKeyName);
 
         // Assert
-        assertThat(actualEvent.getMetadata().getEventType(), equalTo(EXPORT_EVENT_TYPE));
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), equalTo(tableName));
         assertThat(actualEvent.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(primaryKeyValue));
         assertThat(actualEvent.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(EXPORT_EVENT_TYPE));
+        assertThat(actualEvent, sameInstance(testRecord.getData()));
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter.EXPORT_EVENT_TYPE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+
+@ExtendWith(MockitoExtension.class)
+class ExportRecordConverterTest {
+
+    @Test
+    void test_convert() {
+        final String tableName = UUID.randomUUID().toString();
+        final String primaryKeyName = UUID.randomUUID().toString();
+        final String primaryKeyValue = UUID.randomUUID().toString();
+        final Event testEvent = JacksonEvent.builder()
+                .withEventType("EVENT")
+                .withData(Map.of(primaryKeyName, primaryKeyValue))
+                .build();
+
+        Record<Event> testRecord = new Record<>(testEvent);
+
+        ExportRecordConverter exportRecordConverter = new ExportRecordConverter();
+        Event actualEvent = exportRecordConverter.convert(testRecord, tableName, primaryKeyName);
+
+        // Assert
+        assertThat(actualEvent.getMetadata().getEventType(), equalTo(EXPORT_EVENT_TYPE));
+        assertThat(actualEvent.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), equalTo(tableName));
+        assertThat(actualEvent.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(primaryKeyValue));
+        assertThat(actualEvent.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(EXPORT_EVENT_TYPE));
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
+
+import java.io.InputStream;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataFileLoaderTest {
+
+    @Mock
+    private DataFilePartition dataFilePartition;
+
+    @Mock
+    private BufferAccumulator<Record<Event>> bufferAccumulator;
+
+    @Mock
+    private InputCodec codec;
+
+    @Mock
+    private S3ObjectReader s3ObjectReader;
+
+    @Mock
+    private ExportRecordConverter recordConverter;
+
+    @Test
+    void test_run() throws Exception {
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        when(dataFilePartition.getBucket()).thenReturn(bucket);
+        when(dataFilePartition.getKey()).thenReturn(key);
+
+        InputStream inputStream = mock(InputStream.class);
+        when(s3ObjectReader.readFile(bucket, key)).thenReturn(inputStream);
+
+        DataFileLoader objectUnderTest = createObjectUnderTest();
+        objectUnderTest.run();
+
+        verify(codec).parse(eq(inputStream), any(Consumer.class));
+        verify(bufferAccumulator).flush();
+    }
+
+    private DataFileLoader createObjectUnderTest() {
+        return DataFileLoader.create(dataFilePartition, codec, bufferAccumulator, s3ObjectReader, recordConverter);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
@@ -120,7 +120,7 @@ class DataFileSchedulerTest {
     }
 
     @Test
-    void shutdown() {
+    void test_shutdown() {
         DataFileScheduler objectUnderTest = createObjectUnderTest();
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(objectUnderTest);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.source.rds.model.LoadStatus;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataFileSchedulerTest {
+
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @Mock
+    private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private EventFactory eventFactory;
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    @Mock
+    private DataFilePartition dataFilePartition;
+
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        random = new Random();
+    }
+
+    @Test
+    void test_given_no_datafile_partition_then_no_export() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
+        final DataFileScheduler objectUnderTest = createObjectUnderTest();
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(objectUnderTest);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(DataFilePartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verifyNoInteractions(s3Client, buffer);
+    }
+
+    @Test
+    void test_given_available_datafile_partition_then_load_datafile() {
+        DataFileScheduler objectUnderTest = createObjectUnderTest();
+        final String exportTaskId = UUID.randomUUID().toString();
+        when(dataFilePartition.getExportTaskId()).thenReturn(exportTaskId);
+
+        when(sourceCoordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).thenReturn(Optional.of(dataFilePartition));
+        final GlobalState globalStatePartition = mock(GlobalState.class);
+        final int totalFiles = random.nextInt() + 1;
+        final Map<String, Object> loadStatusMap = new LoadStatus(totalFiles, totalFiles - 1).toMap();
+        when(globalStatePartition.getProgressState()).thenReturn(Optional.of(loadStatusMap));
+        when(sourceCoordinator.getPartition(exportTaskId)).thenReturn(Optional.of(globalStatePartition));
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+                    // MockedStatic needs to be created on the same thread it's used
+                    try (MockedStatic<DataFileLoader> dataFileLoaderMockedStatic = mockStatic(DataFileLoader.class)) {
+                        DataFileLoader dataFileLoader = mock(DataFileLoader.class);
+                        dataFileLoaderMockedStatic.when(() -> DataFileLoader.create(
+                                eq(dataFilePartition), any(InputCodec.class), any(BufferAccumulator.class), any(S3ObjectReader.class), any(ExportRecordConverter.class)))
+                                .thenReturn(dataFileLoader);
+                        doNothing().when(dataFileLoader).run();
+                        objectUnderTest.run();
+                    }
+        });
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).completePartition(dataFilePartition));
+        executorService.shutdownNow();
+
+        verify(sourceCoordinator).completePartition(dataFilePartition);
+    }
+
+    @Test
+    void shutdown() {
+        DataFileScheduler objectUnderTest = createObjectUnderTest();
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(objectUnderTest);
+
+        objectUnderTest.shutdown();
+
+        verifyNoMoreInteractions(sourceCoordinator);
+        executorService.shutdownNow();
+    }
+
+    private DataFileScheduler createObjectUnderTest() {
+        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -110,9 +110,9 @@ class ExportSchedulerTest {
         ListObjectsV2Response listObjectsV2Response = mock(ListObjectsV2Response.class);
         String exportTaskId = UUID.randomUUID().toString();
         String tableName = UUID.randomUUID().toString();
-        // objectKey needs to have this structure: "{prefix}/{export task ID}/{database name}/{table name}/..."
+        // objectKey needs to have this structure: "{prefix}/{export task ID}/{database name}/{table name}/{numbered folder}/{file name}"
         S3Object s3Object = S3Object.builder()
-                .key("prefix/" + exportTaskId + "/my_db/" + tableName + PARQUET_SUFFIX)
+                .key("prefix/" + exportTaskId + "/my_db/" + tableName + "/1/file1" + PARQUET_SUFFIX)
                 .build();
         when(listObjectsV2Response.contents()).thenReturn(List.of(s3Object));
         when(listObjectsV2Response.isTruncated()).thenReturn(false);
@@ -169,9 +169,9 @@ class ExportSchedulerTest {
         ListObjectsV2Response listObjectsV2Response = mock(ListObjectsV2Response.class);
         String exportTaskId = UUID.randomUUID().toString();
         String tableName = UUID.randomUUID().toString();
-        // objectKey needs to have this structure: "{prefix}/{export task ID}/{database name}/{table name}/..."
+        // objectKey needs to have this structure: "{prefix}/{export task ID}/{database name}/{table name}/{numbered folder}/{file name}"
         S3Object s3Object = S3Object.builder()
-                .key("prefix/" + exportTaskId + "/my_db/" + tableName + PARQUET_SUFFIX)
+                .key("prefix/" + exportTaskId + "/my_db/" + tableName + "/1/file1" + PARQUET_SUFFIX)
                 .build();
         when(listObjectsV2Response.contents()).thenReturn(List.of(s3Object));
         when(listObjectsV2Response.isTruncated()).thenReturn(false);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/S3ObjectReaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/S3ObjectReaderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class S3ObjectReaderTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    private S3ObjectReader s3ObjectReader;
+
+
+    @BeforeEach
+    void setUp() {
+        s3ObjectReader = createObjectUnderTest();
+    }
+
+    @Test
+    void test_readFile() {
+        final String bucketName = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+
+
+        s3ObjectReader.readFile(bucketName, key);
+
+        ArgumentCaptor<GetObjectRequest> getObjectRequestArgumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObject(getObjectRequestArgumentCaptor.capture());
+
+        GetObjectRequest request = getObjectRequestArgumentCaptor.getValue();
+        assertThat(request.bucket(), equalTo(bucketName));
+        assertThat(request.key(), equalTo(key));
+    }
+
+    private S3ObjectReader createObjectUnderTest() {
+        return new S3ObjectReader(s3Client);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKeyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKeyTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ExportObjectKeyTest {
+
+    @Test
+    void test_fromString_with_valid_input_string() {
+        final String objectKeyString = "prefix/export-task-id/db-name/table-name/1/file-name.parquet";
+        final ExportObjectKey exportObjectKey = ExportObjectKey.fromString(objectKeyString);
+
+        assertThat(exportObjectKey.getPrefix(), equalTo("prefix"));
+        assertThat(exportObjectKey.getExportTaskId(), equalTo("export-task-id"));
+        assertThat(exportObjectKey.getDatabaseName(), equalTo("db-name"));
+        assertThat(exportObjectKey.getTableName(), equalTo("table-name"));
+        assertThat(exportObjectKey.getNumberedFolder(), equalTo("1"));
+        assertThat(exportObjectKey.getFileName(), equalTo("file-name.parquet"));
+    }
+
+    @Test
+    void test_fromString_with_invalid_input_string() {
+        final String objectKeyString = "prefix/export-task-id/db-name/table-name/1/";
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> ExportObjectKey.fromString(objectKeyString));
+        assertThat(exception.getMessage(), containsString("Export object key is not valid: " + objectKeyString));
+    }
+}

--- a/shared-config/log4j2.properties
+++ b/shared-config/log4j2.properties
@@ -27,7 +27,7 @@ logger.parser.name = org.opensearch.dataprepper.parser
 logger.parser.level = info
 
 logger.plugins.name = org.opensearch.dataprepper.plugins
-logger.plugins.level = info
+logger.plugins.level = debug
 
 logger.springframework.name = org.springframework
 logger.springframework.level = info

--- a/shared-config/log4j2.properties
+++ b/shared-config/log4j2.properties
@@ -27,7 +27,7 @@ logger.parser.name = org.opensearch.dataprepper.parser
 logger.parser.level = info
 
 logger.plugins.name = org.opensearch.dataprepper.plugins
-logger.plugins.level = debug
+logger.plugins.level = info
 
 logger.springframework.name = org.springframework
 logger.springframework.level = info


### PR DESCRIPTION
### Description
Following #4664, process the parquet files exported to S3, create events and send to buffer.

#### Testing
Created RDS MySQL instance as source and created a DDB table as coordination store and tested with the following pipeline config and verified the data written to the file sink.
```
rds-mysql-pipeline:
  source:
    rds:
      db_identifier: "mysql-instance"
      table_names:
        - "my_db.cars"
        - "my_db.houses"
      s3_bucket: "rds-data-oeyh"
      s3_region: "us-east-1"
      s3_prefix: "rds-source-test"
      export:
        kms_key_id: xxxxxx
      aws:
        sts_role_arn: "arn:aws:iam::xxxxxxxxxxxxx:role/rdsSourcePipelineRole"
        region: "us-east-1"
  sink:
    - file:
        path: .../.../results.txt
```

### Issues Resolved
Contributes to https://github.com/opensearch-project/data-prepper/issues/4561
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
