### PR TITLE
MAINT: Add json description to AddEntry processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
@@ -16,25 +17,47 @@ import java.util.stream.Stream;
 
 public class AddEntryProcessorConfig {
     public static class Entry {
+
+        @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include `my_key`, " +
+                "`myKey`, and `object/sub_Key`. The key can also be a format expression, for example, `${/key1}` to " +
+                "use the value of field `key1` as the key.")
         private String key;
 
         @JsonProperty("metadata_key")
+        @JsonPropertyDescription("The key for the new metadata attribute. The argument must be a literal string key " +
+                "and not a JSON Pointer. Either one string key or `metadata_key` is required.")
         private String metadataKey;
 
+        @JsonPropertyDescription("The value of the new entry to be added, which can be used with any of the " +
+                "following data types: strings, Booleans, numbers, null, nested objects, and arrays.")
         private Object value;
 
+        @JsonPropertyDescription("A format string to use as the value of the new entry, for example, " +
+                "`${key1}-${key2}`, where `key1` and `key2` are existing keys in the event. Required if neither " +
+                "`value` nor `value_expression` is specified.")
         private String format;
 
         @JsonProperty("value_expression")
+        @JsonPropertyDescription("An expression string to use as the value of the new entry. For example, `/key` " +
+                "is an existing key in the event with a type of either a number, a string, or a Boolean. " +
+                "Expressions can also contain functions returning number/string/integer. For example, " +
+                "`length(/key)` will return the length of the key in the event when the key is a string. For more " +
+                "information about keys, see [Expression syntax](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/).")
         private String valueExpression;
 
         @JsonProperty("add_when")
+        @JsonPropertyDescription("A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
+                "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be run on the event.")
         private String addWhen;
 
         @JsonProperty("overwrite_if_key_exists")
+        @JsonPropertyDescription("When set to `true`, the existing value is overwritten if `key` already exists " +
+                "in the event. The default value is `false`.")
         private boolean overwriteIfKeyExists = false;
 
         @JsonProperty("append_if_key_exists")
+        @JsonPropertyDescription("When set to `true`, the existing value will be appended if a `key` already " +
+                "exists in the event. An array will be created if the existing value is not an array. Default is `false`.")
         private boolean appendIfKeyExists = false;
 
         public String getKey() {
@@ -110,6 +133,7 @@ public class AddEntryProcessorConfig {
     @NotEmpty
     @NotNull
     @Valid
+    @JsonPropertyDescription("A list of entries to add to the event.")
     private List<Entry> entries;
 
     public List<Entry> getEntries() {


### PR DESCRIPTION
### Description
Add json description to AddEntry processor
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
