### PR TITLE
Fixes HistogramAggregateAction startTime

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -5,56 +5,62 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 
-import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.metric.JacksonMetric;
-import org.opensearch.dataprepper.model.metric.Exemplar;
-import org.junit.jupiter.api.extension.ExtendWith; 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.metric.Exemplar;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionOutput;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionTestUtils;
 
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.apache.commons.lang3.RandomStringUtils;
-
-import java.util.Arrays;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-import java.time.Instant;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 @ExtendWith(MockitoExtension.class)
 public class HistogramAggregateActionTests {
-    AggregateActionInput aggregateActionInput;
-
     private AggregateAction histogramAggregateAction;
+    private HistogramAggregateActionConfig histogramAggregateActionConfig;
 
-    private AggregateAction createObjectUnderTest(HistogramAggregateActionConfig config) {
-        return new HistogramAggregateAction(config);
+    @BeforeEach
+    void setUp() {
+        histogramAggregateActionConfig = new HistogramAggregateActionConfig();
+    }
+
+    private AggregateAction createObjectUnderTest() {
+        return new HistogramAggregateAction(histogramAggregateActionConfig);
     }
 
     @ParameterizedTest
     @ValueSource(ints = {10, 20, 50, 100})
-    void testHistogramAggregate(int testCount) throws NoSuchFieldException, IllegalAccessException {
-        HistogramAggregateActionConfig histogramAggregateActionConfig = new HistogramAggregateActionConfig();
+    void testHistogramAggregate(final int testCount) throws NoSuchFieldException, IllegalAccessException {
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "outputFormat", OutputFormat.RAW.toString());
         final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "generatedKeyPrefix", testKeyPrefix);
@@ -73,7 +79,7 @@ public class HistogramAggregateActionTests {
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", buckets);
         final String testKey = RandomStringUtils.randomAlphabetic(10);
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "key", testKey);
-        histogramAggregateAction = createObjectUnderTest(histogramAggregateActionConfig);
+        histogramAggregateAction = createObjectUnderTest();
         final String dataKey = RandomStringUtils.randomAlphabetic(10);
         final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Collections.emptyMap());
         Long[] expectedBucketCounts = new Long[buckets.size()+1];
@@ -135,8 +141,7 @@ public class HistogramAggregateActionTests {
 
     @ParameterizedTest
     @ValueSource(ints = {10, 20, 50, 100})
-    void testHistogramAggregateOTelFormat(int testCount) throws NoSuchFieldException, IllegalAccessException {
-        HistogramAggregateActionConfig histogramAggregateActionConfig = new HistogramAggregateActionConfig();
+    void testHistogramAggregateOTelFormat(final int testCount) throws NoSuchFieldException, IllegalAccessException {
         final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "generatedKeyPrefix", testKeyPrefix);
         final String testUnits = "ms";
@@ -155,7 +160,7 @@ public class HistogramAggregateActionTests {
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", buckets);
         final String testKey = RandomStringUtils.randomAlphabetic(10);
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "key", testKey);
-        histogramAggregateAction = createObjectUnderTest(histogramAggregateActionConfig);
+        histogramAggregateAction = createObjectUnderTest();
         final String dataKey = RandomStringUtils.randomAlphabetic(10);
         final String dataValue = RandomStringUtils.randomAlphabetic(15);
         final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Map.of(dataKey, dataValue));
@@ -194,8 +199,6 @@ public class HistogramAggregateActionTests {
         final AggregateActionOutput actionOutput = histogramAggregateAction.concludeGroup(aggregateActionInput);
         final List<Event> result = actionOutput.getEvents();
         assertThat(result.size(), equalTo(1));
-        final String expectedCountKey = histogramAggregateActionConfig.getCountKey();
-        final String expectedStartTimeKey = histogramAggregateActionConfig.getStartTimeKey();
         Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
         expectedEventMap.put("unit", testUnits);
         expectedEventMap.put("name", HistogramAggregateActionConfig.HISTOGRAM_METRIC_NAME);
@@ -243,20 +246,20 @@ public class HistogramAggregateActionTests {
 
     @ParameterizedTest
     @ValueSource(ints = {10, 20, 50, 100})
-    void testHistogramAggregateOTelFormatWithStartAndEndTimesInTheEvent(int testCount) throws NoSuchFieldException, IllegalAccessException {
-        HistogramAggregateActionConfig mockConfig = mock(HistogramAggregateActionConfig.class);
+    void testHistogramAggregateOTelFormatWithStartAndEndTimesInTheEvent(final int testCount) {
+        histogramAggregateActionConfig = mock(HistogramAggregateActionConfig.class);
         String startTimeKey = UUID.randomUUID().toString();
         String endTimeKey = UUID.randomUUID().toString();
         final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
-        when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);
-        when(mockConfig.getEndTimeKey()).thenReturn(endTimeKey);
+        when(histogramAggregateActionConfig.getStartTimeKey()).thenReturn(startTimeKey);
+        when(histogramAggregateActionConfig.getEndTimeKey()).thenReturn(endTimeKey);
         final String testName = UUID.randomUUID().toString();
-        when(mockConfig.getMetricName()).thenReturn(testName);
-        when(mockConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
+        when(histogramAggregateActionConfig.getMetricName()).thenReturn(testName);
+        when(histogramAggregateActionConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
         String keyPrefix = UUID.randomUUID().toString();
         final String testUnits = "ms";
-        when(mockConfig.getUnits()).thenReturn(testUnits);
-        when(mockConfig.getRecordMinMax()).thenReturn(true);
+        when(histogramAggregateActionConfig.getUnits()).thenReturn(testUnits);
+        when(histogramAggregateActionConfig.getRecordMinMax()).thenReturn(true);
         final double TEST_VALUE_RANGE_MIN = 0.0;
         final double TEST_VALUE_RANGE_MAX = 6.0;
         final double TEST_VALUE_RANGE_STEP = 2.0;
@@ -267,18 +270,18 @@ public class HistogramAggregateActionTests {
         buckets.add(bucket1);
         buckets.add(bucket2);
         buckets.add(bucket3);
-        when(mockConfig.getBuckets()).thenReturn(buckets);
+        when(histogramAggregateActionConfig.getBuckets()).thenReturn(buckets);
         final String testKey = RandomStringUtils.randomAlphabetic(10);
-        when(mockConfig.getKey()).thenReturn(testKey);
+        when(histogramAggregateActionConfig.getKey()).thenReturn(testKey);
         final String testPrefix = RandomStringUtils.randomAlphabetic(7);
-        when(mockConfig.getSumKey()).thenReturn(testPrefix+"sum");
-        when(mockConfig.getMinKey()).thenReturn(testPrefix+"min");
-        when(mockConfig.getMaxKey()).thenReturn(testPrefix+"max");
-        when(mockConfig.getCountKey()).thenReturn(testPrefix+"count");
-        when(mockConfig.getBucketsKey()).thenReturn(testPrefix+"buckets");
-        when(mockConfig.getBucketCountsKey()).thenReturn(testPrefix+"bucketcounts");
-        when(mockConfig.getDurationKey()).thenReturn(testPrefix+"duration");
-        histogramAggregateAction = createObjectUnderTest(mockConfig);
+        when(histogramAggregateActionConfig.getSumKey()).thenReturn(testPrefix+"sum");
+        when(histogramAggregateActionConfig.getMinKey()).thenReturn(testPrefix+"min");
+        when(histogramAggregateActionConfig.getMaxKey()).thenReturn(testPrefix+"max");
+        when(histogramAggregateActionConfig.getCountKey()).thenReturn(testPrefix+"count");
+        when(histogramAggregateActionConfig.getBucketsKey()).thenReturn(testPrefix+"buckets");
+        when(histogramAggregateActionConfig.getBucketCountsKey()).thenReturn(testPrefix+"bucketcounts");
+        when(histogramAggregateActionConfig.getDurationKey()).thenReturn(testPrefix+"duration");
+        histogramAggregateAction = createObjectUnderTest();
         final String dataKey = RandomStringUtils.randomAlphabetic(10);
         final String dataValue = RandomStringUtils.randomAlphabetic(15);
         final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Map.of(dataKey, dataValue));
@@ -321,8 +324,6 @@ public class HistogramAggregateActionTests {
         final AggregateActionOutput actionOutput = histogramAggregateAction.concludeGroup(aggregateActionInput);
         final List<Event> result = actionOutput.getEvents();
         assertThat(result.size(), equalTo(1));
-        final String expectedCountKey = mockConfig.getCountKey();
-        final String expectedStartTimeKey = mockConfig.getStartTimeKey();
         Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
         expectedEventMap.put("unit", testUnits);
         expectedEventMap.put("name", testName);
@@ -343,7 +344,7 @@ public class HistogramAggregateActionTests {
         List<Exemplar> exemplars = (List <Exemplar>)result.get(0).toMap().get("exemplars");
         assertThat(exemplars.size(), equalTo(2));
         assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(dataKey, dataValue));
-        final String expectedDurationKey = mockConfig.getDurationKey();
+        final String expectedDurationKey = histogramAggregateActionConfig.getDurationKey();
         assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasKey(expectedDurationKey));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
@@ -369,5 +370,83 @@ public class HistogramAggregateActionTests {
 
         assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
         assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(100).toString()));
+    }
+
+    @Test
+    void testHistogramAggregateOTelFormat_with_startTime_before_currentTime_and_all_other_times_after_that_has_the_correct_startTime() {
+        histogramAggregateActionConfig = mock(HistogramAggregateActionConfig.class);
+        String startTimeKey = UUID.randomUUID().toString();
+        String endTimeKey = UUID.randomUUID().toString();
+        when(histogramAggregateActionConfig.getStartTimeKey()).thenReturn(startTimeKey);
+        when(histogramAggregateActionConfig.getEndTimeKey()).thenReturn(endTimeKey);
+        final String testName = UUID.randomUUID().toString();
+        when(histogramAggregateActionConfig.getMetricName()).thenReturn(testName);
+        when(histogramAggregateActionConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
+        final String testUnits = "ms";
+        when(histogramAggregateActionConfig.getUnits()).thenReturn(testUnits);
+        when(histogramAggregateActionConfig.getRecordMinMax()).thenReturn(true);
+        final double TEST_VALUE_RANGE_MIN = 0.0;
+        final double TEST_VALUE_RANGE_MAX = 6.0;
+        final double TEST_VALUE_RANGE_STEP = 2.0;
+        final double bucket1 = TEST_VALUE_RANGE_MIN;
+        final double bucket2 = bucket1 + TEST_VALUE_RANGE_STEP;
+        final double bucket3 = bucket2 + TEST_VALUE_RANGE_STEP;
+        List<Number> buckets = new ArrayList<Number>();
+        buckets.add(bucket1);
+        buckets.add(bucket2);
+        buckets.add(bucket3);
+        when(histogramAggregateActionConfig.getBuckets()).thenReturn(buckets);
+        final String testKey = RandomStringUtils.randomAlphabetic(10);
+        when(histogramAggregateActionConfig.getKey()).thenReturn(testKey);
+        final String testPrefix = RandomStringUtils.randomAlphabetic(7);
+        when(histogramAggregateActionConfig.getSumKey()).thenReturn(testPrefix+"sum");
+        when(histogramAggregateActionConfig.getMinKey()).thenReturn(testPrefix+"min");
+        when(histogramAggregateActionConfig.getMaxKey()).thenReturn(testPrefix+"max");
+        when(histogramAggregateActionConfig.getCountKey()).thenReturn(testPrefix+"count");
+        when(histogramAggregateActionConfig.getBucketsKey()).thenReturn(testPrefix+"buckets");
+        when(histogramAggregateActionConfig.getBucketCountsKey()).thenReturn(testPrefix+"bucketcounts");
+        when(histogramAggregateActionConfig.getDurationKey()).thenReturn(testPrefix+"duration");
+        histogramAggregateAction = createObjectUnderTest();
+        final String dataKey = RandomStringUtils.randomAlphabetic(10);
+        final String dataValue = RandomStringUtils.randomAlphabetic(15);
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Map.of(dataKey, dataValue));
+
+        final Instant expectedFirstStartTime = Instant.now().truncatedTo(ChronoUnit.SECONDS).minus(2, ChronoUnit.SECONDS);
+        final double value1 = ThreadLocalRandom.current().nextDouble(TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP, TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP);
+        Map<Object, Object> eventMapEarliest = Collections.synchronizedMap(Map.of(testKey, value1, startTimeKey, expectedFirstStartTime, endTimeKey, expectedFirstStartTime));
+        Event testEventEarliest = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMapEarliest)
+                .build();
+        final AggregateActionResponse aggregateActionResponse = histogramAggregateAction.handleEvent(testEventEarliest, aggregateActionInput);
+        assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+
+        final Instant laterStartTime = Instant.now().truncatedTo(ChronoUnit.SECONDS).plus(5, ChronoUnit.SECONDS);
+        final double value2 = ThreadLocalRandom.current().nextDouble(TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP, TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP);
+        Map<Object, Object> eventMapLater = Collections.synchronizedMap(Map.of(testKey, value2, startTimeKey, laterStartTime, endTimeKey, laterStartTime));
+        Event testEventLater = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMapLater)
+                .build();
+
+        final AggregateActionResponse aggregateActionResponseLater = histogramAggregateAction.handleEvent(testEventLater, aggregateActionInput);
+        assertThat(aggregateActionResponseLater.getEvent(), equalTo(null));
+
+        final AggregateActionOutput actionOutput = histogramAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+
+        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey("time"));
+
+        final String actualStartTime = result.get(0).get("startTime", String.class);
+        assertThat(actualStartTime, notNullValue());
+        final Instant startTimeInstant = Instant.parse(actualStartTime).truncatedTo(ChronoUnit.MILLIS);
+        assertThat(startTimeInstant, equalTo(expectedFirstStartTime));
+
+        final String actualTime = result.get(0).get("time", String.class);
+        assertThat(actualTime, notNullValue());
+        final Instant actualTimeInstant = Instant.parse(actualTime).truncatedTo(ChronoUnit.MILLIS);
+        assertThat(actualTimeInstant, equalTo(laterStartTime));
     }
 }


### PR DESCRIPTION

### Description
Fixes a bug with `HistogramAggregateAction` where the startTime may be incorrect. This was discovered by a [flaky test](https://github.com/opensearch-project/data-prepper/issues/3481#issuecomment-2207244965).

The `HistogramAggregateAction` was incorrectly using the current time as the start time for the aggregation when creating the group. The very first event's time was overridden by the current system time. If this event had the earliest time, then the overall histogram would never get the correct start time. This is fixed by removing an errant line. I also added a unit test to directly test this failure scenario.

Additionally, I cleaned up some code in the tests and main source.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
