### PR TITLE
Update the parse JSON/XML/ION processors to use EventKey.

### DIFF
--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor;
 import org.slf4j.Logger;
@@ -32,8 +33,9 @@ public class ParseIonProcessor extends AbstractParseProcessor {
     @DataPrepperPluginConstructor
     public ParseIonProcessor(final PluginMetrics pluginMetrics,
                              final ParseIonProcessorConfig parseIonProcessorConfig,
-                             final ExpressionEvaluator expressionEvaluator) {
-        super(pluginMetrics, parseIonProcessorConfig, expressionEvaluator);
+                             final ExpressionEvaluator expressionEvaluator,
+                             final EventKeyFactory eventKeyFactory) {
+        super(pluginMetrics, parseIonProcessorConfig, expressionEvaluator, eventKeyFactory);
 
         // Convert Timestamps to ISO-8601 Z strings
         objectMapper.registerModule(new IonTimestampConverterModule());

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessor.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor;
 import org.slf4j.Logger;
@@ -32,8 +33,9 @@ public class ParseJsonProcessor extends AbstractParseProcessor {
     @DataPrepperPluginConstructor
     public ParseJsonProcessor(final PluginMetrics pluginMetrics,
                               final ParseJsonProcessorConfig parseJsonProcessorConfig,
-                              final ExpressionEvaluator expressionEvaluator) {
-        super(pluginMetrics, parseJsonProcessorConfig, expressionEvaluator);
+                              final ExpressionEvaluator expressionEvaluator,
+                              final EventKeyFactory eventKeyFactory) {
+        super(pluginMetrics, parseJsonProcessorConfig, expressionEvaluator, eventKeyFactory);
     }
 
     @Override

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessor.java
@@ -8,6 +8,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor;
 import org.slf4j.Logger;
@@ -27,8 +28,9 @@ public class ParseXmlProcessor extends AbstractParseProcessor {
     @DataPrepperPluginConstructor
     public ParseXmlProcessor(final PluginMetrics pluginMetrics,
                               final ParseXmlProcessorConfig parseXmlProcessorConfig,
-                              final ExpressionEvaluator expressionEvaluator) {
-        super(pluginMetrics, parseXmlProcessorConfig, expressionEvaluator);
+                              final ExpressionEvaluator expressionEvaluator,
+                              final EventKeyFactory eventKeyFactory) {
+        super(pluginMetrics, parseXmlProcessorConfig, expressionEvaluator, eventKeyFactory);
     }
 
     @Override

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorTest.java
@@ -37,7 +37,7 @@ class ParseIonProcessorTest extends ParseJsonProcessorTest {
 
     @Override
     protected AbstractParseProcessor createObjectUnderTest() {
-        return new ParseIonProcessor(pluginMetrics, ionProcessorConfig, expressionEvaluator);
+        return new ParseIonProcessor(pluginMetrics, ionProcessorConfig, expressionEvaluator, testEventKeyFactory);
     }
 
     @Test
@@ -58,7 +58,7 @@ class ParseIonProcessorTest extends ParseJsonProcessorTest {
     @Test
     void test_when_deleteSourceFlagEnabled() {
         when(processorConfig.isDeleteSourceRequested()).thenReturn(true);
-        parseJsonProcessor = new ParseIonProcessor(pluginMetrics, ionProcessorConfig, expressionEvaluator);
+        parseJsonProcessor = createObjectUnderTest();
 
         final String serializedMessage = "{bareKey: 1, symbol: SYMBOL, timestamp: 2023-11-30T21:05:23.383Z, attribute: dollars::100.0 }";
         final Event parsedEvent = createAndParseMessageEvent(serializedMessage);

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
@@ -5,16 +5,20 @@
 
 package org.opensearch.dataprepper.plugins.processor.parse.json;
 
-import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor;
 import org.opensearch.dataprepper.plugins.processor.parse.CommonParseConfig;
 
@@ -48,6 +52,8 @@ public class ParseJsonProcessorTest {
     protected ExpressionEvaluator expressionEvaluator;
 
     protected AbstractParseProcessor parseJsonProcessor;
+    private final EventFactory testEventFactory = TestEventFactory.getTestEventFactory();
+    protected final EventKeyFactory testEventKeyFactory = TestEventKeyFactory.getTestEventFactory();
 
     @BeforeEach
     public void setup() {
@@ -61,7 +67,7 @@ public class ParseJsonProcessorTest {
     }
 
     protected AbstractParseProcessor createObjectUnderTest() {
-        return new ParseJsonProcessor(pluginMetrics, jsonProcessorConfig, expressionEvaluator);
+        return new ParseJsonProcessor(pluginMetrics, jsonProcessorConfig, expressionEvaluator, testEventKeyFactory);
     }
 
     @Test
@@ -197,7 +203,7 @@ public class ParseJsonProcessorTest {
     @Test
     void test_when_deleteSourceFlagEnabled() {
         when(processorConfig.isDeleteSourceRequested()).thenReturn(true);
-        parseJsonProcessor = new ParseJsonProcessor(pluginMetrics, jsonProcessorConfig, expressionEvaluator);
+        parseJsonProcessor = createObjectUnderTest();
 
         final String key = "key";
         final ArrayList<String> value = new ArrayList<>(List.of("Element0","Element1","Element2"));
@@ -434,10 +440,7 @@ public class ParseJsonProcessorTest {
     }
 
     private Record<Event> buildRecordWithEvent(final Map<String, Object> data) {
-        return new Record<>(JacksonEvent.builder()
-                .withData(data)
-                .withEventType("event")
-                .build());
+        return new Record<>(testEventFactory.eventBuilder(EventBuilder.class).withData(data).build());
     }
 
     private void assertThatKeyEquals(final Event parsedEvent, final String key, final Object value) {

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorTest.java
@@ -5,10 +5,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor;
 
@@ -37,6 +41,8 @@ public class ParseXmlProcessorTest {
     private ExpressionEvaluator expressionEvaluator;
 
     private AbstractParseProcessor parseXmlProcessor;
+    private final EventFactory testEventFactory = TestEventFactory.getTestEventFactory();
+    private final EventKeyFactory testEventKeyFactory = TestEventKeyFactory.getTestEventFactory();
 
     @BeforeEach
     public void setup() {
@@ -46,7 +52,7 @@ public class ParseXmlProcessorTest {
     }
 
     protected AbstractParseProcessor createObjectUnderTest() {
-        return new ParseXmlProcessor(pluginMetrics, processorConfig, expressionEvaluator);
+        return new ParseXmlProcessor(pluginMetrics, processorConfig, expressionEvaluator, testEventKeyFactory);
     }
 
     @Test
@@ -104,9 +110,6 @@ public class ParseXmlProcessorTest {
     }
 
     private Record<Event> buildRecordWithEvent(final Map<String, Object> data) {
-        return new Record<>(JacksonEvent.builder()
-                .withData(data)
-                .withEventType("event")
-                .build());
+        return new Record<>(testEventFactory.eventBuilder(EventBuilder.class).withData(data).build());
     }
 }


### PR DESCRIPTION
### Description

Updates the `parse_json`, `parse_ion`, and `parse_xml` processors to use `EventKey`.

I also pushed #4843 that adds a caching `EventKeyFactory`. With those changes, I'm seeing better performance in the `parse_json` processor.

**Before using Event Key**
![pre-EventKey](https://github.com/user-attachments/assets/479768cb-cb3d-4ea5-8081-0780f53a2874)

**After using Event Key**

![post-EventKey](https://github.com/user-attachments/assets/546b402b-db84-4d9d-9be2-642e96c586d3)


### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
