### PR TITLE
AWS Lambda Sink flaky tests & logging

### DIFF
--- a/data-prepper-plugins/lambda/build.gradle
+++ b/data-prepper-plugins/lambda/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-plugins:parse-json-processor')
+    testImplementation testLibs.slf4j.simple
 }
 
 test {

--- a/data-prepper-plugins/lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/sink/LambdaSinkServiceTest.java
+++ b/data-prepper-plugins/lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/sink/LambdaSinkServiceTest.java
@@ -294,7 +294,7 @@ public class LambdaSinkServiceTest {
         when(lambdaSinkConfig.getBatchOptions()).thenReturn(mock(BatchOptions.class));
         when(lambdaSinkConfig.getBatchOptions().getBatchKey()).thenReturn(batchKey);
         when(lambdaSinkConfig.getBatchOptions().getThresholdOptions()).thenReturn(mock(ThresholdOptions.class));
-        when(lambdaSinkConfig.getBatchOptions().getThresholdOptions().getEventCount()).thenReturn(maxEvents);
+        when(lambdaSinkConfig.getBatchOptions().getThresholdOptions().getEventCount()).thenReturn(1);
         when(lambdaSinkConfig.getBatchOptions().getThresholdOptions().getMaximumSize()).thenReturn(ByteCount.parse(maxSize));
         when(lambdaSinkConfig.getBatchOptions().getThresholdOptions().getEventCollectTimeOut()).thenReturn(Duration.ofNanos(10L));
         when(lambdaSinkConfig.getAwsAuthenticationOptions()).thenReturn(mock(AwsAuthenticationOptions.class));

--- a/data-prepper-plugins/lambda/src/test/resources/simplelogger.properties
+++ b/data-prepper-plugins/lambda/src/test/resources/simplelogger.properties
@@ -1,0 +1,8 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd' 'HH:mm:ss.SSS
+org.slf4j.simpleLogger.log.org.opensearch.dataprepper.plugins.lambda.sink=trace


### PR DESCRIPTION
### Description

This fixes a flaky test.

```
LambdaSinkServiceTest > lambda_sink_test_batch_enabled() FAILED
    org.mockito.exceptions.verification.WantedButNotInvoked at LambdaSinkServiceTest.java:316
```

https://github.com/opensearch-project/data-prepper/issues/3481#issuecomment-2221378060
 
Two changes:
* Use a max event count of 1 to verify that we call the Lambda API.
* Adds SLF4J logging to this project. That is partially how I was able to find the cause.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
