### PR TITLE
Several improvements to RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     implementation 'com.zendesk:mysql-binlog-connector-java:0.29.2'
-    implementation 'com.mysql:mysql-connector-j:9.0.0'
+    implementation 'com.mysql:mysql-connector-j:8.4.0'
 
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     implementation 'com.zendesk:mysql-binlog-connector-java:0.29.2'
+    implementation 'com.mysql:mysql-connector-j:9.0.0'
 
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
@@ -7,6 +7,9 @@ package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+import java.util.Map;
+
 public class DataFileProgressState {
 
     @JsonProperty("isLoaded")
@@ -20,6 +23,12 @@ public class DataFileProgressState {
 
     @JsonProperty("sourceTable")
     private String sourceTable;
+
+    /**
+     * Map of table name to primary keys
+     */
+    @JsonProperty("primaryKeyMap")
+    private Map<String, List<String>> primaryKeyMap;
 
     @JsonProperty("snapshotTime")
     private long snapshotTime;
@@ -62,5 +71,13 @@ public class DataFileProgressState {
 
     public void setSnapshotTime(long snapshotTime) {
         this.snapshotTime = snapshotTime;
+    }
+
+    public Map<String, List<String>> getPrimaryKeyMap() {
+        return primaryKeyMap;
+    }
+
+    public void setPrimaryKeyMap(Map<String, List<String>> primaryKeyMap) {
+        this.primaryKeyMap = primaryKeyMap;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/ExportProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/ExportProgressState.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Progress state for an EXPORT partition
@@ -31,6 +32,12 @@ public class ExportProgressState {
 
     @JsonProperty("tables")
     private List<String> tables;
+
+    /**
+     * Map of table name to primary keys
+     */
+    @JsonProperty("primaryKeyMap")
+    private Map<String, List<String>> primaryKeyMap;
 
     @JsonProperty("kmsKeyId")
     private String kmsKeyId;
@@ -87,6 +94,14 @@ public class ExportProgressState {
 
     public void setTables(List<String> tables) {
         this.tables = tables;
+    }
+
+    public Map<String, List<String>> getPrimaryKeyMap() {
+        return primaryKeyMap;
+    }
+
+    public void setPrimaryKeyMap(Map<String, List<String>> primaryKeyMap) {
+        this.primaryKeyMap = primaryKeyMap;
     }
 
     public String getKmsKeyId() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -110,6 +110,7 @@ public class DataFileLoader implements Runnable {
                     eventCount.getAndIncrement();
                     bytesProcessedSummary.record(bytes);
                 } catch (Exception e) {
+                    LOG.error("Failed to process record from object s3://{}/{}", bucket, objectKey, e);
                     throw new RuntimeException(e);
                 }
             });

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -93,8 +93,8 @@ public class DataFileLoader implements Runnable {
 
                     DataFileProgressState progressState = dataFilePartition.getProgressState().get();
 
-                    // TODO: primary key to be obtained by querying database schema
-                    final String primaryKeyName = "id";
+                    final String fullTableName = progressState.getSourceDatabase() + "." + progressState.getSourceTable();
+                    final List<String> primaryKeys = progressState.getPrimaryKeyMap().getOrDefault(fullTableName, List.of());
 
                     final long snapshotTime = progressState.getSnapshotTime();
                     final long eventVersionNumber = snapshotTime - VERSION_OVERLAP_TIME_FOR_EXPORT.toMillis();
@@ -103,7 +103,7 @@ public class DataFileLoader implements Runnable {
                                     record,
                                     progressState.getSourceDatabase(),
                                     progressState.getSourceTable(),
-                                    List.of(primaryKeyName),
+                                    primaryKeys,
                                     snapshotTime,
                                     eventVersionNumber));
                     bufferAccumulator.add(transformedRecord);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -190,12 +190,15 @@ public class ExportScheduler implements Runnable {
         LOG.debug("Start checking status of snapshot {}", snapshotId);
         while (Instant.now().isBefore(endTime)) {
             SnapshotInfo snapshotInfo = snapshotManager.checkSnapshotStatus(snapshotId);
-            String status = snapshotInfo.getStatus();
-            // Valid snapshot statuses are: available, copying, creating
-            // The status should never be "copying" here
-            if (SnapshotStatus.AVAILABLE.getStatusName().equals(status)) {
-                LOG.info("Snapshot {} is available.", snapshotId);
-                return snapshotInfo;
+
+            if (snapshotInfo != null) {
+                String status = snapshotInfo.getStatus();
+                // Valid snapshot statuses are: available, copying, creating
+                // The status should never be "copying" here
+                if (SnapshotStatus.AVAILABLE.getStatusName().equals(status)) {
+                    LOG.info("Snapshot {} is available.", snapshotId);
+                    return snapshotInfo;
+                }
             }
 
             LOG.debug("Snapshot {} is still creating. Wait and check later", snapshotId);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManager.java
@@ -5,14 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
+import org.opensearch.dataprepper.plugins.source.rds.leader.RdsApiStrategy;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 
 import java.util.UUID;
 
 public class SnapshotManager {
-    private final SnapshotStrategy snapshotStrategy;
+    private final RdsApiStrategy snapshotStrategy;
 
-    public SnapshotManager(final SnapshotStrategy snapshotStrategy) {
+    public SnapshotManager(final RdsApiStrategy snapshotStrategy) {
         this.snapshotStrategy = snapshotStrategy;
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/ClusterApiStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/ClusterApiStrategy.java
@@ -3,28 +3,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.source.rds.export;
+package org.opensearch.dataprepper.plugins.source.rds.leader;
 
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 
 import java.time.Instant;
 
 /**
  * This snapshot strategy works with RDS/Aurora Clusters
  */
-public class ClusterSnapshotStrategy implements SnapshotStrategy {
-    private static final Logger LOG = LoggerFactory.getLogger(ClusterSnapshotStrategy.class);
+public class ClusterApiStrategy implements RdsApiStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterApiStrategy.class);
     private final RdsClient rdsClient;
 
-    public ClusterSnapshotStrategy(final RdsClient rdsClient) {
+    public ClusterApiStrategy(final RdsClient rdsClient) {
         this.rdsClient = rdsClient;
+    }
+
+    @Override
+    public DbMetadata describeDb(String dbIdentifier) {
+        final DescribeDbClustersRequest request = DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(dbIdentifier)
+                .build();
+
+        final DescribeDbClustersResponse response = rdsClient.describeDBClusters(request);
+        final DBCluster dbCluster = response.dbClusters().get(0);
+        return new DbMetadata(dbIdentifier, dbCluster.endpoint(), dbCluster.port());
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/InstanceApiStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/InstanceApiStrategy.java
@@ -37,9 +37,13 @@ public class InstanceApiStrategy implements RdsApiStrategy {
                 .dbInstanceIdentifier(dbIdentifier)
                 .build();
 
-        final DescribeDbInstancesResponse response = rdsClient.describeDBInstances(request);
-        final DBInstance dbInstance = response.dbInstances().get(0);
-        return new DbMetadata(dbIdentifier, dbInstance.endpoint().address(), dbInstance.endpoint().port());
+        try {
+            final DescribeDbInstancesResponse response = rdsClient.describeDBInstances(request);
+            final DBInstance dbInstance = response.dbInstances().get(0);
+            return new DbMetadata(dbIdentifier, dbInstance.endpoint().address(), dbInstance.endpoint().port());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to describe DB " + dbIdentifier, e);
+        }
     }
 
     @Override
@@ -69,11 +73,15 @@ public class InstanceApiStrategy implements RdsApiStrategy {
                 .dbSnapshotIdentifier(snapshotId)
                 .build();
 
-        DescribeDbSnapshotsResponse response = rdsClient.describeDBSnapshots(request);
-        String snapshotArn = response.dbSnapshots().get(0).dbSnapshotArn();
-        String status = response.dbSnapshots().get(0).status();
-        Instant createTime = response.dbSnapshots().get(0).snapshotCreateTime();
-
-        return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+        try {
+            DescribeDbSnapshotsResponse response = rdsClient.describeDBSnapshots(request);
+            String snapshotArn = response.dbSnapshots().get(0).dbSnapshotArn();
+            String status = response.dbSnapshots().get(0).status();
+            Instant createTime = response.dbSnapshots().get(0).snapshotCreateTime();
+            return new SnapshotInfo(snapshotId, snapshotArn, createTime, status);
+        } catch (Exception e) {
+            LOG.error("Failed to describe snapshot {}", snapshotId, e);
+            return null;
+        }
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/InstanceApiStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/InstanceApiStrategy.java
@@ -3,14 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.source.rds.export;
+package org.opensearch.dataprepper.plugins.source.rds.leader;
 
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
 
@@ -19,12 +23,23 @@ import java.time.Instant;
 /**
  * This snapshot strategy works with RDS Instances
  */
-public class InstanceSnapshotStrategy implements SnapshotStrategy {
-    private static final Logger LOG = LoggerFactory.getLogger(InstanceSnapshotStrategy.class);
+public class InstanceApiStrategy implements RdsApiStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(InstanceApiStrategy.class);
     private final RdsClient rdsClient;
 
-    public InstanceSnapshotStrategy(final RdsClient rdsClient) {
+    public InstanceApiStrategy(final RdsClient rdsClient) {
         this.rdsClient = rdsClient;
+    }
+
+    @Override
+    public DbMetadata describeDb(String dbIdentifier) {
+        final DescribeDbInstancesRequest request = DescribeDbInstancesRequest.builder()
+                .dbInstanceIdentifier(dbIdentifier)
+                .build();
+
+        final DescribeDbInstancesResponse response = rdsClient.describeDBInstances(request);
+        final DBInstance dbInstance = response.dbInstances().get(0);
+        return new DbMetadata(dbIdentifier, dbInstance.endpoint().address(), dbInstance.endpoint().port());
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Stre
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.LeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
 import org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +143,12 @@ public class LeaderScheduler implements Runnable {
     private void createStreamPartition(RdsSourceConfig sourceConfig) {
         final StreamProgressState progressState = new StreamProgressState();
         progressState.setWaitForExport(sourceConfig.isExportEnabled());
+        getCurrentBinlogPosition().ifPresent(progressState::setStartPosition);
         StreamPartition streamPartition = new StreamPartition(sourceConfig.getDbIdentifier(), progressState);
         sourceCoordinator.createPartition(streamPartition);
+    }
+
+    private Optional<BinlogCoordinate> getCurrentBinlogPosition() {
+        return schemaManager.getCurrentBinaryLogPosition();
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Stre
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.LeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,13 +29,17 @@ public class LeaderScheduler implements Runnable {
     private static final Duration DEFAULT_LEASE_INTERVAL = Duration.ofMinutes(1);
     private final EnhancedSourceCoordinator sourceCoordinator;
     private final RdsSourceConfig sourceConfig;
+    private final SchemaManager schemaManager;
 
     private LeaderPartition leaderPartition;
     private volatile boolean shutdownRequested = false;
 
-    public LeaderScheduler(final EnhancedSourceCoordinator sourceCoordinator, final RdsSourceConfig sourceConfig) {
+    public LeaderScheduler(final EnhancedSourceCoordinator sourceCoordinator,
+                           final RdsSourceConfig sourceConfig,
+                           final SchemaManager schemaManager) {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
+        this.schemaManager = schemaManager;
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/RdsApiStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/RdsApiStrategy.java
@@ -9,7 +9,7 @@ import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 
 /**
- * Provides a strategy for creating and describing RDS snapshots.
+ * Provides a strategy for running RDS APIs.
  */
 public interface RdsApiStrategy {
     /**

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/RdsApiStrategy.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/RdsApiStrategy.java
@@ -3,14 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.source.rds.export;
+package org.opensearch.dataprepper.plugins.source.rds.leader;
 
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 
 /**
  * Provides a strategy for creating and describing RDS snapshots.
  */
-public interface SnapshotStrategy {
+public interface RdsApiStrategy {
+    /**
+     * Describes an RDS instance or cluster.
+     * @param dbIdentifier The identifier of the RDS instance or cluster to describe
+     * @return An {@link DbMetadata} object describing the instance or cluster
+     */
+    DbMetadata describeDb(String dbIdentifier);
+
     /**
      * Creates a snapshot of an RDS instance or cluster.
      *

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/DbMetadata.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/DbMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.util.Map;
+
+public class DbMetadata {
+
+    private static final String DB_IDENTIFIER_KEY = "dbIdentifier";
+    private static final String HOST_NAME_KEY = "hostName";
+    private static final String PORT_KEY = "port";
+    private final String dbIdentifier;
+    private final String hostName;
+    private final int port;
+
+    public DbMetadata(final String dbIdentifier, final String hostName, final int port) {
+        this.dbIdentifier = dbIdentifier;
+        this.hostName = hostName;
+        this.port = port;
+    }
+    
+    public String getDbIdentifier() {
+        return dbIdentifier;
+    }
+    
+    public String getHostName() {
+        return hostName;
+    }
+    
+    public int getPort() {
+        return port;
+    }
+    
+    public Map<String, Object> toMap() {
+        return Map.of(
+                DB_IDENTIFIER_KEY, dbIdentifier,
+                HOST_NAME_KEY, hostName,
+                PORT_KEY, port
+        );
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManager.java
@@ -11,14 +11,16 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 public class ConnectionManager {
-    private static final String JDBC_URL_FORMAT = "jdbc:mysql://%s:%d";
-    private final String jdbcUrl;
+    static final String JDBC_URL_FORMAT = "jdbc:mysql://%s:%d";
+    private final String hostName;
+    private final int port;
     private final String username;
     private final String password;
     private final boolean requireSSL;
 
     public ConnectionManager(String hostName, int port, String username, String password, boolean requireSSL) {
-        this.jdbcUrl = String.format(JDBC_URL_FORMAT, hostName, port);
+        this.hostName = hostName;
+        this.port = port;
         this.username = username;
         this.password = password;
         this.requireSSL = requireSSL;
@@ -34,6 +36,12 @@ public class ConnectionManager {
         } else {
             props.setProperty("useSSL", "false");
         }
+        final String jdbcUrl = String.format(JDBC_URL_FORMAT, hostName, port);
+        return doGetConnection(jdbcUrl, props);
+    }
+
+    // VisibleForTesting
+    Connection doGetConnection(String jdbcUrl, Properties props) throws SQLException {
         return DriverManager.getConnection(jdbcUrl, props);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.schema;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class ConnectionManager {
+    private static final String JDBC_URL_FORMAT = "jdbc:mysql://%s:%d";
+    private final String jdbcUrl;
+    private final String username;
+    private final String password;
+    private final boolean requireSSL;
+
+    public ConnectionManager(String hostName, int port, String username, String password, boolean requireSSL) {
+        this.jdbcUrl = String.format(JDBC_URL_FORMAT, hostName, port);
+        this.username = username;
+        this.password = password;
+        this.requireSSL = requireSSL;
+    }
+
+    public Connection getConnection() throws SQLException {
+        final Properties props = new Properties();
+        props.setProperty("user", username);
+        props.setProperty("password", password);
+        if (requireSSL) {
+            props.setProperty("useSSL", "true");
+            props.setProperty("requireSSL", "true");
+        } else {
+            props.setProperty("useSSL", "false");
+        }
+        return DriverManager.getConnection(jdbcUrl, props);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -19,9 +19,10 @@ import java.util.Optional;
 
 public class SchemaManager {
     private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
-    private static final String COLUMN_NAME = "COLUMN_NAME";
-    private static final String BINLOG_FILE = "File";
-    private static final String BINLOG_POSITION = "Position";
+    static final String COLUMN_NAME = "COLUMN_NAME";
+    static final String BINLOG_STATUS_QUERY = "SHOW MASTER STATUS";
+    static final String BINLOG_FILE = "File";
+    static final String BINLOG_POSITION = "Position";
     private final ConnectionManager connectionManager;
 
     public SchemaManager(ConnectionManager connectionManager) {
@@ -44,7 +45,7 @@ public class SchemaManager {
     public Optional<BinlogCoordinate> getCurrentBinaryLogPosition() {
         try (final Connection connection = connectionManager.getConnection()) {
             final Statement statement = connection.createStatement();
-            final ResultSet rs = statement.executeQuery("SHOW MASTER STATUS");
+            final ResultSet rs = statement.executeQuery(BINLOG_STATUS_QUERY);
             if (rs.next()) {
                 return Optional.of(new BinlogCoordinate(rs.getString(BINLOG_FILE), rs.getLong(BINLOG_POSITION)));
             }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -28,16 +28,15 @@ public class SchemaManager {
         this.connectionManager = connectionManager;
     }
 
-    public List<String> getPrimaryKeys(String tableName) {
+    public List<String> getPrimaryKeys(final String database, final String table) {
         final List<String> primaryKeys = new ArrayList<>();
         try (final Connection connection = connectionManager.getConnection()) {
-            final ResultSet rs = connection.getMetaData().getPrimaryKeys(null, null, tableName);
+            final ResultSet rs = connection.getMetaData().getPrimaryKeys(database, null, table);
             while (rs.next()) {
                 primaryKeys.add(rs.getString(COLUMN_NAME));
             }
         } catch (SQLException e) {
-            LOG.error("Failed to get primary keys for table {}", tableName, e);
-            throw new RuntimeException(e);
+            LOG.error("Failed to get primary keys for table {}", table, e);
         }
         return primaryKeys;
     }
@@ -49,10 +48,9 @@ public class SchemaManager {
             if (rs.next()) {
                 return Optional.of(new BinlogCoordinate(rs.getString(BINLOG_FILE), rs.getLong(BINLOG_POSITION)));
             }
-            return Optional.empty();
         } catch (SQLException e) {
             LOG.error("Failed to get current binary log position", e);
-            throw new RuntimeException(e);
         }
+        return Optional.empty();
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -31,10 +31,9 @@ public class SchemaManager {
     }
 
     public List<String> getPrimaryKeys(final String database, final String table) {
-        final List<String> primaryKeys = new ArrayList<>();
-
         int retry = 0;
         while (retry <= NUM_OF_RETRIES) {
+            final List<String> primaryKeys = new ArrayList<>();
             try (final Connection connection = connectionManager.getConnection()) {
                 final ResultSet rs = connection.getMetaData().getPrimaryKeys(database, null, table);
                 while (rs.next()) {
@@ -48,7 +47,7 @@ public class SchemaManager {
             retry++;
         }
         LOG.warn("Failed to get primary keys for table {}", table);
-        return primaryKeys;
+        return List.of();
     }
 
     public Optional<BinlogCoordinate> getCurrentBinaryLogPosition() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.schema;
+
+import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class SchemaManager {
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
+    private static final String COLUMN_NAME = "COLUMN_NAME";
+    private static final String BINLOG_FILE = "File";
+    private static final String BINLOG_POSITION = "Position";
+    private final ConnectionManager connectionManager;
+
+    public SchemaManager(ConnectionManager connectionManager) {
+        this.connectionManager = connectionManager;
+    }
+
+    public List<String> getPrimaryKeys(String tableName) {
+        final List<String> primaryKeys = new ArrayList<>();
+        try (final Connection connection = connectionManager.getConnection()) {
+            final ResultSet rs = connection.getMetaData().getPrimaryKeys(null, null, tableName);
+            while (rs.next()) {
+                primaryKeys.add(rs.getString(COLUMN_NAME));
+            }
+        } catch (SQLException e) {
+            LOG.error("Failed to get primary keys for table {}", tableName, e);
+            throw new RuntimeException(e);
+        }
+        return primaryKeys;
+    }
+
+    public Optional<BinlogCoordinate> getCurrentBinaryLogPosition() {
+        try (final Connection connection = connectionManager.getConnection()) {
+            final Statement statement = connection.createStatement();
+            final ResultSet rs = statement.executeQuery("SHOW MASTER STATUS");
+            if (rs.next()) {
+                return Optional.of(new BinlogCoordinate(rs.getString(BINLOG_FILE), rs.getLong(BINLOG_POSITION)));
+            }
+            return Optional.empty();
+        } catch (SQLException e) {
+            LOG.error("Failed to get current binary log position", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactory.java
@@ -7,60 +7,28 @@ package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DBCluster;
-import software.amazon.awssdk.services.rds.model.DBInstance;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
-import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 
 public class BinlogClientFactory {
 
     private final RdsSourceConfig sourceConfig;
-
     private final RdsClient rdsClient;
+    private final DbMetadata dbMetadata;
 
-    public BinlogClientFactory(final RdsSourceConfig sourceConfig, final RdsClient rdsClient) {
+    public BinlogClientFactory(final RdsSourceConfig sourceConfig,
+                               final RdsClient rdsClient,
+                               final DbMetadata dbMetadata) {
         this.sourceConfig = sourceConfig;
         this.rdsClient = rdsClient;
+        this.dbMetadata = dbMetadata;
     }
 
     public BinaryLogClient create() {
-        // TODO: refactor SnapshotStrategy to RdsApiStrategy to accommodate more APIs for clusters and instances
-        String hostName;
-        int port;
-        if (sourceConfig.isCluster()) {
-            DBCluster dbCluster = describeDbCluster(sourceConfig.getDbIdentifier());
-            hostName = dbCluster.endpoint();
-            port = dbCluster.port();
-        } else {
-            DBInstance dbInstance = describeDbInstance(sourceConfig.getDbIdentifier());
-            hostName = dbInstance.endpoint().address();
-            port = dbInstance.endpoint().port();
-        }
         return new BinaryLogClient(
-                hostName,
-                port,
+                dbMetadata.getHostName(),
+                dbMetadata.getPort(),
                 sourceConfig.getAuthenticationConfig().getUsername(),
                 sourceConfig.getAuthenticationConfig().getPassword());
-    }
-
-    private DBInstance describeDbInstance(final String dbInstanceIdentifier) {
-        DescribeDbInstancesRequest request = DescribeDbInstancesRequest.builder()
-                .dbInstanceIdentifier(dbInstanceIdentifier)
-                .build();
-
-        DescribeDbInstancesResponse response = rdsClient.describeDBInstances(request);
-        return response.dbInstances().get(0);
-    }
-
-    private DBCluster describeDbCluster(final String dbClusterIdentifier) {
-        DescribeDbClustersRequest request = DescribeDbClustersRequest.builder()
-                .dbClusterIdentifier(dbClusterIdentifier)
-                .build();
-
-        DescribeDbClustersResponse response = rdsClient.describeDBClusters(request);
-        return response.dbClusters().get(0);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -52,17 +52,7 @@ public class StreamWorker {
             }
         }
 
-        // get binlog position to start streaming
-        final BinlogCoordinate startBinlogPosition = streamPartition.getProgressState().get().getStartPosition();
-
-        // set start of binlog stream to current position if exists
-        if (startBinlogPosition != null) {
-            final String binlogFilename = startBinlogPosition.getBinlogFilename();
-            final long binlogPosition = startBinlogPosition.getBinlogPosition();
-            LOG.debug("Will start binlog stream from binlog file {} and position {}.", binlogFilename, binlogPosition);
-            binaryLogClient.setBinlogFilename(binlogFilename);
-            binaryLogClient.setBinlogPosition(binlogPosition);
-        }
+        setStartBinlogPosition(streamPartition);
 
         try {
             LOG.info("Connect to database to read change events.");
@@ -91,5 +81,18 @@ public class StreamWorker {
         final String dbIdentifier = streamPartition.getPartitionKey();
         Optional<EnhancedSourcePartition> globalStatePartition = sourceCoordinator.getPartition("stream-for-" + dbIdentifier);
         return globalStatePartition.isPresent();
+    }
+
+    private void setStartBinlogPosition(final StreamPartition streamPartition) {
+        final BinlogCoordinate startBinlogPosition = streamPartition.getProgressState().get().getStartPosition();
+
+        // set start of binlog stream to current position if exists
+        if (startBinlogPosition != null) {
+            final String binlogFilename = startBinlogPosition.getBinlogFilename();
+            final long binlogPosition = startBinlogPosition.getBinlogPosition();
+            LOG.debug("Will start binlog stream from binlog file {} and position {}.", binlogFilename, binlogPosition);
+            binaryLogClient.setBinlogFilename(binlogFilename);
+            binaryLogClient.setBinlogPosition(binlogPosition);
+        }
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -41,27 +41,27 @@ public class StreamWorker {
     }
 
     public void processStream(final StreamPartition streamPartition) {
-        // get current binlog position
-        BinlogCoordinate currentBinlogCoords = streamPartition.getProgressState().get().getCurrentPosition();
-
-        // set start of binlog stream to current position if exists
-        if (currentBinlogCoords != null) {
-            final String binlogFilename = currentBinlogCoords.getBinlogFilename();
-            final long binlogPosition = currentBinlogCoords.getBinlogPosition();
-            LOG.debug("Will start binlog stream from binlog file {} and position {}.", binlogFilename, binlogPosition);
-            binaryLogClient.setBinlogFilename(binlogFilename);
-            binaryLogClient.setBinlogPosition(binlogPosition);
-        }
-
         while (shouldWaitForExport(streamPartition) && !Thread.currentThread().isInterrupted()) {
             LOG.info("Initial load not completed yet for {}, waiting...", streamPartition.getPartitionKey());
             try {
                 Thread.sleep(DEFAULT_EXPORT_COMPLETE_WAIT_INTERVAL_MILLIS);
             } catch (final InterruptedException ex) {
-                LOG.info("The StreamScheduler was interrupted while waiting to retry, stopping processing");
+                LOG.info("The Stream Scheduler was interrupted while waiting to retry, stopping processing");
                 Thread.currentThread().interrupt();
                 break;
             }
+        }
+
+        // get binlog position to start streaming
+        final BinlogCoordinate startBinlogPosition = streamPartition.getProgressState().get().getStartPosition();
+
+        // set start of binlog stream to current position if exists
+        if (startBinlogPosition != null) {
+            final String binlogFilename = startBinlogPosition.getBinlogFilename();
+            final long binlogPosition = startBinlogPosition.getBinlogPosition();
+            LOG.debug("Will start binlog stream from binlog file {} and position {}.", binlogFilename, binlogPosition);
+            binaryLogClient.setBinlogFilename(binlogFilename);
+            binaryLogClient.setBinlogPosition(binlogPosition);
         }
 
         try {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ClusterSnapshotStrategyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ClusterSnapshotStrategyTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.leader.ClusterApiStrategy;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotRequest;
@@ -37,7 +38,7 @@ class ClusterSnapshotStrategyTest {
     @Mock
     private RdsClient rdsClient;
 
-    private ClusterSnapshotStrategy objectUnderTest;
+    private ClusterApiStrategy objectUnderTest;
 
     @BeforeEach
     void setUp() {
@@ -112,7 +113,7 @@ class ClusterSnapshotStrategyTest {
         assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
     }
 
-    private ClusterSnapshotStrategy createObjectUnderTest() {
-        return new ClusterSnapshotStrategy(rdsClient);
+    private ClusterApiStrategy createObjectUnderTest() {
+        return new ClusterApiStrategy(rdsClient);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/InstanceSnapshotStrategyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/InstanceSnapshotStrategyTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.leader.InstanceApiStrategy;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
@@ -37,7 +38,7 @@ class InstanceSnapshotStrategyTest {
     @Mock
     private RdsClient rdsClient;
 
-    private InstanceSnapshotStrategy objectUnderTest;
+    private InstanceApiStrategy objectUnderTest;
 
     @BeforeEach
     void setUp() {
@@ -112,7 +113,7 @@ class InstanceSnapshotStrategyTest {
         assertThat(snapshotInfo.getCreateTime(), equalTo(createTime));
     }
 
-    private InstanceSnapshotStrategy createObjectUnderTest() {
-        return new InstanceSnapshotStrategy(rdsClient);
+    private InstanceApiStrategy createObjectUnderTest() {
+        return new InstanceApiStrategy(rdsClient);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/SnapshotManagerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.leader.RdsApiStrategy;
 
 import java.util.UUID;
 
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.verify;
 class SnapshotManagerTest {
 
     @Mock
-    private SnapshotStrategy snapshotStrategy;
+    private RdsApiStrategy snapshotStrategy;
 
     private SnapshotManager snapshotManager;
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/ClusterApiStrategyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/ClusterApiStrategyTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.source.rds.export;
+package org.opensearch.dataprepper.plugins.source.rds.leader;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,17 +11,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.dataprepper.plugins.source.rds.leader.ClusterApiStrategy;
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DBClusterSnapshot;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,16 +37,41 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class ClusterSnapshotStrategyTest {
+class ClusterApiStrategyTest {
 
     @Mock
     private RdsClient rdsClient;
 
     private ClusterApiStrategy objectUnderTest;
 
+    private final Random random = new Random();
+
     @BeforeEach
     void setUp() {
         objectUnderTest = createObjectUnderTest();
+    }
+
+    @Test
+    void test_describeDb_returns_correct_results() {
+        final String dbClusterId = UUID.randomUUID().toString();
+        final String host = UUID.randomUUID().toString();
+        final int port = random.nextInt();
+        final DescribeDbClustersRequest describeDbClustersRequest = DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(dbClusterId)
+                .build();
+        final DescribeDbClustersResponse describeDbClustersResponse = DescribeDbClustersResponse.builder()
+                .dbClusters(DBCluster.builder()
+                        .endpoint(host)
+                        .port(port)
+                        .build())
+                .build();
+        when(rdsClient.describeDBClusters(describeDbClustersRequest)).thenReturn(describeDbClustersResponse);
+
+        DbMetadata dbMetadata = objectUnderTest.describeDb(dbClusterId);
+
+        assertThat(dbMetadata.getDbIdentifier(), equalTo(dbClusterId));
+        assertThat(dbMetadata.getHostName(), equalTo(host));
+        assertThat(dbMetadata.getPort(), equalTo(port));
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/InstanceApiStrategyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/InstanceApiStrategyTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.source.rds.export;
+package org.opensearch.dataprepper.plugins.source.rds.leader;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,17 +11,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.dataprepper.plugins.source.rds.leader.InstanceApiStrategy;
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.model.SnapshotInfo;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbSnapshotResponse;
+import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBSnapshot;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.Endpoint;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,16 +38,42 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class InstanceSnapshotStrategyTest {
+class InstanceApiStrategyTest {
 
     @Mock
     private RdsClient rdsClient;
 
     private InstanceApiStrategy objectUnderTest;
+    private final Random random = new Random();
 
     @BeforeEach
     void setUp() {
         objectUnderTest = createObjectUnderTest();
+    }
+
+    @Test
+    void test_describeDb_returns_correct_results() {
+        final String dbInstanceId = UUID.randomUUID().toString();
+        final String host = UUID.randomUUID().toString();
+        final int port = random.nextInt();
+        final DescribeDbInstancesRequest describeDbInstancesRequest = DescribeDbInstancesRequest.builder()
+                .dbInstanceIdentifier(dbInstanceId)
+                .build();
+        final DescribeDbInstancesResponse describeDbInstancesResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(DBInstance.builder()
+                        .endpoint(Endpoint.builder()
+                                .address(host)
+                                .port(port)
+                                .build())
+                        .build())
+                .build();
+        when(rdsClient.describeDBInstances(describeDbInstancesRequest)).thenReturn(describeDbInstancesResponse);
+
+        DbMetadata dbMetadata = objectUnderTest.describeDb(dbInstanceId);
+
+        assertThat(dbMetadata.getDbIdentifier(), equalTo(dbInstanceId));
+        assertThat(dbMetadata.getHostName(), equalTo(host));
+        assertThat(dbMetadata.getPort(), equalTo(port));
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
@@ -19,6 +19,8 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Expo
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.LeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
+import org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -45,6 +47,12 @@ class LeaderSchedulerTest {
 
     @Mock(answer = Answers.RETURNS_DEFAULTS)
     private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private SchemaManager schemaManager;
+
+    @Mock
+    private DbMetadata dbMetadata;
 
     @Mock
     private LeaderPartition leaderPartition;
@@ -130,6 +138,6 @@ class LeaderSchedulerTest {
     }
 
     private LeaderScheduler createObjectUnderTest() {
-        return new LeaderScheduler(sourceCoordinator, sourceConfig);
+        return new LeaderScheduler(sourceCoordinator, sourceConfig, schemaManager, dbMetadata);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManagerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.schema;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+
+class ConnectionManagerTest {
+
+    private String hostName;
+    private int port;
+    private String username;
+    private String password;
+    private boolean requireSSL;
+    private final Random random = new Random();
+
+    @BeforeEach
+    void setUp() {
+        hostName = UUID.randomUUID().toString();
+        port = random.nextInt();
+        username = UUID.randomUUID().toString();
+        password = UUID.randomUUID().toString();
+    }
+
+    @Test
+    void test_getConnection_when_requireSSL_is_true() throws SQLException {
+        requireSSL = true;
+        final ConnectionManager connectionManager = spy(createObjectUnderTest());
+        final ArgumentCaptor<String> jdbcUrlArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Properties> propertiesArgumentCaptor = ArgumentCaptor.forClass(Properties.class);
+        doReturn(mock(Connection.class)).when(connectionManager).doGetConnection(jdbcUrlArgumentCaptor.capture(), propertiesArgumentCaptor.capture());
+
+        connectionManager.getConnection();
+
+        assertThat(jdbcUrlArgumentCaptor.getValue(), is(String.format(ConnectionManager.JDBC_URL_FORMAT, hostName, port)));
+        final Properties properties = propertiesArgumentCaptor.getValue();
+        assertThat(properties.getProperty("user"), is(username));
+        assertThat(properties.getProperty("password"), is(password));
+        assertThat(properties.getProperty("useSSL"), is("true"));
+        assertThat(properties.getProperty("requireSSL"), is("true"));
+    }
+
+    @Test
+    void test_getConnection_when_requireSSL_is_false() throws SQLException {
+        requireSSL = false;
+        final ConnectionManager connectionManager = spy(createObjectUnderTest());
+        final ArgumentCaptor<String> jdbcUrlArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Properties> propertiesArgumentCaptor = ArgumentCaptor.forClass(Properties.class);
+        doReturn(mock(Connection.class)).when(connectionManager).doGetConnection(jdbcUrlArgumentCaptor.capture(), propertiesArgumentCaptor.capture());
+
+        connectionManager.getConnection();
+
+        assertThat(jdbcUrlArgumentCaptor.getValue(), is(String.format(ConnectionManager.JDBC_URL_FORMAT, hostName, port)));
+        final Properties properties = propertiesArgumentCaptor.getValue();
+        assertThat(properties.getProperty("user"), is(username));
+        assertThat(properties.getProperty("password"), is(password));
+        assertThat(properties.getProperty("useSSL"), is("false"));
+    }
+
+    private ConnectionManager createObjectUnderTest() {
+        return new ConnectionManager(hostName, port, username, password, requireSSL);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.schema;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_FILE;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_POSITION;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_STATUS_QUERY;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.COLUMN_NAME;
+
+@ExtendWith(MockitoExtension.class)
+class SchemaManagerTest {
+
+    @Mock
+    private ConnectionManager connectionManager;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private Connection connection;
+
+    @Mock
+    private ResultSet resultSet;
+
+    private SchemaManager schemaManager;
+
+    @BeforeEach
+    void setUp() {
+        schemaManager = createObjectUnderTest();
+    }
+
+    @Test
+    void test_getPrimaryKeys_returns_primary_keys() throws SQLException {
+        final String databaseName = UUID.randomUUID().toString();
+        final String tableName = UUID.randomUUID().toString();
+        final String primaryKey = UUID.randomUUID().toString();
+        when(connectionManager.getConnection()).thenReturn(connection);
+        when(connection.getMetaData().getPrimaryKeys(databaseName, null, tableName)).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString(COLUMN_NAME)).thenReturn(primaryKey);
+
+        final List<String> primaryKeys = schemaManager.getPrimaryKeys(databaseName, tableName);
+
+        assertThat(primaryKeys, contains(primaryKey));
+    }
+
+    @Test
+    void test_getPrimaryKeys_throws_exception_then_returns_empty_list() throws SQLException {
+        final String databaseName = UUID.randomUUID().toString();
+        final String tableName = UUID.randomUUID().toString();
+        when(connectionManager.getConnection()).thenThrow(SQLException.class);
+
+        final List<String> primaryKeys = schemaManager.getPrimaryKeys(databaseName, tableName);
+
+        assertThat(primaryKeys, empty());
+    }
+
+    @Test
+    void test_getCurrentBinaryLogPosition_returns_binlog_coords() throws SQLException {
+        final Statement statement = mock(Statement.class);
+        final String binlogFile = UUID.randomUUID().toString();
+        final long binlogPosition = 123L;
+        when(connectionManager.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery(BINLOG_STATUS_QUERY)).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(BINLOG_FILE)).thenReturn(binlogFile);
+        when(resultSet.getLong(BINLOG_POSITION)).thenReturn(binlogPosition);
+
+        final Optional<BinlogCoordinate> binlogCoordinate = schemaManager.getCurrentBinaryLogPosition();
+
+        assertThat(binlogCoordinate.isPresent(), is(true));
+        assertThat(binlogCoordinate.get().getBinlogFilename(), is(binlogFile));
+        assertThat(binlogCoordinate.get().getBinlogPosition(), is(binlogPosition));
+    }
+
+    @Test
+    void test_getCurrentBinaryLogPosition_throws_exception_then_returns_empty() throws SQLException {
+        when(connectionManager.getConnection()).thenThrow(SQLException.class);
+
+        final Optional<BinlogCoordinate> binlogCoordinate = schemaManager.getCurrentBinaryLogPosition();
+
+        assertThat(binlogCoordinate.isPresent(), is(false));
+    }
+
+    private SchemaManager createObjectUnderTest() {
+        return new SchemaManager(connectionManager);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -49,11 +50,11 @@ class StreamWorkerTest {
 
     @Test
     void test_processStream_with_given_binlog_coordinates() throws IOException {
-        StreamProgressState streamProgressState = mock(StreamProgressState.class);
+        final StreamProgressState streamProgressState = mock(StreamProgressState.class);
+        final String binlogFilename = UUID.randomUUID().toString();
+        final long binlogPosition = 100L;
         when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
-        final String binlogFilename = "binlog-001";
-        final Long binlogPosition = 100L;
-        when(streamProgressState.getCurrentPosition()).thenReturn(new BinlogCoordinate(binlogFilename, binlogPosition));
+        when(streamProgressState.getStartPosition()).thenReturn(new BinlogCoordinate(binlogFilename, binlogPosition));
         when(streamProgressState.shouldWaitForExport()).thenReturn(false);
 
         streamWorker.processStream(streamPartition);
@@ -69,7 +70,7 @@ class StreamWorkerTest {
         when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
         final String binlogFilename = "binlog-001";
         final Long binlogPosition = 100L;
-        when(streamProgressState.getCurrentPosition()).thenReturn(null);
+        when(streamProgressState.getStartPosition()).thenReturn(null);
         when(streamProgressState.shouldWaitForExport()).thenReturn(false);
 
         streamWorker.processStream(streamPartition);


### PR DESCRIPTION
### Description
This PR implements a few follow-up items from previous PRs:
- Get host/port from RDS when source starts and use it in mysql client and binlog client.
- Add SchemaManage to query MySQL to:
  - get primary keys from MySQL and save it in ExportPartition for export record converter to use
  - get binlog position at the beginning, save it in StreamPartition, and use it as the starting position for streaming
- Refactor SnapshotStrategy to a more general RdsApiStrategy to include describeDb APIs (describeDBInstances and describeDBClusters)

### Testing
Tested Data Prepper against RDS instance and verified that both export and stream work as expected. Particularly, new data changes to RDS while export is in progress were captured when stream started.
 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
