### PR TITLE
Add rds source metrics

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -26,4 +26,7 @@ dependencies {
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(path: ':data-prepper-test-event')
+    testImplementation libs.avro.core
+    testImplementation libs.parquet.hadoop
+    testImplementation libs.parquet.avro
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -88,7 +88,7 @@ public class RdsService {
             exportScheduler = new ExportScheduler(
                     sourceCoordinator, snapshotManager, exportTaskManager, s3Client, pluginMetrics);
             dataFileScheduler = new DataFileScheduler(
-                    sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer);
+                    sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer, pluginMetrics);
             runnableList.add(exportScheduler);
             runnableList.add(dataFileScheduler);
         }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.rds;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.rds;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -5,7 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -18,12 +21,18 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class DataFileLoader implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataFileLoader.class);
 
     static final Duration VERSION_OVERLAP_TIME_FOR_EXPORT = Duration.ofMinutes(5);
+    static final String EXPORT_RECORDS_TOTAL_COUNT = "exportRecordsTotal";
+    static final String EXPORT_RECORDS_PROCESSED_COUNT = "exportRecordsProcessed";
+    static final String EXPORT_RECORDS_PROCESSING_ERROR_COUNT = "exportRecordsProcessingErrors";
+    static final String BYTES_RECEIVED = "bytesReceived";
+    static final String BYTES_PROCESSED = "bytesProcessed";
 
     private final DataFilePartition dataFilePartition;
     private final String bucket;
