### PR TITLE
MAINT: backfill documentation into json description for truncate processor

### DIFF
--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.processor.truncate;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue; 
@@ -13,21 +15,29 @@ import jakarta.validation.Valid;
 
 import java.util.List;
 
+@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/truncate/#configuration")
 public class TruncateProcessorConfig {
     public static class Entry {
         @JsonProperty("source_keys")
+        @JsonPropertyDescription("The list of source keys that will be modified by the processor. " +
+                "The default value is an empty list, which indicates that all values will be truncated.")
         private List<String> sourceKeys;
 
         @JsonProperty("start_at")
+        @JsonPropertyDescription("Where in the string value to start truncation. " +
+                "Default is `0`, which specifies to start truncation at the beginning of each key's value.")
         private Integer startAt;
 
         @JsonProperty("length")
+        @JsonPropertyDescription("The length of the string after truncation. " +
+                "When not specified, the processor will measure the length based on where the string ends.")
         private Integer length;
 
         @JsonProperty("recursive")
         private Boolean recurse = false;
 
         @JsonProperty("truncate_when")
+        @JsonPropertyDescription("A condition that, when met, determines when the truncate operation is performed.")
         private String truncateWhen;
 
         public Entry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen, final Boolean recurse) {
@@ -77,6 +87,7 @@ public class TruncateProcessorConfig {
 
     @NotEmpty
     @NotNull
+    @JsonPropertyDescription("A list of entries to add to an event.")
     private List<@Valid Entry> entries;
 
     public List<Entry> getEntries() {

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.truncate;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotEmpty;
@@ -15,7 +14,6 @@ import jakarta.validation.Valid;
 
 import java.util.List;
 
-@JsonClassDescription("https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/truncate/#configuration")
 public class TruncateProcessorConfig {
     public static class Entry {
         @JsonProperty("source_keys")


### PR DESCRIPTION
### Description
This PR serves as the starter for backfill [plugin setting config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/truncate/#configuration) into @JsonPropertyDescription so that a complete json schema can be generated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
