### PR TITLE
Adds integration tests for pipeline connectors.

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Connected_SingleExtraSinkIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Connected_SingleExtraSinkIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+public class Connected_SingleExtraSinkIT {
+    private static final String IN_MEMORY_IDENTIFIER = "Connected_SingleExtraSinkIT";
+    private static final String IN_MEMORY_IDENTIFIER_ENTRY_SINK = IN_MEMORY_IDENTIFIER + "_Entry";
+    private static final String IN_MEMORY_IDENTIFIER_EXIT_SINK = IN_MEMORY_IDENTIFIER + "_Exit";
+    private static final String PIPELINE_CONFIGURATION_UNDER_TEST = "connected/single-connection-extra-sink.yaml";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(PIPELINE_CONFIGURATION_UNDER_TEST)
+                .build();
+
+        dataPrepperTestRunner.start();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void pipeline_with_single_batch_of_records() {
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecords);
+
+        await().atMost(800, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK), not(empty()));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK), not(empty()));
+                });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreate));
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK).size(), equalTo(recordsToCreate));
+    }
+
+    @Test
+    void pipeline_with_multiple_batches_of_records() {
+        final int recordsToCreateBatch1 = 200;
+        final List<Record<Event>> inputRecordsBatch1 = IntStream.range(0, recordsToCreateBatch1)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecordsBatch1);
+
+        await().atMost(800, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK), not(empty()));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK), not(empty()));
+                });
+
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreateBatch1));
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER_EXIT_SINK).size(), equalTo(recordsToCreateBatch1));
+
+        final int recordsToCreateBatch2 = 300;
+        final List<Record<Event>> inputRecordsBatch2 = IntStream.range(0, recordsToCreateBatch2)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecordsBatch2);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK), not(empty()));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK), not(empty()));
+                });
+
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreateBatch2));
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER_EXIT_SINK).size(), equalTo(recordsToCreateBatch2));
+    }
+
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Connected_SingleIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Connected_SingleIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+public class Connected_SingleIT {
+    private static final String IN_MEMORY_IDENTIFIER = "Connected_SingleIT";
+    private static final String PIPELINE_CONFIGURATION_UNDER_TEST = "connected/single-connection.yaml";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(PIPELINE_CONFIGURATION_UNDER_TEST)
+                .build();
+
+        dataPrepperTestRunner.start();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void pipeline_with_no_data() throws InterruptedException {
+        final List<Record<Event>> preRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(preRecords, is(empty()));
+
+        Thread.sleep(1400);
+
+        final List<Record<Event>> postRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(postRecords, is(empty()));
+    }
+
+    @Test
+    void pipeline_with_single_record() {
+        final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final Record<Event> eventRecord = new Record<>(event);
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, Collections.singletonList(eventRecord));
+
+        await().atMost(800, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+                });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(1));
+    }
+
+    @Test
+    void pipeline_with_single_batch_of_records() {
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecords);
+
+        await().atMost(800, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreate));
+                });
+    }
+
+    @Test
+    void pipeline_with_multiple_batches_of_records() {
+        final int recordsToCreateBatch1 = 200;
+        final List<Record<Event>> inputRecordsBatch1 = IntStream.range(0, recordsToCreateBatch1)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecordsBatch1);
+
+        await().atMost(800, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreateBatch1));
+                });
+
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreateBatch1));
+
+        final int recordsToCreateBatch2 = 300;
+        final List<Record<Event>> inputRecordsBatch2 = IntStream.range(0, recordsToCreateBatch2)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecordsBatch2);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreateBatch2));
+                });
+
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreateBatch2));
+    }
+
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
@@ -68,7 +68,11 @@ public class InMemorySource implements Source<Record<Event>> {
     @Override
     public void stop() {
         isStopped = true;
-        runningThread.interrupt();
+        try {
+            runningThread.join(1000);
+        } catch (final InterruptedException e) {
+            runningThread.interrupt();
+        }
     }
 
     private class SourceRunner implements Runnable {

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
@@ -66,6 +66,7 @@ public class DataPrepperTestRunner {
     public void stop() {
         final DataPrepper dataPrepper = contextManager.getDataPrepperBean();
         dataPrepper.shutdown();
+        contextManager.shutdown();
     }
 
     /**

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/connected/single-connection-extra-sink.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/connected/single-connection-extra-sink.yaml
@@ -1,0 +1,19 @@
+entry-pipeline:
+  delay: 5
+  source:
+    in_memory:
+      testing_key: Connected_SingleExtraSinkIT
+  sink:
+    - pipeline:
+        name: exit-pipeline
+    - in_memory:
+        testing_key: Connected_SingleExtraSinkIT_Entry
+
+exit-pipeline:
+  delay: 5
+  source:
+    pipeline:
+      name: entry-pipeline
+  sink:
+    - in_memory:
+        testing_key: Connected_SingleExtraSinkIT_Exit

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/connected/single-connection.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/connected/single-connection.yaml
@@ -1,0 +1,17 @@
+entry-pipeline:
+  delay: 5
+  source:
+    in_memory:
+      testing_key: Connected_SingleIT
+  sink:
+    - pipeline:
+        name: exit-pipeline
+
+exit-pipeline:
+  delay: 5
+  source:
+    pipeline:
+      name: entry-pipeline
+  sink:
+    - in_memory:
+        testing_key: Connected_SingleIT

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
@@ -33,8 +33,8 @@ public class DataPrepperServer {
     private final ShutdownHandler shutdownHandler;
     private final PrometheusMeterRegistry prometheusMeterRegistry;
     private final Authenticator authenticator;
+    private final ExecutorService executorService;
     private HttpServer server;
-    static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(3);
 
     @Inject
     public DataPrepperServer(
@@ -49,6 +49,7 @@ public class DataPrepperServer {
         this.shutdownHandler = shutdownHandler;
         this.prometheusMeterRegistry = prometheusMeterRegistry;
         this.authenticator = authenticator;
+        executorService = Executors.newFixedThreadPool(3);
     }
 
     /**
@@ -56,7 +57,7 @@ public class DataPrepperServer {
      */
     public void start() {
         server = createServer();
-        server.setExecutor(EXECUTOR_SERVICE);
+        server.setExecutor(executorService);
         server.start();
         LOG.info("Data Prepper server running at :{}", server.getAddress().getPort());
     }
@@ -95,7 +96,7 @@ public class DataPrepperServer {
      */
     public void stop() {
         server.stop(0);
-        EXECUTOR_SERVICE.shutdownNow();
+        executorService.shutdownNow();
         LOG.info("Data Prepper server stopped");
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -55,6 +55,7 @@ public class ListPipelinesHandler implements HttpHandler {
                     .stream()
                     .map(PipelineListing::new)
                     .collect(Collectors.toList());
+            LOG.debug("List pipelines request responding with {} pipelines.", pipelines.size());
             final byte[] response = OBJECT_MAPPER.writeValueAsString(Collections.singletonMap("pipelines", pipelines)).getBytes();
             exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);


### PR DESCRIPTION
### Description

This commit adds integration testing for the pipeline connector sink/source which connects two pipelines. There are two tests. The first tests against a single connection with a single sink. The second test also includes a second sink to verify that pipeline connections work with additional sinks.

This commit also includes fixes for CoreHttpServerIT. When running the new pipeline connector tests, the CoreHttpServerIT tests started failing. I found some places where shutdowns were not occurring and fixed those. And I added some additional logging to help debug. The root problem turned out to be that the ExecutorService used in the DataPrepperServer was a static field. The CoreHttpServerIT was working because it was the first test that JUnit chose. With the new tests, it is being chosen later and by that point, the static ExecutorService was shutdown. The fix is simply to avoid using a static ExecutorService.

### Issues Resolved

None. But, I am using this to prepare for #406.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