@@ -32,12 +41,18 @@ public class DataFileLoader implements Runnable {
     private final InputCodec codec;
     private final BufferAccumulator<Record<Event>> bufferAccumulator;
     private final ExportRecordConverter recordConverter;
+    private final Counter exportRecordsTotalCounter;
+    private final Counter exportRecordSuccessCounter;
+    private final Counter exportRecordErrorCounter;
+    private final DistributionSummary bytesReceivedSummary;
+    private final DistributionSummary bytesProcessedSummary;
 
     private DataFileLoader(final DataFilePartition dataFilePartition,
-                   final InputCodec codec,
-                   final BufferAccumulator<Record<Event>> bufferAccumulator,
-                   final S3ObjectReader objectReader,
-                   final ExportRecordConverter recordConverter) {
+                           final InputCodec codec,
+                           final BufferAccumulator<Record<Event>> bufferAccumulator,
+                           final S3ObjectReader objectReader,
+                           final ExportRecordConverter recordConverter,
+                           final PluginMetrics pluginMetrics) {
         this.dataFilePartition = dataFilePartition;
         bucket = dataFilePartition.getBucket();
         objectKey = dataFilePartition.getKey();
@@ -45,24 +60,37 @@ public class DataFileLoader implements Runnable {
         this.codec = codec;
         this.bufferAccumulator = bufferAccumulator;
         this.recordConverter = recordConverter;
+
+        exportRecordsTotalCounter = pluginMetrics.counter(EXPORT_RECORDS_TOTAL_COUNT);
+        exportRecordSuccessCounter = pluginMetrics.counter(EXPORT_RECORDS_PROCESSED_COUNT);
+        exportRecordErrorCounter = pluginMetrics.counter(EXPORT_RECORDS_PROCESSING_ERROR_COUNT);
+        bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
+        bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
     }
 
     public static DataFileLoader create(final DataFilePartition dataFilePartition,
                                         final InputCodec codec,
                                         final BufferAccumulator<Record<Event>> bufferAccumulator,
                                         final S3ObjectReader objectReader,
-                                        final ExportRecordConverter recordConverter) {
-        return new DataFileLoader(dataFilePartition, codec, bufferAccumulator, objectReader, recordConverter);
+                                        final ExportRecordConverter recordConverter,
+                                        final PluginMetrics pluginMetrics) {
+        return new DataFileLoader(dataFilePartition, codec, bufferAccumulator, objectReader, recordConverter, pluginMetrics);
     }
 
     @Override
     public void run() {
         LOG.info("Start loading s3://{}/{}", bucket, objectKey);
 
+        AtomicLong eventCount = new AtomicLong();
         try (InputStream inputStream = objectReader.readFile(bucket, objectKey)) {
-
             codec.parse(inputStream, record -> {
                 try {
+                    exportRecordsTotalCounter.increment();
+                    final Event event = record.getData();
+                    final String string = event.toJsonString();
+                    final long bytes = string.getBytes().length;
+                    bytesReceivedSummary.record(bytes);
+
                     DataFileProgressState progressState = dataFilePartition.getProgressState().get();
 
                     // TODO: primary key to be obtained by querying database schema
@@ -79,6 +107,8 @@ public class DataFileLoader implements Runnable {
                                     snapshotTime,
                                     eventVersionNumber));
                     bufferAccumulator.add(transformedRecord);
+                    eventCount.getAndIncrement();
+                    bytesProcessedSummary.record(bytes);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -92,8 +122,10 @@ public class DataFileLoader implements Runnable {
 
         try {
             bufferAccumulator.flush();
+            exportRecordSuccessCounter.increment(eventCount.get());
         } catch (Exception e) {
             LOG.error("Failed to write events to buffer", e);
+            exportRecordErrorCounter.increment(eventCount.get());
         }
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
+import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
@@ -42,12 +43,15 @@ public class ExportScheduler implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ExportScheduler.class);
 
     private static final int DEFAULT_TAKE_LEASE_INTERVAL_MILLIS = 60_000;
-    private static final Duration DEFAULT_CLOSE_DURATION = Duration.ofMinutes(10);
-    private static final int DEFAULT_MAX_CLOSE_COUNT = 36;
+    static final Duration DEFAULT_CLOSE_DURATION = Duration.ofMinutes(10);
+    static final int DEFAULT_MAX_CLOSE_COUNT = 36;
     private static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 5 * 60_000;
     private static final int DEFAULT_CHECK_STATUS_INTERVAL_MILLS = 30 * 1000;
     private static final Duration DEFAULT_SNAPSHOT_STATUS_CHECK_TIMEOUT = Duration.ofMinutes(60);
     static final String PARQUET_SUFFIX = ".parquet";
+    static final String EXPORT_JOB_SUCCESS_COUNT = "exportJobSuccess";
+    static final String EXPORT_JOB_FAILURE_COUNT = "exportJobFailure";
+    static final String EXPORT_S3_OBJECTS_TOTAL_COUNT = "exportS3ObjectsTotal";
 
     private final S3Client s3Client;
     private final PluginMetrics pluginMetrics;
@@ -55,6 +59,10 @@ public class ExportScheduler implements Runnable {
     private final ExecutorService executor;
     private final ExportTaskManager exportTaskManager;
     private final SnapshotManager snapshotManager;
+
+    private final Counter exportJobSuccessCounter;
+    private final Counter exportJobFailureCounter;
+    private final Counter exportS3ObjectsTotalCounter;
 
     private volatile boolean shutdownRequested = false;
 
@@ -69,6 +77,10 @@ public class ExportScheduler implements Runnable {
         this.executor = Executors.newCachedThreadPool();
         this.snapshotManager = snapshotManager;
         this.exportTaskManager = exportTaskManager;
+
+        exportJobSuccessCounter = pluginMetrics.counter(EXPORT_JOB_SUCCESS_COUNT);
+        exportJobFailureCounter = pluginMetrics.counter(EXPORT_JOB_FAILURE_COUNT);
+        exportS3ObjectsTotalCounter = pluginMetrics.counter(EXPORT_S3_OBJECTS_TOTAL_COUNT);
     }
 
     @Override
@@ -133,8 +145,7 @@ public class ExportScheduler implements Runnable {
             progressState.setSnapshotId(snapshotInfo.getSnapshotId());
             sourceCoordinator.saveProgressStateForPartition(exportPartition, null);
         } else {
-            LOG.error("The snapshot failed to create, it will be retried");
-            closeExportPartitionWithError(exportPartition);
+            LOG.error("The snapshot failed to create. The export will be retried");
             return null;
         }
 
@@ -142,8 +153,7 @@ public class ExportScheduler implements Runnable {
         try {
             snapshotInfo = checkSnapshotStatus(snapshotId, DEFAULT_SNAPSHOT_STATUS_CHECK_TIMEOUT);
         } catch (Exception e) {
-            LOG.warn("Check snapshot status for {} failed", snapshotId, e);
-            sourceCoordinator.giveUpPartition(exportPartition);
+            LOG.warn("Check snapshot status for {} failed. The export will be retried", snapshotId, e);
             return null;
         }
         progressState.setSnapshotTime(snapshotInfo.getCreateTime().toEpochMilli());
@@ -159,7 +169,6 @@ public class ExportScheduler implements Runnable {
             sourceCoordinator.saveProgressStateForPartition(exportPartition, null);
         } else {
             LOG.error("The export task failed to create, it will be retried");
-            closeExportPartitionWithError(exportPartition);
             return null;
         }
 
@@ -167,6 +176,7 @@ public class ExportScheduler implements Runnable {
     }
 
     private void closeExportPartitionWithError(ExportPartition exportPartition) {
+        exportJobFailureCounter.increment();
         ExportProgressState exportProgressState = exportPartition.getProgressState().get();
         // Clear current task id, so that a new export can be submitted.
         exportProgressState.setExportTaskId(null);
@@ -309,12 +319,15 @@ public class ExportScheduler implements Runnable {
             totalFiles.getAndIncrement();
         }
 
+        exportS3ObjectsTotalCounter.increment(totalFiles.get());
+
         // Create a global state to track overall progress for data file processing
         LoadStatus loadStatus = new LoadStatus(totalFiles.get(), 0);
         sourceCoordinator.createPartition(new GlobalState(exportTaskId, loadStatus.toMap()));
     }
 
     private void completeExportPartition(ExportPartition exportPartition) {
+        exportJobSuccessCounter.increment();
         ExportProgressState progressState = exportPartition.getProgressState().get();
         progressState.setStatus("Completed");
         sourceCoordinator.completePartition(exportPartition);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
@@ -41,8 +41,9 @@ public class StreamScheduler implements Runnable {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
         this.binaryLogClient = binaryLogClient;
-        this.binaryLogClient.registerEventListener(new BinlogEventListener(buffer, sourceConfig));
+        this.binaryLogClient.registerEventListener(new BinlogEventListener(buffer, sourceConfig, pluginMetrics));
         this.pluginMetrics = pluginMetrics;
+
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -5,38 +5,61 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.event.BaseEventBuilder;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.io.InputFile;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.codec.parquet.ParquetInputCodec;
 import org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.DataFileProgressState;
 
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileLoader.BYTES_PROCESSED;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileLoader.BYTES_RECEIVED;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileLoader.EXPORT_RECORDS_PROCESSED_COUNT;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileLoader.EXPORT_RECORDS_PROCESSING_ERROR_COUNT;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileLoader.EXPORT_RECORDS_TOTAL_COUNT;
 
 @ExtendWith(MockitoExtension.class)
 class DataFileLoaderTest {
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private DataFilePartition dataFilePartition;
 
     @Mock
     private BufferAccumulator<Record<Event>> bufferAccumulator;
 
     @Mock
-    private InputCodec codec;
+    private EventFactory eventFactory;
 
     @Mock
     private S3ObjectReader s3ObjectReader;
@@ -44,24 +67,120 @@ class DataFileLoaderTest {
     @Mock
     private ExportRecordConverter recordConverter;
 
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Counter exportRecordsTotalCounter;
+
+    @Mock
+    private Counter exportRecordSuccessCounter;
+
+    @Mock
+    private Counter exportRecordErrorCounter;
+
+    @Mock
+    private DistributionSummary bytesReceivedSummary;
+
+    @Mock
+    private DistributionSummary bytesProcessedSummary;
+
+    @BeforeEach
+    void setUp() {
+        when(pluginMetrics.counter(EXPORT_RECORDS_TOTAL_COUNT)).thenReturn(exportRecordsTotalCounter);
+        when(pluginMetrics.counter(EXPORT_RECORDS_PROCESSED_COUNT)).thenReturn(exportRecordSuccessCounter);
+        when(pluginMetrics.counter(EXPORT_RECORDS_PROCESSING_ERROR_COUNT)).thenReturn(exportRecordErrorCounter);
+        when(pluginMetrics.summary(BYTES_RECEIVED)).thenReturn(bytesReceivedSummary);
+        when(pluginMetrics.summary(BYTES_PROCESSED)).thenReturn(bytesProcessedSummary);
+    }
+
     @Test
-    void test_run() throws Exception {
+    void test_run_success() throws Exception {
         final String bucket = UUID.randomUUID().toString();
         final String key = UUID.randomUUID().toString();
         when(dataFilePartition.getBucket()).thenReturn(bucket);
         when(dataFilePartition.getKey()).thenReturn(key);
+        final DataFileProgressState progressState = mock(DataFileProgressState.class, RETURNS_DEEP_STUBS);
+        when(dataFilePartition.getProgressState()).thenReturn(Optional.of(progressState));
 
         InputStream inputStream = mock(InputStream.class);
         when(s3ObjectReader.readFile(bucket, key)).thenReturn(inputStream);
 
-        DataFileLoader objectUnderTest = createObjectUnderTest();
-        objectUnderTest.run();
+        DataFileLoader dataFileLoader = createObjectUnderTest();
 
-        verify(codec).parse(eq(inputStream), any(Consumer.class));
+        final String randomString = UUID.randomUUID().toString();
+        final long sizeBytes = randomString.getBytes().length;
+        final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        final Event event = mock(Event.class);
+        when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
+        when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
+        when(event.toJsonString()).thenReturn(randomString);
+
+        try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class)) {
+            ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
+            AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
+            readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
+            when(builder.build()).thenReturn(parquetReader);
+            when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), null);
+
+            dataFileLoader.run();
+        }
+
+        verify(bufferAccumulator).add(any(Record.class));
         verify(bufferAccumulator).flush();
+
+        verify(exportRecordsTotalCounter).increment();
+        verify(bytesReceivedSummary).record(sizeBytes);
+        verify(bytesProcessedSummary).record(sizeBytes);
+        verify(exportRecordSuccessCounter).increment(1);
+        verify(exportRecordErrorCounter, never()).increment(1);
+    }
+
+    @Test
+    void test_flush_failure_then_error_metric_updated() throws Exception {
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        when(dataFilePartition.getBucket()).thenReturn(bucket);
+        when(dataFilePartition.getKey()).thenReturn(key);
+        final DataFileProgressState progressState = mock(DataFileProgressState.class, RETURNS_DEEP_STUBS);
+        when(dataFilePartition.getProgressState()).thenReturn(Optional.of(progressState));
+
+        InputStream inputStream = mock(InputStream.class);
+        when(s3ObjectReader.readFile(bucket, key)).thenReturn(inputStream);
+
+        DataFileLoader dataFileLoader = createObjectUnderTest();
+
+        final String randomString = UUID.randomUUID().toString();
+        final long sizeBytes = randomString.getBytes().length;
+        final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        final Event event = mock(Event.class);
+        when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
+        when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
+        when(event.toJsonString()).thenReturn(randomString);
+        doThrow(new RuntimeException("testing")).when(bufferAccumulator).flush();
+
+        try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class)) {
+            ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
+            AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
+            readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
+            when(builder.build()).thenReturn(parquetReader);
+            when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), null);
+
+            dataFileLoader.run();
+        }
+
+        verify(bufferAccumulator).add(any(Record.class));
+        verify(bufferAccumulator).flush();
+
+        verify(exportRecordsTotalCounter).increment();
+        verify(bytesReceivedSummary).record(sizeBytes);
+        verify(bytesProcessedSummary).record(sizeBytes);
+        verify(exportRecordSuccessCounter, never()).increment(1);
+        verify(exportRecordErrorCounter).increment(1);
     }
 
     private DataFileLoader createObjectUnderTest() {
-        return DataFileLoader.create(dataFilePartition, codec, bufferAccumulator, s3ObjectReader, recordConverter);
+        final InputCodec codec = new ParquetInputCodec(eventFactory);
+        return DataFileLoader.create(dataFilePartition, codec, bufferAccumulator, s3ObjectReader, recordConverter, pluginMetrics);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
@@ -32,6 +34,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +46,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileScheduler.ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE;
+import static org.opensearch.dataprepper.plugins.source.rds.export.DataFileScheduler.EXPORT_S3_OBJECTS_PROCESSED_COUNT;
 
 @ExtendWith(MockitoExtension.class)
 class DataFileSchedulerTest {
@@ -63,18 +68,31 @@ class DataFileSchedulerTest {
     private Buffer<Record<Event>> buffer;
 
     @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
     private DataFilePartition dataFilePartition;
+
+    @Mock
+    private Counter exportFileSuccessCounter;
+
+    @Mock
+    private AtomicInteger activeExportS3ObjectConsumersGauge;
 
     private Random random;
 
     @BeforeEach
     void setUp() {
         random = new Random();
+        when(pluginMetrics.counter(EXPORT_S3_OBJECTS_PROCESSED_COUNT)).thenReturn(exportFileSuccessCounter);
+        when(pluginMetrics.gauge(eq(ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE), any(AtomicInteger.class), any()))
+                .thenReturn(activeExportS3ObjectConsumersGauge);
     }
 
     @Test
     void test_given_no_datafile_partition_then_no_export() throws InterruptedException {
         when(sourceCoordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).thenReturn(Optional.empty());
+
 
         final DataFileScheduler objectUnderTest = createObjectUnderTest();
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -84,12 +102,11 @@ class DataFileSchedulerTest {
         Thread.sleep(100);
         executorService.shutdownNow();
 
-        verifyNoInteractions(s3Client, buffer);
+        verifyNoInteractions(s3Client, buffer, exportFileSuccessCounter, activeExportS3ObjectConsumersGauge);
     }
 
     @Test
     void test_given_available_datafile_partition_then_load_datafile() {
-        DataFileScheduler objectUnderTest = createObjectUnderTest();
         final String exportTaskId = UUID.randomUUID().toString();
         when(dataFilePartition.getExportTaskId()).thenReturn(exportTaskId);
 
@@ -100,13 +117,15 @@ class DataFileSchedulerTest {
         when(globalStatePartition.getProgressState()).thenReturn(Optional.of(loadStatusMap));
         when(sourceCoordinator.getPartition(exportTaskId)).thenReturn(Optional.of(globalStatePartition));
 
+        DataFileScheduler objectUnderTest = createObjectUnderTest();
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {
                     // MockedStatic needs to be created on the same thread it's used
                     try (MockedStatic<DataFileLoader> dataFileLoaderMockedStatic = mockStatic(DataFileLoader.class)) {
                         DataFileLoader dataFileLoader = mock(DataFileLoader.class);
                         dataFileLoaderMockedStatic.when(() -> DataFileLoader.create(
-                                eq(dataFilePartition), any(InputCodec.class), any(BufferAccumulator.class), any(S3ObjectReader.class), any(ExportRecordConverter.class)))
+                                eq(dataFilePartition), any(InputCodec.class), any(BufferAccumulator.class), any(S3ObjectReader.class),
+                                        any(ExportRecordConverter.class), any(PluginMetrics.class)))
                                 .thenReturn(dataFileLoader);
                         doNothing().when(dataFileLoader).run();
                         objectUnderTest.run();
@@ -116,6 +135,7 @@ class DataFileSchedulerTest {
                 .untilAsserted(() -> verify(sourceCoordinator).completePartition(dataFilePartition));
         executorService.shutdownNow();
 
+        verify(exportFileSuccessCounter).increment();
         verify(sourceCoordinator).completePartition(dataFilePartition);
     }
 
@@ -132,6 +152,6 @@ class DataFileSchedulerTest {
     }
 
     private DataFileScheduler createObjectUnderTest() {
-        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer);
+        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer, pluginMetrics);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
 
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +43,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler.DEFAULT_CLOSE_DURATION;
+import static org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler.DEFAULT_MAX_CLOSE_COUNT;
+import static org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler.EXPORT_JOB_FAILURE_COUNT;
+import static org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler.EXPORT_JOB_SUCCESS_COUNT;
+import static org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler.EXPORT_S3_OBJECTS_TOTAL_COUNT;
 import static org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler.PARQUET_SUFFIX;
 
 
@@ -64,6 +70,15 @@ class ExportSchedulerTest {
     private PluginMetrics pluginMetrics;
 
     @Mock
+    private Counter exportJobSuccessCounter;
+
+    @Mock
+    private Counter exportJobFailureCounter;
+
+    @Mock
+    private Counter exportS3ObjectsTotalCounter;
+
+    @Mock
     private ExportPartition exportPartition;
 
     @Mock(answer = Answers.RETURNS_DEFAULTS)
@@ -73,6 +88,10 @@ class ExportSchedulerTest {
 
     @BeforeEach
     void setUp() {
+        when(pluginMetrics.counter(EXPORT_JOB_SUCCESS_COUNT)).thenReturn(exportJobSuccessCounter);
+        when(pluginMetrics.counter(EXPORT_JOB_FAILURE_COUNT)).thenReturn(exportJobFailureCounter);
+        when(pluginMetrics.counter(EXPORT_S3_OBJECTS_TOTAL_COUNT)).thenReturn(exportS3ObjectsTotalCounter);
+
         exportScheduler = createObjectUnderTest();
     }
 
@@ -87,7 +106,8 @@ class ExportSchedulerTest {
         Thread.sleep(100);
         executorService.shutdownNow();
 
-        verifyNoInteractions(snapshotManager, exportTaskManager, s3Client);
+        verifyNoInteractions(snapshotManager, exportTaskManager, s3Client, exportJobSuccessCounter,
+                exportJobFailureCounter, exportS3ObjectsTotalCounter);
     }
 
     @Test
@@ -123,8 +143,10 @@ class ExportSchedulerTest {
                 any(String.class), any(String.class), any(List.class));
         verify(sourceCoordinator).createPartition(any(DataFilePartition.class));
         verify(sourceCoordinator).completePartition(exportPartition);
+        verify(exportJobSuccessCounter).increment();
+        verify(exportS3ObjectsTotalCounter).increment(1);
+        verify(exportJobFailureCounter, never()).increment();
     }
-
 
     @Test
     void test_given_export_partition_without_export_task_id_then_start_and_complete_export() throws InterruptedException {
@@ -184,6 +206,59 @@ class ExportSchedulerTest {
                 any(String.class), any(String.class), any(List.class));
         verify(sourceCoordinator).createPartition(any(DataFilePartition.class));
         verify(sourceCoordinator).completePartition(exportPartition);
+        verify(exportJobSuccessCounter).increment();
+        verify(exportS3ObjectsTotalCounter).increment(1);
+        verify(exportJobFailureCounter, never()).increment();
+    }
+
+    @Test
+    void test_given_export_partition_and_null_export_task_id_then_close_partition_with_error() throws InterruptedException {
+        when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.of(exportPartition));
+        when(exportPartition.getPartitionKey()).thenReturn(UUID.randomUUID().toString());
+        when(exportProgressState.getExportTaskId()).thenReturn(null);
+        when(exportPartition.getProgressState()).thenReturn(Optional.of(exportProgressState));
+        final String dbIdentifier = UUID.randomUUID().toString();
+        when(exportPartition.getDbIdentifier()).thenReturn(dbIdentifier);
+
+        // Mock snapshot response
+        final String snapshotId = UUID.randomUUID().toString();
+        final String snapshotArn = "arn:aws:rds:us-east-1:123456789012:snapshot:" + snapshotId;
+        final Instant createTime = Instant.now();
+        final SnapshotInfo snapshotInfoWhenCreate = new SnapshotInfo(
+                snapshotId, snapshotArn, createTime, SnapshotStatus.CREATING.getStatusName());
+        final SnapshotInfo snapshotInfoWhenComplete = new SnapshotInfo(
+                snapshotId, snapshotArn, createTime, SnapshotStatus.AVAILABLE.getStatusName());
+        when(snapshotManager.createSnapshot(dbIdentifier)).thenReturn(snapshotInfoWhenCreate);
+        when(snapshotManager.checkSnapshotStatus(snapshotId)).thenReturn(snapshotInfoWhenComplete);
+
+        // Mock export response
+        when(exportProgressState.getIamRoleArn()).thenReturn(UUID.randomUUID().toString());
+        when(exportProgressState.getBucket()).thenReturn(UUID.randomUUID().toString());
+        when(exportProgressState.getPrefix()).thenReturn(UUID.randomUUID().toString());
+        when(exportProgressState.getKmsKeyId()).thenReturn(UUID.randomUUID().toString());
+        when(exportTaskManager.startExportTask(any(String.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(List.class))).thenReturn(null);
+
+        // Act
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(exportScheduler);
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> verify(sourceCoordinator).acquireAvailablePartition(ExportPartition.PARTITION_TYPE));
+        Thread.sleep(200);
+        executorService.shutdownNow();
+
+        // Assert
+        verify(snapshotManager).createSnapshot(dbIdentifier);
+        verify(exportTaskManager).startExportTask(
+                any(String.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(List.class));
+        verify(sourceCoordinator).closePartition(exportPartition, DEFAULT_CLOSE_DURATION, DEFAULT_MAX_CLOSE_COUNT);
+        verify(sourceCoordinator, never()).createPartition(any(DataFilePartition.class));
+        verify(sourceCoordinator, never()).completePartition(exportPartition);
+
+        verify(exportJobFailureCounter).increment();
+        verify(exportJobSuccessCounter, never()).increment();
+        verify(exportS3ObjectsTotalCounter, never()).increment(1);
     }
 
     @Test
@@ -193,7 +268,8 @@ class ExportSchedulerTest {
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(exportScheduler);
         exportScheduler.shutdown();
-        verifyNoMoreInteractions(sourceCoordinator, snapshotManager, exportTaskManager, s3Client);
+        verifyNoMoreInteractions(sourceCoordinator, snapshotManager, exportTaskManager, s3Client,
+                exportJobSuccessCounter, exportJobFailureCounter, exportS3ObjectsTotalCounter);
         executorService.shutdownNow();
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -32,6 +33,9 @@ class BinlogEventListenerTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private com.github.shyiko.mysql.binlog.event.Event binlogEvent;
@@ -87,6 +91,6 @@ class BinlogEventListenerTest {
     }
 
     private BinlogEventListener createObjectUnderTest() {
-        return new BinlogEventListener(buffer, sourceConfig);
+        return new BinlogEventListener(buffer, sourceConfig, pluginMetrics);
     }
 }


### PR DESCRIPTION
### Description
Adds the following rds source metrics, named to be consistent with dynamodb and documentdb source metrics:
* exportJobSuccess
* exportJobFailure
* exportS3ObjectsTotal
* exportS3ObjectsProcessed
* exportRecordsTotal 
* exportRecordsProcessed
* exportRecordsProcessingErrors
* activeExportS3ObjectConsumers
* changeEventsProcessed
* changeEventsProcessingErrors
* bytesReceived
* bytesProcessed


 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
