### PR TITLE
MAINT: backfill documentation in JsonPropertyDescription for split_string

### DIFF
--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutatestring;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -17,7 +16,6 @@ import org.opensearch.dataprepper.model.event.EventKey;
 
 import java.util.List;
 
-@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/split-string/")
 public class SplitStringProcessorConfig implements StringProcessorConfig<SplitStringProcessorConfig.Entry> {
     public static class Entry {
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -5,8 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutatestring;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -15,20 +17,29 @@ import org.opensearch.dataprepper.model.event.EventKey;
 
 import java.util.List;
 
+@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/split-string/")
 public class SplitStringProcessorConfig implements StringProcessorConfig<SplitStringProcessorConfig.Entry> {
     public static class Entry {
 
         @NotEmpty
         @NotNull
+        @JsonPropertyDescription("The key to split.")
         private EventKey source;
 
         @JsonProperty("delimiter_regex")
+        @JsonPropertyDescription("The regex string responsible for the split. Cannot be defined at the same time as `delimiter`. " +
+                "At least `delimiter` or `delimiter_regex` must be defined.")
         private String delimiterRegex;
 
         @Size(min = 1, max = 1)
+        @JsonPropertyDescription("The separator character responsible for the split. " +
+                "Cannot be defined at the same time as `delimiter_regex`. " +
+                "At least `delimiter` or `delimiter_regex` must be defined.")
         private String delimiter;
 
         @JsonProperty("split_when")
+        @JsonPropertyDescription("Specifies under what condition the `split_string` processor should perform splitting. " +
+                "Default is no condition.")
         private String splitWhen;
 
         public EventKey getSource() {
@@ -61,6 +72,7 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         return entries;
     }
 
+    @JsonPropertyDescription("List of entries. Valid values are `source`, `delimiter`, and `delimiter_regex`.")
     private List<@Valid Entry> entries;
 
     public List<Entry> getEntries() {


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/split-string) into @JsonPropertyDescription so that a complete json schema can be generated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
