### PR TITLE
Corrects the TRIAGING.md with a video meeting text

### DIFF
--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -19,7 +19,7 @@ However, should we run out of time before your issue is discussed, you are alway
 Meetings are hosted regularly Tuesdays at 2:30 PM US Central Time (12:30 PM Pacific Time) and can be joined via the links posted on the [OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events.
 The event will be titled `Data Prepper Triage Meeting`.
 
-After joining the Zoom meeting, you can enable your video / voice to join the discussion.
+After joining the video meeting, you can enable your video / voice to join the discussion.
 If you do not have a webcam or microphone available, you can still join in via the text chat.
 
 If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to everyone in the meeting.


### PR DESCRIPTION
### Description

The current text says "Zoom meeting," but we actually use Chime. I changed this to "video meeting" so that we don't have to keep changing it. We'll have the meeting information in the Meetup.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
