### PR TITLE
MAINT: backfill documentation into json description for delete_entries

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.model.event.EventKey;
@@ -14,14 +16,18 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
 import java.util.List;
 
+@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/delete-entries/#configuration")
 public class DeleteEntryProcessorConfig {
     @NotEmpty
     @NotNull
     @JsonProperty("with_keys")
     @EventKeyConfiguration(EventKeyFactory.EventAction.DELETE)
+    @JsonPropertyDescription("An array of keys for the entries to be deleted.")
     private List<@NotNull @NotEmpty EventKey> withKeys;
 
     @JsonProperty("delete_when")
+    @JsonPropertyDescription("Specifies under what condition the `delete_entries` processor should perform deletion. " +
+            "Default is no condition.")
     private String deleteWhen;
 
     public List<EventKey> getWithKeys() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotEmpty;
@@ -16,7 +15,6 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
 import java.util.List;
 
-@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/delete-entries/#configuration")
 public class DeleteEntryProcessorConfig {
     @NotEmpty
     @NotNull

--- a/settings.gradle
+++ b/settings.gradle
@@ -97,7 +97,6 @@ dependencyResolutionManagement {
 }
 
 include 'data-prepper-api'
-include 'data-prepper-validation-api'
 include 'data-prepper-plugins'
 include 'data-prepper-event'
 include 'data-prepper-test-event'

--- a/settings.gradle
+++ b/settings.gradle
@@ -97,6 +97,7 @@ dependencyResolutionManagement {
 }
 
 include 'data-prepper-api'
+include 'data-prepper-validation-api'
 include 'data-prepper-plugins'
 include 'data-prepper-event'
 include 'data-prepper-test-event'


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/delete_entries) into @JsonPropertyDescription so that a complete json schema can be generated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
