### PR TITLE
Add progress check callback to update partition ownership in S3 scan source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -139,5 +139,12 @@ public interface SourceCoordinator<T> {
      */
     void updatePartitionForAcknowledgmentWait(final String partitionKey, final Duration ackowledgmentTimeout);
 
+    /**
+     * Should be called by the source to keep ownership of the partition
+     * before another instance of Data Prepper can pick it up for processing.
+     * @param partitionKey - the partition to renew ownership for
+     */
+    void renewPartitionOwnership(final String partitionKey);
+
     void deletePartition(final String partitionKey);
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
@@ -108,7 +108,7 @@ class S3ObjectWorker implements S3ObjectHandler {
                     }
                     bufferAccumulator.add(record);
 
-                    if (sourceCoordinator != null && partitionKey != null &&
+                    if (acknowledgementSet != null && sourceCoordinator != null && partitionKey != null &&
                             (System.currentTimeMillis() - lastCheckpointTime.get() > DEFAULT_CHECKPOINT_INTERVAL_MILLS)) {
                         LOG.debug("Renew partition ownership for the object {}", partitionKey);
                         sourceCoordinator.saveProgressStateForPartition(partitionKey, null);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -52,6 +52,8 @@ public class ScanObjectWorker implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ScanObjectWorker.class);
     private static final Integer MAX_OBJECTS_PER_ACKNOWLEDGMENT_SET = 1;
 
+    static final Duration CHECKPOINT_OWNERSHIP_INTERVAL = Duration.ofMinutes(2);
+
     static final Duration NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION = Duration.ofHours(1);
     private static final int RETRY_BACKOFF_ON_EXCEPTION_MILLIS = 5_000;
 
@@ -60,6 +62,7 @@ public class ScanObjectWorker implements Runnable {
 
     static final String NO_OBJECTS_FOUND_FOR_FOLDER_PARTITION = "folderPartitionNoObjectsFound";
 
+    static final String PARTITION_OWNERSHIP_UPDATE_ERRORS = "partitionOwnershipUpdateErrors";
     private final S3Client s3Client;
 
     private final List<ScanOptions> scanOptionsBuilderList;
@@ -85,6 +88,8 @@ public class ScanObjectWorker implements Runnable {
     private final Counter acknowledgementSetCallbackCounter;
 
     private final Counter folderPartitionNoObjectsFound;
+
+    private final Counter partitionOwnershipUpdateFailures;
     private final long backOffMs;
     private final List<String> partitionKeys;
 
@@ -118,6 +123,7 @@ public class ScanObjectWorker implements Runnable {
         this.pluginMetrics = pluginMetrics;
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME);
         this.folderPartitionNoObjectsFound = pluginMetrics.counter(NO_OBJECTS_FOUND_FOR_FOLDER_PARTITION);
+        this.partitionOwnershipUpdateFailures = pluginMetrics.counter(PARTITION_OWNERSHIP_UPDATE_ERRORS);
         this.sourceCoordinator.initialize();
         this.partitionKeys = new ArrayList<>();
         this.folderPartitioningOptions = s3SourceConfig.getS3ScanScanOptions().getPartitioningOptions();
@@ -209,6 +215,17 @@ public class ScanObjectWorker implements Runnable {
                     }
                     partitionKeys.remove(objectToProcess.get().getPartitionKey());
                 }, ACKNOWLEDGEMENT_SET_TIMEOUT);
+
+                acknowledgementSet.addProgressCheck(
+                        (ratio) -> {
+                            try {
+                                sourceCoordinator.renewPartitionOwnership(objectToProcess.get().getPartitionKey());
+                            } catch (final PartitionUpdateException | PartitionNotOwnedException | PartitionNotFoundException e) {
+                                LOG.debug("Failed to update partition ownership for {} in the acknowledgment progress check", objectToProcess.get().getPartitionKey());
+                                partitionOwnershipUpdateFailures.increment();
+                            }
+                        },
+                        CHECKPOINT_OWNERSHIP_INTERVAL);
             }
 
 
@@ -217,7 +234,11 @@ public class ScanObjectWorker implements Runnable {
 
             if (endToEndAcknowledgementsEnabled) {
                 deleteObjectRequest.ifPresent(deleteRequest -> objectsToDeleteForAcknowledgmentSets.put(objectToProcess.get().getPartitionKey(), Set.of(deleteRequest)));
-                sourceCoordinator.updatePartitionForAcknowledgmentWait(objectToProcess.get().getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
+                try {
+                    sourceCoordinator.updatePartitionForAcknowledgmentWait(objectToProcess.get().getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
+                } catch (final PartitionUpdateException e) {
+                    LOG.debug("Failed to update the partition for the acknowledgment wait.");
+                }
                 acknowledgementSet.complete();
             } else {
                 sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey(), false);


### PR DESCRIPTION


### Description
This change adds an asynchronous progressCheck ack callback to update the partition ownership for S3 scan source. 

This fixes an issue where circuit breaker or full buffer can cause the synchronous thread to be blocked that was previously updating the partition ownership timeout.

Tested by blocking the write to the buffer and confirming that the partition for an object had it's partition ownership updated every 2 minutes


### Issues Resolved
Related to #4422 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
