### PR TITLE
MAINT: backfill documentation into json description for string_converter

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.processor;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -39,7 +41,9 @@ public class StringProcessor implements Processor<Record<Event>, Record<Event>> 
 
     private final boolean upperCase;
 
+    @JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/string-converter/")
     public static class Configuration {
+        @JsonPropertyDescription("Whether to convert to uppercase (`true`) or lowercase (`false`).")
         private boolean upperCase = true;
 
         public boolean getUpperCase() {

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -41,7 +40,6 @@ public class StringProcessor implements Processor<Record<Event>, Record<Event>> 
 
     private final boolean upperCase;
 
-    @JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/string-converter/")
     public static class Configuration {
         @JsonPropertyDescription("Whether to convert to uppercase (`true`) or lowercase (`false`).")
         private boolean upperCase = true;


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/string-converter/) into @JsonPropertyDescription so that a complete json schema can be generated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
