### PR TITLE
REF: grok processor with the latest config model

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -5,8 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.processor.grok;
 
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -39,69 +41,57 @@ public class GrokProcessorConfig {
     static final int DEFAULT_TIMEOUT_MILLIS = 30000;
     static final String DEFAULT_TARGET_KEY = null;
 
-    private final boolean breakOnMatch;
-    private final boolean keepEmptyCaptures;
-    private final Map<String, List<String>> match;
-    private final boolean namedCapturesOnly;
-    private final List<String> keysToOverwrite;
-    private final List<String> patternsDirectories;
-    private final String patternsFilesGlob;
-    private final Map<String, String> patternDefinitions;
-    private final int timeoutMillis;
-    private final String targetKey;
-    private final String grokWhen;
-    private final List<String> tagsOnMatchFailure;
-    private final List<String> tagsOnTimeout;
-
-    private final boolean includePerformanceMetadata;
-
-    private GrokProcessorConfig(final boolean breakOnMatch,
-                                final boolean keepEmptyCaptures,
-                                final Map<String, List<String>> match,
-                                final boolean namedCapturesOnly,
-                                final List<String> keysToOverwrite,
-                                final List<String> patternsDirectories,
-                                final String patternsFilesGlob,
-                                final Map<String, String> patternDefinitions,
-                                final int timeoutMillis,
-                                final String targetKey,
-                                final String grokWhen,
-                                final List<String> tagsOnMatchFailure,
-                                final List<String> tagsOnTimeout,
-                                final boolean includePerformanceMetadata) {
-
-        this.breakOnMatch = breakOnMatch;
-        this.keepEmptyCaptures = keepEmptyCaptures;
-        this.match = match;
-        this.namedCapturesOnly = namedCapturesOnly;
-        this.keysToOverwrite = keysToOverwrite;
-        this.patternsDirectories = patternsDirectories;
-        this.patternsFilesGlob = patternsFilesGlob;
-        this.patternDefinitions = patternDefinitions;
-        this.timeoutMillis = timeoutMillis;
-        this.targetKey = targetKey;
-        this.grokWhen = grokWhen;
-        this.tagsOnMatchFailure = tagsOnMatchFailure;
-        this.tagsOnTimeout = tagsOnTimeout.isEmpty() ? tagsOnMatchFailure : tagsOnTimeout;
-        this.includePerformanceMetadata = includePerformanceMetadata;
-    }
-
-    public static GrokProcessorConfig buildConfig(final PluginSetting pluginSetting) {
-        return new GrokProcessorConfig(pluginSetting.getBooleanOrDefault(BREAK_ON_MATCH, DEFAULT_BREAK_ON_MATCH),
-                pluginSetting.getBooleanOrDefault(KEEP_EMPTY_CAPTURES, DEFAULT_KEEP_EMPTY_CAPTURES),
-                pluginSetting.getTypedListMap(MATCH, String.class, String.class),
-                pluginSetting.getBooleanOrDefault(NAMED_CAPTURES_ONLY, DEFAULT_NAMED_CAPTURES_ONLY),
-                pluginSetting.getTypedList(KEYS_TO_OVERWRITE, String.class),
-                pluginSetting.getTypedList(PATTERNS_DIRECTORIES, String.class),
-                pluginSetting.getStringOrDefault(PATTERNS_FILES_GLOB, DEFAULT_PATTERNS_FILES_GLOB),
-                pluginSetting.getTypedMap(PATTERN_DEFINITIONS, String.class, String.class),
-                pluginSetting.getIntegerOrDefault(TIMEOUT_MILLIS, DEFAULT_TIMEOUT_MILLIS),
-                pluginSetting.getStringOrDefault(TARGET_KEY, DEFAULT_TARGET_KEY),
-                pluginSetting.getStringOrDefault(GROK_WHEN, null),
-                pluginSetting.getTypedList(TAGS_ON_MATCH_FAILURE, String.class),
-                pluginSetting.getTypedList(TAGS_ON_TIMEOUT, String.class),
-                pluginSetting.getBooleanOrDefault(INCLUDE_PERFORMANCE_METADATA, false));
-    }
+    @JsonProperty(BREAK_ON_MATCH)
+    @JsonPropertyDescription("Specifies under what condition the `grok` processor should perform matching. " +
+            "Default is no condition.")
+    private boolean breakOnMatch = DEFAULT_BREAK_ON_MATCH;
+    @JsonProperty(KEEP_EMPTY_CAPTURES)
+    @JsonPropertyDescription("Enables the preservation of `null` captures from the processed output. Default is `false`.")
+    private boolean keepEmptyCaptures = DEFAULT_KEEP_EMPTY_CAPTURES;
+    @JsonProperty(MATCH)
+    @JsonPropertyDescription("Specifies which keys should match specific patterns. Default is an empty response body.")
+    private Map<String, List<String>> match = Collections.emptyMap();
+    @JsonProperty(NAMED_CAPTURES_ONLY)
+    @JsonPropertyDescription("Specifies whether to keep only named captures. Default is `true`.")
+    private boolean namedCapturesOnly = DEFAULT_NAMED_CAPTURES_ONLY;
+    @JsonProperty(KEYS_TO_OVERWRITE)
+    @JsonPropertyDescription("Specifies which existing keys will be overwritten if there is a capture with the same key value. " +
+            "Default is `[]`.")
+    private List<String> keysToOverwrite = Collections.emptyList();
+    @JsonProperty(PATTERNS_DIRECTORIES)
+    @JsonPropertyDescription("Specifies which directory paths contain the custom pattern files. Default is an empty list.")
+    private List<String> patternsDirectories = Collections.emptyList();
+    @JsonProperty(PATTERNS_FILES_GLOB)
+    @JsonPropertyDescription("Specifies which pattern files to use from the directories specified for " +
+            "`pattern_directories`. Default is `*`.")
+    private String patternsFilesGlob = DEFAULT_PATTERNS_FILES_GLOB;
+    @JsonProperty(PATTERN_DEFINITIONS)
+    @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
+            "Default is an empty response body.")
+    private Map<String, String> patternDefinitions = Collections.emptyMap();
+    @JsonProperty(TIMEOUT_MILLIS)
+    @JsonPropertyDescription("The maximum amount of time during which matching occurs. " +
+            "Setting to `0` prevents any matching from occurring. Default is `30,000`.")
+    private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+    @JsonProperty(TARGET_KEY)
+    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is `null`.")
+    private String targetKey = DEFAULT_TARGET_KEY;
+    @JsonProperty(GROK_WHEN)
+    @JsonPropertyDescription("Specifies under what condition the `grok` processor should perform matching. " +
+            "Default is no condition.")
+    private String grokWhen;
+    @JsonProperty(TAGS_ON_MATCH_FAILURE)
+    @JsonPropertyDescription("A `List` of `String`s that specifies the tags to be set in the event when grok fails to " +
+            "match or an unknown exception occurs while matching. This tag may be used in conditional expressions in " +
+            "other parts of the configuration")
+    private List<String> tagsOnMatchFailure = Collections.emptyList();
+    @JsonProperty(TAGS_ON_TIMEOUT)
+    @JsonPropertyDescription("A `List` of `String`s that specifies the tags to be set in the event when grok match times out.")
+    private List<String> tagsOnTimeout = Collections.emptyList();
+    @JsonProperty(INCLUDE_PERFORMANCE_METADATA)
+    @JsonPropertyDescription("A `Boolean` on whether to include performance metadata into event metadata, " +
+            "e.g. _total_grok_patterns_attempted, _total_grok_processing_time.")
+    private boolean includePerformanceMetadata = false;
 
     public boolean isBreakOnMatch() {
         return breakOnMatch;

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -42,8 +42,8 @@ public class GrokProcessorConfig {
     static final String DEFAULT_TARGET_KEY = null;
 
     @JsonProperty(BREAK_ON_MATCH)
-    @JsonPropertyDescription("Specifies whether to match all patterns (`true`) or stop once the first successful " +
-            "match is found (`false`). Default is `true`.")
+    @JsonPropertyDescription("Specifies whether to match all patterns (`false`) or stop once the first successful " +
+            "match is found (`true`). Default is `true`.")
     private boolean breakOnMatch = DEFAULT_BREAK_ON_MATCH;
     @JsonProperty(KEEP_EMPTY_CAPTURES)
     @JsonPropertyDescription("Enables the preservation of `null` captures from the processed output. Default is `false`.")

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -42,8 +42,8 @@ public class GrokProcessorConfig {
     static final String DEFAULT_TARGET_KEY = null;
 
     @JsonProperty(BREAK_ON_MATCH)
-    @JsonPropertyDescription("Specifies under what condition the `grok` processor should perform matching. " +
-            "Default is no condition.")
+    @JsonPropertyDescription("Specifies whether to match all patterns (`true`) or stop once the first successful " +
+            "match is found (`false`). Default is `true`.")
     private boolean breakOnMatch = DEFAULT_BREAK_ON_MATCH;
     @JsonProperty(KEEP_EMPTY_CAPTURES)
     @JsonPropertyDescription("Enables the preservation of `null` captures from the processed output. Default is `false`.")

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.grok;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import static org.opensearch.dataprepper.plugins.processor.grok.GrokProcessorCon
 import static org.opensearch.dataprepper.plugins.processor.grok.GrokProcessorConfig.DEFAULT_TIMEOUT_MILLIS;
 
 public class GrokProcessorConfigTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String PLUGIN_NAME = "grok";
 
     private static final Map<String, List<String>> TEST_MATCH = new HashMap<>();
@@ -62,7 +64,8 @@ public class GrokProcessorConfigTests {
 
     @Test
     public void testDefault() {
-        final GrokProcessorConfig grokProcessorConfig = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME, null));
+        final GrokProcessorConfig grokProcessorConfig = OBJECT_MAPPER.convertValue(
+                Collections.emptyMap(), GrokProcessorConfig.class);
 
         assertThat(grokProcessorConfig.isBreakOnMatch(), equalTo(DEFAULT_BREAK_ON_MATCH));
         assertThat(grokProcessorConfig.isKeepEmptyCaptures(), equalTo(DEFAULT_KEEP_EMPTY_CAPTURES));
@@ -95,7 +98,8 @@ public class GrokProcessorConfigTests {
                 TEST_TARGET_KEY,
                 true);
 
-        final GrokProcessorConfig grokProcessorConfig = GrokProcessorConfig.buildConfig(validPluginSetting);
+        final GrokProcessorConfig grokProcessorConfig = OBJECT_MAPPER.convertValue(
+                validPluginSetting.getSettings(), GrokProcessorConfig.class);
 
         assertThat(grokProcessorConfig.isBreakOnMatch(), equalTo(false));
         assertThat(grokProcessorConfig.isKeepEmptyCaptures(), equalTo(true));
@@ -127,7 +131,8 @@ public class GrokProcessorConfigTests {
 
         invalidPluginSetting.getSettings().put(GrokProcessorConfig.MATCH, TEST_INVALID_MATCH);
 
-        assertThrows(IllegalArgumentException.class, () -> GrokProcessorConfig.buildConfig(invalidPluginSetting));
+        assertThrows(IllegalArgumentException.class, () -> OBJECT_MAPPER.convertValue(
+                invalidPluginSetting.getSettings(), GrokProcessorConfig.class));
     }
 
     private PluginSetting completePluginSettingForGrokProcessor(final boolean breakOnMatch,
@@ -160,33 +165,22 @@ public class GrokProcessorConfigTests {
     @Test
     void getTagsOnMatchFailure_returns_tagOnMatch() {
         final List<String> tagsOnMatch = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
-                Map.of(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch)
-        ));
+        final GrokProcessorConfig objectUnderTest = OBJECT_MAPPER.convertValue(
+                Map.of(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch), GrokProcessorConfig.class);
 
         assertThat(objectUnderTest.getTagsOnMatchFailure(), equalTo(tagsOnMatch));
-    }
-
-    @Test
-    void getTagsOnTimeout_returns_tagsOnMatch_if_no_tagsOnTimeout() {
-        final List<String> tagsOnMatch = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
-                Map.of(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch)
-        ));
-
-        assertThat(objectUnderTest.getTagsOnTimeout(), equalTo(tagsOnMatch));
     }
 
     @Test
     void getTagsOnTimeout_returns_tagsOnTimeout_if_present() {
         final List<String> tagsOnMatch = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         final List<String> tagsOnTimeout = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
+        final GrokProcessorConfig objectUnderTest = OBJECT_MAPPER.convertValue(
                 Map.of(
                         GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch,
                         GrokProcessorConfig.TAGS_ON_TIMEOUT, tagsOnTimeout
-                )
-        ));
+                ),
+                GrokProcessorConfig.class);
 
         assertThat(objectUnderTest.getTagsOnTimeout(), equalTo(tagsOnTimeout));
     }
