### PR TITLE
Run tests on the current JVM / Gradle 8.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,9 @@ subprojects {
 
     test {
         useJUnitPlatform()
+        javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.current()
+        }
         reports {
             junitXml.required
             html.required

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
@@ -28,6 +28,7 @@ public abstract class AbstractSink<T extends Record<?>> implements Sink<T> {
     private Thread retryThread;
     private int maxRetries;
     private int waitTimeMs;
+    private SinkThread sinkThread;
 
     public AbstractSink(final PluginSetting pluginSetting, int numRetries, int waitTimeMs) {
         this.pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
@@ -51,7 +52,8 @@ public abstract class AbstractSink<T extends Record<?>> implements Sink<T> {
         // the exceptions which are not retryable.
         doInitialize();
         if (!isReady() && retryThread == null) {
-            retryThread = new Thread(new SinkThread(this, maxRetries, waitTimeMs));
+            sinkThread = new SinkThread(this, maxRetries, waitTimeMs);
+            retryThread = new Thread(sinkThread);
             retryThread.start();
         }
     }
@@ -76,7 +78,7 @@ public abstract class AbstractSink<T extends Record<?>> implements Sink<T> {
     @Override
     public void shutdown() {
         if (retryThread != null) {
-            retryThread.stop();
+            sinkThread.stop();
         }
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkThread.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkThread.java
@@ -10,6 +10,8 @@ class SinkThread implements Runnable {
     private int maxRetries;
     private int waitTimeMs;
 
+    private volatile boolean isStopped = false;
+
     public SinkThread(AbstractSink sink, int maxRetries, int waitTimeMs) {
         this.sink = sink;
         this.maxRetries = maxRetries;
@@ -19,11 +21,15 @@ class SinkThread implements Runnable {
     @Override
     public void run() {
         int numRetries = 0;
-        while (!sink.isReady() && numRetries++ < maxRetries) {
+        while (!sink.isReady() && numRetries++ < maxRetries && !isStopped) {
             try {
                 Thread.sleep(waitTimeMs);
                 sink.doInitialize();
             } catch (InterruptedException e){}
         }
+    }
+
+    public void stop() {
+        isStopped = true;
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
@@ -11,15 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.event.EventHandle;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -30,6 +25,12 @@ import java.util.StringJoiner;
 import java.util.UUID;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AbstractSinkTest {
     private int count;
@@ -71,13 +72,13 @@ class AbstractSinkTest {
     }
 
     @Test
-    void testSinkNotReady() {
+    void testSinkNotReady() throws InterruptedException {
         final String sinkName = "testSink";
         final String pipelineName = "pipelineName";
         MetricsTestUtil.initMetrics();
         PluginSetting pluginSetting = new PluginSetting(sinkName, Collections.emptyMap());
         pluginSetting.setPipelineName(pipelineName);
-        AbstractSink<Record<String>> abstractSink = new AbstractSinkNotReadyImpl(pluginSetting);
+        AbstractSinkNotReadyImpl abstractSink = new AbstractSinkNotReadyImpl(pluginSetting);
         abstractSink.initialize();
         assertEquals(abstractSink.isReady(), false);
         assertEquals(abstractSink.getRetryThreadState(), Thread.State.RUNNABLE);
@@ -87,7 +88,10 @@ class AbstractSinkTest {
         await().atMost(Duration.ofSeconds(5))
                 .until(abstractSink::isReady);
         assertEquals(abstractSink.getRetryThreadState(), Thread.State.TERMINATED);
+        int initCountBeforeShutdown = abstractSink.initCount;
         abstractSink.shutdown();
+        Thread.sleep(200);
+        assertThat(abstractSink.initCount, equalTo(initCountBeforeShutdown));
     }
 
     @Test

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -48,7 +48,6 @@ dependencies {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0-beta-1'
-    testImplementation 'org.apache.logging.log4j:log4j-jpl:2.23.0'
     testImplementation testLibs.spring.test
     implementation libs.armeria.core
     implementation libs.armeria.grpc

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -89,8 +89,6 @@ task integrationTest(type: Test) {
 
     classpath = sourceSets.integrationTest.runtimeClasspath
 
-    systemProperty 'log4j.configurationFile', 'src/test/resources/log4j2.properties'
-
     filter {
         includeTestsMatching '*IT'
     }

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGeneratorTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGeneratorTest.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.Timer;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -218,7 +218,7 @@ class AvroAutoSchemaGeneratorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    arguments(Random.class),
+                    arguments(Timer.class),
                     arguments(InputStream.class),
                     arguments(File.class)
             );

--- a/data-prepper-plugins/blocking-buffer/src/test/java/org/opensearch/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/blocking-buffer/src/test/java/org/opensearch/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
@@ -328,7 +328,7 @@ public class BlockingBufferTests {
             return Stream.of(
                     Arguments.of(0, randomInt + 1, 0.0),
                     Arguments.of(1, 100, 1.0),
-                    Arguments.of(randomInt, randomInt, 100.0),
+                    Arguments.of(randomInt + 1, randomInt + 1, 100.0),
                     Arguments.of(randomInt, randomInt + 250, ((double) randomInt / (randomInt + 250)) * 100),
                     Arguments.of(6, 9, 66.66666666666666),
                     Arguments.of(531, 1000, 53.1),

--- a/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonInputCodecTest.java
+++ b/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonInputCodecTest.java
@@ -11,9 +11,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+
 import org.mockito.Mock;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -28,6 +31,7 @@ import org.opensearch.dataprepper.model.log.JacksonLog;
 import java.io.ByteArrayInputStream;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
@@ -56,7 +60,7 @@ public class EventJsonInputCodecTest {
     @ParameterizedTest
     @ValueSource(strings = {"", "{}"})
     public void emptyTest(String input) throws Exception {
-        input = "{\""+EventJsonDefines.VERSION+"\":\""+DataPrepperVersion.getCurrentVersion().toString()+"\", \""+EventJsonDefines.EVENTS+"\":["+input+"]}";
+        input = "{\"" + EventJsonDefines.VERSION + "\":\"" + DataPrepperVersion.getCurrentVersion().toString() + "\", \"" + EventJsonDefines.EVENTS + "\":[" + input + "]}";
         ByteArrayInputStream inputStream = new ByteArrayInputStream(input.getBytes());
         inputCodec = createInputCodec();
         Consumer<Record<Event>> consumer = mock(Consumer.class);
@@ -70,15 +74,15 @@ public class EventJsonInputCodecTest {
         final String key = UUID.randomUUID().toString();
         final String value = UUID.randomUUID().toString();
         Map<String, Object> data = Map.of(key, value);
-        Instant startTime = Instant.now();
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
         Event event = createEvent(data, startTime);
 
         Map<String, Object> dataMap = event.toMap();
         Map<String, Object> metadataMap = objectMapper.convertValue(event.getMetadata(), Map.class);
-        String input = "{\""+EventJsonDefines.VERSION+"\":\"3.0\", \""+EventJsonDefines.EVENTS+"\":[";
+        String input = "{\"" + EventJsonDefines.VERSION + "\":\"3.0\", \"" + EventJsonDefines.EVENTS + "\":[";
         String comma = "";
         for (int i = 0; i < 2; i++) {
-            input += comma+"{\"data\":"+objectMapper.writeValueAsString(dataMap)+","+"\"metadata\":"+objectMapper.writeValueAsString(metadataMap)+"}";
+            input += comma + "{\"data\":" + objectMapper.writeValueAsString(dataMap) + "," + "\"metadata\":" + objectMapper.writeValueAsString(metadataMap) + "}";
             comma = ",";
         }
         input += "]}";
@@ -95,15 +99,15 @@ public class EventJsonInputCodecTest {
         final String key = UUID.randomUUID().toString();
         final String value = UUID.randomUUID().toString();
         Map<String, Object> data = Map.of(key, value);
-        Instant startTime = Instant.now();
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
         Event event = createEvent(data, startTime);
 
         Map<String, Object> dataMap = event.toMap();
         Map<String, Object> metadataMap = objectMapper.convertValue(event.getMetadata(), Map.class);
-        String input = "{\""+EventJsonDefines.VERSION+"\":\""+DataPrepperVersion.getCurrentVersion().toString()+"\", \""+EventJsonDefines.EVENTS+"\":[";
+        String input = "{\"" + EventJsonDefines.VERSION + "\":\"" + DataPrepperVersion.getCurrentVersion().toString() + "\", \"" + EventJsonDefines.EVENTS + "\":[";
         String comma = "";
         for (int i = 0; i < 2; i++) {
-            input += comma+"{\"data\":"+objectMapper.writeValueAsString(dataMap)+","+"\"metadata\":"+objectMapper.writeValueAsString(metadataMap)+"}";
+            input += comma + "{\"data\":" + objectMapper.writeValueAsString(dataMap) + "," + "\"metadata\":" + objectMapper.writeValueAsString(metadataMap) + "}";
             comma = ",";
         }
         input += "]}";
@@ -111,8 +115,8 @@ public class EventJsonInputCodecTest {
         List<Record<Event>> records = new LinkedList<>();
         inputCodec.parse(inputStream, records::add);
         assertThat(records.size(), equalTo(2));
-        for(Record record : records) {
-            Event e = (Event)record.getData();
+        for (Record record : records) {
+            Event e = (Event) record.getData();
             assertThat(e.get(key, String.class), equalTo(value));
             assertThat(e.getMetadata().getTimeReceived(), equalTo(startTime));
             assertThat(e.getMetadata().getTags().size(), equalTo(0));
@@ -126,15 +130,15 @@ public class EventJsonInputCodecTest {
         final String key = UUID.randomUUID().toString();
         final String value = UUID.randomUUID().toString();
         Map<String, Object> data = Map.of(key, value);
-        Instant startTime = Instant.now().minusSeconds(5);
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS).minusSeconds(5);
         Event event = createEvent(data, startTime);
 
         Map<String, Object> dataMap = event.toMap();
         Map<String, Object> metadataMap = objectMapper.convertValue(event.getMetadata(), Map.class);
-        String input = "{\""+EventJsonDefines.VERSION+"\":\""+DataPrepperVersion.getCurrentVersion().toString()+"\", \""+EventJsonDefines.EVENTS+"\":[";
+        String input = "{\"" + EventJsonDefines.VERSION + "\":\"" + DataPrepperVersion.getCurrentVersion().toString() + "\", \"" + EventJsonDefines.EVENTS + "\":[";
         String comma = "";
         for (int i = 0; i < 2; i++) {
-            input += comma+"{\"data\":"+objectMapper.writeValueAsString(dataMap)+","+"\"metadata\":"+objectMapper.writeValueAsString(metadataMap)+"}";
+            input += comma + "{\"data\":" + objectMapper.writeValueAsString(dataMap) + "," + "\"metadata\":" + objectMapper.writeValueAsString(metadataMap) + "}";
             comma = ",";
         }
         input += "]}";
@@ -142,8 +146,8 @@ public class EventJsonInputCodecTest {
         List<Record<Event>> records = new LinkedList<>();
         inputCodec.parse(inputStream, records::add);
         assertThat(records.size(), equalTo(2));
-        for(Record record : records) {
-            Event e = (Event)record.getData();
+        for (Record record : records) {
+            Event e = (Event) record.getData();
             assertThat(e.get(key, String.class), equalTo(value));
             assertThat(e.getMetadata().getTimeReceived(), not(equalTo(startTime)));
             assertThat(e.getMetadata().getTags().size(), equalTo(0));
@@ -159,7 +163,7 @@ public class EventJsonInputCodecTest {
         if (timeReceived != null) {
             logBuilder.withTimeReceived(timeReceived);
         }
-        final JacksonEvent event = (JacksonEvent)logBuilder.build();
+        final JacksonEvent event = (JacksonEvent) logBuilder.build();
 
         return event;
     }

--- a/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonInputOutputCodecTest.java
+++ b/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonInputOutputCodecTest.java
@@ -6,9 +6,12 @@ package org.opensearch.dataprepper.plugins.codec.event_json;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+
 import org.mockito.Mock;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -22,6 +25,7 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.log.JacksonLog;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
@@ -64,7 +68,7 @@ public class EventJsonInputOutputCodecTest {
         final String value = UUID.randomUUID().toString();
         Map<String, Object> data = Map.of(key, value);
 
-        Instant startTime = Instant.now();
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
         Event event = createEvent(data, startTime);
         outputCodec = createOutputCodec();
         inputCodec = createInputCodec();
@@ -75,8 +79,8 @@ public class EventJsonInputOutputCodecTest {
         inputCodec.parse(new ByteArrayInputStream(outputStream.toByteArray()), records::add);
 
         assertThat(records.size(), equalTo(1));
-        for(Record record : records) {
-            Event e = (Event)record.getData();
+        for (Record record : records) {
+            Event e = (Event) record.getData();
             assertThat(e.get(key, String.class), equalTo(value));
             assertThat(e.getMetadata().getTimeReceived(), equalTo(startTime));
             assertThat(e.getMetadata().getTags().size(), equalTo(0));
@@ -90,7 +94,7 @@ public class EventJsonInputOutputCodecTest {
         final String value = UUID.randomUUID().toString();
         Map<String, Object> data = Map.of(key, value);
 
-        Instant startTime = Instant.now();
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
         Event event = createEvent(data, startTime);
         outputCodec = createOutputCodec();
         inputCodec = createInputCodec();
@@ -103,8 +107,8 @@ public class EventJsonInputOutputCodecTest {
         inputCodec.parse(new ByteArrayInputStream(outputStream.toByteArray()), records::add);
 
         assertThat(records.size(), equalTo(3));
-        for(Record record : records) {
-            Event e = (Event)record.getData();
+        for (Record record : records) {
+            Event e = (Event) record.getData();
             assertThat(e.get(key, String.class), equalTo(value));
             assertThat(e.getMetadata().getTimeReceived(), equalTo(startTime));
             assertThat(e.getMetadata().getTags().size(), equalTo(0));
@@ -122,7 +126,7 @@ public class EventJsonInputOutputCodecTest {
 
         Set<String> tags = Set.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         List<String> tagsList = tags.stream().collect(Collectors.toList());
-        Instant startTime = Instant.now();
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
         Event event = createEvent(data, startTime);
         Instant origTime = startTime.minusSeconds(5);
         event.getMetadata().setExternalOriginationTime(origTime);
@@ -135,11 +139,11 @@ public class EventJsonInputOutputCodecTest {
         outputCodec.complete(outputStream);
         assertThat(outputCodec.getExtension(), equalTo(EventJsonOutputCodec.EVENT_JSON));
         List<Record<Event>> records = new LinkedList<>();
-inputCodec.parse(new ByteArrayInputStream(outputStream.toByteArray()), records::add);
+        inputCodec.parse(new ByteArrayInputStream(outputStream.toByteArray()), records::add);
 
         assertThat(records.size(), equalTo(1));
-        for(Record record : records) {
-            Event e = (Event)record.getData();
+        for (Record record : records) {
+            Event e = (Event) record.getData();
             assertThat(e.get(key, String.class), equalTo(value));
             assertThat(e.getMetadata().getTimeReceived(), equalTo(startTime));
             assertThat(e.getMetadata().getTags(), equalTo(tags));
@@ -157,7 +161,7 @@ inputCodec.parse(new ByteArrayInputStream(outputStream.toByteArray()), records::
         if (timeReceived != null) {
             logBuilder.withTimeReceived(timeReceived);
         }
-        final JacksonEvent event = (JacksonEvent)logBuilder.build();
+        final JacksonEvent event = (JacksonEvent) logBuilder.build();
 
         return event;
     }

--- a/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonOutputCodecTest.java
+++ b/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonOutputCodecTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -22,6 +23,7 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.log.JacksonLog;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 
@@ -49,7 +51,7 @@ public class EventJsonOutputCodecTest {
         final String value = UUID.randomUUID().toString();
         Map<String, Object> data = Map.of(key, value);
 
-        Instant startTime = Instant.now();
+        Instant startTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
         Event event = createEvent(data, startTime);
         outputCodec = createOutputCodec();
         outputCodec.start(outputStream, null, null);
@@ -59,10 +61,10 @@ public class EventJsonOutputCodecTest {
         Map<String, Object> dataMap = event.toMap();
         Map<String, Object> metadataMap = objectMapper.convertValue(event.getMetadata(), Map.class);
         //String expectedOutput = "{\"version\":\""+DataPrepperVersion.getCurrentVersion().toString()+"\",\""+EventJsonDefines.EVENTS+"\":[";
-        String expectedOutput = "{\""+EventJsonDefines.VERSION+"\":\""+DataPrepperVersion.getCurrentVersion().toString()+"\",\""+EventJsonDefines.EVENTS+"\":[";
+        String expectedOutput = "{\"" + EventJsonDefines.VERSION + "\":\"" + DataPrepperVersion.getCurrentVersion().toString() + "\",\"" + EventJsonDefines.EVENTS + "\":[";
         String comma = "";
         for (int i = 0; i < 2; i++) {
-            expectedOutput += comma+"{\""+EventJsonDefines.DATA+"\":"+objectMapper.writeValueAsString(dataMap)+","+"\""+EventJsonDefines.METADATA+"\":"+objectMapper.writeValueAsString(metadataMap)+"}";
+            expectedOutput += comma + "{\"" + EventJsonDefines.DATA + "\":" + objectMapper.writeValueAsString(dataMap) + "," + "\"" + EventJsonDefines.METADATA + "\":" + objectMapper.writeValueAsString(metadataMap) + "}";
             comma = ",";
         }
         expectedOutput += "]}";
@@ -78,7 +80,7 @@ public class EventJsonOutputCodecTest {
         if (timeReceived != null) {
             logBuilder.withTimeReceived(timeReceived);
         }
-        final JacksonEvent event = (JacksonEvent)logBuilder.build();
+        final JacksonEvent event = (JacksonEvent) logBuilder.build();
 
         return event;
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.


### PR DESCRIPTION
### Description

While debugging a test recently, I noticed that the Java 17 test reports a basic `java.lang.NullPointerException`. Java 17 provides better NPE information that Java 11. It turns out that the tests are actually running against Java 11 entirely. Even in our matrix tests, these run on Java 11.

This PR uses the current JVM versions (ie. what Gradle is running on) to execute the Java tests. This way, our tests will test actually test against other Java versions.

Also, I updated the Gradle 8.8 because `JavaLanguageVersion.current()` was added in 8.8.

#### Verification

I created a simple test to prove this:

```
public class QuickFail {
    @Test
    void fails() {
        A a = new A();
        B b = new B();
        
        a.b.c.doSomething();
    }

    static class A {
        B b;
    }

    static class B {
        C c;
    }

    static class C {
        void doSomething() {}
    }
}
```

Running on Java 11:

```
java11 ./gradlew -p data-prepper-api clean build
```

yields:

```
java.lang.NullPointerException
	at org.opensearch.dataprepper.QuickFail.fails(QuickFail.java:15)
```

Running on Java 17:

```
java17 ./gradlew -p data-prepper-api clean build
```

yields:

```
java.lang.NullPointerException: Cannot read field "c" because "a.b" is null
	at org.opensearch.dataprepper.QuickFail.fails(QuickFail.java:15)
```
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
