### PR TITLE
Adds the hold_forever sink which will not release EventHandles

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/HoldForeverSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/HoldForeverSink.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A sink for testing purposes. It will hold data forever, which can be useful for
+ * testing situations where data does not depart from Data Prepper.
+ */
+@DataPrepperPlugin(name = "hold_forever", pluginType = Sink.class, pluginConfigurationType = HoldForeverSink.HoldForeverSinkConfig.class)
+public class HoldForeverSink implements Sink<Record<?>> {
+    private static final Logger LOG = LoggerFactory.getLogger(HoldForeverSink.class);
+
+    private final AtomicLong recordsHeld = new AtomicLong(0);
+    private final HoldForeverSinkConfig holdForeverSinkConfig;
+    private final ReentrantLock lock;
+    private Instant nextOutputTime;
+
+    @DataPrepperPluginConstructor
+    public HoldForeverSink(final HoldForeverSinkConfig holdForeverSinkConfig) {
+        this.holdForeverSinkConfig = holdForeverSinkConfig;
+        nextOutputTime = calculateNextOutputTime();
+        lock = new ReentrantLock(true);
+        LOG.warn("You are using the hold_forever sink which will not release events for acknowledgments. This is intended for testing, debugging, and experimenting only.");
+    }
+
+    @Override
+    public void output(final Collection<Record<?>> records) {
+        final long recordsHeldNow = recordsHeld.addAndGet(records.size());
+
+        final boolean logThisIteration;
+        lock.lock();
+        try {
+            if (Instant.now().isAfter(nextOutputTime)) {
+                logThisIteration = true;
+                nextOutputTime = calculateNextOutputTime();
+            } else {
+                logThisIteration = false;
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        if(logThisIteration) {
+            LOG.info("Hold forever has {} records", recordsHeldNow);
+        }
+    }
+
+    private Instant calculateNextOutputTime() {
+        return Instant.now().plus(holdForeverSinkConfig.getOutputFrequency());
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public void initialize() {
+
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    public static class HoldForeverSinkConfig {
+        @JsonProperty("output_frequency")
+        @JsonPropertyDescription("This sink will log how many records it is holding. This determines the frequency of the logging.")
+        private Duration outputFrequency = Duration.of(2, ChronoUnit.MINUTES);
+
+        public Duration getOutputFrequency() {
+            return outputFrequency;
+        }
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/HoldForeverSinkTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/HoldForeverSinkTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HoldForeverSinkTest {
+    @Mock
+    private HoldForeverSink.HoldForeverSinkConfig sinkConfig;
+    private List<Event> events;
+    private List<Record<Event>> records;
+
+    @BeforeEach
+    void setUp() {
+        when(sinkConfig.getOutputFrequency()).thenReturn(Duration.ZERO);
+
+        events = IntStream.range(0, 3)
+                .mapToObj(i -> mock(Event.class))
+                .collect(Collectors.toList());
+        records = events.stream()
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+    }
+
+    private HoldForeverSink createObjectUnderTest() {
+        return new HoldForeverSink(sinkConfig);
+    }
+
+    @Test
+    void output_should_not_release_when_logging() throws InterruptedException {
+        Thread.sleep(50);
+
+        createObjectUnderTest().output((Collection) records);
+
+        for (final Event event : events) {
+            verify(event, never()).getEventHandle();
+        }
+    }
+
+    @Test
+    void output_should_not_release_when_not_logging() {
+        reset(sinkConfig);
+        when(sinkConfig.getOutputFrequency()).thenReturn(Duration.ofDays(30));
+
+        createObjectUnderTest().output((Collection) records);
+
+        for (final Event event : events) {
+            verify(event, never()).getEventHandle();
+        }
+    }
+
+    @Test
+    void isReady_returns_true() {
+        assertThat(createObjectUnderTest().isReady(), equalTo(true));
+    }
+
+    @Test
+    void initialize_is_ok() {
+        createObjectUnderTest().initialize();
+    }
+
+    @Test
+    void shutdown_is_ok() {
+        createObjectUnderTest().shutdown();
+    }
+}


### PR DESCRIPTION
### Description

Adds a new sink - `hold_forever`. I've been using this for testing and debugging. So I think it would be useful to make it generally available.
 
### Issues Resolved

Resolves #4737
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
