### PR TITLE
MAINT: backfill documentation in json description for otel_traces

### DIFF
--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -5,21 +5,29 @@
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import java.time.Duration;
 
+@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/#configuration")
 public class OtelTraceRawProcessorConfig {
     static final long DEFAULT_TG_FLUSH_INTERVAL_SEC = 180L;
     static final Duration DEFAULT_TRACE_ID_TTL = Duration.ofSeconds(15L);
     static final long MAX_TRACE_ID_CACHE_SIZE = 1_000_000L;
     @JsonProperty("trace_flush_interval")
+    @JsonPropertyDescription("Represents the time interval in seconds to flush all the descendant spans without any " +
+            "root span. Default is 180.")
     private long traceFlushInterval = DEFAULT_TG_FLUSH_INTERVAL_SEC;
 
     @JsonProperty("trace_group_cache_ttl")
+    @JsonPropertyDescription("Represents the time-to-live to cache a trace group details. Default is 15 seconds.")
     private Duration traceGroupCacheTimeToLive = DEFAULT_TRACE_ID_TTL;
 
     @JsonProperty("trace_group_cache_max_size")
+    @JsonPropertyDescription("Represents the maximum size of the cache to store the trace group details from root spans. " +
+            "Default is 1000000.")
     private long traceGroupCacheMaxSize = MAX_TRACE_ID_CACHE_SIZE;
 
     public long getTraceFlushIntervalSeconds() {

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -5,13 +5,11 @@
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import java.time.Duration;
 
-@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/#configuration")
 public class OtelTraceRawProcessorConfig {
     static final long DEFAULT_TG_FLUSH_INTERVAL_SEC = 180L;
     static final Duration DEFAULT_TRACE_ID_TTL = Duration.ofSeconds(15L);


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/#configuration) into @JsonPropertyDescription so that a complete json schema can be generated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
