### PR TITLE
MAINT: Add json property descriptions for csv processor

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -57,6 +57,9 @@ public class CsvProcessorConfig {
     private List<String> columnNames;
 
     @JsonProperty("csv_when")
+    @JsonPropertyDescription("Allows you to specify a [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
+            "such as `/some-key == \"test\"`, that will be evaluated to determine whether " +
+            "the processor should be applied to the event.")
     private String csvWhen;
 
     /**

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.csv;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.AssertTrue;
 
 import java.util.List;
@@ -20,21 +21,39 @@ public class CsvProcessorConfig {
     static final Boolean DEFAULT_DELETE_HEADERS = true;
 
     @JsonProperty("source")
+    @JsonPropertyDescription("The field in the event that will be parsed. Default value is `message`.")
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("delimiter")
+    @JsonPropertyDescription("The character separating each column. Default value is `,`.")
     private String delimiter = DEFAULT_DELIMITER;
 
     @JsonProperty("delete_header")
+    @JsonPropertyDescription("If specified, the event header (`column_names_source_key`) is deleted after the event " +
+            "is parsed. If there is no event header, no action is taken. Default value is true.")
     private Boolean deleteHeader = DEFAULT_DELETE_HEADERS;
 
     @JsonProperty("quote_character")
+    @JsonPropertyDescription("The character used as a text qualifier for a single column of data. " +
+            "Default value is `\"`.")
     private String quoteCharacter = DEFAULT_QUOTE_CHARACTER;
 
     @JsonProperty("column_names_source_key")
+    @JsonPropertyDescription("The field in the event that specifies the CSV column names, which will be " +
+            "automatically detected. If there need to be extra column names, the column names are automatically " +
+            "generated according to their index. If `column_names` is also defined, the header in " +
+            "`column_names_source_key` can also be used to generate the event fields. " +
+            "If too few columns are specified in this field, the remaining column names are automatically generated. " +
+            "If too many column names are specified in this field, the CSV processor omits the extra column names.")
     private String columnNamesSourceKey;
 
     @JsonProperty("column_names")
+    @JsonPropertyDescription("User-specified names for the CSV columns. " +
+            "Default value is `[column1, column2, ..., columnN]` if there are no columns of data in the CSV " +
+            "record and `column_names_source_key` is not defined. If `column_names_source_key` is defined, " +
+            "the header in `column_names_source_key` generates the event fields. If too few columns are specified " +
+            "in this field, the remaining column names are automatically generated. " +
+            "If too many column names are specified in this field, the CSV processor omits the extra column names.")
     private List<String> columnNames;
 
     @JsonProperty("csv_when")


### PR DESCRIPTION
### Description
This PR serves as the starter for [plugin config table](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/csv/) into @JsonPropertyDescription so that a complete JSON schema can be generated for the CSV Processor. Also added documentation for `csv_when` config.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
