### PR TITLE
Require dnsjava 3.6.1 to resolve CVE-2024-25638

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,12 @@ subprojects {
         testImplementation testLibs.hamcrest
         testImplementation testLibs.awaitility
         constraints {
+            implementation('dnsjava:dnsjava') {
+                version {
+                    require '3.6.1'
+                }
+                because 'Fixes CVE-2023-39410.'
+            }
             implementation('org.apache.avro:avro') {
                 version {
                     require '1.11.3'


### PR DESCRIPTION
### Description

The Hadoop project pulls in dnsjava 3.4.0. This has a CVE against it: CVE-2024-25638.

Updates to dnsjava 3.6.1
 
### Issues Resolved

None, but fixes CVE-2024-25638.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
