### PR TITLE
Corrects the S3SinkStack for AWS testing

### DIFF
--- a/testing/aws-testing-cdk/bin/aws-testing-cdk.ts
+++ b/testing/aws-testing-cdk/bin/aws-testing-cdk.ts
@@ -4,7 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 import {GitHubAccessStack} from '../lib/common/GitHubAccessStack';
 import {SecretsManagerStack} from '../lib/aws-secrets-manager/SecretsManagerStack';
 import {KmsStack} from '../lib/common/KmsStack';
-import {S3SinkStack} from "../lib/s3/S3SinkStack";
+import {S3SinkStack} from '../lib/s3/S3SinkStack';
 
 const app = new cdk.App();
 

--- a/testing/aws-testing-cdk/bin/aws-testing-cdk.ts
+++ b/testing/aws-testing-cdk/bin/aws-testing-cdk.ts
@@ -4,6 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 import {GitHubAccessStack} from '../lib/common/GitHubAccessStack';
 import {SecretsManagerStack} from '../lib/aws-secrets-manager/SecretsManagerStack';
 import {KmsStack} from '../lib/common/KmsStack';
+import {S3SinkStack} from "../lib/s3/S3SinkStack";
 
 const app = new cdk.App();
 
@@ -14,5 +15,9 @@ new KmsStack(app, 'CommonKmsStack', {
 })
 
 new SecretsManagerStack(app, 'SecretsManagerStack', {
+  testingRole: githubStack.gitHubActionsTestingRole
+});
+
+new S3SinkStack(app, 'S3SinkStack', {
   testingRole: githubStack.gitHubActionsTestingRole
 });

--- a/testing/aws-testing-cdk/lib/s3/S3SinkStack.ts
+++ b/testing/aws-testing-cdk/lib/s3/S3SinkStack.ts
@@ -21,7 +21,7 @@ export class S3SinkStack extends Stack {
   constructor(scope: Construct, id: string, props: S3SinkStackProps) {
     super(scope, id, props);
 
-    new Bucket(this, 'MyBucket', {
+    this.bucket = new Bucket(this, 'DataPrepperSinkTest', {
       removalPolicy: RemovalPolicy.DESTROY,
       lifecycleRules: [
         {


### PR DESCRIPTION
### Description

The `S3SinkStack` was not in use and didn't quite work. This corrects it so that we can use it to automate the tests for the S3 sink in GitHub.

```
export AWS_REGION=us-east-2
cdk deploy --all --context dataPrepperOrganization=MYORG --context gitHubOidcProviderExists=true
```
 
Then test:

```
./gradlew :data-prepper-plugins:s3-sink:integrationTest -Dtests.s3sink.region=us-east-2 -Dtests.s3sink.bucket=s3sinkstack-s3sinkbucketUUID
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
