### PR TITLE
Catch error that could cause LeaderScheduler thread to crash

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
@@ -127,7 +127,11 @@ public class LeaderScheduler implements Runnable {
                 if(leaderPartition != null) {
                     // Extend the timeout
                     // will always be a leader until shutdown
-                    coordinator.saveProgressStateForPartition(leaderPartition, Duration.ofMinutes(DEFAULT_EXTEND_LEASE_MINUTES));
+                    try {
+                        coordinator.saveProgressStateForPartition(leaderPartition, Duration.ofMinutes(DEFAULT_EXTEND_LEASE_MINUTES));
+                    } catch (final Exception e) {
+                        LOG.error("Failed to update ownership for leader partition. Retrying...");
+                    }
                 }
                 try {
                     Thread.sleep(leaseInterval.toMillis());


### PR DESCRIPTION
### Description
If the source coordination store has a dependency failure (i.e. 5xx from DynamoDB), then the `LeaderScheduler` thread crashes and will not continue shard discovery on the node, causing single-node pipelines to stop processing. 

### Issues Resolved
Resolves #4775 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
