### PR TITLE
Refactor json codecs from parse-json-processor to common

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.codec.JsonDecoder;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+/**
+ * An implementation of {@link InputCodec} which parses JSON Objects for arrays.
+ */
+@DataPrepperPlugin(name = "json", pluginType = InputCodec.class)
+public class JsonInputCodec extends JsonDecoder implements InputCodec {
+    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+        parse(inputStream, null, eventConsumer);
+    }
+
+}

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodec.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodec.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of {@link OutputCodec} which deserializes Data-Prepper events
+ * and writes them to Output Stream as JSON Data
+ */
+@DataPrepperPlugin(name = "json", pluginType = OutputCodec.class, pluginConfigurationType = JsonOutputCodecConfig.class)
+public class JsonOutputCodec implements OutputCodec {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String JSON = "json";
+    private static final JsonFactory factory = new JsonFactory();
+    private final JsonOutputCodecConfig config;
+    private JsonGenerator generator;
+    private OutputCodecContext codecContext;
+
+    @DataPrepperPluginConstructor
+    public JsonOutputCodec(final JsonOutputCodecConfig config) {
+        Objects.requireNonNull(config);
+        this.config = config;
+    }
+
+    @Override
+    public String getExtension() {
+        return JSON;
+    }
+
+    @Override
+    public void start(final OutputStream outputStream, Event event, final OutputCodecContext codecContext) throws IOException {
+        Objects.requireNonNull(outputStream);
+        Objects.requireNonNull(codecContext);
+        this.codecContext = codecContext;
+        generator = factory.createGenerator(outputStream, JsonEncoding.UTF8);
+        generator.writeStartObject();
+        generator.writeFieldName(config.getKeyName());
+        generator.writeStartArray();
+    }
+
+    @Override
+    public void complete(final OutputStream outputStream) throws IOException {
+        generator.writeEndArray();
+        generator.writeEndObject();
+        generator.close();
+        outputStream.flush();
+        outputStream.close();
+    }
+
+    @Override
+    public synchronized void writeEvent(final Event event, final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(event);
+        Map<String, Object> dataMap = getDataMapToSerialize(event);
+        objectMapper.writeValue(generator, dataMap);
+        generator.flush();
+    }
+
+    private Map<String, Object> getDataMapToSerialize(Event event) throws JsonProcessingException {
+        final Event modifiedEvent;
+        if (codecContext.getTagsTargetKey() != null) {
+            modifiedEvent = addTagsToEvent(event, codecContext.getTagsTargetKey());
+        } else {
+            modifiedEvent = event;
+        }
+        Map<String, Object> dataMap = modifiedEvent.toMap();
+
+        if ((codecContext.getIncludeKeys() != null && !codecContext.getIncludeKeys().isEmpty()) ||
+                (codecContext.getExcludeKeys() != null && !codecContext.getExcludeKeys().isEmpty())) {
+
+            Map<String, Object> finalDataMap = dataMap;
+            dataMap = dataMap.keySet()
+                    .stream()
+                    .filter(codecContext::shouldIncludeKey)
+                    .collect(Collectors.toMap(Function.identity(), finalDataMap::get));
+        }
+        return dataMap;
+    }
+}
+
+

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecConfig.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecConfig.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+
+public class JsonOutputCodecConfig {
+    static final String DEFAULT_KEY_NAME = "events";
+
+    @JsonProperty("key_name")
+    @Size(min = 1, max = 2048)
+    private String keyName = DEFAULT_KEY_NAME;
+
+    public String getKeyName() {
+        return keyName;
+    }
+}

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonInputCodec.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonInputCodec.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.log.Log;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A Data Prepper {@link InputCodec} which reads ND-JSON and other similar
+ * formats which have JSON objects together.
+ */
+@DataPrepperPlugin(name = "ndjson", pluginType = InputCodec.class, pluginConfigurationType = NdjsonInputConfig.class)
+public class NdjsonInputCodec implements InputCodec {
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {};
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final NdjsonInputConfig ndjsonInputConfig;
+    private final EventFactory eventFactory;
+    private final JsonFactory jsonFactory;
+
+    @DataPrepperPluginConstructor
+    public NdjsonInputCodec(final NdjsonInputConfig ndjsonInputConfig, final EventFactory eventFactory) {
+        this.ndjsonInputConfig = ndjsonInputConfig;
+        this.eventFactory = eventFactory;
+        jsonFactory = new JsonFactory();
+    }
+
+    @Override
+    public void parse(final InputStream inputStream, final Consumer<Record<Event>> eventConsumer) throws IOException {
+        Objects.requireNonNull(inputStream, "Parameter inputStream must not be null.");
+        Objects.requireNonNull(eventConsumer, "Parameter eventConsumer must not be null.");
+
+        final JsonParser parser = jsonFactory.createParser(inputStream);
+
+        final MappingIterator<Map<String, Object>> mapMappingIterator = objectMapper.readValues(parser, MAP_TYPE_REFERENCE);
+        while (mapMappingIterator.hasNext()) {
+            final Map<String, Object> json = mapMappingIterator.next();
+
+            if(!ndjsonInputConfig.isIncludeEmptyObjects() && json.isEmpty())
+                continue;
+
+            final Record<Event> record = createRecord(json);
+            eventConsumer.accept(record);
+        }
+    }
+
+    private Record<Event> createRecord(final Map<String, Object> json) {
+        final Log event = eventFactory.eventBuilder(LogEventBuilder.class)
+                .withData(json)
+                .build();
+
+        return new Record<>(event);
+    }
+}

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonInputConfig.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonInputConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration for the {@link NdjsonInputCodec} input codec.
+ */
+public class NdjsonInputConfig {
+    /**
+     * By default, we will not create events for empty objects. However, we will
+     * permit users to include them if they desire.
+     */
+    @JsonProperty("include_empty_objects")
+    private boolean includeEmptyObjects = false;
+
+    public boolean isIncludeEmptyObjects() {
+        return includeEmptyObjects;
+    }
+}

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonOutputCodec.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonOutputCodec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+/**
+ * An implementation of {@link OutputCodec} which deserializes Data-Prepper events
+ * and writes them to Output Stream as ND-JSON data
+ */
+@DataPrepperPlugin(name = "ndjson", pluginType = OutputCodec.class, pluginConfigurationType = NdjsonOutputConfig.class)
+public class NdjsonOutputCodec implements OutputCodec {
+    private static final String NDJSON = "ndjson";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final NdjsonOutputConfig config;
+    private OutputCodecContext codecContext;
+
+    @DataPrepperPluginConstructor
+    public NdjsonOutputCodec(final NdjsonOutputConfig config) {
+        Objects.requireNonNull(config);
+        this.config = config;
+    }
+
+    @Override
+    public void start(final OutputStream outputStream, Event event, final OutputCodecContext codecContext) throws IOException {
+        Objects.requireNonNull(outputStream);
+        Objects.requireNonNull(codecContext);
+        this.codecContext = codecContext;
+    }
+
+    @Override
+    public void writeEvent(final Event event, final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(event);
+
+        String json = event.jsonBuilder()
+                .includeKeys(codecContext.getIncludeKeys())
+                .excludeKeys(codecContext.getExcludeKeys())
+                .includeTags(codecContext.getTagsTargetKey())
+                .toJsonString();
+        outputStream.write(json.getBytes());
+        outputStream.write(System.lineSeparator().getBytes());
+    }
+
+    @Override
+    public void complete(final OutputStream outputStream) throws IOException {
+        outputStream.close();
+    }
+
+    @Override
+    public String getExtension() {
+        return NDJSON;
+    }
+}

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonOutputConfig.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonOutputConfig.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+/**
+ * Configuration class for the newline delimited codec.
+ */
+public class NdjsonOutputConfig {
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class JsonCodecsIT {
+
+    private ObjectMapper objectMapper;
+    private Consumer<Record<Event>> eventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+
+        eventConsumer = mock(Consumer.class);
+    }
+
+    private JsonInputCodec createJsonInputCodecObjectUnderTest() {
+        return new JsonInputCodec();
+    }
+
+    private JsonOutputCodec createJsonOutputCodecObjectUnderTest() {
+        return new JsonOutputCodec(new JsonOutputCodecConfig());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void parse_with_InputStream_calls_Consumer_with_Event(final int numberOfObjects) throws IOException {
+        final List<HashMap> initialRecords = generateRecords(numberOfObjects);
+        ByteArrayInputStream inputStream = (ByteArrayInputStream) createInputStream(initialRecords);
+        createJsonInputCodecObjectUnderTest().parse(inputStream, eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(eventConsumer, times(numberOfObjects)).accept(recordArgumentCaptor.capture());
+
+        final List<Record<Event>> actualRecords = recordArgumentCaptor.getAllValues();
+        JsonOutputCodec jsonOutputCodec = createJsonOutputCodecObjectUnderTest();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext();
+        jsonOutputCodec.start(outputStream, null, codecContext);
+
+        assertThat(actualRecords.size(), equalTo(numberOfObjects));
+
+
+        for (int i = 0; i < actualRecords.size(); i++) {
+
+            final Record<Event> actualRecord = actualRecords.get(i);
+            jsonOutputCodec.writeEvent(actualRecord.getData(), outputStream);
+        }
+        jsonOutputCodec.complete(outputStream);
+        int index = 0;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        for (JsonNode element : jsonNode) {
+            Set<String> keys = initialRecords.get(index).keySet();
+            Map<String, Object> actualMap = new HashMap<>();
+            for (String key : keys) {
+                actualMap.put(key, element.get(key).asText());
+            }
+            assertThat(initialRecords.get(index), Matchers.equalTo(actualMap));
+            index++;
+        }
+    }
+
+    private InputStream createInputStream(final List<HashMap> jsonObjects) throws JsonProcessingException {
+        final String keyName = UUID.randomUUID().toString();
+        final Map<String, Object> jsonRoot = Collections.singletonMap(keyName, jsonObjects);
+        return createInputStream(jsonRoot);
+    }
+
+    private InputStream createInputStream(final Map<String, ?> jsonRoot) throws JsonProcessingException {
+        final byte[] jsonBytes = objectMapper.writeValueAsBytes(jsonRoot);
+
+        return new ByteArrayInputStream(jsonBytes);
+    }
+
+    private static List<HashMap> generateRecords(int numberOfRecords) {
+
+        List<HashMap> recordList = new ArrayList<>();
+
+        for (int rows = 0; rows < numberOfRecords; rows++) {
+
+            HashMap<String, String> eventData = new HashMap<>();
+
+            eventData.put("name", "Person" + rows);
+            eventData.put("age", Integer.toString(rows));
+            recordList.add((eventData));
+
+        }
+        return recordList;
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventType;
+import org.opensearch.dataprepper.model.io.InputFile;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.codec.NoneDecompressionEngine;
+import org.opensearch.dataprepper.plugins.fs.LocalInputFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class JsonInputCodecTest {
+
+    private ObjectMapper objectMapper;
+    private Consumer<Record<Event>> eventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+
+        eventConsumer = mock(Consumer.class);
+    }
+
+    private JsonInputCodec createObjectUnderTest() {
+        return new JsonInputCodec();
+    }
+
+    @Test
+    void parse_with_null_InputStream_throws() {
+        final JsonInputCodec objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class, () ->
+                objectUnderTest.parse((InputStream) null, eventConsumer));
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @Test
+    void parse_with_InputStream_null_Consumer_throws() {
+        final JsonInputCodec objectUnderTest = createObjectUnderTest();
+
+        final InputStream inputStream = mock(InputStream.class);
+        assertThrows(NullPointerException.class, () ->
+                objectUnderTest.parse(inputStream, null));
+
+        verifyNoInteractions(inputStream);
+    }
+
+    @Test
+    void parse_with_null_InputFile_throws() {
+        final JsonInputCodec objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class, () ->
+                objectUnderTest.parse((InputFile) null, new NoneDecompressionEngine(), eventConsumer));
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @Test
+    void parse_with_InputFile_null_Consumer_throws() {
+        final JsonInputCodec objectUnderTest = createObjectUnderTest();
+
+        final InputFile inputFile = mock(InputFile.class);
+        assertThrows(NullPointerException.class, () ->
+                objectUnderTest.parse(inputFile, new NoneDecompressionEngine(), null));
+
+        verifyNoInteractions(inputFile);
+    }
+
+    @Test
+    void parse_with_empty_InputStream_does_not_call_Consumer() throws IOException {
+        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[]{});
+
+        createObjectUnderTest().parse(emptyInputStream, eventConsumer);
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @Test
+    void parse_with_InputStream_with_empty_object_does_not_call_Consumer() throws IOException {
+        final ByteArrayInputStream emptyObjectInputStream = new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8));
+
+        createObjectUnderTest().parse(emptyObjectInputStream, eventConsumer);
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @Test
+    void parse_with_InputStream_with_object_and_no_array_does_not_call_Consumer() throws IOException {
+        final Map<String, Object> jsonWithoutList = Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+        createObjectUnderTest().parse(createInputStream(jsonWithoutList), eventConsumer);
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @Test
+    void parse_with_InputStream_with_empty_array_does_not_call_Consumer() throws IOException {
+        final Map<String, List<Object>> jsonWithEmptyList = Collections.singletonMap(UUID.randomUUID().toString(), Collections.emptyList());
+
+        createObjectUnderTest().parse(createInputStream(jsonWithEmptyList), eventConsumer);
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void parse_with_InputFile_calls_Consumer_with_Event(final int numberOfObjects) throws IOException {
+        final List<Map<String, Object>> jsonObjects = generateJsonObjectsAsList(numberOfObjects);
+        final InputStream inputStream = createInputStream(jsonObjects);
+
+        // write inputSteam to a file
+        byte[] buffer = new byte[1024];
+        int bytesRead;
+
+        File testDataFile = File.createTempFile("JsonCodecTest-" + numberOfObjects, ".json");
+        testDataFile.deleteOnExit();
+
+        OutputStream outStream = new FileOutputStream(testDataFile);
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+            outStream.write(buffer, 0, bytesRead);
+        }
+        outStream.flush();
+        outStream.close();
+
+        final InputFile inputFile = new LocalInputFile(testDataFile);
+
+        createObjectUnderTest().parse(inputFile, new NoneDecompressionEngine(), eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(eventConsumer, times(numberOfObjects)).accept(recordArgumentCaptor.capture());
+
+        final List<Record<Event>> actualRecords = recordArgumentCaptor.getAllValues();
+
+        assertThat(actualRecords.size(), equalTo(numberOfObjects));
+        for (int i = 0; i < actualRecords.size(); i++) {
+
+            final Record<Event> actualRecord = actualRecords.get(i);
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getData(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
+
+            final Map<String, Object> expectedMap = jsonObjects.get(i);
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void parse_with_InputStream_calls_Consumer_with_Event(final int numberOfObjects) throws IOException {
+        final List<Map<String, Object>> jsonObjects = generateJsonObjectsAsList(numberOfObjects);
+
+        createObjectUnderTest().parse(createInputStream(jsonObjects), eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(eventConsumer, times(numberOfObjects)).accept(recordArgumentCaptor.capture());
+
+        final List<Record<Event>> actualRecords = recordArgumentCaptor.getAllValues();
+
+        assertThat(actualRecords.size(), equalTo(numberOfObjects));
+        for (int i = 0; i < actualRecords.size(); i++) {
+
+            final Record<Event> actualRecord = actualRecords.get(i);
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getData(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
+
+            final Map<String, Object> expectedMap = jsonObjects.get(i);
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(JsonPermutations.class)
+    void parse_with_InputStream_calls_Consumer_for_arrays_in_Json_permutations(final Function<List<Map<String, Object>>, Map<String, Object>> rootJsonGenerator) throws IOException {
+        final int numberOfObjects = 10;
+        final List<Map<String, Object>> jsonObjects = generateJsonObjectsAsList(numberOfObjects);
+
+        createObjectUnderTest().parse(createInputStream(jsonObjects), eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(eventConsumer, times(numberOfObjects)).accept(recordArgumentCaptor.capture());
+
+        final List<Record<Event>> actualRecords = recordArgumentCaptor.getAllValues();
+
+        assertThat(actualRecords.size(), equalTo(numberOfObjects));
+        for (int i = 0; i < actualRecords.size(); i++) {
+
+            final Record<Event> actualRecord = actualRecords.get(i);
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getData(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
+
+            final Map<String, Object> expectedMap = jsonObjects.get(i);
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void parse_with_InputStream_calls_Consumer_with_Event_for_two_parallel_arrays(final int numberOfObjectsPerList) throws IOException {
+        final List<Map<String, Object>> jsonObjectsFirst = generateJsonObjectsAsList(numberOfObjectsPerList);
+        final List<Map<String, Object>> jsonObjectsSecond = generateJsonObjectsAsList(numberOfObjectsPerList);
+
+        final Map<String, Object> rootJson = new LinkedHashMap<>();
+        rootJson.put(UUID.randomUUID().toString(), jsonObjectsFirst);
+        rootJson.put(UUID.randomUUID().toString(), jsonObjectsSecond);
+
+        createObjectUnderTest().parse(createInputStream(rootJson), eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(eventConsumer, times(numberOfObjectsPerList * 2)).accept(recordArgumentCaptor.capture());
+
+        final List<Record<Event>> actualRecords = recordArgumentCaptor.getAllValues();
+
+        assertThat(actualRecords.size(), equalTo(numberOfObjectsPerList * 2));
+        final List<Map<String, Object>> expectedJsonObjects = new ArrayList<>(jsonObjectsFirst);
+        expectedJsonObjects.addAll(jsonObjectsSecond);
+        for (int i = 0; i < actualRecords.size(); i++) {
+
+            final Record<Event> actualRecord = actualRecords.get(i);
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getData(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata(), notNullValue());
+            assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
+
+            final Map<String, Object> expectedMap = expectedJsonObjects.get(i);
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+        }
+    }
+
+    static class JsonPermutations implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments((Function<List<Map<String, Object>>, Map<String, Object>>) jsonObjects -> {
+                        final Map<String, Object> deepestJson = Collections.singletonMap(UUID.randomUUID().toString(), jsonObjects);
+                        final Map<String, Object> deeperJson = Collections.singletonMap(UUID.randomUUID().toString(), deepestJson);
+                        return Collections.singletonMap(UUID.randomUUID().toString(), deeperJson);
+                    }),
+                    arguments((Function<List<Map<String, Object>>, Map<String, Object>>) jsonObjects -> {
+                        final Map<String, Object> rootJson = new LinkedHashMap<>();
+                        rootJson.put(UUID.randomUUID().toString(), Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+                        rootJson.put(UUID.randomUUID().toString(), jsonObjects);
+                        return rootJson;
+                    }),
+                    arguments((Function<List<Map<String, Object>>, Map<String, Object>>) jsonObjects -> {
+                        final Map<String, Object> rootJson = new LinkedHashMap<>();
+                        rootJson.put(UUID.randomUUID().toString(), jsonObjects);
+                        rootJson.put(UUID.randomUUID().toString(), Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+                        return rootJson;
+                    }),
+                    arguments((Function<List<Map<String, Object>>, Map<String, Object>>) jsonObjects -> {
+                        final Map<String, Object> rootJson = new LinkedHashMap<>();
+                        rootJson.put(UUID.randomUUID().toString(), Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+                        rootJson.put(UUID.randomUUID().toString(), jsonObjects);
+                        rootJson.put(UUID.randomUUID().toString(), Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+                        return rootJson;
+                    })
+            );
+        }
+    }
+
+    private InputStream createInputStream(final List<Map<String, Object>> jsonObjects) throws JsonProcessingException {
+        final String keyName = UUID.randomUUID().toString();
+        final Map<String, Object> jsonRoot = Collections.singletonMap(keyName, jsonObjects);
+        return createInputStream(jsonRoot);
+    }
+
+    private InputStream createInputStream(final Map<String, ?> jsonRoot) throws JsonProcessingException {
+        final byte[] jsonBytes = objectMapper.writeValueAsBytes(jsonRoot);
+
+        return new ByteArrayInputStream(jsonBytes);
+    }
+
+    private static List<Map<String, Object>> generateJsonObjectsAsList(final int numberOfObjects) {
+        final List<Map<String, Object>> jsonObjects = new ArrayList<>(numberOfObjects);
+        for (int i = 0; i < numberOfObjects; i++)
+            jsonObjects.add(generateJson());
+        return Collections.unmodifiableList(jsonObjects);
+    }
+
+    private static Map<String, Object> generateJson() {
+        final Map<String, Object> jsonObject = new LinkedHashMap<>();
+        for (int i = 0; i < 7; i++) {
+            jsonObject.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        }
+        jsonObject.put(UUID.randomUUID().toString(), Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+
+        return jsonObject;
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JsonOutputCodecTest {
+    private ByteArrayOutputStream outputStream;
+
+    private JsonOutputCodec createObjectUnderTest() {
+        return new JsonOutputCodec(new JsonOutputCodecConfig());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void test_happy_case(final int numberOfRecords) throws IOException {
+        JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext();
+        jsonOutputCodec.start(outputStream, null, codecContext);
+
+        final List<Map<String, Object>> expectedData = generateRecords(numberOfRecords);
+        for (int index = 0; index < numberOfRecords; index++) {
+            final Event event = convertToEvent(expectedData.get(index));
+            jsonOutputCodec.writeEvent(event, outputStream);
+        }
+        jsonOutputCodec.complete(outputStream);
+
+        int index = 0;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        for (JsonNode actualElement : jsonNode) {
+            Map<String, Object> expectedMap = expectedData.get(index);
+            Set<String> keys = expectedMap.keySet();
+            Map<String, Object> actualMap = new HashMap<>();
+            for (String key : keys) {
+                actualMap.put(key, getValue(actualElement.get(key)));
+            }
+            assertThat(actualMap, equalTo(expectedMap));
+            index++;
+        }
+
+        assertThat(index, equalTo(numberOfRecords));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void writeEvent_with_include_keys(final int numberOfRecords) throws IOException {
+        JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext(null, List.of("name"), null);
+        jsonOutputCodec.start(outputStream, null, codecContext);
+
+        final List<Map<String, Object>> expectedData = generateRecords(numberOfRecords);
+        for (int index = 0; index < numberOfRecords; index++) {
+            final Event event = convertToEvent(expectedData.get(index));
+            jsonOutputCodec.writeEvent(event, outputStream);
+        }
+        jsonOutputCodec.complete(outputStream);
+
+        int index = 0;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        for (JsonNode actualElement : jsonNode) {
+            Map<String, Object> expectedMap = expectedData.get(index);
+            assertThat(actualElement.has("age"), equalTo(false));
+            assertThat(actualElement.has("name"), equalTo(true));
+            assertThat(actualElement.get("name").getNodeType(), equalTo(JsonNodeType.STRING));
+            assertThat(actualElement.get("name").asText(), equalTo(expectedMap.get("name")));
+            index++;
+        }
+
+        assertThat(index, equalTo(numberOfRecords));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void writeEvent_with_exclude_keys(final int numberOfRecords) throws IOException {
+        JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext(null, null, List.of("age"));
+        jsonOutputCodec.start(outputStream, null, codecContext);
+
+        final List<Map<String, Object>> expectedData = generateRecords(numberOfRecords);
+        for (int index = 0; index < numberOfRecords; index++) {
+            final Event event = convertToEvent(expectedData.get(index));
+            jsonOutputCodec.writeEvent(event, outputStream);
+        }
+        jsonOutputCodec.complete(outputStream);
+
+        int index = 0;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        for (JsonNode actualElement : jsonNode) {
+            Map<String, Object> expectedMap = expectedData.get(index);
+            assertThat(actualElement.has("age"), equalTo(false));
+            assertThat(actualElement.has("name"), equalTo(true));
+            assertThat(actualElement.get("name").getNodeType(), equalTo(JsonNodeType.STRING));
+            assertThat(actualElement.get("name").asText(), equalTo(expectedMap.get("name")));
+            index++;
+        }
+
+        assertThat(index, equalTo(numberOfRecords));
+    }
+
+    @Test
+    void testGetExtension() {
+        JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
+
+        assertThat("json", equalTo(jsonOutputCodec.getExtension()));
+    }
+
+    private static Event convertToEvent(Map<String, Object> data) {
+        return JacksonLog.builder().withData(data).build();
+    }
+
+    private static List<Map<String, Object>> generateRecords(int numberOfRecords) {
+
+        List<Map<String, Object>> recordList = new ArrayList<>();
+
+        for (int rows = 0; rows < numberOfRecords; rows++) {
+
+            Map<String, Object> eventData = new HashMap<>();
+
+            eventData.put("name", "Person" + rows);
+            eventData.put("age", rows);
+            recordList.add(eventData);
+
+        }
+
+        return recordList;
+    }
+
+
+    private Object getValue(JsonNode jsonNode) {
+        if(jsonNode.isTextual())
+            return jsonNode.asText();
+
+        if(jsonNode.isInt())
+            return jsonNode.asInt();
+
+        throw new RuntimeException("Test not setup correctly.");
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonInputCodecTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/NdjsonInputCodecTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NdjsonInputCodecTest {
+    @Mock
+    private NdjsonInputConfig config;
+
+    private EventFactory eventFactory;
+
+    @Mock
+    private Consumer<Record<Event>> eventConsumer;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        eventFactory = TestEventFactory.getTestEventFactory();
+    }
+
+    private NdjsonInputCodec createObjectUnderTest() {
+        return new NdjsonInputCodec(config, eventFactory);
+    }
+
+    @Test
+    void parse_with_null_InputStream_throws() {
+        final NdjsonInputCodec objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class, () ->
+                objectUnderTest.parse(null, eventConsumer));
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @Test
+    void parse_with_InputStream_null_Consumer_throws() {
+        final NdjsonInputCodec objectUnderTest = createObjectUnderTest();
+
+        final InputStream inputStream = mock(InputStream.class);
+        assertThrows(NullPointerException.class, () ->
+                objectUnderTest.parse(inputStream, null));
+
+        verifyNoInteractions(inputStream);
+    }
+
+    @Test
+    void parse_with_empty_InputStream_does_not_call_Consumer() throws IOException {
+        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[]{});
+
+        createObjectUnderTest().parse(emptyInputStream, eventConsumer);
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidInputStreamFormatsArgumentsProvider.class)
+    void parse_includes_objects_from_single_line_of_JSON_objects(final InputStreamFormat inputStreamFormat, final int numberOfObjects) throws IOException {
+        final List<Map<String, Object>> objects = IntStream.range(0, numberOfObjects)
+                .mapToObj(i -> generateJson())
+                .collect(Collectors.toList());
+
+        final InputStream inputStream = inputStreamFormat.createInputStream(objects);
+
+        createObjectUnderTest().parse(inputStream, eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> eventConsumerCaptor = ArgumentCaptor.forClass(Record.class);
+
+        verify(eventConsumer, times(numberOfObjects)).accept(eventConsumerCaptor.capture());
+
+        final List<Record<Event>> capturedRecords = eventConsumerCaptor.getAllValues();
+
+        for (int i = 0; i < numberOfObjects; i++) {
+            final Map<String, Object> expectedObject = objects.get(i);
+            final Record<Event> actualRecord = capturedRecords.get(i);
+            assertThat(actualRecord, notNullValue());
+            final Event actualEvent = actualRecord.getData();
+            assertThat(actualEvent, notNullValue());
+
+            final Map<String, Object> actualEventMap = actualEvent.toMap();
+            assertThat(actualEventMap, equalTo(expectedObject));
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidInputStreamFormatsArgumentsProvider.class)
+    void parse_excludes_empty_objects(final InputStreamFormat inputStreamFormat, final int numberOfObjects) throws IOException {
+        final List<Map<String, Object>> objects = new ArrayList<>();
+        final List<Map<String, Object>> expectedObjects = new ArrayList<>();
+        for (int i = 0; i < numberOfObjects; i++) {
+            final Map<String, Object> emptyJson = Collections.emptyMap();
+            final Map<String, Object> json = generateJson();
+            objects.add(emptyJson);
+            objects.add(json);
+            expectedObjects.add(json);
+        }
+
+        final InputStream inputStream = inputStreamFormat.createInputStream(objects);
+
+        createObjectUnderTest().parse(inputStream, eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> eventConsumerCaptor = ArgumentCaptor.forClass(Record.class);
+
+        verify(eventConsumer, times(numberOfObjects)).accept(eventConsumerCaptor.capture());
+
+        final List<Record<Event>> capturedRecords = eventConsumerCaptor.getAllValues();
+
+        for (int i = 0; i < numberOfObjects; i++) {
+            final Map<String, Object> expectedObject = expectedObjects.get(i);
+            final Record<Event> actualRecord = capturedRecords.get(i);
+            assertThat(actualRecord, notNullValue());
+            final Event actualEvent = actualRecord.getData();
+            assertThat(actualEvent, notNullValue());
+
+            final Map<String, Object> actualEventMap = actualEvent.toMap();
+            assertThat(actualEventMap, equalTo(expectedObject));
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidInputStreamFormatsArgumentsProvider.class)
+    void parse_includes_empty_objects_when_configured(final InputStreamFormat inputStreamFormat, final int numberOfObjects) throws IOException {
+        final List<Map<String, Object>> objects = new ArrayList<>();
+        for (int i = 0; i < numberOfObjects; i++) {
+            final Map<String, Object> emptyJson = Collections.emptyMap();
+            final Map<String, Object> json = generateJson();
+            objects.add(emptyJson);
+            objects.add(json);
+        }
+
+        final InputStream inputStream = inputStreamFormat.createInputStream(objects);
+
+        when(config.isIncludeEmptyObjects()).thenReturn(true);
+        createObjectUnderTest().parse(inputStream, eventConsumer);
+
+        final ArgumentCaptor<Record<Event>> eventConsumerCaptor = ArgumentCaptor.forClass(Record.class);
+
+        verify(eventConsumer, times(objects.size())).accept(eventConsumerCaptor.capture());
+
+        final List<Record<Event>> capturedRecords = eventConsumerCaptor.getAllValues();
+
+        for (int i = 0; i < numberOfObjects; i++) {
+            final Map<String, Object> expectedObject = objects.get(2*i+1);
+            final Record<Event> expectedEmptyRecord = capturedRecords.get(2*i);
+            assertThat(expectedEmptyRecord, notNullValue());
+            assertThat(expectedEmptyRecord.getData(), notNullValue());
+            assertThat(expectedEmptyRecord.getData().toMap().size(), equalTo(0));
+
+            final Record<Event> actualRecord = capturedRecords.get(2*i+1);
+            assertThat(actualRecord, notNullValue());
+            final Event actualEvent = actualRecord.getData();
+            assertThat(actualEvent, notNullValue());
+
+            final Map<String, Object> actualEventMap = actualEvent.toMap();
+            assertThat(actualEventMap, equalTo(expectedObject));
+        }
+    }
+
+    static class ValidInputStreamFormatsArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    arguments(new StrictNdJsonInputStreamFormat(), 1),
+                    arguments(new StrictNdJsonInputStreamFormat(), 2),
+                    arguments(new StrictNdJsonInputStreamFormat(), 10),
+                    arguments(new AllObjectsOnSameLineInputStreamFormat(), 1),
+                    arguments(new AllObjectsOnSameLineInputStreamFormat(), 2),
+                    arguments(new AllObjectsOnSameLineInputStreamFormat(), 10),
+                    arguments(new AllObjectsOnSameLineWithSpacesInputStreamFormat(), 10),
+                    arguments(new MixedInputStreamFormat(), 3),
+                    arguments(new MixedInputStreamFormat(), 10)
+            );
+        }
+    }
+
+    interface InputStreamFormat {
+        InputStream createInputStream(final List<Map<String, Object>> jsonObjects) throws JsonProcessingException;
+    }
+
+    static class StrictNdJsonInputStreamFormat implements InputStreamFormat {
+        @Override
+        public InputStream createInputStream(final List<Map<String, Object>> jsonObjects) throws JsonProcessingException {
+            final StringWriter writer = new StringWriter();
+
+            for (final Map<String, Object> jsonObject : jsonObjects) {
+                writer.append(OBJECT_MAPPER.writeValueAsString(jsonObject));
+                writer.append(System.lineSeparator());
+            }
+
+            return new ByteArrayInputStream(writer.toString().getBytes());
+        }
+
+        @Override
+        public String toString() {
+            return "Strict ND-JSON";
+        }
+    }
+
+    static class AllObjectsOnSameLineInputStreamFormat implements InputStreamFormat {
+        @Override
+        public InputStream createInputStream(final List<Map<String, Object>> jsonObjects) throws JsonProcessingException {
+            final StringWriter writer = new StringWriter();
+
+            for (final Map<String, Object> jsonObject : jsonObjects) {
+                writer.append(OBJECT_MAPPER.writeValueAsString(jsonObject));
+            }
+
+            return new ByteArrayInputStream(writer.toString().getBytes());
+        }
+
+        @Override
+        public String toString() {
+            return "Single line";
+        }
+    }
+
+    static class AllObjectsOnSameLineWithSpacesInputStreamFormat implements InputStreamFormat {
+        @Override
+        public InputStream createInputStream(final List<Map<String, Object>> jsonObjects) throws JsonProcessingException {
+            final StringWriter writer = new StringWriter();
+
+            for (final Map<String, Object> jsonObject : jsonObjects) {
+                writer.append(OBJECT_MAPPER.writeValueAsString(jsonObject));
+                writer.append(" ");
+            }
+
+            return new ByteArrayInputStream(writer.toString().getBytes());
+        }
+
+        @Override
+        public String toString() {
+            return "Spaces";
+        }
+    }
+
+    static class MixedInputStreamFormat implements InputStreamFormat {
+        @Override
+        public InputStream createInputStream(final List<Map<String, Object>> jsonObjects) throws JsonProcessingException {
+            final StringWriter writer = new StringWriter();
+
+            int counter = 0;
+            for (final Map<String, Object> jsonObject : jsonObjects) {
+                writer.append(OBJECT_MAPPER.writeValueAsString(jsonObject));
+                if(counter % 2 == 0)
+                    writer.append(System.lineSeparator());
+                counter++;
+            }
+
+            return new ByteArrayInputStream(writer.toString().getBytes());
+        }
+
+        @Override
+        public String toString() {
+            return "Mixed";
+        }
+    }
+
+    private static Map<String, Object> generateJson() {
+        final Map<String, Object> jsonObject = new LinkedHashMap<>();
+        for (int i = 0; i < 1; i++) {
+            jsonObject.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        }
+        jsonObject.put(UUID.randomUUID().toString(), Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+
+        return jsonObject;
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/NewlineDelimitedOutputCodecTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/json/NewlineDelimitedOutputCodecTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class NewlineDelimitedOutputCodecTest {
+    private ByteArrayOutputStream outputStream;
+
+    private static NdjsonOutputConfig config;
+
+    private static int numberOfRecords;
+    private static final String REGEX = "\\r?\\n";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private NdjsonOutputCodec createObjectUnderTest() {
+        config = new NdjsonOutputConfig();
+        return new NdjsonOutputCodec(config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 3, 10, 100})
+    void test_happy_case(final int numberOfRecords) throws IOException {
+        NewlineDelimitedOutputCodecTest.numberOfRecords = numberOfRecords;
+        NdjsonOutputCodec ndjsonOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext();
+        ndjsonOutputCodec.start(outputStream, null, codecContext);
+        for (int index = 0; index < numberOfRecords; index++) {
+            final Event event = (Event) getRecord(index).getData();
+            ndjsonOutputCodec.writeEvent(event, outputStream);
+        }
+        ndjsonOutputCodec.complete(outputStream);
+        String jsonString = outputStream.toString(StandardCharsets.UTF_8);
+        int index = 0;
+        List<HashMap> expectedRecords = generateRecords(numberOfRecords);
+        String[] jsonObjects = jsonString.split(REGEX);
+        for (String jsonObject : jsonObjects) {
+            Object expectedMap = expectedRecords.get(index);
+            Object actualMap = objectMapper.readValue(jsonObject, Map.class);
+            assertThat(expectedMap, Matchers.equalTo(actualMap));
+            index++;
+        }
+    }
+
+    private static Record getRecord(int index) {
+        List<HashMap> recordList = generateRecords(numberOfRecords);
+        final Event event = JacksonLog.builder().withData(recordList.get(index)).build();
+        return new Record<>(event);
+    }
+
+    private static List<HashMap> generateRecords(int numberOfRecords) {
+
+        List<HashMap> recordList = new ArrayList<>();
+        for (int rows = 0; rows < numberOfRecords; rows++) {
+            HashMap<String, Object> eventData = new HashMap<>();
+            eventData.put("name", "Person" + rows);
+            eventData.put("age", rows);
+            recordList.add(eventData);
+        }
+        return recordList;
+    }
+
+    @Test
+    void testGetExtension() {
+        NdjsonOutputCodec ndjsonOutputCodec = createObjectUnderTest();
+
+        assertThat("ndjson", equalTo(ndjsonOutputCodec.getExtension()));
+    }
+}


### PR DESCRIPTION
### Description
Refactor json codecs from parse-json-processor to data-prepper-plugins/common for reuse.
 
### Issues Resolved
Resolves #[1082]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
