### PR TITLE
Correct SQS shutdown to avoid crashes

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.plugins.source.s3.S3EventNotification;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ParsedMessage {
     private final Message message;
@@ -24,14 +25,14 @@ public class ParsedMessage {
     private String detailType;
 
     public ParsedMessage(final Message message, final boolean failedParsing) {
-        this.message = message;
+        this.message = Objects.requireNonNull(message);
         this.failedParsing = failedParsing;
         this.emptyNotification = true;
     }
 
-    // S3EventNotification contains only one S3EventNotificationRecord
      ParsedMessage(final Message message, final List<S3EventNotification.S3EventNotificationRecord> notificationRecords) {
-        this.message = message;
+        this.message = Objects.requireNonNull(message);
+         // S3EventNotification contains only one S3EventNotificationRecord
         this.bucketName = notificationRecords.get(0).getS3().getBucket().getName();
         this.objectKey = notificationRecords.get(0).getS3().getObject().getUrlDecodedKey();
         this.objectSize = notificationRecords.get(0).getS3().getObject().getSizeAsLong();
@@ -42,7 +43,7 @@ public class ParsedMessage {
     }
 
     ParsedMessage(final Message message, final S3EventBridgeNotification eventBridgeNotification) {
-        this.message = message;
+        this.message = Objects.requireNonNull(message);
         this.bucketName = eventBridgeNotification.getDetail().getBucket().getName();
         this.objectKey = eventBridgeNotification.getDetail().getObject().getUrlDecodedKey();
         this.objectSize = eventBridgeNotification.getDetail().getObject().getSize();
@@ -84,5 +85,13 @@ public class ParsedMessage {
 
     public String getDetailType() {
         return detailType;
+    }
+
+    @Override
+    public String toString() {
+        return "Message{" +
+                "messageId=" + message.messageId() +
+                ", objectKey=" + objectKey +
+                '}';
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/SqsMessageParser.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/SqsMessageParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.s3.parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.plugins.source.s3.S3SourceConfig;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class SqsMessageParser {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final S3SourceConfig s3SourceConfig;
+    private final S3NotificationParser s3NotificationParser;
+
+    public SqsMessageParser(final S3SourceConfig s3SourceConfig) {
+        this.s3SourceConfig = s3SourceConfig;
+        s3NotificationParser = createNotificationParser(s3SourceConfig);
+    }
+
+    public Collection<ParsedMessage> parseSqsMessages(final Collection<Message> sqsMessages) {
+        return sqsMessages.stream()
+                .map(this::convertS3EventMessages)
+                .collect(Collectors.toList());
+    }
+
+    private ParsedMessage convertS3EventMessages(final Message message) {
+        return s3NotificationParser.parseMessage(message, OBJECT_MAPPER);
+    }
+
+    private static S3NotificationParser createNotificationParser(final S3SourceConfig s3SourceConfig) {
+        switch (s3SourceConfig.getNotificationSource()) {
+            case EVENTBRIDGE:
+                return new S3EventBridgeNotificationParser();
+            case S3:
+            default:
+                return new S3EventNotificationParser();
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.s3.parser;
 
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.source.s3.S3EventBridgeNotification;
 import org.opensearch.dataprepper.plugins.source.s3.S3EventNotification;
@@ -12,33 +13,31 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ParsedMessageTest {
     private static final Random RANDOM = new Random();
     private Message message;
-    private S3EventNotification.S3Entity s3Entity;
-    private S3EventNotification.S3BucketEntity s3BucketEntity;
-    private S3EventNotification.S3ObjectEntity s3ObjectEntity;
-    private S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord;
-    private S3EventBridgeNotification s3EventBridgeNotification;
-    private S3EventBridgeNotification.Detail detail;
-    private S3EventBridgeNotification.Bucket bucket;
-    private S3EventBridgeNotification.Object object;
+    private String testBucketName;
+    private String testDecodedObjectKey;
+    private long testSize;
 
     @BeforeEach
     void setUp() {
         message = mock(Message.class);
-        s3Entity = mock(S3EventNotification.S3Entity.class);
-        s3BucketEntity = mock(S3EventNotification.S3BucketEntity.class);
-        s3ObjectEntity = mock(S3EventNotification.S3ObjectEntity.class);
-        s3EventNotificationRecord = mock(S3EventNotification.S3EventNotificationRecord.class);
-        s3EventBridgeNotification = mock(S3EventBridgeNotification.class);
-        detail = mock(S3EventBridgeNotification.Detail.class);
-        bucket = mock(S3EventBridgeNotification.Bucket.class);
-        object = mock(S3EventBridgeNotification.Object.class);
+        testBucketName = UUID.randomUUID().toString();
+        testDecodedObjectKey = UUID.randomUUID().toString();
+        testSize = RANDOM.nextInt(1_000_000_000) + 1;
+    }
+
+    @Test
+    void constructor_with_failed_parsing_throws_if_Message_is_null() {
+        assertThrows(NullPointerException.class, () -> new ParsedMessage(null, true));
     }
 
     @Test
@@ -50,61 +49,156 @@ class ParsedMessageTest {
     }
 
     @Test
-    void test_parsed_message_with_S3EventNotificationRecord() {
-        final String  testBucketName = UUID.randomUUID().toString();
-        final String  testDecodedObjectKey = UUID.randomUUID().toString();
-        final String  testEventName = UUID.randomUUID().toString();
-        final DateTime testEventTime = DateTime.now();
-        final long testSize = RANDOM.nextLong();
+    void toString_with_failed_parsing_and_messageId() {
+        final String messageId = UUID.randomUUID().toString();
+        when(message.messageId()).thenReturn(messageId);
 
-        when(s3EventNotificationRecord.getS3()).thenReturn(s3Entity);
-        when(s3Entity.getBucket()).thenReturn(s3BucketEntity);
-        when(s3Entity.getObject()).thenReturn(s3ObjectEntity);
-        when(s3ObjectEntity.getSizeAsLong()).thenReturn(testSize);
-        when(s3BucketEntity.getName()).thenReturn(testBucketName);
-        when(s3ObjectEntity.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
-        when(s3EventNotificationRecord.getEventName()).thenReturn(testEventName);
-        when(s3EventNotificationRecord.getEventTime()).thenReturn(testEventTime);
-
-        final ParsedMessage parsedMessage = new ParsedMessage(message, List.of(s3EventNotificationRecord));
-
-        assertThat(parsedMessage.getMessage(), equalTo(message));
-        assertThat(parsedMessage.getBucketName(), equalTo(testBucketName));
-        assertThat(parsedMessage.getObjectKey(), equalTo(testDecodedObjectKey));
-        assertThat(parsedMessage.getObjectSize(), equalTo(testSize));
-        assertThat(parsedMessage.getEventName(), equalTo(testEventName));
-        assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
-        assertThat(parsedMessage.isFailedParsing(), equalTo(false));
-        assertThat(parsedMessage.isEmptyNotification(), equalTo(false));
+        final ParsedMessage parsedMessage = new ParsedMessage(message, true);
+        final String actualString = parsedMessage.toString();
+        assertThat(actualString, notNullValue());
+        assertThat(actualString, containsString(messageId));
     }
 
     @Test
-    void test_parsed_message_with_S3EventBridgeNotification() {
-        final String  testBucketName = UUID.randomUUID().toString();
-        final String  testDecodedObjectKey = UUID.randomUUID().toString();
-        final String  testDetailType = UUID.randomUUID().toString();
-        final DateTime testEventTime = DateTime.now();
-        final int testSize = RANDOM.nextInt();
+    void toString_with_failed_parsing_and_no_messageId() {
+        final ParsedMessage parsedMessage = new ParsedMessage(message, true);
+        final String actualString = parsedMessage.toString();
+        assertThat(actualString, notNullValue());
+    }
 
-        when(s3EventBridgeNotification.getDetail()).thenReturn(detail);
-        when(s3EventBridgeNotification.getDetail().getBucket()).thenReturn(bucket);
-        when(s3EventBridgeNotification.getDetail().getObject()).thenReturn(object);
+    @Nested
+    class WithS3EventNotificationRecord {
+        private S3EventNotification.S3Entity s3Entity;
+        private S3EventNotification.S3BucketEntity s3BucketEntity;
+        private S3EventNotification.S3ObjectEntity s3ObjectEntity;
+        private S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord;
+        private List<S3EventNotification.S3EventNotificationRecord> s3EventNotificationRecords;
+        private String testEventName;
+        private DateTime testEventTime;
 
-        when(bucket.getName()).thenReturn(testBucketName);
-        when(object.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
-        when(object.getSize()).thenReturn(testSize);
-        when(s3EventBridgeNotification.getDetailType()).thenReturn(testDetailType);
-        when(s3EventBridgeNotification.getTime()).thenReturn(testEventTime);
+        @BeforeEach
+        void setUp() {
+            testEventName = UUID.randomUUID().toString();
+            testEventTime = DateTime.now();
 
-        final ParsedMessage parsedMessage = new ParsedMessage(message, s3EventBridgeNotification);
+            s3Entity = mock(S3EventNotification.S3Entity.class);
+            s3BucketEntity = mock(S3EventNotification.S3BucketEntity.class);
+            s3ObjectEntity = mock(S3EventNotification.S3ObjectEntity.class);
+            s3EventNotificationRecord = mock(S3EventNotification.S3EventNotificationRecord.class);
 
-        assertThat(parsedMessage.getMessage(), equalTo(message));
-        assertThat(parsedMessage.getBucketName(), equalTo(testBucketName));
-        assertThat(parsedMessage.getObjectKey(), equalTo(testDecodedObjectKey));
-        assertThat(parsedMessage.getObjectSize(), equalTo((long) testSize));
-        assertThat(parsedMessage.getDetailType(), equalTo(testDetailType));
-        assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
-        assertThat(parsedMessage.isFailedParsing(), equalTo(false));
-        assertThat(parsedMessage.isEmptyNotification(), equalTo(false));
+            when(s3EventNotificationRecord.getS3()).thenReturn(s3Entity);
+            when(s3Entity.getBucket()).thenReturn(s3BucketEntity);
+            when(s3Entity.getObject()).thenReturn(s3ObjectEntity);
+            when(s3ObjectEntity.getSizeAsLong()).thenReturn(testSize);
+            when(s3BucketEntity.getName()).thenReturn(testBucketName);
+            when(s3ObjectEntity.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
+            when(s3EventNotificationRecord.getEventName()).thenReturn(testEventName);
+            when(s3EventNotificationRecord.getEventTime()).thenReturn(testEventTime);
+
+            s3EventNotificationRecords = List.of(s3EventNotificationRecord);
+        }
+
+        private ParsedMessage createObjectUnderTest() {
+            return new ParsedMessage(message, s3EventNotificationRecords);
+        }
+
+        @Test
+        void constructor_with_S3EventNotificationRecord_throws_if_Message_is_null() {
+            message = null;
+            assertThrows(NullPointerException.class, this::createObjectUnderTest);
+        }
+
+        @Test
+        void test_parsed_message_with_S3EventNotificationRecord() {
+            final ParsedMessage parsedMessage = createObjectUnderTest();
+
+            assertThat(parsedMessage.getMessage(), equalTo(message));
+            assertThat(parsedMessage.getBucketName(), equalTo(testBucketName));
+            assertThat(parsedMessage.getObjectKey(), equalTo(testDecodedObjectKey));
+            assertThat(parsedMessage.getObjectSize(), equalTo(testSize));
+            assertThat(parsedMessage.getEventName(), equalTo(testEventName));
+            assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
+            assertThat(parsedMessage.isFailedParsing(), equalTo(false));
+            assertThat(parsedMessage.isEmptyNotification(), equalTo(false));
+        }
+
+        @Test
+        void toString_with_messageId() {
+            final String messageId = UUID.randomUUID().toString();
+            when(message.messageId()).thenReturn(messageId);
+
+            final ParsedMessage parsedMessage = createObjectUnderTest();
+            final String actualString = parsedMessage.toString();
+            assertThat(actualString, notNullValue());
+            assertThat(actualString, containsString(messageId));
+            assertThat(actualString, containsString(testDecodedObjectKey));
+        }
+    }
+
+    @Nested
+    class WithS3EventBridgeNotification {
+        private String testDetailType;
+        private DateTime testEventTime;
+        private S3EventBridgeNotification s3EventBridgeNotification;
+        private S3EventBridgeNotification.Detail detail;
+        private S3EventBridgeNotification.Bucket bucket;
+        private S3EventBridgeNotification.Object object;
+
+        @BeforeEach
+        void setUp() {
+            s3EventBridgeNotification = mock(S3EventBridgeNotification.class);
+            detail = mock(S3EventBridgeNotification.Detail.class);
+            bucket = mock(S3EventBridgeNotification.Bucket.class);
+            object = mock(S3EventBridgeNotification.Object.class);
+
+            testDetailType = UUID.randomUUID().toString();
+            testEventTime = DateTime.now();
+
+            when(s3EventBridgeNotification.getDetail()).thenReturn(detail);
+            when(s3EventBridgeNotification.getDetail().getBucket()).thenReturn(bucket);
+            when(s3EventBridgeNotification.getDetail().getObject()).thenReturn(object);
+
+            when(bucket.getName()).thenReturn(testBucketName);
+            when(object.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
+            when(object.getSize()).thenReturn((int) testSize);
+            when(s3EventBridgeNotification.getDetailType()).thenReturn(testDetailType);
+            when(s3EventBridgeNotification.getTime()).thenReturn(testEventTime);
+        }
+
+        private ParsedMessage createObjectUnderTest() {
+            return new ParsedMessage(message, s3EventBridgeNotification);
+        }
+
+        @Test
+        void constructor_with_S3EventBridgeNotification_throws_if_Message_is_null() {
+            message = null;
+            assertThrows(NullPointerException.class, () -> createObjectUnderTest());
+        }
+
+        @Test
+        void test_parsed_message_with_S3EventBridgeNotification() {
+            final ParsedMessage parsedMessage = createObjectUnderTest();
+
+            assertThat(parsedMessage.getMessage(), equalTo(message));
+            assertThat(parsedMessage.getBucketName(), equalTo(testBucketName));
+            assertThat(parsedMessage.getObjectKey(), equalTo(testDecodedObjectKey));
+            assertThat(parsedMessage.getObjectSize(), equalTo(testSize));
+            assertThat(parsedMessage.getDetailType(), equalTo(testDetailType));
+            assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
+            assertThat(parsedMessage.isFailedParsing(), equalTo(false));
+            assertThat(parsedMessage.isEmptyNotification(), equalTo(false));
+        }
+
+        @Test
+        void toString_with_messageId() {
+            final String messageId = UUID.randomUUID().toString();
+            when(message.messageId()).thenReturn(messageId);
+
+            final ParsedMessage parsedMessage = createObjectUnderTest();
+            final String actualString = parsedMessage.toString();
+            assertThat(actualString, notNullValue());
+            assertThat(actualString, containsString(messageId));
+            assertThat(actualString, containsString(testDecodedObjectKey));
+        }
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventBridgeNotificationParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventBridgeNotificationParserTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 
 class S3EventBridgeNotificationParserTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final String EVENTBRIDGE_MESSAGE = "{\"version\":\"0\",\"id\":\"17793124-05d4-b198-2fde-7ededc63b103\",\"detail-type\":\"Object Created\"," +
+    static final String EVENTBRIDGE_MESSAGE = "{\"version\":\"0\",\"id\":\"17793124-05d4-b198-2fde-7ededc63b103\",\"detail-type\":\"Object Created\"," +
             "\"source\":\"aws.s3\",\"account\":\"111122223333\",\"time\":\"2021-11-12T00:00:00Z\"," +
             "\"region\":\"ca-central-1\",\"resources\":[\"arn:aws:s3:::DOC-EXAMPLE-BUCKET1\"]," +
             "\"detail\":{\"version\":\"0\",\"bucket\":{\"name\":\"DOC-EXAMPLE-BUCKET1\"}," +

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParserTest.java
@@ -16,8 +16,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class S3EventNotificationParserTest {
-    private static final String DIRECT_SQS_MESSAGE =
+public class S3EventNotificationParserTest {
+    static final String DIRECT_SQS_MESSAGE =
             "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\",\"eventTime\":\"2023-04-28T16:00:11.324Z\"," +
                     "\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:xyz\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
                     "\"responseElements\":{\"x-amz-request-id\":\"xyz\",\"x-amz-id-2\":\"xyz\"},\"s3\":{\"s3SchemaVersion\":\"1.0\"," +
@@ -25,7 +25,7 @@ class S3EventNotificationParserTest {
                     "\"arn\":\"arn:aws:s3:::my-bucket\"},\"object\":{\"key\":\"path/to/myfile.log.gz\",\"size\":3159112,\"eTag\":\"abcd123\"," +
                     "\"sequencer\":\"000\"}}}]}";
 
-    private static final String SNS_BASED_MESSAGE = "{\n" +
+    public static final String SNS_BASED_MESSAGE = "{\n" +
             "  \"Type\" : \"Notification\",\n" +
             "  \"MessageId\" : \"4e01e115-5b91-5096-8a74-bee95ed1e123\",\n" +
             "  \"TopicArn\" : \"arn:aws:sns:us-east-1:123456789012:notifications\",\n" +

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/SqsMessageParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/SqsMessageParserTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.s3.parser;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.s3.S3SourceConfig;
+import org.opensearch.dataprepper.plugins.source.s3.configuration.NotificationSourceOption;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SqsMessageParserTest {
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    private SqsMessageParser createObjectUnderTest() {
+        return new SqsMessageParser(s3SourceConfig);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SourceArgumentsProvider.class)
+    void parseSqsMessages_returns_empty_for_empty_messages(final NotificationSourceOption sourceOption) {
+        when(s3SourceConfig.getNotificationSource()).thenReturn(sourceOption);
+        final Collection<ParsedMessage> parsedMessages = createObjectUnderTest().parseSqsMessages(Collections.emptyList());
+
+        assertThat(parsedMessages, notNullValue());
+        assertThat(parsedMessages, empty());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SourceArgumentsProvider.class)
+    void parseSqsMessages_parsed_messages(final NotificationSourceOption sourceOption,
+                                          final String messageBody,
+                                          final String replacementString) {
+        when(s3SourceConfig.getNotificationSource()).thenReturn(sourceOption);
+        final int numberOfMessages = 10;
+        List<Message> messages = IntStream.range(0, numberOfMessages)
+                .mapToObj(i -> messageBody.replaceAll(replacementString, replacementString + i))
+                .map(SqsMessageParserTest::createMockMessage)
+                .collect(Collectors.toList());
+        final Collection<ParsedMessage> parsedMessages = createObjectUnderTest().parseSqsMessages(messages);
+
+        assertThat(parsedMessages, notNullValue());
+        assertThat(parsedMessages.size(), equalTo(numberOfMessages));
+
+        final Set<String> bucketNames = parsedMessages.stream().map(ParsedMessage::getBucketName).collect(Collectors.toSet());
+        assertThat("The bucket names are unique, so the bucketNames should match the numberOfMessages.",
+                bucketNames.size(), equalTo(numberOfMessages));
+    }
+
+    static class SourceArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.arguments(
+                            NotificationSourceOption.S3,
+                            S3EventNotificationParserTest.DIRECT_SQS_MESSAGE,
+                            "my-bucket"),
+                    Arguments.arguments(
+                            NotificationSourceOption.EVENTBRIDGE,
+                            S3EventBridgeNotificationParserTest.EVENTBRIDGE_MESSAGE,
+                            "DOC-EXAMPLE-BUCKET1")
+            );
+        }
+    }
+
+    private static Message createMockMessage(final String body) {
+        final Message message = mock(Message.class);
+        when(message.body()).thenReturn(body);
+        return message;
+    }
+}


### PR DESCRIPTION
### Description

Improve the SQS shutdown process such that it does not prevent the pipeline from shutting down and no longer results in failures. 

The previous approach to shutting down the SQS thread closed the SqsClient. However, with acknowledgments enabled, asynchronous callbacks would result in further attempts to either ChangeVisibilityTimeout or DeleteMessages. These were failing because the client was closed. Also, the threads would remain and prevent Data Prepper from correctly shutting down. With this change, we correctly stop each processing thread. Then we close the client. Additionally, the SqsWorker now checks that it is not stopped before attempting to change the message visibility or delete messages.

Additionally, I found some missing test cases. Also, modifying this code and especially unit testing it is becoming more difficult, so I performed some refactoring to move message parsing out of the SqsWorker.

 
### Issues Resolved

Resolves #4575
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
