### PR TITLE
Move event processing to separate threads and add event processing timer in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
@@ -12,13 +12,23 @@ import jakarta.validation.constraints.Min;
 public class StreamConfig {
 
     private static final int DEFAULT_S3_FOLDER_PARTITION_COUNT = 100;
+    private static final int DEFAULT_NUM_WORKERS = 1;
 
     @JsonProperty("partition_count")
     @Min(1)
     @Max(1000)
     private int s3FolderPartitionCount = DEFAULT_S3_FOLDER_PARTITION_COUNT;
 
+    @JsonProperty("workers")
+    @Min(1)
+    @Max(1000)
+    private int numWorkers = DEFAULT_NUM_WORKERS;
+
     public int getPartitionCount() {
         return s3FolderPartitionCount;
+    }
+
+    public int getNumWorkers() {
+        return numWorkers;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -16,6 +16,7 @@ import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
 import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
@@ -38,6 +39,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -51,6 +54,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
     static final String CHANGE_EVENTS_PROCESSING_ERROR_COUNT = "changeEventsProcessingErrors";
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
+    static final String REPLICATION_LOG_EVENT_PROCESSING_TIME = "replicationLogEventProcessingTime";
 
     /**
      * TableId to TableMetadata mapping
@@ -59,17 +63,20 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
 
     private final StreamRecordConverter recordConverter;
     private final BinaryLogClient binaryLogClient;
-    private final BufferAccumulator<Record<Event>> bufferAccumulator;
+    private final Buffer<Record<Event>> buffer;
     private final List<String> tableNames;
     private final String s3Prefix;
     private final boolean isAcknowledgmentsEnabled;
     private final PluginMetrics pluginMetrics;
     private final List<Event> pipelineEvents;
     private final StreamCheckpointManager streamCheckpointManager;
+    private final ExecutorService executorService;
     private final Counter changeEventSuccessCounter;
     private final Counter changeEventErrorCounter;
     private final DistributionSummary bytesReceivedSummary;
     private final DistributionSummary bytesProcessedSummary;
+    private final Timer eventProcessingTimer;
+
 
     /**
      * currentBinlogCoordinate is the coordinate where next event will start
@@ -82,15 +89,16 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                                final BinaryLogClient binaryLogClient,
                                final StreamCheckpointer streamCheckpointer,
                                final AcknowledgementSetManager acknowledgementSetManager) {
+        this.buffer = buffer;
         this.binaryLogClient = binaryLogClient;
         tableMetadataMap = new HashMap<>();
         recordConverter = new StreamRecordConverter(sourceConfig.getStream().getPartitionCount());
-        bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
         s3Prefix = sourceConfig.getS3Prefix();
         tableNames = sourceConfig.getTableNames();
         isAcknowledgmentsEnabled = sourceConfig.isAcknowledgmentsEnabled();
         this.pluginMetrics = pluginMetrics;
         pipelineEvents = new ArrayList<>();
+        executorService = Executors.newCachedThreadPool();
 
         this.streamCheckpointManager = new StreamCheckpointManager(
                 streamCheckpointer, sourceConfig.isAcknowledgmentsEnabled(),
@@ -101,6 +109,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         changeEventErrorCounter = pluginMetrics.counter(CHANGE_EVENTS_PROCESSING_ERROR_COUNT);
         bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
         bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
+        eventProcessingTimer = pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME);
     }
 
     @Override
@@ -109,22 +118,22 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
 
         switch (eventType) {
             case ROTATE:
-                handleEventAndErrors(event, this::handleRotateEvent);
+                processEvent(event, this::handleRotateEvent);
                 break;
             case TABLE_MAP:
-                handleEventAndErrors(event, this::handleTableMapEvent);
+                processEvent(event, this::handleTableMapEvent);
                 break;
             case WRITE_ROWS:
             case EXT_WRITE_ROWS:
-                handleEventAndErrors(event, this::handleInsertEvent);
+                processEvent(event, this::handleInsertEvent);
                 break;
             case UPDATE_ROWS:
             case EXT_UPDATE_ROWS:
-                handleEventAndErrors(event, this::handleUpdateEvent);
+                processEvent(event, this::handleUpdateEvent);
                 break;
             case DELETE_ROWS:
             case EXT_DELETE_ROWS:
-                handleEventAndErrors(event, this::handleDeleteEvent);
+                processEvent(event, this::handleDeleteEvent);
                 break;
         }
     }
@@ -132,6 +141,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
     public void stopClient() {
         try {
             binaryLogClient.disconnect();
+            executorService.shutdownNow();
             LOG.info("Binary log client disconnected.");
         } catch (Exception e) {
             LOG.error("Binary log client failed to disconnect.", e);
@@ -223,6 +233,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         final List<String> primaryKeys = tableMetadata.getPrimaryKeys();
         final long eventTimestampMillis = event.getHeader().getTimestamp();
 
+        final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
+
         for (Object[] rowDataArray : rows) {
             final Map<String, Object> rowDataMap = new HashMap<>();
             for (int i = 0; i < rowDataArray.length; i++) {
@@ -242,7 +254,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             pipelineEvents.add(pipelineEvent);
         }
 
-        writeToBuffer(acknowledgementSet);
+        writeToBuffer(bufferAccumulator, acknowledgementSet);
         bytesProcessedSummary.record(bytes);
 
         if (isAcknowledgmentsEnabled) {
@@ -256,19 +268,19 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         return new HashSet<>(tableNames).contains(tableName);
     }
 
-    private void writeToBuffer(AcknowledgementSet acknowledgementSet) {
+    private void writeToBuffer(BufferAccumulator<Record<Event>> bufferAccumulator, AcknowledgementSet acknowledgementSet) {
         for (Event pipelineEvent : pipelineEvents) {
-            addToBufferAccumulator(new Record<>(pipelineEvent));
+            addToBufferAccumulator(bufferAccumulator, new Record<>(pipelineEvent));
             if (acknowledgementSet != null) {
                 acknowledgementSet.add(pipelineEvent);
             }
         }
 
-        flushBufferAccumulator(pipelineEvents.size());
+        flushBufferAccumulator(bufferAccumulator, pipelineEvents.size());
         pipelineEvents.clear();
     }
 
-    private void addToBufferAccumulator(final Record<Event> record) {
+    private void addToBufferAccumulator(final BufferAccumulator<Record<Event>> bufferAccumulator, final Record<Event> record) {
         try {
             bufferAccumulator.add(record);
         } catch (Exception e) {
@@ -276,7 +288,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         }
     }
 
-    private void flushBufferAccumulator(int eventCount) {
+    private void flushBufferAccumulator(BufferAccumulator<Record<Event>> bufferAccumulator, int eventCount) {
         try {
             bufferAccumulator.flush();
             changeEventSuccessCounter.increment(eventCount);
@@ -288,10 +300,14 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         }
     }
 
+    private void processEvent(com.github.shyiko.mysql.binlog.event.Event event, Consumer<com.github.shyiko.mysql.binlog.event.Event> function) {
+        executorService.submit(() -> handleEventAndErrors(event, function));
+    }
+
     private void handleEventAndErrors(com.github.shyiko.mysql.binlog.event.Event event,
                                       Consumer<com.github.shyiko.mysql.binlog.event.Event> function) {
         try {
-            function.accept(event);
+            eventProcessingTimer.record(() -> function.accept(event));
         } catch (Exception e) {
             LOG.error("Failed to process change event of type {}", event.getHeader().getEventType(), e);
         }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -7,13 +7,17 @@ package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.EventType;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -22,10 +26,15 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.REPLICATION_LOG_EVENT_PROCESSING_TIME;
 
 @ExtendWith(MockitoExtension.class)
 class BinlogEventListenerTest {
@@ -48,14 +57,28 @@ class BinlogEventListenerTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
+    @Mock
+    private ExecutorService eventListnerExecutorService;
+
+    @Mock
+    private ExecutorService checkpointManagerExecutorService;
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private com.github.shyiko.mysql.binlog.event.Event binlogEvent;
 
-    private static BinlogEventListener objectUnderTest;
+    private BinlogEventListener objectUnderTest;
+
+    private Timer eventProcessingTimer;
 
     @BeforeEach
     void setUp() {
-        objectUnderTest = spy(createObjectUnderTest());
+        eventProcessingTimer = Metrics.timer("test-timer");
+        when(pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME)).thenReturn(eventProcessingTimer);
+        try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
+            executorsMockedStatic.when(Executors::newCachedThreadPool).thenReturn(eventListnerExecutorService);
+            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(checkpointManagerExecutorService);
+            objectUnderTest = spy(createObjectUnderTest());
+        }
     }
 
     @Test
@@ -65,6 +88,7 @@ class BinlogEventListenerTest {
 
         objectUnderTest.onEvent(binlogEvent);
 
+        verifyHandlerCallHelper();
         verify(objectUnderTest).handleTableMapEvent(binlogEvent);
     }
 
@@ -76,6 +100,7 @@ class BinlogEventListenerTest {
 
         objectUnderTest.onEvent(binlogEvent);
 
+        verifyHandlerCallHelper();
         verify(objectUnderTest).handleInsertEvent(binlogEvent);
     }
 
@@ -87,6 +112,7 @@ class BinlogEventListenerTest {
 
         objectUnderTest.onEvent(binlogEvent);
 
+        verifyHandlerCallHelper();
         verify(objectUnderTest).handleUpdateEvent(binlogEvent);
     }
 
@@ -98,10 +124,19 @@ class BinlogEventListenerTest {
 
         objectUnderTest.onEvent(binlogEvent);
 
+        verifyHandlerCallHelper();
         verify(objectUnderTest).handleDeleteEvent(binlogEvent);
     }
 
     private BinlogEventListener createObjectUnderTest() {
         return new BinlogEventListener(buffer, sourceConfig, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager);
+    }
+
+    private void verifyHandlerCallHelper() {
+        ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(eventListnerExecutorService).submit(runnableArgumentCaptor.capture());
+
+        Runnable capturedRunnable = runnableArgumentCaptor.getValue();
+        capturedRunnable.run();
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
@@ -42,6 +42,7 @@ class StreamSchedulerTest {
 
     @Mock
     private EnhancedSourceCoordinator sourceCoordinator;
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RdsSourceConfig sourceConfig;
 
@@ -85,6 +86,8 @@ class StreamSchedulerTest {
 
         StreamWorker streamWorker = mock(StreamWorker.class);
         doNothing().when(streamWorker).processStream(streamPartition);
+        when(sourceConfig.getStream().getNumWorkers()).thenReturn(1);
+
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {
             try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class)) {


### PR DESCRIPTION
### Description
Move event processing to separate threads and add event processing timer in RDS source. This will help with performance testing.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
