### PR TITLE
REF: service-map processor with the latest config model

### DIFF
--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -19,6 +19,7 @@ dependencies {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
     implementation libs.protobuf.core
+    testImplementation project(':data-prepper-test-common')
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
@@ -5,8 +5,20 @@
 
 package org.opensearch.dataprepper.plugins.processor;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 public class ServiceMapProcessorConfig {
     static final String WINDOW_DURATION = "window_duration";
     static final int DEFAULT_WINDOW_DURATION = 180;
     static final String DEFAULT_DB_PATH = "data/service-map/";
+
+    @JsonProperty(WINDOW_DURATION)
+    @JsonPropertyDescription("Represents the fixed time window, in seconds, " +
+            "during which service map relationships are evaluated. Default value is 180.")
+    private int windowDuration = DEFAULT_WINDOW_DURATION;
+
+    public int getWindowDuration() {
+        return windowDuration;
+    }
 }

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class ServiceMapProcessorConfig {
-    static final String WINDOW_DURATION = "window_duration";
+    private static final String WINDOW_DURATION = "window_duration";
     static final int DEFAULT_WINDOW_DURATION = 180;
     static final String DEFAULT_DB_PATH = "data/service-map/";
 

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
@@ -11,7 +11,6 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.annotations.SingleThread;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.peerforwarder.RequiresPeerForwarding;

--- a/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfigTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfigTest.java
@@ -1,0 +1,38 @@
+package org.opensearch.dataprepper.plugins.processor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
+
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.plugins.processor.ServiceMapProcessorConfig.DEFAULT_WINDOW_DURATION;
+
+class ServiceMapProcessorConfigTest {
+    private ServiceMapProcessorConfig serviceMapProcessorConfig;
+    Random random;
+
+    @BeforeEach
+    void setUp() {
+        serviceMapProcessorConfig = new ServiceMapProcessorConfig();
+        random = new Random();
+    }
+
+    @Test
+    void testDefaultConfig() {
+        assertThat(serviceMapProcessorConfig.getWindowDuration(), equalTo(DEFAULT_WINDOW_DURATION));
+    }
+
+    @Test
+    void testGetter() throws NoSuchFieldException, IllegalAccessException {
+        final int windowDuration = 1 + random.nextInt(300);
+        ReflectivelySetField.setField(
+                ServiceMapProcessorConfig.class,
+                serviceMapProcessorConfig,
+                "windowDuration",
+                windowDuration);
+        assertThat(serviceMapProcessorConfig.getWindowDuration(), equalTo(windowDuration));
+    }
+}


### PR DESCRIPTION
### Description
This PR

* refactors service-map processor to use latest config model
* backfill plugin config table in the documentation into @JsonPropertyDescription in ServiceMapProcessorConfig
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
