### PR TITLE
ENH: respect JsonProperty defaultValue in JsonSchemaConverter

### DIFF
--- a/data-prepper-plugin-schema/src/main/java/org/opensearch/dataprepper/schemas/JsonSchemaConverter.java
+++ b/data-prepper-plugin-schema/src/main/java/org/opensearch/dataprepper/schemas/JsonSchemaConverter.java
@@ -1,5 +1,6 @@
 package org.opensearch.dataprepper.schemas;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.FieldScope;
@@ -29,6 +30,7 @@ public class JsonSchemaConverter {
         loadJsonSchemaGeneratorModules(configBuilder);
         final SchemaGeneratorConfigPart<FieldScope> scopeSchemaGeneratorConfigPart = configBuilder.forFields();
         overrideInstanceAttributeWithDeprecated(scopeSchemaGeneratorConfigPart);
+        resolveDefaultValueFromJsonProperty(scopeSchemaGeneratorConfigPart);
 
         final SchemaGeneratorConfig config = configBuilder.build();
         final SchemaGenerator generator = new SchemaGenerator(config);
@@ -47,6 +49,14 @@ public class JsonSchemaConverter {
             if (deprecatedAnnotation != null) {
                 node.put(DEPRECATED_SINCE_KEY, deprecatedAnnotation.since());
             }
+        });
+    }
+
+    private void resolveDefaultValueFromJsonProperty(
+            final SchemaGeneratorConfigPart<FieldScope> scopeSchemaGeneratorConfigPart) {
+        scopeSchemaGeneratorConfigPart.withDefaultResolver(field -> {
+            final JsonProperty annotation = field.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
+            return annotation == null || annotation.defaultValue().isEmpty() ? null : annotation.defaultValue();
         });
     }
 }

--- a/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterTest.java
+++ b/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.victools.jsonschema.generator.Module;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaVersion;
@@ -14,6 +15,7 @@ import org.opensearch.dataprepper.schemas.module.CustomJacksonModule;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,6 +32,13 @@ class JsonSchemaConverterTest {
         final ObjectNode jsonSchemaNode = jsonSchemaConverter.convertIntoJsonSchema(
                 SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON, TestConfig.class);
         assertThat(jsonSchemaNode, instanceOf(ObjectNode.class));
+        final JsonNode propertiesNode = jsonSchemaNode.at("/properties");
+        assertThat(propertiesNode, instanceOf(ObjectNode.class));
+        assertThat(propertiesNode.has("testAttributeWithDefaultValue"), is(true));
+        final JsonNode testAttributeWithDefaultValueNode = propertiesNode.at("/testAttributeWithDefaultValue");
+        assertThat(testAttributeWithDefaultValueNode, instanceOf(ObjectNode.class));
+        assertThat(testAttributeWithDefaultValueNode.has("default"), is(true));
+        assertThat(testAttributeWithDefaultValueNode.get("default"), equalTo(TextNode.valueOf("default_value")));
     }
 
     @Test
@@ -52,6 +61,9 @@ class JsonSchemaConverterTest {
 
         @JsonProperty("custom_test_attribute")
         private String testAttributeWithJsonPropertyAnnotation;
+
+        @JsonProperty(defaultValue = "default_value")
+        private String testAttributeWithDefaultValue;
 
         public String getTestAttributeWithGetter() {
             return testAttributeWithGetter;

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -74,7 +74,7 @@ public class GrokProcessorConfig {
     @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
             "Default is an empty response body.")
     private Map<String, String> patternDefinitions = Collections.emptyMap();
-    @JsonProperty(value = TIMEOUT_MILLIS)
+    @JsonProperty(TIMEOUT_MILLIS)
     @JsonPropertyDescription("The maximum amount of time during which matching occurs. " +
             "Setting to `0` prevents any matching from occurring. Default is `30,000`.")
     private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -74,7 +74,7 @@ public class GrokProcessorConfig {
     @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
             "Default is an empty response body.")
     private Map<String, String> patternDefinitions = Collections.emptyMap();
-    @JsonProperty(TIMEOUT_MILLIS)
+    @JsonProperty(value = TIMEOUT_MILLIS)
     @JsonPropertyDescription("The maximum amount of time during which matching occurs. " +
             "Setting to `0` prevents any matching from occurring. Default is `30,000`.")
     private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;


### PR DESCRIPTION
### Description
with this change, defaultValue in JsonProperty will be respected in result json schema as long as it is non-empty:
```
"timeout_millis" : {
      "type" : "integer",
      "description" : "The maximum amount of time during which matching occurs. Setting to `0` prevents any matching from occurring. Default is `30,000`.",
      "default" : "30000"
    },

```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
