### PR TITLE
Add stream processing for rds source

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    implementation 'com.zendesk:mysql-binlog-connector-java:0.29.2'
+
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(path: ':data-prepper-test-event')

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -52,6 +52,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
 
     @Override
     public void start(Buffer<Record<Event>> buffer) {
+        LOG.info("Starting RDS source");
         Objects.requireNonNull(sourceCoordinator);
         sourceCoordinator.createPartition(new LeaderPartition());
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.ExportConfig;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.StreamConfig;
 
 import java.util.List;
 
@@ -70,6 +71,12 @@ public class RdsSourceConfig {
     @Valid
     private ExportConfig exportConfig;
 
+    @JsonProperty("stream")
+    private StreamConfig streamConfig;
+
+    @JsonProperty("authentication")
+    private AuthenticationConfig authenticationConfig;
+
     public String getDbIdentifier() {
         return dbIdentifier;
     }
@@ -116,5 +123,34 @@ public class RdsSourceConfig {
 
     public boolean isExportEnabled() {
         return exportConfig != null;
+    }
+
+    public StreamConfig getStream() {
+        return streamConfig;
+    }
+
+    public boolean isStreamEnabled() {
+        return streamConfig != null;
+    }
+
+    public AuthenticationConfig getAuthenticationConfig() {
+        return this.authenticationConfig;
+    }
+
+    public static class AuthenticationConfig {
+        @JsonProperty("username")
+        private String username;
+
+        @JsonProperty("password")
+        private String password;
+
+        public String getUsername() {
+            return username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.Min;
 
 public class StreamConfig {
 
-    private static final int DEFAULT_S3_FOLDER_PARTITION_COUNT = 20;
+    private static final int DEFAULT_S3_FOLDER_PARTITION_COUNT = 100;
 
     @JsonProperty("partition_count")
     @Min(1)

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public class StreamConfig {
+
+    private static final int DEFAULT_S3_FOLDER_PARTITION_COUNT = 20;
+
+    @JsonProperty("partition_count")
+    @Min(1)
+    @Max(1000)
+    private int s3FolderPartitionCount = DEFAULT_S3_FOLDER_PARTITION_COUNT;
+
+    public int getPartitionCount() {
+        return s3FolderPartitionCount;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
@@ -17,4 +17,6 @@ public class MetadataKeyAttributes {
     static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
 
     static final String INGESTION_EVENT_TYPE_ATTRIBUTE = "ingestion_type";
+
+    static final String EVENT_S3_PARTITION_KEY = "s3_partition_key";
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
@@ -14,6 +14,8 @@ public class MetadataKeyAttributes {
 
     static final String EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE = "opensearch_action";
 
+    static final String EVENT_DATABASE_NAME_METADATA_ATTRIBUTE = "database_name";
+
     static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
 
     static final String INGESTION_EVENT_TYPE_ATTRIBUTE = "ingestion_type";

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/S3PartitionCreator.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/S3PartitionCreator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class S3PartitionCreator {
+    private static final Logger LOG = LoggerFactory.getLogger(S3PartitionCreator.class);
+    private final int partitionCount;
+
+    S3PartitionCreator(final int partitionCount) {
+        this.partitionCount = partitionCount;
+    }
+
+    List<String> createPartitions() {
+        final List<String> partitions = new ArrayList<>();
+        for (int i = 0; i < partitionCount; i++) {
+            String partitionName = String.format("%02x", i) + "/";
+            partitions.add(partitionName);
+        }
+        LOG.info("S3 partitions created successfully.");
+        return partitions;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
@@ -12,12 +12,14 @@ import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
@@ -41,7 +43,12 @@ public class StreamRecordConverter {
         folderNames = s3PartitionCreator.createPartitions();
     }
 
-    public Event convert(Map<String, Object> rowData, String tableName, OpenSearchBulkActions bulkAction, List<String> primaryKeys, String s3Prefix) {
+    public Event convert(Map<String, Object> rowData,
+                         String databaseName,
+                         String tableName,
+                         OpenSearchBulkActions bulkAction,
+                         List<String> primaryKeys,
+                         String s3Prefix) {
         final Event event = JacksonEvent.builder()
                 .withEventType("event")
                 .withData(rowData)
@@ -49,6 +56,7 @@ public class StreamRecordConverter {
 
         EventMetadata eventMetadata = event.getMetadata();
 
+        eventMetadata.setAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE, databaseName);
         eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
         eventMetadata.setAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, bulkAction.toString());
         eventMetadata.setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, STREAM_EVENT_TYPE);
@@ -76,17 +84,11 @@ public class StreamRecordConverter {
             int hashValue = bytesToInt(hashBytes);
             // Map the hash value to an index in the list
             return Math.abs(hashValue) % folderNames.size();
-        } catch (final NoSuchAlgorithmException
-                e) {
+        } catch (final NoSuchAlgorithmException e) {
             return -1;
         }
     }
-    private static int bytesToInt(byte[] bytes) {
-        int result = 0;
-        for (int i = 0; i < 4 && i < bytes.length; i++) {
-            result <<= 8;
-            result |= (bytes[i] & 0xFF);
-        }
-        return result;
+    private int bytesToInt(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).getInt();
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+
+/**
+ * Convert binlog row data into JacksonEvent
+ */
+public class StreamRecordConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamRecordConverter.class);
+
+    private final List<String> folderNames;
+
+    static final String S3_PATH_DELIMITER = "/";
+
+    static final String STREAM_EVENT_TYPE = "STREAM";
+
+    public StreamRecordConverter(final int partitionCount) {
+        S3PartitionCreator s3PartitionCreator = new S3PartitionCreator(partitionCount);
+        folderNames = s3PartitionCreator.createPartitions();
+    }
+
+    public Event convert(Map<String, Object> rowData, String tableName, OpenSearchBulkActions bulkAction, List<String> primaryKeys, String s3Prefix) {
+        final Event event = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(rowData)
+                .build();
+
+        EventMetadata eventMetadata = event.getMetadata();
+
+        eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
+        eventMetadata.setAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, bulkAction.toString());
+        eventMetadata.setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, STREAM_EVENT_TYPE);
+
+        final String primaryKeyValue = primaryKeys.stream()
+                .map(rowData::get)
+                .map(String::valueOf)
+                .collect(Collectors.joining("|"));
+        eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, primaryKeyValue);
+        eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, s3Prefix + S3_PATH_DELIMITER + hashKeyToPartition(primaryKeyValue));
+
+        return event;
+    }
+
+    private String hashKeyToPartition(final String key) {
+        return folderNames.get(hashKeyToIndex(key));
+    }
+    private int hashKeyToIndex(final String key) {
+        try {
+            // Create a SHA-256 hash instance
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            // Hash the key
+            byte[] hashBytes = digest.digest(key.getBytes());
+            // Convert the hash to an integer
+            int hashValue = bytesToInt(hashBytes);
+            // Map the hash value to an index in the list
+            return Math.abs(hashValue) % folderNames.size();
+        } catch (final NoSuchAlgorithmException
+                e) {
+            return -1;
+        }
+    }
+    private static int bytesToInt(byte[] bytes) {
+        int result = 0;
+        for (int i = 0; i < 4 && i < bytes.length; i++) {
+            result <<= 8;
+            result |= (bytes[i] & 0xFF);
+        }
+        return result;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Data
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
 
 import java.util.function.Function;
 
@@ -24,15 +25,18 @@ public class PartitionFactory implements Function<SourcePartitionStoreItem, Enha
         String sourceIdentifier = partitionStoreItem.getSourceIdentifier();
         String partitionType = sourceIdentifier.substring(sourceIdentifier.lastIndexOf('|') + 1);
 
-        if (LeaderPartition.PARTITION_TYPE.equals(partitionType)) {
-            return new LeaderPartition(partitionStoreItem);
-        } else if (ExportPartition.PARTITION_TYPE.equals(partitionType)) {
-            return new ExportPartition(partitionStoreItem);
-        } else if (DataFilePartition.PARTITION_TYPE.equals(partitionType)) {
-            return new DataFilePartition(partitionStoreItem);
-        } else {
-            // Unable to acquire other partitions.
-            return new GlobalState(partitionStoreItem);
+        switch (partitionType) {
+            case LeaderPartition.PARTITION_TYPE:
+                return new LeaderPartition(partitionStoreItem);
+            case ExportPartition.PARTITION_TYPE:
+                return new ExportPartition(partitionStoreItem);
+            case DataFilePartition.PARTITION_TYPE:
+                return new DataFilePartition(partitionStoreItem);
+            case StreamPartition.PARTITION_TYPE:
+                return new StreamPartition(partitionStoreItem);
+            default:
+                // Unable to acquire other partitions.
+                return new GlobalState(partitionStoreItem);
         }
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/GlobalState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/GlobalState.java
@@ -11,6 +11,12 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Global State is a special type of partition. The partition type is null.
+ * You can't acquire (own) a Global State.
+ * However, you can read and update Global State whenever required.
+ * The progress state is a Map object.
+ */
 public class GlobalState extends EnhancedSourcePartition<Map<String, Object>> {
 
     private final String stateName;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/StreamPartition.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/StreamPartition.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.partition;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
+
+import java.util.Optional;
+
+public class StreamPartition extends EnhancedSourcePartition<StreamProgressState> {
+
+    public static final String PARTITION_TYPE = "STREAM";
+
+    private final String dbIdentifier;
+    private final StreamProgressState state;
+
+    public StreamPartition(String dbIdentifier, StreamProgressState state) {
+        this.dbIdentifier = dbIdentifier;
+        this.state = state;
+    }
+
+    public StreamPartition(SourcePartitionStoreItem sourcePartitionStoreItem) {
+        setSourcePartitionStoreItem(sourcePartitionStoreItem);
+        dbIdentifier = sourcePartitionStoreItem.getSourcePartitionKey();
+        state = convertStringToPartitionProgressState(StreamProgressState.class, sourcePartitionStoreItem.getPartitionProgressState());
+    }
+
+    @Override
+    public String getPartitionType() {
+        return PARTITION_TYPE;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return dbIdentifier;
+    }
+
+    @Override
+    public Optional<StreamProgressState> getProgressState() {
+        if (state != null) {
+            return Optional.of(state);
+        }
+        return Optional.empty();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/StreamProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/StreamProgressState.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+
+public class StreamProgressState {
+
+    @JsonProperty("startPosition")
+    private BinlogCoordinate startPosition;
+
+    @JsonProperty("currentPosition")
+    private BinlogCoordinate currentPosition;
+
+    @JsonProperty("waitForExport")
+    private boolean waitForExport = false;
+
+    public BinlogCoordinate getStartPosition() {
+        return startPosition;
+    }
+
+    public void setStartPosition(BinlogCoordinate startPosition) {
+        this.startPosition = startPosition;
+    }
+
+    public BinlogCoordinate getCurrentPosition() {
+        return currentPosition;
+    }
+
+    public void setCurrentPosition(BinlogCoordinate currentPosition) {
+        this.currentPosition = currentPosition;
+    }
+
+    public boolean shouldWaitForExport() {
+        return waitForExport;
+    }
+
+    public void setWaitForExport(boolean waitForExport) {
+        this.waitForExport = waitForExport;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -128,8 +128,6 @@ public class LeaderScheduler implements Runnable {
     private void createStreamPartition(RdsSourceConfig sourceConfig) {
         final StreamProgressState progressState = new StreamProgressState();
         progressState.setWaitForExport(sourceConfig.isExportEnabled());
-        // For testing
-//        progressState.setCurrentPosition(new BinlogCoordinate("mysql-bin-changelog.001891", 1003));
         StreamPartition streamPartition = new StreamPartition(sourceConfig.getDbIdentifier(), progressState);
         sourceCoordinator.createPartition(streamPartition);
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/BinlogCoordinate.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/BinlogCoordinate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BinlogCoordinate {
+
+    @JsonProperty("binlogFilename")
+    private final String binlogFilename;
+
+    @JsonProperty("binlogPosition")
+    private final long binlogPosition;
+
+    @JsonCreator
+    public BinlogCoordinate(@JsonProperty("binlogFilename") String binlogFilename,
+                            @JsonProperty("binlogPosition") long binlogPosition) {
+        this.binlogFilename = binlogFilename;
+        this.binlogPosition = binlogPosition;
+    }
+
+    public String getBinlogFilename() {
+        return binlogFilename;
+    }
+
+    public long getBinlogPosition() {
+        return binlogPosition;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/TableMetadata.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/TableMetadata.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.util.List;
+
+public class TableMetadata {
+    private String databaseName;
+    private String tableName;
+    private List<String> columnNames;
+    private List<String> primaryKeys;
+
+    public TableMetadata(String tableName, String databaseName, List<String> columnNames, List<String> primaryKeys) {
+        this.tableName = tableName;
+        this.databaseName = databaseName;
+        this.columnNames = columnNames;
+        this.primaryKeys = primaryKeys;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getFullTableName() {
+        return databaseName + "." + tableName;
+    }
+
+    public List<String> getColumnNames() {
+        return columnNames;
+    }
+
+    public List<String> getPrimaryKeys() {
+        return primaryKeys;
+    }
+
+    public void setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public void setColumnNames(List<String> columnNames) {
+        this.columnNames = columnNames;
+    }
+
+    public void setPrimaryKeys(List<String> primaryKeys) {
+        this.primaryKeys = primaryKeys;
+    }
+
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+
+public class BinlogClientFactory {
+
+    private final RdsSourceConfig sourceConfig;
+
+    private final RdsClient rdsClient;
+
+    public BinlogClientFactory(final RdsSourceConfig sourceConfig, final RdsClient rdsClient) {
+        this.sourceConfig = sourceConfig;
+        this.rdsClient = rdsClient;
+    }
+
+    public BinaryLogClient create() {
+        DBInstance dbInstance = describeDbInstance(sourceConfig.getDbIdentifier());
+        return new BinaryLogClient(
+                dbInstance.endpoint().address(),
+                dbInstance.endpoint().port(),
+                // For test
+                // "127.0.0.1",
+                // 3306,
+                sourceConfig.getAuthenticationConfig().getUsername(),
+                sourceConfig.getAuthenticationConfig().getPassword());
+    }
+
+    private DBInstance describeDbInstance(final String dbInstanceIdentifier) {
+        DescribeDbInstancesRequest request = DescribeDbInstancesRequest.builder()
+                .dbInstanceIdentifier(dbInstanceIdentifier)
+                .build();
+
+        DescribeDbInstancesResponse response = rdsClient.describeDBInstances(request);
+        return response.dbInstances().get(0);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.DeleteRowsEventData;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
+import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
+import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
+import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.converter.StreamRecordConverter;
+import org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BinlogEventListener implements BinaryLogClient.EventListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BinlogEventListener.class);
+
+    static final Duration BUFFER_TIMEOUT = Duration.ofSeconds(60);
+    static final int DEFAULT_BUFFER_BATCH_SIZE = 1_000;
+
+    /**
+     * TableId to TableMetadata mapping
+     */
+    private final Map<Long, TableMetadata> tableMetadataMap;
+
+    private final StreamRecordConverter recordConverter;
+    private final BufferAccumulator<Record<Event>> bufferAccumulator;
+    private final List<String> tableNames;
+    private final String s3Prefix;
+
+    public BinlogEventListener(final Buffer<Record<Event>> buffer, final RdsSourceConfig sourceConfig) {
+        tableMetadataMap = new HashMap<>();
+        recordConverter = new StreamRecordConverter(sourceConfig.getStream().getPartitionCount());
+        bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
+        s3Prefix = sourceConfig.getS3Prefix();
+        tableNames = sourceConfig.getTableNames();
+    }
+
+    @Override
+    public void onEvent(com.github.shyiko.mysql.binlog.event.Event event) {
+        EventType eventType = event.getHeader().getEventType();
+
+        switch (eventType) {
+            case TABLE_MAP:
+                handleTableMapEvent(event);
+                break;
+            case WRITE_ROWS:
+            case EXT_WRITE_ROWS:
+                handleInsertEvent(event);
+                break;
+            case UPDATE_ROWS:
+            case EXT_UPDATE_ROWS:
+                handleUpdateEvent(event);
+                break;
+            case DELETE_ROWS:
+            case EXT_DELETE_ROWS:
+                handleDeleteEvent(event);
+                break;
+        }
+    }
+
+    void handleTableMapEvent(com.github.shyiko.mysql.binlog.event.Event event) {
+        final TableMapEventData data = event.getData();
+        final TableMapEventMetadata tableMapEventMetadata = data.getEventMetadata();
+        final List<String> columnNames = tableMapEventMetadata.getColumnNames();
+        final List<String> primaryKeys = tableMapEventMetadata.getSimplePrimaryKeys().stream()
+                .map(columnNames::get)
+                .collect(Collectors.toList());
+        final TableMetadata tableMetadata = new TableMetadata(
+                data.getTable(), data.getDatabase(), columnNames, primaryKeys);
+        if (isTableOfInterest(tableMetadata.getFullTableName())) {
+            tableMetadataMap.put(data.getTableId(), tableMetadata);
+        }
+    }
+
+    void handleInsertEvent(com.github.shyiko.mysql.binlog.event.Event event) {
+        // get new row data from the event
+        LOG.debug("Handling insert event");
+        final WriteRowsEventData data = event.getData();
+        if (!tableMetadataMap.containsKey(data.getTableId())) {
+            LOG.debug("Cannot find table metadata, the event is likely not from a table of interest or the table metadata was not read");
+            return;
+        }
+        final TableMetadata tableMetadata = tableMetadataMap.get(data.getTableId());
+        final String tableName = tableMetadata.getFullTableName();
+        if (!isTableOfInterest(tableName)) {
+            LOG.debug("The event is not from a table of interest");
+            return;
+        }
+        final List<String> columnNames = tableMetadata.getColumnNames();
+        final List<String> primaryKeys = tableMetadata.getPrimaryKeys();
+
+        // Construct data prepper JacksonEvent
+        for (final Object[] rowDataArray : data.getRows()) {
+            final Map<String, Object> rowDataMap = new HashMap<>();
+            for (int i = 0; i < rowDataArray.length; i++) {
+                rowDataMap.put(columnNames.get(i), rowDataArray[i]);
+            }
+
+            Event pipelineEvent = recordConverter.convert(rowDataMap, tableName, OpenSearchBulkActions.INDEX, primaryKeys, s3Prefix);
+            addToBuffer(new Record<>(pipelineEvent));
+        }
+
+        flushBuffer();
+    }
+
+    void handleUpdateEvent(com.github.shyiko.mysql.binlog.event.Event event) {
+        LOG.debug("Handling update event");
+        final UpdateRowsEventData data = event.getData();
+        if (!tableMetadataMap.containsKey(data.getTableId())) {
+            return;
+        }
+        final TableMetadata tableMetadata = tableMetadataMap.get(data.getTableId());
+        final String tableName = tableMetadata.getFullTableName();
+        if (!isTableOfInterest(tableName)) {
+            LOG.debug("The event is not from a table of interest");
+            return;
+        }
+        final List<String> columnNames = tableMetadata.getColumnNames();
+        final List<String> primaryKeys = tableMetadata.getPrimaryKeys();
+
+        for (Map.Entry<Serializable[], Serializable[]> updatedRow : data.getRows()) {
+            // updatedRow contains data before update as key and data after update as value
+            final Object[] rowData = updatedRow.getValue();
+
+            final Map<String, Object> dataMap = new HashMap<>();
+            for (int i = 0; i < rowData.length; i++) {
+                dataMap.put(columnNames.get(i), rowData[i]);
+            }
+
+            final Event pipelineEvent = recordConverter.convert(dataMap, tableName, OpenSearchBulkActions.INDEX, primaryKeys, s3Prefix);
+            addToBuffer(new Record<>(pipelineEvent));
+        }
+
+        flushBuffer();
+    }
+
+    void handleDeleteEvent(com.github.shyiko.mysql.binlog.event.Event event) {
+        LOG.debug("Handling delete event");
+        final DeleteRowsEventData data = event.getData();
+        if (!tableMetadataMap.containsKey(data.getTableId())) {
+            LOG.debug("Cannot find table metadata, the event is likely not from a table of interest or the table metadata was not read");
+            return;
+        }
+        final TableMetadata tableMetadata = tableMetadataMap.get(data.getTableId());
+        final String tableName = tableMetadata.getFullTableName();
+        if (!isTableOfInterest(tableName)) {
+            LOG.debug("The event is not from a table of interest");
+            return;
+        }
+        final List<String> columnNames = tableMetadata.getColumnNames();
+        final List<String> primaryKeys = tableMetadata.getPrimaryKeys();
+
+        for (Object[] rowDataArray : data.getRows()) {
+            final Map<String, Object> rowDataMap = new HashMap<>();
+            for (int i = 0; i < rowDataArray.length; i++) {
+                rowDataMap.put(columnNames.get(i), rowDataArray[i]);
+            }
+
+            final Event pipelineEvent = recordConverter.convert(rowDataMap, tableName, OpenSearchBulkActions.DELETE, primaryKeys, s3Prefix);
+            addToBuffer(new Record<>(pipelineEvent));
+        }
+
+        flushBuffer();
+    }
+
+    private boolean isTableOfInterest(String tableName) {
+        return new HashSet<>(tableNames).contains(tableName);
+    }
+
+    private void addToBuffer(final Record<Event> record) {
+        try {
+            bufferAccumulator.add(record);
+        } catch (Exception e) {
+            LOG.error("Failed to add event to buffer", e);
+        }
+    }
+
+    private void flushBuffer() {
+        try {
+            bufferAccumulator.flush();
+        } catch (Exception e) {
+            LOG.error("Failed to flush buffer", e);
+        }
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -102,8 +102,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             return;
         }
         final TableMetadata tableMetadata = tableMetadataMap.get(data.getTableId());
-        final String tableName = tableMetadata.getFullTableName();
-        if (!isTableOfInterest(tableName)) {
+        final String fullTableName = tableMetadata.getFullTableName();
+        if (!isTableOfInterest(fullTableName)) {
             LOG.debug("The event is not from a table of interest");
             return;
         }
@@ -117,7 +117,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                 rowDataMap.put(columnNames.get(i), rowDataArray[i]);
             }
 
-            Event pipelineEvent = recordConverter.convert(rowDataMap, tableName, OpenSearchBulkActions.INDEX, primaryKeys, s3Prefix);
+            Event pipelineEvent = recordConverter.convert(
+                    rowDataMap, tableMetadata.getDatabaseName(), tableMetadata.getTableName(), OpenSearchBulkActions.INDEX, primaryKeys, s3Prefix);
             addToBuffer(new Record<>(pipelineEvent));
         }
 
@@ -131,8 +132,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             return;
         }
         final TableMetadata tableMetadata = tableMetadataMap.get(data.getTableId());
-        final String tableName = tableMetadata.getFullTableName();
-        if (!isTableOfInterest(tableName)) {
+        final String fullTableName = tableMetadata.getFullTableName();
+        if (!isTableOfInterest(fullTableName)) {
             LOG.debug("The event is not from a table of interest");
             return;
         }
@@ -148,7 +149,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                 dataMap.put(columnNames.get(i), rowData[i]);
             }
 
-            final Event pipelineEvent = recordConverter.convert(dataMap, tableName, OpenSearchBulkActions.INDEX, primaryKeys, s3Prefix);
+            final Event pipelineEvent = recordConverter.convert(
+                    dataMap, tableMetadata.getDatabaseName(), tableMetadata.getTableName(), OpenSearchBulkActions.INDEX, primaryKeys, s3Prefix);
             addToBuffer(new Record<>(pipelineEvent));
         }
 
@@ -163,8 +165,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             return;
         }
         final TableMetadata tableMetadata = tableMetadataMap.get(data.getTableId());
-        final String tableName = tableMetadata.getFullTableName();
-        if (!isTableOfInterest(tableName)) {
+        final String fullTableName = tableMetadata.getFullTableName();
+        if (!isTableOfInterest(fullTableName)) {
             LOG.debug("The event is not from a table of interest");
             return;
         }
@@ -177,7 +179,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                 rowDataMap.put(columnNames.get(i), rowDataArray[i]);
             }
 
-            final Event pipelineEvent = recordConverter.convert(rowDataMap, tableName, OpenSearchBulkActions.DELETE, primaryKeys, s3Prefix);
+            final Event pipelineEvent = recordConverter.convert(
+                    rowDataMap, tableMetadata.getDatabaseName(), tableMetadata.getTableName(), OpenSearchBulkActions.DELETE, primaryKeys, s3Prefix);
             addToBuffer(new Record<>(pipelineEvent));
         }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+
+public class StreamScheduler implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamScheduler.class);
+
+    private static final int DEFAULT_TAKE_LEASE_INTERVAL_MILLIS = 60_000;
+
+    private final EnhancedSourceCoordinator sourceCoordinator;
+    private final RdsSourceConfig sourceConfig;
+    private final BinaryLogClient binaryLogClient;
+    private final PluginMetrics pluginMetrics;
+
+    private volatile boolean shutdownRequested = false;
+
+    public StreamScheduler(final EnhancedSourceCoordinator sourceCoordinator,
+                           final RdsSourceConfig sourceConfig,
+                           final BinaryLogClient binaryLogClient,
+                           final Buffer<Record<Event>> buffer,
+                           final PluginMetrics pluginMetrics) {
+        this.sourceCoordinator = sourceCoordinator;
+        this.sourceConfig = sourceConfig;
+        this.binaryLogClient = binaryLogClient;
+        this.binaryLogClient.registerEventListener(new BinlogEventListener(buffer, sourceConfig));
+        this.pluginMetrics = pluginMetrics;
+    }
+
+    @Override
+    public void run() {
+        LOG.debug("Start running Stream Scheduler");
+        while (!shutdownRequested && !Thread.currentThread().isInterrupted()) {
+            try {
+                final Optional<EnhancedSourcePartition> sourcePartition = sourceCoordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE);
+                if (sourcePartition.isPresent()) {
+                    LOG.info("Acquired partition to read from stream");
+
+                    final StreamPartition streamPartition = (StreamPartition) sourcePartition.get();
+                    final StreamWorker streamWorker = StreamWorker.create(sourceCoordinator, binaryLogClient, pluginMetrics);
+                    streamWorker.processStream(streamPartition);
+                }
+
+                try {
+                    LOG.debug("Waiting to acquire stream partition.");
+                    Thread.sleep(DEFAULT_TAKE_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException e) {
+                    LOG.info("The StreamScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+
+            } catch (Exception e) {
+                LOG.error("Received an exception during stream processing, backing off and retrying", e);
+                try {
+                    Thread.sleep(DEFAULT_TAKE_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException ex) {
+                    LOG.info("The StreamScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            }
+        }
+    }
+
+    public void shutdown() {
+        shutdownRequested = true;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class StreamWorker {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamWorker.class);
+
+    private static final int DEFAULT_EXPORT_COMPLETE_WAIT_INTERVAL_MILLIS = 60_000;
+
+    private final EnhancedSourceCoordinator sourceCoordinator;
+    private final BinaryLogClient binaryLogClient;
+    private final PluginMetrics pluginMetrics;
+
+    StreamWorker(final EnhancedSourceCoordinator sourceCoordinator,
+                 final BinaryLogClient binaryLogClient,
+                 final PluginMetrics pluginMetrics) {
+        this.sourceCoordinator = sourceCoordinator;
+        this.binaryLogClient = binaryLogClient;
+        this.pluginMetrics = pluginMetrics;
+    }
+
+    public static StreamWorker create(final EnhancedSourceCoordinator sourceCoordinator,
+                                      final BinaryLogClient binaryLogClient,
+                                      final PluginMetrics pluginMetrics) {
+        return new StreamWorker(sourceCoordinator, binaryLogClient, pluginMetrics);
+    }
+
+    public void processStream(final StreamPartition streamPartition) {
+        // get current binlog position
+        BinlogCoordinate currentBinlogCoords = streamPartition.getProgressState().get().getCurrentPosition();
+
+        // set start of binlog stream to current position if exists
+        if (currentBinlogCoords != null) {
+            final String binlogFilename = currentBinlogCoords.getBinlogFilename();
+            final long binlogPosition = currentBinlogCoords.getBinlogPosition();
+            LOG.debug("Will start binlog stream from binlog file {} and position {}.", binlogFilename, binlogPosition);
+            binaryLogClient.setBinlogFilename(binlogFilename);
+            binaryLogClient.setBinlogPosition(binlogPosition);
+        }
+
+        while (shouldWaitForExport(streamPartition) && !Thread.currentThread().isInterrupted()) {
+            LOG.info("Initial load not completed yet for {}, waiting...", streamPartition.getPartitionKey());
+            try {
+                Thread.sleep(DEFAULT_EXPORT_COMPLETE_WAIT_INTERVAL_MILLIS);
+            } catch (final InterruptedException ex) {
+                LOG.info("The StreamScheduler was interrupted while waiting to retry, stopping processing");
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        try {
+            LOG.info("Connecting to binary log stream.");
+            binaryLogClient.connect();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                binaryLogClient.disconnect();
+            } catch (IOException e) {
+                LOG.error("Binary log client failed to disconnect.", e);
+            }
+        }
+    }
+
+    private boolean shouldWaitForExport(final StreamPartition streamPartition) {
+        if (!streamPartition.getProgressState().get().shouldWaitForExport()) {
+            LOG.debug("Export is not enabled. Proceed with streaming.");
+            return false;
+        }
+
+        return !isExportDone(streamPartition);
+    }
+
+    private boolean isExportDone(StreamPartition streamPartition) {
+        final String dbIdentifier = streamPartition.getPartitionKey();
+        Optional<EnhancedSourcePartition> globalStatePartition = sourceCoordinator.getPartition("stream-for-" + dbIdentifier);
+        return globalStatePartition.isPresent();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/S3PartitionCreatorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/S3PartitionCreatorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+class S3PartitionCreatorTest {
+
+    @Test
+    void test_createPartition_create_correct_number_of_distinct_partition_strings() {
+        final int partitionCount = new Random().nextInt(10) + 1;
+        final S3PartitionCreator s3PartitionCreator = createObjectUnderTest(partitionCount);
+
+        final List<String> partitions = s3PartitionCreator.createPartitions();
+
+        assertThat(partitions.size(), is(partitionCount));
+        assertThat(new HashSet<>(partitions).size(), is(partitionCount));
+    }
+
+    private S3PartitionCreator createObjectUnderTest(final int partitionCount) {
+        return new S3PartitionCreator(partitionCount);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_S3_PARTITION_KEY;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
@@ -37,14 +38,16 @@ class StreamRecordConverterTest {
     @Test
     void test_convert_returns_expected_event() {
         Map<String, Object> rowData = Map.of("key1", "value1", "key2", "value2");
+        final String databaseName = UUID.randomUUID().toString();
         final String tableName = UUID.randomUUID().toString();
         final OpenSearchBulkActions bulkAction = OpenSearchBulkActions.INDEX;
         final List<String> primaryKeys = List.of("key1");
         final String s3Prefix = UUID.randomUUID().toString();
 
-        Event event = streamRecordConverter.convert(rowData, tableName, bulkAction, primaryKeys, s3Prefix);
+        Event event = streamRecordConverter.convert(rowData, databaseName, tableName, bulkAction, primaryKeys, s3Prefix);
 
         assertThat(event.toMap(), is(rowData));
+        assertThat(event.getMetadata().getAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE), is(databaseName));
         assertThat(event.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), is(tableName));
         assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), is(bulkAction.toString()));
         assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), is("value1"));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_S3_PARTITION_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.StreamRecordConverter.S3_PATH_DELIMITER;
+
+
+class StreamRecordConverterTest {
+
+    private StreamRecordConverter streamRecordConverter;
+
+    @BeforeEach
+    void setUp() {
+        streamRecordConverter = createObjectUnderTest();
+    }
+
+    @Test
+    void test_convert_returns_expected_event() {
+        Map<String, Object> rowData = Map.of("key1", "value1", "key2", "value2");
+        final String tableName = UUID.randomUUID().toString();
+        final OpenSearchBulkActions bulkAction = OpenSearchBulkActions.INDEX;
+        final List<String> primaryKeys = List.of("key1");
+        final String s3Prefix = UUID.randomUUID().toString();
+
+        Event event = streamRecordConverter.convert(rowData, tableName, bulkAction, primaryKeys, s3Prefix);
+
+        assertThat(event.toMap(), is(rowData));
+        assertThat(event.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), is(tableName));
+        assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), is(bulkAction.toString()));
+        assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), is("value1"));
+        assertThat(event.getMetadata().getAttribute(EVENT_S3_PARTITION_KEY).toString(), startsWith(s3Prefix + S3_PATH_DELIMITER));
+    }
+
+    private StreamRecordConverter createObjectUnderTest() {
+        return new StreamRecordConverter(new Random().nextInt(1000) + 1);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactoryTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BinlogClientFactoryTest {
+
+    @Mock
+    private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private RdsClient rdsClient;
+
+    private BinlogClientFactory binlogClientFactory;
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        binlogClientFactory = createBinlogClientFactory();
+        random = new Random();
+    }
+
+    @Test
+    void test_create() {
+        DescribeDbInstancesResponse describeDbInstancesResponse = mock(DescribeDbInstancesResponse.class);
+        DBInstance dbInstance = mock(DBInstance.class, RETURNS_DEEP_STUBS);
+        final String address = UUID.randomUUID().toString();
+        final Integer port = random.nextInt();
+        when(dbInstance.endpoint().address()).thenReturn(address);
+        when(dbInstance.endpoint().port()).thenReturn(port);
+        when(describeDbInstancesResponse.dbInstances()).thenReturn(List.of(dbInstance));
+        when(sourceConfig.getDbIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class))).thenReturn(describeDbInstancesResponse);
+        RdsSourceConfig.AuthenticationConfig authenticationConfig = mock(RdsSourceConfig.AuthenticationConfig.class);
+        when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
+
+        binlogClientFactory.create();
+    }
+
+    private BinlogClientFactory createBinlogClientFactory() {
+        return new BinlogClientFactory(sourceConfig, rdsClient);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.event.EventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BinlogEventListenerTest {
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RdsSourceConfig sourceConfig;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private com.github.shyiko.mysql.binlog.event.Event binlogEvent;
+
+    private static BinlogEventListener objectUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        objectUnderTest = spy(createObjectUnderTest());
+    }
+
+    @Test
+    void test_given_TableMap_event_then_calls_correct_handler() {
+        when(binlogEvent.getHeader().getEventType()).thenReturn(EventType.TABLE_MAP);
+        doNothing().when(objectUnderTest).handleTableMapEvent(binlogEvent);
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verify(objectUnderTest).handleTableMapEvent(binlogEvent);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"WRITE_ROWS", "EXT_WRITE_ROWS"})
+    void test_given_WriteRows_event_then_calls_correct_handler(EventType eventType) {
+        when(binlogEvent.getHeader().getEventType()).thenReturn(eventType);
+        doNothing().when(objectUnderTest).handleInsertEvent(binlogEvent);
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verify(objectUnderTest).handleInsertEvent(binlogEvent);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"UPDATE_ROWS", "EXT_UPDATE_ROWS"})
+    void test_given_UpdateRows_event_then_calls_correct_handler(EventType eventType) {
+        when(binlogEvent.getHeader().getEventType()).thenReturn(eventType);
+        doNothing().when(objectUnderTest).handleUpdateEvent(binlogEvent);
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verify(objectUnderTest).handleUpdateEvent(binlogEvent);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"DELETE_ROWS", "EXT_DELETE_ROWS"})
+    void test_given_DeleteRows_event_then_calls_correct_handler(EventType eventType) {
+        when(binlogEvent.getHeader().getEventType()).thenReturn(eventType);
+        doNothing().when(objectUnderTest).handleDeleteEvent(binlogEvent);
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verify(objectUnderTest).handleDeleteEvent(binlogEvent);
+    }
+
+    private BinlogEventListener createObjectUnderTest() {
+        return new BinlogEventListener(buffer, sourceConfig);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StreamSchedulerTest {
+
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private BinaryLogClient binaryLogClient;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    private StreamScheduler objectUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        objectUnderTest = createObjectUnderTest();
+    }
+
+    @Test
+    void test_given_no_stream_partition_then_no_stream_actions() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(objectUnderTest);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(StreamPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verify(binaryLogClient).registerEventListener(any(BinlogEventListener.class));
+        verifyNoMoreInteractions(binaryLogClient);
+    }
+
+    @Test
+    void test_given_stream_partition_then_start_stream() throws InterruptedException {
+        final StreamPartition streamPartition = mock(StreamPartition.class);
+        when(sourceCoordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).thenReturn(Optional.of(streamPartition));
+
+        StreamWorker streamWorker = mock(StreamWorker.class);
+        doNothing().when(streamWorker).processStream(streamPartition);
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class)) {
+                streamWorkerMockedStatic.when(() -> StreamWorker.create(sourceCoordinator, binaryLogClient, pluginMetrics))
+                        .thenReturn(streamWorker);
+                objectUnderTest.run();
+            }
+
+        });
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(StreamPartition.PARTITION_TYPE));
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verify(streamWorker).processStream(streamPartition);
+    }
+
+    @Test
+    void test_shutdown() {
+        lenient().when(sourceCoordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(objectUnderTest);
+        objectUnderTest.shutdown();
+        verifyNoMoreInteractions(sourceCoordinator);
+        executorService.shutdownNow();
+    }
+
+    private StreamScheduler createObjectUnderTest() {
+        return new StreamScheduler(sourceCoordinator, sourceConfig, binaryLogClient, buffer, pluginMetrics);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StreamWorkerTest {
+
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @Mock
+    private BinaryLogClient binaryLogClient;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private StreamPartition streamPartition;
+
+    private StreamWorker streamWorker;
+
+    @BeforeEach
+    void setUp() {
+        streamWorker = createObjectUnderTest();
+    }
+
+    @Test
+    void test_processStream_with_given_binlog_coordinates() throws IOException {
+        StreamProgressState streamProgressState = mock(StreamProgressState.class);
+        when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+        final String binlogFilename = "binlog-001";
+        final Long binlogPosition = 100L;
+        when(streamProgressState.getCurrentPosition()).thenReturn(new BinlogCoordinate(binlogFilename, binlogPosition));
+        when(streamProgressState.shouldWaitForExport()).thenReturn(false);
+
+        streamWorker.processStream(streamPartition);
+
+        verify(binaryLogClient).setBinlogFilename(binlogFilename);
+        verify(binaryLogClient).setBinlogPosition(binlogPosition);
+        verify(binaryLogClient).connect();
+    }
+
+    @Test
+    void test_processStream_without_current_binlog_coordinates() throws IOException {
+        StreamProgressState streamProgressState = mock(StreamProgressState.class);
+        when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+        final String binlogFilename = "binlog-001";
+        final Long binlogPosition = 100L;
+        when(streamProgressState.getCurrentPosition()).thenReturn(null);
+        when(streamProgressState.shouldWaitForExport()).thenReturn(false);
+
+        streamWorker.processStream(streamPartition);
+
+        verify(binaryLogClient, never()).setBinlogFilename(binlogFilename);
+        verify(binaryLogClient, never()).setBinlogPosition(binlogPosition);
+        verify(binaryLogClient).connect();
+    }
+
+    private StreamWorker createObjectUnderTest() {
+        return new StreamWorker(sourceCoordinator, binaryLogClient, pluginMetrics);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -152,6 +152,7 @@ public class ScanObjectWorker implements Runnable {
 
         }
         for (String partitionKey: partitionKeys) {
+            LOG.info("Scan object worker is stopped, giving up partitions.");
             sourceCoordinator.giveUpPartition(partitionKey);
         }
     }
@@ -203,6 +204,7 @@ public class ScanObjectWorker implements Runnable {
                         deleteObjectsForPartition.forEach(s3ObjectDeleteWorker::deleteS3Object);
                         objectsToDeleteForAcknowledgmentSets.remove(objectToProcess.get().getPartitionKey());
                     } else {
+                        LOG.info("Did not receive positive acknowledgement, giving up partition.");
                         sourceCoordinator.giveUpPartition(objectToProcess.get().getPartitionKey());
                     }
                     partitionKeys.remove(objectToProcess.get().getPartitionKey());
@@ -268,7 +270,7 @@ public class ScanObjectWorker implements Runnable {
                 sourceCoordinator.deletePartition(folderPartition.getPartitionKey());
                 return;
             }
-
+            LOG.info("No objects to process, giving up partition");
             sourceCoordinator.giveUpPartition(folderPartition.getPartitionKey(), Instant.now());
             return;
         }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -152,7 +152,7 @@ public class ScanObjectWorker implements Runnable {
 
         }
         for (String partitionKey: partitionKeys) {
-            LOG.info("Scan object worker is stopped, giving up partitions.");
+            LOG.debug("Scan object worker is stopped, giving up partitions.");
             sourceCoordinator.giveUpPartition(partitionKey);
         }
     }
@@ -204,7 +204,7 @@ public class ScanObjectWorker implements Runnable {
                         deleteObjectsForPartition.forEach(s3ObjectDeleteWorker::deleteS3Object);
                         objectsToDeleteForAcknowledgmentSets.remove(objectToProcess.get().getPartitionKey());
                     } else {
-                        LOG.info("Did not receive positive acknowledgement, giving up partition.");
+                        LOG.debug("Did not receive positive acknowledgement, giving up partition.");
                         sourceCoordinator.giveUpPartition(objectToProcess.get().getPartitionKey());
                     }
                     partitionKeys.remove(objectToProcess.get().getPartitionKey());
@@ -270,7 +270,7 @@ public class ScanObjectWorker implements Runnable {
                 sourceCoordinator.deletePartition(folderPartition.getPartitionKey());
                 return;
             }
-            LOG.info("No objects to process, giving up partition");
+            LOG.debug("No objects to process, giving up partition");
             sourceCoordinator.giveUpPartition(folderPartition.getPartitionKey(), Instant.now());
             return;
         }


### PR DESCRIPTION
### Description
Add stream processing for rds source:
- Uses `BinaryLogClient` to get change events and process the events based on insert/update/delete types
- The binlog events are then converted to JacksonEvents and attached with metadata before sending to buffer

#### Testing
Smoked tested in some Data Prepper pipelines and verified it's working as expected.
<details>
<summary>Test pipeline config example</summary>

```yaml
rds-mysql-pipeline:
  source:
    rds:
      db_identifier: "mysql-multiaz-instance"
      table_names:
        - "my_db.cars"
      s3_bucket: "aurora-datasets-oeyh"
      s3_region: "us-east-1"
      s3_prefix: "rds-stream-test"
      export:
        kms_key_id: xxx
      stream:
        partition_count: 8
      aws:
        sts_role_arn: "arn:aws:iam::xxx:role/rdsSourcePipelineRole"
        region: "us-east-1"
      authentication:
        username: ${{aws_secrets:secret:username}}
        password: ${{aws_secrets:secret:password}}
  processor:
    - add_entries:
        entries:
          - key: table_name
            value_expression: getMetadata("table_name")
          - key: primary_key
            value_expression: getMetadata("primary_key")
          - key: s3_partition_key
            value_expression: getMetadata("s3_partition_key")
            add_when: getMetadata("s3_partition_key") != null
          - key: bulk_action
            value_expression: getMetadata("opensearch_action")
  sink: 
    - stdout:
extension:
  aws:
    secrets:
      secret:
        # Secret name or secret ARN
        secret_id: "xxx"
        region: "us-east-1"
        sts_role_arn: "arn:aws:iam::xxx:role/rdsSourcePipelineRole"
        refresh_interval: PT1H
```

</details>
 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
