### PR TITLE
Support cross account DynamoDB tables for streams.

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
@@ -14,7 +14,6 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.Lea
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.StreamProgressState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
-import org.opensearch.dataprepper.plugins.source.dynamodb.utils.TableUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -230,8 +229,8 @@ public class LeaderScheduler implements Runnable {
      * Conduct Metadata info for table and also perform validation on configuration.
      * Once created, the info should not be changed.
      */
-    private TableInfo getTableInfo(TableConfig tableConfig) {
-        String tableName = TableUtil.getTableNameFromArn(tableConfig.getTableArn());
+    private TableInfo getTableInfo(final TableConfig tableConfig) {
+        final String tableName = tableConfig.getTableArn();
         DescribeTableResponse describeTableResult;
         try {
             // Need to call describe table to get the Key schema for table

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/TableUtil.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/TableUtil.java
@@ -1,14 +1,6 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.utils;
 
-import software.amazon.awssdk.arns.Arn;
-
 public class TableUtil {
-
-    public static String getTableNameFromArn(String tableArn) {
-        Arn arn = Arn.fromString(tableArn);
-        // resourceAsString is table/xxx
-        return arn.resourceAsString().substring("table/".length());
-    }
 
     public static String getTableArnFromStreamArn(String streamArn) {
         // e.g. Given a stream arn: arn:aws:dynamodb:us-west-2:xxx:table/test-table/stream/2023-07-31T04:59:58.190
@@ -21,6 +13,4 @@ public class TableUtil {
         // returns: arn:aws:dynamodb:us-west-2:123456789012:table/Thread
         return exportArn.substring(0, exportArn.lastIndexOf("/export/"));
     }
-
-
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderSchedulerTest.java
@@ -3,6 +3,7 @@ package org.opensearch.dataprepper.plugins.source.dynamodb.leader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
@@ -223,7 +224,10 @@ class LeaderSchedulerTest {
 
 
         // Should call describe table to get basic table info
-        verify(dynamoDbClient).describeTable(any(DescribeTableRequest.class));
+        ArgumentCaptor<DescribeTableRequest> describeTableRequestArgumentCaptor = ArgumentCaptor.forClass(DescribeTableRequest.class);
+        verify(dynamoDbClient).describeTable(describeTableRequestArgumentCaptor.capture());
+        DescribeTableRequest actualDescribeTableRequest = describeTableRequestArgumentCaptor.getValue();
+        assertThat(actualDescribeTableRequest.tableName(), equalTo(tableArn));
         // Should check PITR enabled or not
         verify(dynamoDbClient).describeContinuousBackups(any(DescribeContinuousBackupsRequest.class));
         // Acquire the init partition
@@ -252,7 +256,11 @@ class LeaderSchedulerTest {
         executorService.shutdownNow();
 
         // Should call describe table to get basic table info
-        verify(dynamoDbClient).describeTable(any(DescribeTableRequest.class));
+        ArgumentCaptor<DescribeTableRequest> describeTableRequestArgumentCaptor = ArgumentCaptor.forClass(DescribeTableRequest.class);
+        verify(dynamoDbClient).describeTable(describeTableRequestArgumentCaptor.capture());
+        DescribeTableRequest actualDescribeTableRequest = describeTableRequestArgumentCaptor.getValue();
+        assertThat(actualDescribeTableRequest.tableName(), equalTo(tableArn));
+
         // Should check PITR enabled or not
         verify(dynamoDbClient).describeContinuousBackups(any(DescribeContinuousBackupsRequest.class));
 
@@ -277,7 +285,11 @@ class LeaderSchedulerTest {
         executorService.shutdownNow();
 
         // Should call describe table to get basic table info
-        verify(dynamoDbClient).describeTable(any(DescribeTableRequest.class));
+        ArgumentCaptor<DescribeTableRequest> describeTableRequestArgumentCaptor = ArgumentCaptor.forClass(DescribeTableRequest.class);
+        verify(dynamoDbClient).describeTable(describeTableRequestArgumentCaptor.capture());
+        DescribeTableRequest actualDescribeTableRequest = describeTableRequestArgumentCaptor.getValue();
+        assertThat(actualDescribeTableRequest.tableName(), equalTo(tableArn));
+
         // Should check PITR enabled or not
         verify(dynamoDbClient).describeContinuousBackups(any(DescribeContinuousBackupsRequest.class));
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/TableUtilTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/TableUtilTest.java
@@ -16,12 +16,6 @@ class TableUtilTest {
     private final String streamArn = tableArn + "/stream/2023-09-14T05:46:45.367";
 
     @Test
-    void test_getTableNameFromArn_should_return_tableName() {
-        String result = TableUtil.getTableNameFromArn(tableArn);
-        assertThat(result, equalTo(tableName));
-    }
-
-    @Test
     void test_getTableArnFromStreamArn_should_return_tableArn() {
         String result = TableUtil.getTableArnFromStreamArn(streamArn);
         assertThat(result, equalTo(tableArn));


### PR DESCRIPTION
### Description

Update requests to DynamoDB to provide the table ARN instead of the table name. This allows Data Prepper to use the new cross-account and resource policy changes available in DynamoDB.

This works for DynamoDB streams only. DynamoDB's export APIs do not support cross-account presently.

Sample from working pipeline that I tested.

```
  source:
    dynamodb:
      tables:
        - table_arn: arn:aws:dynamodb:us-west-2:123456789012:table/SampleCrossAccount
          stream:
            start_position: LATEST
      aws:
        sts_role_arn: arn:aws:iam::999999999999:role/DynamoDB-DataPrepper-CrossAccount
        region: us-west-2
```
 
### Issues Resolved

Resolves #4424
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
