### PR TITLE
MAINT: backfill doc in json property description for otel_metrics

### DIFF
--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -6,17 +6,25 @@
 package org.opensearch.dataprepper.plugins.processor.otelmetrics;
 
 import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-metrics/#configuration")
 public class OtelMetricsRawProcessorConfig {
 
     @JsonProperty("flatten_attributes")
+    @JsonPropertyDescription("Whether or not to flatten the `attributes` field in the JSON data.")
     boolean flattenAttributesFlag = true;
 
+    @JsonPropertyDescription("Whether or not to calculate histogram buckets.")
     private Boolean calculateHistogramBuckets = true;
 
+    @JsonPropertyDescription("Whether or not to calculate exponential histogram buckets.")
     private Boolean calculateExponentialHistogramBuckets = true;
 
+    @JsonPropertyDescription("Maximum allowed scale in exponential histogram calculation.")
     private Integer exponentialHistogramMaxAllowedScale = DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE;
 
     public Boolean getCalculateExponentialHistogramBuckets() {

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -7,11 +7,9 @@ package org.opensearch.dataprepper.plugins.processor.otelmetrics;
 
 import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
-@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-metrics/#configuration")
 public class OtelMetricsRawProcessorConfig {
 
     @JsonProperty("flatten_attributes")


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-metrics/#configuration) into @JsonPropertyDescription so that a complete json schema can be generated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
