### PR TITLE
Removes the trace-analytics-sample-app from release examples directory

### DIFF
--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -154,7 +154,9 @@ CopySpec archiveToTar() {
             fileMode 0755
         }
         into('examples') {
-            from("${rootDir}/examples")
+            from("${rootDir}/examples") {
+                exclude 'trace-analytics-sample-app'
+            }
             dirMode 0750
             fileMode 0755
         }


### PR DESCRIPTION
### Description

Removes the `trace-analytics-sample-app` from release examples directory when creating the archive and Docker images that we release.

The motivation for removing this is that the samples pull in dependencies which often trigger CVE reports. It is not likely customers are trying to run this example from a Data Prepper deployment, especially since the example is not made to run from the installed version, but runs from Docker and runs using the latest 2.x version.

### Testing

```
./gradlew --parallel clean :release:docker:docker
```

Then:

```
docker run opensearch-data-prepper:2.10.0-SNAPSHOT ls /usr/share/data-prepper/examples
```
```
adot
aws
certificates
config
data-prepper-config.yaml
demo
dev
jaeger-hotrod
log-ingestion
log-ingestion-ecs-firelens
log-ingestion-fluentd
log-ingestion-k8s
trace_analytics.yml
trace_analytics_no_ssl.yml
trace_analytics_no_ssl_2x.yml
zipkin-sleuth-webmvc-example
```

See that the `trace-analytics-sample-app` directory is not present anymore.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
