### PR TITLE
Update testing GitHub workflows to use pull_request

### DIFF
--- a/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
+++ b/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
@@ -5,7 +5,7 @@ name: Data Prepper AWS secrets End-to-end test with Gradle
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 # permission can be added at job level or workflow level

--- a/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
+++ b/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
@@ -5,7 +5,7 @@ name: Data Prepper AWS secrets End-to-end test with Gradle
 on:
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 # permission can be added at job level or workflow level

--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'data-prepper-plugins/kafka-plugins/**'
       - '*gradle*'
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
       - 'data-prepper-plugins/kafka-plugins/**'


### PR DESCRIPTION
### Description

Update testing GitHub workflows to use `pull_request` instead of `pull_request_target`.

Using `pull_request_target` runs against the target branch, but this doesn't let us test the changes coming in as we'd like.

I noticed this in my PR #4703 which failed to run. But, I see that after it was merged, the test pass.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
