### PR TITLE
Updates Bouncy Castle to 1.78.1 and removes jdk15on dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,10 @@ subprojects {
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
                 details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'
+            } else if (details.requested.group == 'org.bouncycastle' && details.requested.name.endsWith('-jdk15on')) {
+                def java8Name = details.requested.name.replace('-jdk15on', '-jdk18on')
+                details.useTarget group: 'org.bouncycastle', name: java8Name, version: libs.bouncycastle.bcprov.get().version
+                details.because 'Use only the Java 8 artifacts of BouncyCastle'
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -49,7 +49,7 @@ dependencyResolutionManagement {
             version('spring', '5.3.28')
             library('spring-core', 'org.springframework', 'spring-core').versionRef('spring')
             library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
-            version('bouncycastle', '1.76')
+            version('bouncycastle', '1.78.1')
             library('bouncycastle-bcprov', 'org.bouncycastle', 'bcprov-jdk18on').versionRef('bouncycastle')
             library('bouncycastle-bcpkix', 'org.bouncycastle', 'bcpkix-jdk18on').versionRef('bouncycastle')
             version('guava', '32.1.2-jre')


### PR DESCRIPTION
### Description
Updates Bouncy Castle to 1.78.1. Update any projects that attempt to use Bouncy Castle jdk15on dependencies with the jdk18on dependency instead. This will prevent any of the older jdk15on dependencies from getting into our classpath. In particular, this was coming from hadoop-common.
 
### Verification

```
./gradlew -p data-prepper-main dependencies
```

```
|    |    +--- org.apache.hadoop:hadoop-common:3.4.0
...
|    |    |    +--- org.bouncycastle:bcprov-jdk15on:1.70 -> org.bouncycastle:bcprov-jdk18on:1.78.1
```

### Issues Resolved

None

Fixes a few CVEs:

* CVE-2024-29857
* CVE-2024-30171
* CVE-2024-30172
* CVE-2023-33201
* CVE-2024-29857
*  CVE-2024-30171
* CVE-2024-30172
* CVE-2024-29857
* CVE-2024-30171
* CVE-2024-30172
* CVE-2024-34447
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