@@ -194,9 +188,8 @@ public class GrokProcessorConfigTests {
     @Test
     void getTagsOnTimeout_returns_tagsOnTimeout_if_present_and_no_tagsOnMatch() {
         final List<String> tagsOnTimeout = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
-                Map.of(GrokProcessorConfig.TAGS_ON_TIMEOUT, tagsOnTimeout)
-        ));
+        final GrokProcessorConfig objectUnderTest = OBJECT_MAPPER.convertValue(
+                Map.of(GrokProcessorConfig.TAGS_ON_TIMEOUT, tagsOnTimeout), GrokProcessorConfig.class);
 
         assertThat(objectUnderTest.getTagsOnTimeout(), equalTo(tagsOnTimeout));
     }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorIT.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorIT.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -38,6 +39,8 @@ import static org.opensearch.dataprepper.plugins.processor.grok.GrokProcessorTes
 
 public class GrokProcessorIT {
     private PluginSetting pluginSetting;
+    private PluginMetrics pluginMetrics;
+    private GrokProcessorConfig grokProcessorConfig;
     private GrokProcessor grokProcessor;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
@@ -65,6 +68,8 @@ public class GrokProcessorIT {
                 null);
 
         pluginSetting.setPipelineName("grokPipeline");
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
 
         // This is a COMMONAPACHELOG pattern with the following format
         // COMMONAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
@@ -115,7 +120,8 @@ public class GrokProcessorIT {
         matchConfig.put("bad_key", Collections.singletonList(nonMatchingPattern));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
@@ -135,7 +141,8 @@ public class GrokProcessorIT {
         matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
@@ -173,7 +180,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.BREAK_ON_MATCH, false);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
@@ -208,7 +216,8 @@ public class GrokProcessorIT {
         matchConfig.put("message", Collections.singletonList("\"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response:int} (?:%{NUMBER:bytes:float}|-)"));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
@@ -240,7 +249,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.BREAK_ON_MATCH, false);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
@@ -278,7 +288,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.KEEP_EMPTY_CAPTURES, true);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
@@ -314,7 +325,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.NAMED_CAPTURES_ONLY, false);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "This is my greedy data before matching 192.0.2.1 123456");
@@ -346,7 +358,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.PATTERN_DEFINITIONS, patternDefinitions);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "This is my greedy data before matching with my phone number 123-456-789");
@@ -389,7 +402,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
@@ -422,7 +436,8 @@ public class GrokProcessorIT {
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
         pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_FILES_GLOB, "*1.txt");
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
@@ -436,8 +451,10 @@ public class GrokProcessorIT {
         matchConfigWithPatterns2Pattern.put("message", Collections.singletonList("My birthday is %{CUSTOMBIRTHDAYPATTERN:my_birthday}"));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfigWithPatterns2Pattern);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
 
