### PR TITLE
Add delete_source parameter to the csv processor

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -99,6 +99,10 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                 if (thisEventHasHeaderSource && Boolean.TRUE.equals(config.isDeleteHeader())) {
                     event.delete(config.getColumnNamesSourceKey());
                 }
+
+                if (config.isDeleteSource()) {
+                    event.delete(config.getSource());
+                }
             } catch (final IOException e) {
                 csvInvalidEventsCounter.increment();
                 LOG.error(EVENT, "An exception occurred while reading event [{}]", event, e);

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -62,6 +62,10 @@ public class CsvProcessorConfig {
             "the processor should be applied to the event.")
     private String csvWhen;
 
+    @JsonPropertyDescription("If true, the configured source field will be deleted after the CSV data is parsed into separate fields.")
+    @JsonProperty
+    private boolean deleteSource = false;
+
     /**
      * The field of the Event that contains the CSV data to be processed.
      *
@@ -119,6 +123,8 @@ public class CsvProcessorConfig {
     }
 
     public String getCsvWhen() { return csvWhen; }
+
+    public Boolean isDeleteSource() { return deleteSource; }
 
     @AssertTrue(message = "delimiter must be exactly one character.")
     boolean isValidDelimiter() {

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
@@ -56,6 +56,7 @@ class CsvProcessorTest {
         lenient().when(processorConfig.getQuoteCharacter()).thenReturn(defaultConfig.getQuoteCharacter());
         lenient().when(processorConfig.getColumnNamesSourceKey()).thenReturn(defaultConfig.getColumnNamesSourceKey());
         lenient().when(processorConfig.getColumnNames()).thenReturn(defaultConfig.getColumnNames());
+        lenient().when(processorConfig.isDeleteSource()).thenReturn(false);
 
         lenient().when(pluginMetrics.counter(CsvProcessor.CSV_INVALID_EVENTS)).thenReturn(csvInvalidEventsCounter);
 
@@ -64,6 +65,24 @@ class CsvProcessorTest {
 
     private CsvProcessor createObjectUnderTest() {
         return new CsvProcessor(pluginMetrics, processorConfig, expressionEvaluator);
+    }
+
+    @Test
+    void delete_source_true_deletes_the_source() {
+        when(processorConfig.isDeleteSource()).thenReturn(true);
+
+        when(processorConfig.getSource()).thenReturn("different_source");
+
+        final Map<String, Object> eventData = new HashMap<>();
+        eventData.put("different_source","1,2,3");
+        final Record<Event> eventUnderTest = buildRecordWithEvent(eventData);
+
+        final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
+        final Event parsedEvent = getSingleEvent(editedEvents);
+        assertThat(parsedEvent.containsKey("different_source"), equalTo(false));
+        assertThatKeyEquals(parsedEvent, "column1", "1");
+        assertThatKeyEquals(parsedEvent, "column2", "2");
+        assertThatKeyEquals(parsedEvent, "column3", "3");
     }
 
     @Test


### PR DESCRIPTION
### Description
Similar to https://github.com/opensearch-project/data-prepper/pull/4702, this change adds the `delete_source` option to remove the `source` from the Event after it is processed with the csv processor
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. https://github.com/opensearch-project/documentation-website/issues/7973
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
