### PR TITLE
Add support for RDS/Aurora clusters in rds source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -11,8 +11,13 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.export.ClusterSnapshotStrategy;
 import org.opensearch.dataprepper.plugins.source.rds.export.DataFileScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler;
+import org.opensearch.dataprepper.plugins.source.rds.export.ExportTaskManager;
+import org.opensearch.dataprepper.plugins.source.rds.export.InstanceSnapshotStrategy;
+import org.opensearch.dataprepper.plugins.source.rds.export.SnapshotManager;
+import org.opensearch.dataprepper.plugins.source.rds.export.SnapshotStrategy;
 import org.opensearch.dataprepper.plugins.source.rds.leader.LeaderScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +76,12 @@ public class RdsService {
         runnableList.add(leaderScheduler);
 
         if (sourceConfig.isExportEnabled()) {
-            exportScheduler = new ExportScheduler(sourceCoordinator, rdsClient, s3Client, pluginMetrics);
+            final SnapshotStrategy snapshotStrategy = sourceConfig.isCluster() ?
+                    new ClusterSnapshotStrategy(rdsClient) : new InstanceSnapshotStrategy(rdsClient);
+            final SnapshotManager snapshotManager = new SnapshotManager(snapshotStrategy);
+            final ExportTaskManager exportTaskManager = new ExportTaskManager(rdsClient);
+            exportScheduler = new ExportScheduler(
+                    sourceCoordinator, snapshotManager, exportTaskManager, s3Client, pluginMetrics);
             dataFileScheduler = new DataFileScheduler(
                     sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer);
             runnableList.add(exportScheduler);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
@@ -75,7 +75,7 @@ public class RdsSourceConfig {
     }
 
     public boolean isCluster() {
-        return isCluster;
+        return isCluster || isAurora;
     }
 
     public EngineType getEngine() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ClusterSnapshotStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ClusterSnapshotStrategy.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsResponse;
+
+import java.time.Instant;
+
+/**
+ * This snapshot strategy works with RDS/Aurora Clusters
+ */
+public class ClusterSnapshotStrategy implements SnapshotStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterSnapshotStrategy.class);
+    private final RdsClient rdsClient;
+
+    public ClusterSnapshotStrategy(final RdsClient rdsClient) {
+        this.rdsClient = rdsClient;
+    }
+
+    @Override
+    public SnapshotInfo createSnapshot(String dbIdentifier, String snapshotId) {
+        CreateDbClusterSnapshotRequest request = CreateDbClusterSnapshotRequest.builder()
+                .dbClusterIdentifier(dbIdentifier)
+                .dbClusterSnapshotIdentifier(snapshotId)
+                .build();
+
+        try {
+            CreateDbClusterSnapshotResponse response = rdsClient.createDBClusterSnapshot(request);
+            String snapshotArn = response.dbClusterSnapshot().dbClusterSnapshotArn();
+            String status = response.dbClusterSnapshot().status();
+            Instant createTime = response.dbClusterSnapshot().snapshotCreateTime();
+            LOG.info("Creating snapshot with id {} for {} and the current status is {}", snapshotId, dbIdentifier, status);
+
+            return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+        } catch (Exception e) {
+            LOG.error("Failed to create snapshot for {}", dbIdentifier, e);
+            return null;
+        }
+    }
+
+    @Override
+    public SnapshotInfo describeSnapshot(String snapshotId) {
+        DescribeDbClusterSnapshotsRequest request = DescribeDbClusterSnapshotsRequest.builder()
+                .dbClusterSnapshotIdentifier(snapshotId)
+                .build();
+
+        DescribeDbClusterSnapshotsResponse response = rdsClient.describeDBClusterSnapshots(request);
+        String snapshotArn = response.dbClusterSnapshots().get(0).dbClusterSnapshotArn();
+        String status = response.dbClusterSnapshots().get(0).status();
+        Instant createTime = response.dbClusterSnapshots().get(0).snapshotCreateTime();
+
+        return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -20,7 +20,6 @@ import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
@@ -50,7 +49,6 @@ public class ExportScheduler implements Runnable {
     private static final Duration DEFAULT_SNAPSHOT_STATUS_CHECK_TIMEOUT = Duration.ofMinutes(60);
     static final String PARQUET_SUFFIX = ".parquet";
 
-    private final RdsClient rdsClient;
     private final S3Client s3Client;
     private final PluginMetrics pluginMetrics;
     private final EnhancedSourceCoordinator sourceCoordinator;
@@ -61,16 +59,16 @@ public class ExportScheduler implements Runnable {
     private volatile boolean shutdownRequested = false;
 
     public ExportScheduler(final EnhancedSourceCoordinator sourceCoordinator,
-                           final RdsClient rdsClient,
+                           final SnapshotManager snapshotManager,
+                           final ExportTaskManager exportTaskManager,
                            final S3Client s3Client,
                            final PluginMetrics pluginMetrics) {
         this.pluginMetrics = pluginMetrics;
         this.sourceCoordinator = sourceCoordinator;
-        this.rdsClient = rdsClient;
         this.s3Client = s3Client;
         this.executor = Executors.newCachedThreadPool();
-        this.exportTaskManager = new ExportTaskManager(rdsClient);
-        this.snapshotManager = new SnapshotManager(rdsClient);
+        this.snapshotManager = snapshotManager;
+        this.exportTaskManager = exportTaskManager;
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/InstanceSnapshotStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/InstanceSnapshotStrategy.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+
+import java.time.Instant;
+
+/**
+ * This snapshot strategy works with RDS Instances
+ */
+public class InstanceSnapshotStrategy implements SnapshotStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(InstanceSnapshotStrategy.class);
+    private final RdsClient rdsClient;
+
+    public InstanceSnapshotStrategy(final RdsClient rdsClient) {
+        this.rdsClient = rdsClient;
+    }
+
+    @Override
+    public SnapshotInfo createSnapshot(String dbIdentifier, String snapshotId) {
+        CreateDbSnapshotRequest request = CreateDbSnapshotRequest.builder()
+                .dbInstanceIdentifier(dbIdentifier)
+                .dbSnapshotIdentifier(snapshotId)
+                .build();
+
+        try {
+            CreateDbSnapshotResponse response = rdsClient.createDBSnapshot(request);
+            String snapshotArn = response.dbSnapshot().dbSnapshotArn();
+            String status = response.dbSnapshot().status();
+            Instant createTime = response.dbSnapshot().snapshotCreateTime();
+            LOG.info("Creating snapshot with id {} for {} and the current status is {}", snapshotId, dbIdentifier, status);
+
+            return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+        } catch (Exception e) {
+            LOG.error("Failed to create snapshot for {}", dbIdentifier, e);
+            return null;
+        }
+    }
+
+    @Override
+    public SnapshotInfo describeSnapshot(String snapshotId) {
+        DescribeDbSnapshotsRequest request = DescribeDbSnapshotsRequest.builder()
+                .dbSnapshotIdentifier(snapshotId)
+                .build();
+
+        DescribeDbSnapshotsResponse response = rdsClient.describeDBSnapshots(request);
+        String snapshotArn = response.dbSnapshots().get(0).dbSnapshotArn();
+        String status = response.dbSnapshots().get(0).status();
+        Instant createTime = response.dbSnapshots().get(0).snapshotCreateTime();
+
+        return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManager.java
@@ -6,61 +6,26 @@
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
-import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
-import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
 
-import java.time.Instant;
 import java.util.UUID;
 
 public class SnapshotManager {
-    private static final Logger LOG = LoggerFactory.getLogger(SnapshotManager.class);
+    private final SnapshotStrategy snapshotStrategy;
 
-    private final RdsClient rdsClient;
-
-    public SnapshotManager(final RdsClient rdsClient) {
-        this.rdsClient = rdsClient;
+    public SnapshotManager(final SnapshotStrategy snapshotStrategy) {
+        this.snapshotStrategy = snapshotStrategy;
     }
 
-    public SnapshotInfo createSnapshot(String dbInstanceId) {
-        final String snapshotId = generateSnapshotId(dbInstanceId);
-        CreateDbSnapshotRequest request = CreateDbSnapshotRequest.builder()
-                .dbInstanceIdentifier(dbInstanceId)
-                .dbSnapshotIdentifier(snapshotId)
-                .build();
-
-        try {
-            CreateDbSnapshotResponse response = rdsClient.createDBSnapshot(request);
-            String snapshotArn = response.dbSnapshot().dbSnapshotArn();
-            String status = response.dbSnapshot().status();
-            Instant createTime = response.dbSnapshot().snapshotCreateTime();
-            LOG.info("Creating snapshot with id {} and status {}", snapshotId, status);
-
-            return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
-        } catch (Exception e) {
-            LOG.error("Failed to create snapshot for {}", dbInstanceId, e);
-            return null;
-        }
+    public SnapshotInfo createSnapshot(String dbIdentifier) {
+        final String snapshotId = generateSnapshotId(dbIdentifier);
+        return snapshotStrategy.createSnapshot(dbIdentifier, snapshotId);
     }
 
     public SnapshotInfo checkSnapshotStatus(String snapshotId) {
-        DescribeDbSnapshotsRequest request = DescribeDbSnapshotsRequest.builder()
-                .dbSnapshotIdentifier(snapshotId)
-                .build();
-
-        DescribeDbSnapshotsResponse response = rdsClient.describeDBSnapshots(request);
-        String snapshotArn = response.dbSnapshots().get(0).dbSnapshotArn();
-        String status = response.dbSnapshots().get(0).status();
-        Instant createTime = response.dbSnapshots().get(0).snapshotCreateTime();
-
-        return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+        return snapshotStrategy.describeSnapshot(snapshotId);
     }
 
-    private String generateSnapshotId(String dbClusterId) {
-        return dbClusterId + "-snapshot-" + UUID.randomUUID().toString().substring(0, 8);
+    private String generateSnapshotId(String dbIdentifier) {
+        return dbIdentifier + "-snapshot-" + UUID.randomUUID().toString().substring(0, 8);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+
+/**
+ * Provides a strategy for creating and describing RDS snapshots.
+ */
+public interface SnapshotStrategy {
+    /**
+     * Creates a snapshot of an RDS instance or cluster.
+     *
+     * @param dbIdentifier The identifier of the RDS instance or cluster to snapshot.
+     * @param snapshotId   The identifier of the snapshot.
+     * @return An {@link SnapshotInfo} object describing the snapshot.
+     */
+    SnapshotInfo createSnapshot(String dbIdentifier, String snapshotId);
+
+    /**
+     * Checks the status of a snapshot.
+     *
+     * @param snapshotId   The identifier of the snapshot.
+     * @return An {@link SnapshotInfo} object describing the snapshot.
+     */
+    SnapshotInfo describeSnapshot(String snapshotId);
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ClusterSnapshotStrategyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ClusterSnapshotStrategyTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBClusterSnapshot;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsResponse;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterSnapshotStrategyTest {
+
+    @Mock
+    private RdsClient rdsClient;
+
+    private ClusterSnapshotStrategy objectUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        objectUnderTest = createObjectUnderTest();
+    }
+
+    @Test
+    void test_create_snapshot_with_success() {
+        final String dbInstanceId = UUID.randomUUID().toString();
+        final String snapshotId = UUID.randomUUID().toString();
+        CreateDbClusterSnapshotResponse createDbClusterSnapshotResponse = mock(CreateDbClusterSnapshotResponse.class);
+        DBClusterSnapshot dbClusterSnapshot = mock(DBClusterSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:" + snapshotId;
+        final String status = "creating";
+        final Instant createTime = Instant.now();
+        when(dbClusterSnapshot.dbClusterSnapshotArn()).thenReturn(snapshotArn);
+        when(dbClusterSnapshot.status()).thenReturn(status);
+        when(dbClusterSnapshot.snapshotCreateTime()).thenReturn(createTime);
+        when(createDbClusterSnapshotResponse.dbClusterSnapshot()).thenReturn(dbClusterSnapshot);
+        when(rdsClient.createDBClusterSnapshot(any(CreateDbClusterSnapshotRequest.class))).thenReturn(createDbClusterSnapshotResponse);
+
+        SnapshotInfo snapshotInfo = objectUnderTest.createSnapshot(dbInstanceId, snapshotId);
+
+        ArgumentCaptor<CreateDbClusterSnapshotRequest> argumentCaptor = ArgumentCaptor.forClass(CreateDbClusterSnapshotRequest.class);
+        verify(rdsClient).createDBClusterSnapshot(argumentCaptor.capture());
+
+        CreateDbClusterSnapshotRequest request = argumentCaptor.getValue();
+        assertThat(request.dbClusterIdentifier(), equalTo(dbInstanceId));
+        assertThat(request.dbClusterSnapshotIdentifier(), equalTo(snapshotId));
+
+        assertThat(snapshotInfo, notNullValue());
+        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
+        assertThat(snapshotInfo.getStatus(), equalTo(status));
+        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+    }
+
+    @Test
+    void test_create_snapshot_throws_exception_then_returns_null() {
+        final String dbInstanceId = UUID.randomUUID().toString();
+        final String snapshotId = UUID.randomUUID().toString();
+        when(rdsClient.createDBClusterSnapshot(any(CreateDbClusterSnapshotRequest.class))).thenThrow(new RuntimeException("Error"));
+
+        SnapshotInfo snapshotInfo = objectUnderTest.createSnapshot(dbInstanceId, snapshotId);
+
+        assertThat(snapshotInfo, equalTo(null));
+    }
+
+    @Test
+    void test_check_snapshot_status_returns_correct_result() {
+        DBClusterSnapshot dbClusterSnapshot = mock(DBClusterSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:" + UUID.randomUUID();
+        final String status = "creating";
+        final Instant createTime = Instant.now();
+        when(dbClusterSnapshot.dbClusterSnapshotArn()).thenReturn(snapshotArn);
+        when(dbClusterSnapshot.status()).thenReturn(status);
+        when(dbClusterSnapshot.snapshotCreateTime()).thenReturn(createTime);
+        DescribeDbClusterSnapshotsResponse describeDbClusterSnapshotsResponse = mock(DescribeDbClusterSnapshotsResponse.class);
+        when(describeDbClusterSnapshotsResponse.dbClusterSnapshots()).thenReturn(List.of(dbClusterSnapshot));
+
+        final String snapshotId = UUID.randomUUID().toString();
+        DescribeDbClusterSnapshotsRequest describeDbClusterSnapshotsRequest = DescribeDbClusterSnapshotsRequest.builder()
+                .dbClusterSnapshotIdentifier(snapshotId)
+                .build();
+        when(rdsClient.describeDBClusterSnapshots(describeDbClusterSnapshotsRequest)).thenReturn(describeDbClusterSnapshotsResponse);
+
+        SnapshotInfo snapshotInfo = objectUnderTest.describeSnapshot(snapshotId);
+
+        assertThat(snapshotInfo, notNullValue());
+        assertThat(snapshotInfo.getSnapshotId(), equalTo(snapshotId));
+        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
+        assertThat(snapshotInfo.getStatus(), equalTo(status));
+        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+    }
+
+    private ClusterSnapshotStrategy createObjectUnderTest() {
+        return new ClusterSnapshotStrategy(rdsClient);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/InstanceSnapshotStrategyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/InstanceSnapshotStrategyTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.export;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBSnapshot;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceSnapshotStrategyTest {
+
+    @Mock
+    private RdsClient rdsClient;
+
+    private InstanceSnapshotStrategy objectUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        objectUnderTest = createObjectUnderTest();
+    }
+
+    @Test
+    void test_create_snapshot_with_success() {
+        final String dbInstanceId = UUID.randomUUID().toString();
+        final String snapshotId = UUID.randomUUID().toString();
+        CreateDbSnapshotResponse createDbSnapshotResponse = mock(CreateDbSnapshotResponse.class);
+        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:" + snapshotId;
+        final String status = "creating";
+        final Instant createTime = Instant.now();
+        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
+        when(dbSnapshot.status()).thenReturn(status);
+        when(dbSnapshot.snapshotCreateTime()).thenReturn(createTime);
+        when(createDbSnapshotResponse.dbSnapshot()).thenReturn(dbSnapshot);
+        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenReturn(createDbSnapshotResponse);
+
+        SnapshotInfo snapshotInfo = objectUnderTest.createSnapshot(dbInstanceId, snapshotId);
+
+        ArgumentCaptor<CreateDbSnapshotRequest> argumentCaptor = ArgumentCaptor.forClass(CreateDbSnapshotRequest.class);
+        verify(rdsClient).createDBSnapshot(argumentCaptor.capture());
+
+        CreateDbSnapshotRequest request = argumentCaptor.getValue();
+        assertThat(request.dbInstanceIdentifier(), equalTo(dbInstanceId));
+        assertThat(request.dbSnapshotIdentifier(), equalTo(snapshotId));
+
+        assertThat(snapshotInfo, notNullValue());
+        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
+        assertThat(snapshotInfo.getStatus(), equalTo(status));
+        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+    }
+
+    @Test
+    void test_create_snapshot_throws_exception_then_returns_null() {
+        final String dbInstanceId = UUID.randomUUID().toString();
+        final String snapshotId = UUID.randomUUID().toString();
+        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenThrow(new RuntimeException("Error"));
+
+        SnapshotInfo snapshotInfo = objectUnderTest.createSnapshot(dbInstanceId, snapshotId);
+
+        assertThat(snapshotInfo, equalTo(null));
+    }
+
+    @Test
+    void test_check_snapshot_status_returns_correct_result() {
+        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:" + UUID.randomUUID();
+        final String status = "creating";
+        final Instant createTime = Instant.now();
+        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
+        when(dbSnapshot.status()).thenReturn(status);
+        when(dbSnapshot.snapshotCreateTime()).thenReturn(createTime);
+        DescribeDbSnapshotsResponse describeDbSnapshotsResponse = mock(DescribeDbSnapshotsResponse.class);
+        when(describeDbSnapshotsResponse.dbSnapshots()).thenReturn(List.of(dbSnapshot));
+
+        final String snapshotId = UUID.randomUUID().toString();
+        DescribeDbSnapshotsRequest describeDbSnapshotsRequest = DescribeDbSnapshotsRequest.builder()
+                .dbSnapshotIdentifier(snapshotId)
+                .build();
+        when(rdsClient.describeDBSnapshots(describeDbSnapshotsRequest)).thenReturn(describeDbSnapshotsResponse);
+
+        SnapshotInfo snapshotInfo = objectUnderTest.describeSnapshot(snapshotId);
+
+        assertThat(snapshotInfo, notNullValue());
+        assertThat(snapshotInfo.getSnapshotId(), equalTo(snapshotId));
+        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
+        assertThat(snapshotInfo.getStatus(), equalTo(status));
+        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+    }
+
+    private InstanceSnapshotStrategy createObjectUnderTest() {
+        return new InstanceSnapshotStrategy(rdsClient);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManagerTest.java
@@ -8,34 +8,20 @@ package org.opensearch.dataprepper.plugins.source.rds.export;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
-import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
-import software.amazon.awssdk.services.rds.model.DBSnapshot;
-import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
 
-import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SnapshotManagerTest {
 
     @Mock
-    private RdsClient rdsClient;
+    private SnapshotStrategy snapshotStrategy;
 
     private SnapshotManager snapshotManager;
 
@@ -45,71 +31,24 @@ class SnapshotManagerTest {
     }
 
     @Test
-    void test_create_snapshot_with_success() {
-        String dbInstanceId = UUID.randomUUID().toString();
-        CreateDbSnapshotResponse createDbSnapshotResponse = mock(CreateDbSnapshotResponse.class);
-        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
-        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
-        final String status = "creating";
-        final Instant createTime = Instant.now();
-        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
-        when(dbSnapshot.status()).thenReturn(status);
-        when(dbSnapshot.snapshotCreateTime()).thenReturn(createTime);
-        when(createDbSnapshotResponse.dbSnapshot()).thenReturn(dbSnapshot);
-        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenReturn(createDbSnapshotResponse);
+    void test_create_snapshot() {
+        final String dbIdentifier = UUID.randomUUID().toString();
 
-        SnapshotInfo snapshotInfo = snapshotManager.createSnapshot(dbInstanceId);
+        snapshotManager.createSnapshot(dbIdentifier);
 
-        ArgumentCaptor<CreateDbSnapshotRequest> argumentCaptor = ArgumentCaptor.forClass(CreateDbSnapshotRequest.class);
-        verify(rdsClient).createDBSnapshot(argumentCaptor.capture());
-
-        CreateDbSnapshotRequest request = argumentCaptor.getValue();
-        assertThat(request.dbInstanceIdentifier(), equalTo(dbInstanceId));
-
-        assertThat(snapshotInfo, notNullValue());
-        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
-        assertThat(snapshotInfo.getStatus(), equalTo(status));
-        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+        verify(snapshotStrategy).createSnapshot(eq(dbIdentifier), startsWith(dbIdentifier + "-snapshot-"));
     }
 
     @Test
-    void test_create_snapshot_throws_exception_then_returns_null() {
-        String dbInstanceId = UUID.randomUUID().toString();
-        when(rdsClient.createDBSnapshot(any(CreateDbSnapshotRequest.class))).thenThrow(new RuntimeException("Error"));
-
-        SnapshotInfo snapshotInfo = snapshotManager.createSnapshot(dbInstanceId);
-
-        assertThat(snapshotInfo, equalTo(null));
-    }
-
-    @Test
-    void test_check_snapshot_status_returns_correct_result() {
-        DBSnapshot dbSnapshot = mock(DBSnapshot.class);
-        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:snapshot-0b5ae174";
-        final String status = "creating";
-        final Instant createTime = Instant.now();
-        when(dbSnapshot.dbSnapshotArn()).thenReturn(snapshotArn);
-        when(dbSnapshot.status()).thenReturn(status);
-        when(dbSnapshot.snapshotCreateTime()).thenReturn(createTime);
-        DescribeDbSnapshotsResponse describeDbSnapshotsResponse = mock(DescribeDbSnapshotsResponse.class);
-        when(describeDbSnapshotsResponse.dbSnapshots()).thenReturn(List.of(dbSnapshot));
-
+    void test_check_snapshot_status() {
         final String snapshotId = UUID.randomUUID().toString();
-        DescribeDbSnapshotsRequest describeDbSnapshotsRequest = DescribeDbSnapshotsRequest.builder()
-                .dbSnapshotIdentifier(snapshotId)
-                .build();
-        when(rdsClient.describeDBSnapshots(describeDbSnapshotsRequest)).thenReturn(describeDbSnapshotsResponse);
 
-        SnapshotInfo snapshotInfo = snapshotManager.checkSnapshotStatus(snapshotId);
+        snapshotManager.checkSnapshotStatus(snapshotId);
 
-        assertThat(snapshotInfo, notNullValue());
-        assertThat(snapshotInfo.getSnapshotId(), equalTo(snapshotId));
-        assertThat(snapshotInfo.getSnapshotArn(), equalTo(snapshotArn));
-        assertThat(snapshotInfo.getStatus(), equalTo(status));
-        assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
+        verify(snapshotStrategy).describeSnapshot(snapshotId);
     }
 
     private SnapshotManager createObjectUnderTest() {
-        return new SnapshotManager(rdsClient);
+        return new SnapshotManager(snapshotStrategy);
     }
 }


### PR DESCRIPTION
### Description
There are 2 sets of RDS APIs for snapshots:
- For RDS instances: `CreateDBSnapshot` and `DescribeDBSnapshots`
- For RDS/Aurora clusters: `CreateDBClusterSnapshot` and `DescribeDBClusterSnapshots`

This PR adds support for the clusters:
- Adds strategy interface and implementations for both APIs
- Refactors SnapshotManager to use SnapshotStrategy
- Refactors ExportSchedulerTest to make it simpler

#### Testing
Tested pipelines against RDS instance and Aurora cluster, both worked.
 
### Issues Resolved
Contributes to https://github.com/opensearch-project/data-prepper/issues/4561
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