-        Throwable throwable = assertThrows(IllegalArgumentException.class, () -> new GrokProcessor(pluginSetting, expressionEvaluator));
+        Throwable throwable = assertThrows(IllegalArgumentException.class, () -> new GrokProcessor(
+                pluginMetrics, grokProcessorConfig, expressionEvaluator));
         assertThat("No definition for key 'CUSTOMBIRTHDAYPATTERN' found, aborting", equalTo(throwable.getMessage()));
     }
 
@@ -447,7 +464,8 @@ public class GrokProcessorIT {
         matchConfig.put("message", Collections.singletonList("%{GREEDYDATA:greedy_data} (?<mynumber>\\d\\d\\d-\\d\\d\\d-\\d\\d\\d)"));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "This is my greedy data before matching with my phone number 123-456-789");
@@ -477,7 +495,8 @@ public class GrokProcessorIT {
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
         pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, List.of(tagOnMatchFailure1, tagOnMatchFailure2));
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("log", "This is my greedy data before matching with my phone number 123-456-789");
@@ -495,14 +514,16 @@ public class GrokProcessorIT {
     @Test
     public void testCompileNonRegisteredPatternThrowsIllegalArgumentException() {
 
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, List<String>> matchConfig = new HashMap<>();
         matchConfig.put("message", Collections.singletonList("%{NONEXISTENTPATTERN}"));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
 
-        assertThrows(IllegalArgumentException.class, () -> new GrokProcessor(pluginSetting, expressionEvaluator));
+        assertThrows(IllegalArgumentException.class, () -> new GrokProcessor(
+                pluginMetrics, grokProcessorConfig, expressionEvaluator));
     }
 
     @ParameterizedTest
@@ -512,7 +533,8 @@ public class GrokProcessorIT {
         matchConfig.put("message", Collections.singletonList(matchPattern));
 
         pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessor = new GrokProcessor(pluginSetting, expressionEvaluator);
+        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap();
         testData.put("message", logInput);

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -20,11 +20,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
@@ -52,7 +50,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -109,23 +106,22 @@ public class GrokProcessorTests {
 
     @Mock
     private ExpressionEvaluator expressionEvaluator;
-
-    private PluginSetting pluginSetting;
+    @Mock
+    private GrokProcessorConfig grokProcessorConfig;
     private final String PLUGIN_NAME = "grok";
     private Map<String, Object> capture;
     private final Map<String, List<String>> matchConfig = new HashMap<>();
 
     @BeforeEach
     public void setup() throws TimeoutException, ExecutionException, InterruptedException {
-        pluginSetting = getDefaultPluginSetting();
-        pluginSetting.setPipelineName("grokPipeline");
+        configureDefaultGrokProcessorConfig();
 
         final List<String> matchPatterns = new ArrayList<>();
         matchPatterns.add("%{PATTERN1}");
         matchPatterns.add("%{PATTERN2}");
         matchConfig.put("message", matchPatterns);
 
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
+        when(grokProcessorConfig.getMatch()).thenReturn(matchConfig);
 
         lenient().when(pluginMetrics.counter(GrokProcessor.GROK_PROCESSING_MATCH)).thenReturn(grokProcessingMatchCounter);
         lenient().when(pluginMetrics.counter(GrokProcessor.GROK_PROCESSING_MISMATCH)).thenReturn(grokProcessingMismatchCounter);
@@ -155,15 +151,13 @@ public class GrokProcessorTests {
     }
 
     private GrokProcessor createObjectUnderTest() {
-        try (MockedStatic<PluginMetrics> pluginMetricsMockedStatic = mockStatic(PluginMetrics.class)) {
-            pluginMetricsMockedStatic.when(() -> PluginMetrics.fromPluginSetting(pluginSetting)).thenReturn(pluginMetrics);
-            return new GrokProcessor(pluginSetting, grokCompiler, executorService, expressionEvaluator);
-        }
+        return new GrokProcessor(
+                pluginMetrics, grokProcessorConfig, grokCompiler, executorService, expressionEvaluator);
     }
 
     @Test
     public void testMatchMerge() throws JsonProcessingException, ExecutionException, InterruptedException, TimeoutException {
-        pluginSetting.getSettings().put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, false);
+        when(grokProcessorConfig.getIncludePerformanceMetadata()).thenReturn(false);
 
         grokProcessor = createObjectUnderTest();
 
@@ -202,7 +196,7 @@ public class GrokProcessorTests {
 
     @Test
     public void testTarget() throws JsonProcessingException, ExecutionException, InterruptedException, TimeoutException {
-        pluginSetting.getSettings().put(GrokProcessorConfig.TARGET_KEY, "test_target");
+        when(grokProcessorConfig.getTargetKey()).thenReturn("test_target");
         grokProcessor = createObjectUnderTest();
 
         capture.put("key_capture_1", "value_capture_1");
@@ -238,7 +232,7 @@ public class GrokProcessorTests {
 
     @Test
     public void testOverwrite() throws JsonProcessingException {
-        pluginSetting.getSettings().put(GrokProcessorConfig.KEYS_TO_OVERWRITE, Collections.singletonList("message"));
+        when(grokProcessorConfig.getkeysToOverwrite()).thenReturn(Collections.singletonList("message"));
         grokProcessor = createObjectUnderTest();
 
         capture.put("key_capture_1", "value_capture_1");
@@ -423,7 +417,7 @@ public class GrokProcessorTests {
 
     @Test
     public void testThatProcessingWithTimeoutMillisOfZeroDoesNotInteractWithExecutorServiceAndReturnsCorrectResult() throws JsonProcessingException {
-        pluginSetting.getSettings().put(GrokProcessorConfig.TIMEOUT_MILLIS, 0);
+        when(grokProcessorConfig.getTimeoutMillis()).thenReturn(0);
         grokProcessor = createObjectUnderTest();
 
         capture.put("key_capture_1", "value_capture_1");
@@ -528,7 +522,7 @@ public class GrokProcessorTests {
 
         @Test
         public void testMatchOnSecondPattern() throws JsonProcessingException {
-            pluginSetting.getSettings().put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, true);
+            when(grokProcessorConfig.getIncludePerformanceMetadata()).thenReturn(true);
 
             when(match.capture()).thenReturn(Collections.emptyMap());
             when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
@@ -556,7 +550,7 @@ public class GrokProcessorTests {
 
         @Test
         public void testMatchOnSecondPatternWithExistingMetadataForTotalPatternMatches() throws JsonProcessingException {
-            pluginSetting.getSettings().put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, true);
+            when(grokProcessorConfig.getIncludePerformanceMetadata()).thenReturn(true);
 
             when(match.capture()).thenReturn(Collections.emptyMap());
             when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
@@ -598,8 +592,10 @@ public class GrokProcessorTests {
                 tagOnMatchFailure2 = UUID.randomUUID().toString();
                 tagOnTimeout1 = UUID.randomUUID().toString();
                 tagOnTimeout2 = UUID.randomUUID().toString();
-                pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, List.of(tagOnMatchFailure1, tagOnMatchFailure2));
-                pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_TIMEOUT, List.of(tagOnTimeout1, tagOnTimeout2));
+                when(grokProcessorConfig.getTagsOnMatchFailure()).thenReturn(
+                        List.of(tagOnMatchFailure1, tagOnMatchFailure2));
+                when(grokProcessorConfig.getTagsOnTimeout()).thenReturn(
+                        List.of(tagOnTimeout1, tagOnTimeout2));
             }
 
             @Test
@@ -649,6 +645,34 @@ public class GrokProcessorTests {
                 assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnTimeout2));
                 assertThat(record.getData().getMetadata().getTags(), not(hasItem(tagOnMatchFailure1)));
                 assertThat(record.getData().getMetadata().getTags(), not(hasItem(tagOnMatchFailure2)));
+                verify(grokProcessingTimeoutsCounter, times(1)).increment();
+                verify(grokProcessingTime, times(1)).record(any(Runnable.class));
+                verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMismatchCounter);
+            }
+
+            @Test
+            public void timeout_exception_tags_the_event_with_tags_on_match_failure()
+                    throws JsonProcessingException, TimeoutException, ExecutionException, InterruptedException {
+                when(grokProcessorConfig.getTagsOnTimeout()).thenReturn(Collections.emptyList());
+                when(task.get(GrokProcessorConfig.DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).thenThrow(TimeoutException.class);
+
+                grokProcessor = createObjectUnderTest();
+
+                capture.put("key_capture_1", "value_capture_1");
+                capture.put("key_capture_2", "value_capture_2");
+                capture.put("key_capture_3", "value_capture_3");
+
+                final Map<String, Object> testData = new HashMap();
+                testData.put("message", messageInput);
+                final Record<Event> record = buildRecordWithEvent(testData);
+
+                final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+
+                assertThat(grokkedRecords.size(), equalTo(1));
+                assertThat(grokkedRecords.get(0), notNullValue());
+                assertRecordsAreEqual(grokkedRecords.get(0), record);
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure1));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure2));
                 verify(grokProcessingTimeoutsCounter, times(1)).increment();
                 verify(grokProcessingTime, times(1)).record(any(Runnable.class));
                 verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMismatchCounter);
@@ -720,7 +744,7 @@ public class GrokProcessorTests {
 
         @Test
         public void testBreakOnMatchFalse() throws JsonProcessingException {
-            pluginSetting.getSettings().put(GrokProcessorConfig.BREAK_ON_MATCH, false);
+            when(grokProcessorConfig.isBreakOnMatch()).thenReturn(false);
             grokProcessor = createObjectUnderTest();
 
             when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
@@ -756,10 +780,8 @@ public class GrokProcessorTests {
         }
     }
 
-    private PluginSetting getDefaultPluginSetting() {
-
-        return completePluginSettingForGrokProcessor(
-                GrokProcessorConfig.DEFAULT_BREAK_ON_MATCH,
+    private void configureDefaultGrokProcessorConfig() {
+        completeMockGrokProcessorConfig(GrokProcessorConfig.DEFAULT_BREAK_ON_MATCH,
                 GrokProcessorConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
                 matchConfig,
                 GrokProcessorConfig.DEFAULT_NAMED_CAPTURES_ONLY,
@@ -775,7 +797,7 @@ public class GrokProcessorTests {
     @Test
     public void testNoGrok_when_GrokWhen_returns_false() throws JsonProcessingException {
         final String grokWhen = UUID.randomUUID().toString();
-        pluginSetting.getSettings().put(GrokProcessorConfig.GROK_WHEN, grokWhen);
+        when(grokProcessorConfig.getGrokWhen()).thenReturn(grokWhen);
         grokProcessor = createObjectUnderTest();
 
         capture.put("key_capture_1", "value_capture_1");
@@ -796,31 +818,28 @@ public class GrokProcessorTests {
         verifyNoInteractions(grok, grokSecondMatch);
     }
 
-    private PluginSetting completePluginSettingForGrokProcessor(final boolean breakOnMatch,
-                                                              final boolean keepEmptyCaptures,
-                                                              final Map<String, List<String>> match,
-                                                              final boolean namedCapturesOnly,
-                                                              final List<String> keysToOverwrite,
-                                                              final List<String> patternsDirectories,
-                                                              final String patternsFilesGlob,
-                                                              final Map<String, String> patternDefinitions,
-                                                              final int timeoutMillis,
-                                                              final String targetKey,
-                                                              final String grokWhen) {
-        final Map<String, Object> settings = new HashMap<>();
-        settings.put(GrokProcessorConfig.BREAK_ON_MATCH, breakOnMatch);
-        settings.put(GrokProcessorConfig.NAMED_CAPTURES_ONLY, namedCapturesOnly);
-        settings.put(GrokProcessorConfig.MATCH, match);
-        settings.put(GrokProcessorConfig.KEEP_EMPTY_CAPTURES, keepEmptyCaptures);
-        settings.put(GrokProcessorConfig.KEYS_TO_OVERWRITE, keysToOverwrite);
-        settings.put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
-        settings.put(GrokProcessorConfig.PATTERN_DEFINITIONS, patternDefinitions);
-        settings.put(GrokProcessorConfig.PATTERNS_FILES_GLOB, patternsFilesGlob);
-        settings.put(GrokProcessorConfig.TIMEOUT_MILLIS, timeoutMillis);
-        settings.put(GrokProcessorConfig.TARGET_KEY, targetKey);
-        settings.put(GrokProcessorConfig.GROK_WHEN, grokWhen);
-
-        return new PluginSetting(PLUGIN_NAME, settings);
+    private void completeMockGrokProcessorConfig(final boolean breakOnMatch,
+                                                 final boolean keepEmptyCaptures,
+                                                 final Map<String, List<String>> match,
+                                                 final boolean namedCapturesOnly,
+                                                 final List<String> keysToOverwrite,
+                                                 final List<String> patternsDirectories,
+                                                 final String patternsFilesGlob,
+                                                 final Map<String, String> patternDefinitions,
+                                                 final int timeoutMillis,
+                                                 final String targetKey,
+                                                 final String grokWhen) {
+        lenient().when(grokProcessorConfig.isBreakOnMatch()).thenReturn(breakOnMatch);
+        lenient().when(grokProcessorConfig.isNamedCapturesOnly()).thenReturn(namedCapturesOnly);
+        lenient().when(grokProcessorConfig.getMatch()).thenReturn(match);
+        lenient().when(grokProcessorConfig.isKeepEmptyCaptures()).thenReturn(keepEmptyCaptures);
+        lenient().when(grokProcessorConfig.getkeysToOverwrite()).thenReturn(keysToOverwrite);
+        lenient().when(grokProcessorConfig.getPatternsDirectories()).thenReturn(patternsDirectories);
+        lenient().when(grokProcessorConfig.getPatternDefinitions()).thenReturn(patternDefinitions);
+        lenient().when(grokProcessorConfig.getPatternsFilesGlob()).thenReturn(patternsFilesGlob);
+        lenient().when(grokProcessorConfig.getTimeoutMillis()).thenReturn(timeoutMillis);
+        lenient().when(grokProcessorConfig.getTargetKey()).thenReturn(targetKey);
+        lenient().when(grokProcessorConfig.getGrokWhen()).thenReturn(grokWhen);
     }
 
      private void assertRecordsAreEqual(final Record<Event> first, final Record<Event> second) throws JsonProcessingException {


### PR DESCRIPTION
### Description
This PR 
* refactors grok processor to use latest config model
* backfill plugin config table in the documentation into @JsonPropertyDescription in GrokProcessorConfig
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
