### PR TITLE
Logging improvements when failing to parse JSON/XML/ION. 

### DIFF
--- a/data-prepper-plugins/parse-json-processor/build.gradle
+++ b/data-prepper-plugins/parse-json-processor/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation libs.parquet.common
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-test-event')
+    testImplementation testLibs.slf4j.simple
 }
 
 test {

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Optional;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 
 @DataPrepperPlugin(name = "parse_ion", pluginType = Processor.class, pluginConfigurationType = ParseIonProcessorConfig.class)
 public class ParseIonProcessor extends AbstractParseProcessor {
@@ -45,10 +45,10 @@ public class ParseIonProcessor extends AbstractParseProcessor {
             // We need to do a two-step process here, read the value in, then convert away any Ion types like Timestamp
             return Optional.of(objectMapper.convertValue(objectMapper.readValue(message, new TypeReference<>() {}), new TypeReference<>() {}));
         } catch (JsonProcessingException e) {
-            LOG.error(EVENT, "An exception occurred due to invalid Ion while reading event [{}]", context, e);
+            LOG.error(SENSITIVE, "An exception occurred due to invalid Ion while parsing [{}] due to {}", message, e.getMessage());
             return Optional.empty();
         } catch (Exception e) {
-            LOG.error(EVENT, "An exception occurred while using the parse_ion processor on Event [{}]", context, e);
+            LOG.error(SENSITIVE, "An exception occurred while using the parse_ion processor while parsing [{}]", message, e);
             return Optional.empty();
         }
     }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessor.java
@@ -5,15 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.processor.parse.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.processor.Processor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Optional;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 
 @DataPrepperPlugin(name = "parse_json", pluginType = Processor.class, pluginConfigurationType = ParseJsonProcessorConfig.class)
 public class ParseJsonProcessor extends AbstractParseProcessor {
@@ -41,10 +41,10 @@ public class ParseJsonProcessor extends AbstractParseProcessor {
         try {
             return Optional.of(objectMapper.readValue(message, new TypeReference<>() {}));
         } catch (JsonProcessingException e) {
-            LOG.error(EVENT, "An exception occurred due to invalid JSON while reading event [{}]", context, e);
+            LOG.error(SENSITIVE, "An exception occurred due to invalid JSON while parsing [{}] due to {}", message, e.getMessage());
             return Optional.empty();
         } catch (Exception e) {
-            LOG.error(EVENT, "An exception occurred while using the parse_json processor on Event [{}]", context, e);
+            LOG.error(SENSITIVE, "An exception occurred while using the parse_json processor while parsing [{}]", message, e);
             return Optional.empty();
         }
     }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessor.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Optional;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 
 @DataPrepperPlugin(name = "parse_xml", pluginType =Processor.class, pluginConfigurationType =ParseXmlProcessorConfig.class)
 public class ParseXmlProcessor extends AbstractParseProcessor {
@@ -36,10 +36,10 @@ public class ParseXmlProcessor extends AbstractParseProcessor {
         try {
             return Optional.of(xmlMapper.readValue(message, new TypeReference<>() {}));
         } catch (JsonProcessingException e) {
-            LOG.error(EVENT, "An exception occurred due to invalid XML while reading event [{}]", context, e);
+            LOG.error(SENSITIVE, "An exception occurred due to invalid XML while parsing [{}] due to {}", message, e.getMessage());
             return Optional.empty();
         } catch (Exception e) {
-            LOG.error(EVENT, "An exception occurred while using the parse_xml processor on Event [{}]", context, e);
+            LOG.error(SENSITIVE, "An exception occurred while using the parse_xml processor while parsing [{}]", message, e);
             return Optional.empty();
         }
     }


### PR DESCRIPTION
### Description

Do not include the stack trace since it doesn't provide any value with these exceptions which are expected when the JSON is invalid. Log the input string rather than the Event which was not readable.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
