### PR TITLE
CVE fixes from Spring expression and commons-configuration2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,12 @@ subprojects {
                 }
                 because 'Fixes CVE-2023-39410.'
             }
+            implementation('org.apache.commons:commons-configuration2') {
+                version {
+                    require '2.11.0'
+                }
+                because 'Fixes CVE-2024-29131 and CVE-2024-29133.'
+            }
             implementation('org.apache.httpcomponents:httpclient') {
                 version {
                     require '4.5.14'

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,7 @@ dependencyResolutionManagement {
             version('opensearch', '1.3.14')
             library('opensearch-client', 'org.opensearch.client', 'opensearch-rest-client').versionRef('opensearch')
             library('opensearch-rhlc', 'org.opensearch.client', 'opensearch-rest-high-level-client').versionRef('opensearch')
-            version('spring', '5.3.28')
+            version('spring', '5.3.39')
             library('spring-core', 'org.springframework', 'spring-core').versionRef('spring')
             library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
             version('bouncycastle', '1.78.1')


### PR DESCRIPTION
### Description

* Update Spring to 5.3.39 to fix CVE-2024-38808. 
* Require commons-configuration2 2.11.0 to fix CVE-2024-29131 and CVE-2024-29133. Hadoop pulls this dependency in.
 
### Issues Resolved

None

Fixes CVEs:

* CVE-2024-38808
* CVE-2024-29131
* CVE-2024-29133
 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
