### PR TITLE
Minor updates and bug fixes for RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -146,7 +146,7 @@ public class RdsService {
                 dbMetadata.getPort(),
                 sourceConfig.getAuthenticationConfig().getUsername(),
                 sourceConfig.getAuthenticationConfig().getPassword(),
-                !sourceConfig.isTlsEnabled());
+                sourceConfig.isTlsEnabled());
         return new SchemaManager(connectionManager);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -105,7 +105,7 @@ public class RdsService {
 
         if (sourceConfig.isStreamEnabled()) {
             BinaryLogClient binaryLogClient = new BinlogClientFactory(sourceConfig, rdsClient, dbMetadata).create();
-            if (sourceConfig.getTlsConfig() == null || !sourceConfig.getTlsConfig().isInsecure()) {
+            if (sourceConfig.isTlsEnabled()) {
                 binaryLogClient.setSSLMode(SSLMode.REQUIRED);
             } else {
                 binaryLogClient.setSSLMode(SSLMode.DISABLED);
@@ -146,7 +146,7 @@ public class RdsService {
                 dbMetadata.getPort(),
                 sourceConfig.getAuthenticationConfig().getUsername(),
                 sourceConfig.getAuthenticationConfig().getPassword(),
-                !sourceConfig.getTlsConfig().isInsecure());
+                !sourceConfig.isTlsEnabled());
         return new SchemaManager(connectionManager);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
@@ -85,6 +85,9 @@ public class RdsSourceConfig {
     @JsonProperty("tls")
     private TlsConfig tlsConfig;
 
+    @JsonProperty("disable_s3_read_for_leader")
+    private boolean disableS3ReadForLeader = false;
+
     public String getDbIdentifier() {
         return dbIdentifier;
     }
@@ -151,6 +154,14 @@ public class RdsSourceConfig {
 
     public TlsConfig getTlsConfig() {
         return tlsConfig;
+    }
+
+    public boolean isTlsEnabled() {
+        return tlsConfig == null || !tlsConfig.isInsecure();
+    }
+
+    public boolean isDisableS3ReadForLeader() {
+        return disableS3ReadForLeader;
     }
 
     public AuthenticationConfig getAuthenticationConfig() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -62,6 +63,11 @@ public class StreamRecordConverter {
                 .build();
 
         EventMetadata eventMetadata = event.getMetadata();
+
+        // Only set external origination time for stream events, not export
+        final Instant externalOriginationTime = Instant.ofEpochMilli(eventCreateTimeEpochMillis);
+        event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
+        eventMetadata.setExternalOriginationTime(externalOriginationTime);
 
         eventMetadata.setAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE, databaseName);
         eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKey.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKey.java
@@ -36,7 +36,9 @@ public class ExportObjectKey {
         final String prefix = parts[0];
         final String exportTaskId = parts[1];
         final String databaseName = parts[2];
-        final String tableName = parts[3];
+        // fullTableName is in the format of "databaseName.tableName"
+        final String fullTableName = parts[3];
+        final String tableName = fullTableName.split("\\.")[1];
         final String numberedFolder = parts[4];
         final String fileName = parts[5];
         return new ExportObjectKey(prefix, exportTaskId, databaseName, tableName, numberedFolder, fileName);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -124,7 +124,7 @@ class ExportSchedulerTest {
         String tableName = UUID.randomUUID().toString();
         // objectKey needs to have this structure: "{prefix}/{export task ID}/{database name}/{table name}/{numbered folder}/{file name}"
         S3Object s3Object = S3Object.builder()
-                .key("prefix/" + exportTaskId + "/my_db/" + tableName + "/1/file1" + PARQUET_SUFFIX)
+                .key("prefix/" + exportTaskId + "/my_db/my_db." + tableName + "/1/file1" + PARQUET_SUFFIX)
                 .build();
         when(listObjectsV2Response.contents()).thenReturn(List.of(s3Object));
         when(listObjectsV2Response.isTruncated()).thenReturn(false);
@@ -185,7 +185,7 @@ class ExportSchedulerTest {
         String tableName = UUID.randomUUID().toString();
         // objectKey needs to have this structure: "{prefix}/{export task ID}/{database name}/{table name}/{numbered folder}/{file name}"
         S3Object s3Object = S3Object.builder()
-                .key("prefix/" + exportTaskId + "/my_db/" + tableName + "/1/file1" + PARQUET_SUFFIX)
+                .key("prefix/" + exportTaskId + "/my_db/my_db." + tableName + "/1/file1" + PARQUET_SUFFIX)
                 .build();
         when(listObjectsV2Response.contents()).thenReturn(List.of(s3Object));
         when(listObjectsV2Response.isTruncated()).thenReturn(false);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKeyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKeyTest.java
@@ -16,7 +16,7 @@ class ExportObjectKeyTest {
 
     @Test
     void test_fromString_with_valid_input_string() {
-        final String objectKeyString = "prefix/export-task-id/db-name/table-name/1/file-name.parquet";
+        final String objectKeyString = "prefix/export-task-id/db-name/db-name.table-name/1/file-name.parquet";
         final ExportObjectKey exportObjectKey = ExportObjectKey.fromString(objectKeyString);
 
         assertThat(exportObjectKey.getPrefix(), equalTo("prefix"));


### PR DESCRIPTION
### Description
- Sets external origination time for stream events to enable end to end latency metric
- Adds a config to allow disabling primary stream node from doing S3 scan work
- Fixes a bug with parsing ExportObjectKey
- Fixes an NPE when getting TlsConfig
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
