### PR TITLE
Caching implementation of EventKeyFactory

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/event/EventFactoryApplicationConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/event/EventFactoryApplicationConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.core.event;
+
+import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class EventFactoryApplicationConfiguration {
+    @Bean
+    EventConfiguration eventConfiguration(@Autowired(required = false) final DataPrepperConfiguration dataPrepperConfiguration) {
+        if(dataPrepperConfiguration == null || dataPrepperConfiguration.getEventConfiguration() == null)
+            return EventConfiguration.defaultConfiguration();
+        return dataPrepperConfiguration.getEventConfiguration();
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.opensearch.dataprepper.core.event.EventConfiguration;
 import org.opensearch.dataprepper.model.configuration.PipelineExtensions;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.parser.config.MetricTagFilter;
@@ -47,6 +48,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration {
     private CircuitBreakerConfig circuitBreakerConfig;
     private SourceCoordinationConfig sourceCoordinationConfig;
     private PipelineShutdownOption pipelineShutdown;
+    private EventConfiguration eventConfiguration;
     private Map<String, String> metricTags = new HashMap<>();
     private List<MetricTagFilter> metricTagFilters = new LinkedList<>();
     private PeerForwarderConfiguration peerForwarderConfiguration;
@@ -92,6 +94,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration {
             @JsonProperty("circuit_breakers") final CircuitBreakerConfig circuitBreakerConfig,
             @JsonProperty("source_coordination") final SourceCoordinationConfig sourceCoordinationConfig,
             @JsonProperty("pipeline_shutdown") final PipelineShutdownOption pipelineShutdown,
+            @JsonProperty("event") final EventConfiguration eventConfiguration,
             @JsonProperty("extensions")
             @JsonInclude(JsonInclude.Include.NON_NULL)
             @JsonSetter(nulls = Nulls.SKIP)
@@ -102,6 +105,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration {
                 ? new SourceCoordinationConfig(new PluginModel(DEFAULT_SOURCE_COORDINATION_STORE, Collections.emptyMap()), null)
                 : sourceCoordinationConfig;
         this.pipelineShutdown = pipelineShutdown != null ? pipelineShutdown : DEFAULT_PIPELINE_SHUTDOWN;
+        this.eventConfiguration = eventConfiguration != null ? eventConfiguration : EventConfiguration.defaultConfiguration();
         setSsl(ssl);
         this.keyStoreFilePath = keyStoreFilePath != null ? keyStoreFilePath : "";
         this.keyStorePassword = keyStorePassword != null ? keyStorePassword : "";
@@ -224,6 +228,10 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration {
 
     public PipelineShutdownOption getPipelineShutdown() {
         return pipelineShutdown;
+    }
+
+    public EventConfiguration getEventConfiguration() {
+        return eventConfiguration;
     }
 
     @Override

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
@@ -112,6 +112,7 @@ class PipelineTransformerTests {
 
     @AfterEach
     void tearDown() {
+        verify(dataPrepperConfiguration).getEventConfiguration();
         verifyNoMoreInteractions(dataPrepperConfiguration);
     }
 

--- a/data-prepper-event/build.gradle
+++ b/data-prepper-event/build.gradle
@@ -19,5 +19,7 @@ dependencies {
     implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation libs.caffeine
     testImplementation libs.commons.lang3
 }

--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultEventKeyFactory.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultEventKeyFactory.java
@@ -11,7 +11,7 @@ import org.opensearch.dataprepper.model.event.InternalOnlyEventKeyBridge;
 
 import javax.inject.Named;
 
-@Named
+@Named("innerEventKeyFactory")
 public class DefaultEventKeyFactory implements EventKeyFactory {
     @Override
     public EventKey createEventKey(final String key, final EventAction... forActions) {

--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/EventConfiguration.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/EventConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.core.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Data Prepper configurations for events.
+ */
+public class EventConfiguration {
+    @JsonProperty("maximum_cached_keys")
+    private Integer maximumCachedKeys = 512;
+
+    public static EventConfiguration defaultConfiguration() {
+        return new EventConfiguration();
+    }
+
+    /**
+     * Gets the maximum number of cached {@link org.opensearch.dataprepper.model.event.EventKey} objects.
+     *
+     * @return the cache maximum count
+     */
+    Integer getMaximumCachedKeys() {
+        return maximumCachedKeys;
+    }
+}

--- a/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/CachingEventKeyFactoryTest.java
+++ b/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/CachingEventKeyFactoryTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.core.event;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CachingEventKeyFactoryTest {
+    private static final int CACHE_SIZE = 2;
+    @Mock
+    private EventKeyFactory innerEventKeyFactory;
+
+    @Mock
+    private EventConfiguration eventConfiguration;
+
+    @BeforeEach
+    void setUp() {
+        when(eventConfiguration.getMaximumCachedKeys()).thenReturn(CACHE_SIZE);
+    }
+
+    private EventKeyFactory createObjectUnderTest() {
+        return new CachingEventKeyFactory(innerEventKeyFactory, eventConfiguration);
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void createEventKey_with_EventAction_returns_inner_createEventKey(final EventKeyFactory.EventAction eventAction) {
+        final String key = UUID.randomUUID().toString();
+        final EventKey eventKey = mock(EventKey.class);
+
+        when(innerEventKeyFactory.createEventKey(key, eventAction)).thenReturn(eventKey);
+
+        final EventKey actualEventKey = createObjectUnderTest().createEventKey(key, eventAction);
+        assertThat(actualEventKey, sameInstance(eventKey));
+    }
+
+    @Test
+    void createEventKey_returns_inner_createEventKey() {
+        final String key = UUID.randomUUID().toString();
+        final EventKey eventKey = mock(EventKey.class);
+
+        when(innerEventKeyFactory.createEventKey(key, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey);
+        final EventKey actualEventKey = createObjectUnderTest().createEventKey(key);
+        assertThat(actualEventKey, sameInstance(eventKey));
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void createEventKey_with_EventAction_returns_same_instance_without_calling_inner_createEventKey_for_same_key(final EventKeyFactory.EventAction eventAction) {
+        final String key = UUID.randomUUID().toString();
+        final EventKey eventKey = mock(EventKey.class);
+
+        when(innerEventKeyFactory.createEventKey(key, eventAction)).thenReturn(eventKey);
+
+        final EventKeyFactory objectUnderTest = createObjectUnderTest();
+        final EventKey actualKey = objectUnderTest.createEventKey(key, eventAction);
+        final EventKey actualKey2 = objectUnderTest.createEventKey(key, eventAction);
+
+        assertThat(actualKey, sameInstance(eventKey));
+        assertThat(actualKey2, sameInstance(eventKey));
+
+        verify(innerEventKeyFactory).createEventKey(key, eventAction);
+    }
+
+    @Test
+    void createEventKey_returns_same_instance_without_calling_inner_createEventKey_for_same_key() {
+        final String key = UUID.randomUUID().toString();
+        final EventKey eventKey = mock(EventKey.class);
+
+        when(innerEventKeyFactory.createEventKey(key, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey);
+
+        final EventKeyFactory objectUnderTest = createObjectUnderTest();
+        final EventKey actualKey = objectUnderTest.createEventKey(key);
+        final EventKey actualKey2 = objectUnderTest.createEventKey(key);
+
+        assertThat(actualKey, sameInstance(eventKey));
+        assertThat(actualKey2, sameInstance(eventKey));
+
+        verify(innerEventKeyFactory).createEventKey(key, EventKeyFactory.EventAction.ALL);
+    }
+
+    @Test
+    void createEventKey_with_EventAction_returns_different_values_for_different_keys() {
+        final String key1 = UUID.randomUUID().toString();
+        final String key2 = UUID.randomUUID().toString();
+        final EventKey eventKey1 = mock(EventKey.class);
+        final EventKey eventKey2 = mock(EventKey.class);
+
+        when(innerEventKeyFactory.createEventKey(key1, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey1);
+        when(innerEventKeyFactory.createEventKey(key2, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey2);
+
+        final EventKeyFactory objectUnderTest = createObjectUnderTest();
+        final EventKey actualEventKey1 = objectUnderTest.createEventKey(key1, EventKeyFactory.EventAction.ALL);
+        assertThat(actualEventKey1, sameInstance(eventKey1));
+        final EventKey actualEventKey2 = objectUnderTest.createEventKey(key2, EventKeyFactory.EventAction.ALL);
+        assertThat(actualEventKey2, sameInstance(eventKey2));
+    }
+
+    @Test
+    void createEventKey_with_EventAction_returns_different_values_for_different_actions() {
+        final String key = UUID.randomUUID().toString();
+        final EventKey eventKeyGet = mock(EventKey.class);
+        final EventKey eventKeyPut = mock(EventKey.class);
+
+        when(innerEventKeyFactory.createEventKey(key, EventKeyFactory.EventAction.GET)).thenReturn(eventKeyGet);
+        when(innerEventKeyFactory.createEventKey(key, EventKeyFactory.EventAction.PUT)).thenReturn(eventKeyPut);
+
+        final EventKeyFactory objectUnderTest = createObjectUnderTest();
+        final EventKey actualEventKeyGet = objectUnderTest.createEventKey(key, EventKeyFactory.EventAction.GET);
+        assertThat(actualEventKeyGet, sameInstance(eventKeyGet));
+        final EventKey actualEventKeyPut = objectUnderTest.createEventKey(key, EventKeyFactory.EventAction.PUT);
+        assertThat(actualEventKeyPut, sameInstance(eventKeyPut));
+    }
+
+    @Test
+    void createEventKey_expires_after_reaching_maximum() {
+
+        final List<String> keys = new ArrayList<>(CACHE_SIZE);
+        for (int i = 0; i < CACHE_SIZE * 2; i++) {
+            final String key = UUID.randomUUID().toString();
+            final EventKey eventKey = mock(EventKey.class);
+            when(innerEventKeyFactory.createEventKey(key, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey);
+            keys.add(key);
+        }
+
+        final EventKeyFactory objectUnderTest = createObjectUnderTest();
+
+        final int numberOfIterations = 10;
+        for (int i = 0; i < numberOfIterations; i++) {
+            for (final String key : keys) {
+                objectUnderTest.createEventKey(key);
+            }
+        }
+
+        verify(innerEventKeyFactory, atLeast(numberOfIterations * CACHE_SIZE))
+                .createEventKey(anyString(), eq(EventKeyFactory.EventAction.ALL));
+    }
+}


### PR DESCRIPTION
### Description

Update the `EventKeyFactory` to support caching of `EventKey` objects across plugins and within them.
 
Also adds a configuration to data-prepper-config.yaml:

```
event:
  maximum_cached_keys: 512
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
