### PR TITLE
FIX: build service map relationship even when trace group is missing

### DIFF
--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
@@ -242,7 +242,7 @@ public class ServiceMapStatefulProcessor extends AbstractProcessor<Record<Event>
                 }
 
                 final String traceGroupName = getTraceGroupName(child.traceId);
-                if (traceGroupName == null || parent == null || parent.serviceName.equals(child.serviceName)) {
+                if (parent == null || parent.serviceName.equals(child.serviceName)) {
                     return;
                 }
 


### PR DESCRIPTION
### Description
This PR fixes service-map on building relationship even when traceGroupName is missing so that user can still find service relations when the upstream service instrumentation info is missing
 
### Issues Resolved
Resolves #4821 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
