### PR TITLE
Updates to the code for HTTP chunking

### DIFF
--- a/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/Codec.java
+++ b/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/Codec.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.http.codec;
 import com.linecorp.armeria.common.HttpData;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Codec parses the content of HTTP request into custom Java type.
@@ -22,7 +23,32 @@ public interface Codec<T> {
      */
     T parse(HttpData httpData) throws IOException;
 
-    default T parse(HttpData httpData, int maxSize) throws IOException {
-        return parse(httpData);
+    /**
+     * Serializes parsed data back into a UTF-8 string.
+     * <p>
+     * This API will split into multiple bodies based on splitLength. Note that if a single
+     * item is larger than this, it will be output and exceed that length.
+     *
+     * @param parsedData The parsed data
+     * @param serializedBodyConsumer A {@link Consumer} to accept each serialized body
+     * @param splitLength The length at which to split serialized bodies.
+     * @throws IOException A failure writing data.
+     */
+    void serialize(final T parsedData,
+                   final Consumer<String> serializedBodyConsumer,
+                   final int splitLength) throws IOException;
+
+
+    /**
+     * Serializes parsed data back into a UTF-8 string.
+     * <p>
+     * This API will not split the data into chunks.
+     *
+     * @param parsedData The parsed data
+     * @param serializedBodyConsumer A {@link Consumer} to accept the serialized body
+     * @throws IOException A failure writing data.
+     */
+    default void serialize(final T parsedData, final Consumer<String> serializedBodyConsumer) throws IOException {
+        serialize(parsedData, serializedBodyConsumer, Integer.MAX_VALUE);
     }
 }

--- a/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/JsonCodec.java
+++ b/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/JsonCodec.java
@@ -5,68 +5,126 @@
 
 package org.opensearch.dataprepper.http.codec;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CountingOutputStream;
 import com.linecorp.armeria.common.HttpData;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * JsonCodec parses the json array format HTTP data into List&lt;{@link String}&gt;.
  * TODO: replace output List&lt;String&gt; with List&lt;InternalModel&gt; type
  * <p>
  */
-public class JsonCodec implements Codec<List<List<String>>> {
-    // To account for "[" and "]" when the list is converted to String
-    private static final String OVERHEAD_CHARACTERS = "[]";
-    // To account for "," when the list is converted to String
-    private static final int COMMA_OVERHEAD_LENGTH = 1;
+public class JsonCodec implements Codec<List<String>> {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final TypeReference<List<Map<String, Object>>> LIST_OF_MAP_TYPE_REFERENCE =
-            new TypeReference<List<Map<String, Object>>>() {};
+            new TypeReference<List<Map<String, Object>>>() {
+            };
+
 
     @Override
-    public List<List<String>> parse(HttpData httpData) throws IOException {
-        List<String> jsonList = new ArrayList<>();
+    public List<String> parse(final HttpData httpData) throws IOException {
+        final List<String> jsonList = new ArrayList<>();
         final List<Map<String, Object>> logList = mapper.readValue(httpData.toInputStream(),
                 LIST_OF_MAP_TYPE_REFERENCE);
-        for (final Map<String, Object> log: logList) {
+        for (final Map<String, Object> log : logList) {
             final String recordString = mapper.writeValueAsString(log);
             jsonList.add(recordString);
         }
 
-        return List.of(jsonList);
-    }
-
-    @Override
-    public List<List<String>> parse(HttpData httpData, int maxSize) throws IOException {
-        List<List<String>> jsonList = new ArrayList<>();
-        final List<Map<String, Object>> logList = mapper.readValue(httpData.toInputStream(),
-                LIST_OF_MAP_TYPE_REFERENCE);
-        List<String> innerJsonList = new ArrayList<>();
-        int size = OVERHEAD_CHARACTERS.length();
-        for (Map<String, Object> log: logList) {
-            final String recordString = mapper.writeValueAsString(log);
-            final int nextRecordLength = recordString.getBytes(Charset.defaultCharset()).length;
-            // It is possible that the first record is larger than maxSize, then
-            // innerJsonList size would be zero.
-            if (size + nextRecordLength > maxSize && !innerJsonList.isEmpty()) {
-                jsonList.add(innerJsonList);
-                innerJsonList = new ArrayList<>();
-                size = OVERHEAD_CHARACTERS.length();
-            }
-            // The following may result in a innerJsonList with larger than "maxSize" length recordString
-            innerJsonList.add(recordString);
-            size += nextRecordLength + COMMA_OVERHEAD_LENGTH;
-        }
-        if (size > OVERHEAD_CHARACTERS.length()) {
-            jsonList.add(innerJsonList);
-        }
-
         return jsonList;
     }
+
+    public void serialize(final List<String> jsonList,
+                          final Consumer<String> serializedBodyConsumer,
+                          final int splitLength) throws IOException {
+        if (splitLength < 0)
+            throw new IllegalArgumentException("The splitLength must be greater than or equal to 0.");
+
+        if (splitLength == 0) {
+            performSerialization(jsonList, serializedBodyConsumer, Integer.MAX_VALUE);
+        } else {
+            performSerialization(jsonList, serializedBodyConsumer, splitLength);
+        }
+    }
+
+    private void performSerialization(final List<String> jsonList,
+                                      final Consumer<String> serializedBodyConsumer,
+                                      final int splitLength) throws IOException {
+
+        JsonArrayWriter jsonArrayWriter = new JsonArrayWriter(splitLength, serializedBodyConsumer);
+
+        for (final String individualJsonLine : jsonList) {
+            if (jsonArrayWriter.willExceedByWriting(individualJsonLine)) {
+                jsonArrayWriter.close();
+
+                jsonArrayWriter = new JsonArrayWriter(splitLength, serializedBodyConsumer);
+
+            }
+            jsonArrayWriter.write(individualJsonLine);
+        }
+
+        jsonArrayWriter.close();
+    }
+
+    private static class JsonArrayWriter {
+        private static final JsonFactory JSON_FACTORY = new JsonFactory().setCodec(mapper);
+        private static final int BUFFER_SIZE = 16 * 1024;
+        private static final String NECESSARY_CHARACTERS_TO_WRITE = ",]";
+        private final CountingOutputStream countingOutputStream;
+        private final ByteArrayOutputStream outputStream;
+        private final int splitLength;
+        private final Consumer<String> serializedBodyConsumer;
+        private final JsonGenerator generator;
+        private boolean hasItem = false;
+
+        JsonArrayWriter(final int splitLength, final Consumer<String> serializedBodyConsumer) throws IOException {
+            outputStream = new ByteArrayOutputStream(Math.min(splitLength, BUFFER_SIZE));
+            countingOutputStream = new CountingOutputStream(outputStream);
+            this.splitLength = splitLength;
+            this.serializedBodyConsumer = serializedBodyConsumer;
+            generator = JSON_FACTORY.createGenerator(countingOutputStream, JsonEncoding.UTF8);
+            generator.writeStartArray();
+        }
+
+        boolean willExceedByWriting(final String individualJsonLine) {
+            final int lengthToWrite = individualJsonLine.getBytes(StandardCharsets.UTF_8).length;
+            final long lengthOfDataWritten = countingOutputStream.getCount();
+            return lengthToWrite + lengthOfDataWritten + NECESSARY_CHARACTERS_TO_WRITE.length() > splitLength;
+        }
+
+        void write(final String individualJsonLine) throws IOException {
+            final JsonNode jsonNode = mapper.readTree(individualJsonLine);
+            generator.writeTree(jsonNode);
+            generator.flush();
+            hasItem = true;
+        }
+
+        void close() throws IOException {
+            if (hasItem) {
+                generator.writeEndArray();
+                generator.flush();
+                final String resultJson = outputStream.toString(Charset.defaultCharset());
+
+                serializedBodyConsumer.accept(resultJson);
+            }
+
+            generator.close();
+            outputStream.close();
+        }
+    }
+
 }

--- a/data-prepper-plugins/http-source-common/src/test/java/org/opensearch/dataprepper/http/codec/JsonCodecTest.java
+++ b/data-prepper-plugins/http-source-common/src/test/java/org/opensearch/dataprepper/http/codec/JsonCodecTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -24,15 +27,30 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class JsonCodecTest {
-    private final HttpData goodTestData = HttpData.ofUtf8("[{\"a\":\"b\"}, {\"c\":\"d\"}]");
-    private final HttpData goodLargeTestData = HttpData.ofUtf8("[{\"a1\":\"b1\"}, {\"a2\":\"b2\"}, {\"a3\":\"b3\"}, {\"a4\":\"b4\"}, {\"a5\":\"b5\"}]");
-    private final HttpData goodLargeTestDataUnicode = HttpData.ofUtf8("[{\"ὊὊὊ1\":\"ὊὊὊ1\"}, {\"ὊὊὊ2\":\"ὊὊὊ2\"}, {\"a3\":\"b3\"}, {\"ὊὊὊ4\":\"ὊὊὊ4\"}]");
+    private static final HttpData GOOD_TEST_DATA = HttpData.ofUtf8("[{\"a\":\"b\"}, {\"c\":\"d\"}]");
+    private static final HttpData GOOD_LARGE_TEST_DATA = HttpData.ofUtf8("[{\"a1\":\"b1\"}, {\"a2\":\"b2\"}, {\"a3\":\"b3\"}, {\"a4\":\"b4\"}, {\"a5\":\"b5\"}]");
+    private static final HttpData GOOD_LARGE_TEST_DATA_UNICODE = HttpData.ofUtf8("[{\"ὊὊὊ1\":\"ὊὊὊ1\"}, {\"ὊὊὊ2\":\"ὊὊὊ2\"}, {\"a3\":\"b3\"}, {\"ὊὊὊ4\":\"ὊὊὊ4\"}]");
+    public static final List<String> JSON_BODIES_LIST = List.of(
+            "{\"a1\":\"b1\"}",
+            "{\"a2\":\"b2\"}",
+            "{\"a3\":\"b3\"}",
+            "{\"a4\":\"b4\"}",
+            "{\"a5\":\"b5\"}"
+    );
+    public static final List<String> JSON_BODIES_UNICODE_MIXED_LIST = List.of(
+            "{\"ὊὊὊ1\":\"ὊὊὊ1\"}",
+            "{\"ὊὊὊ2\":\"ὊὊὊ2\"}",
+            "{\"a3\":\"b3\"}",
+            "{\"ὊὊὊ4\":\"ὊὊὊ4\"}"
+    );
     private final HttpData badTestDataJsonLine = HttpData.ofUtf8("{\"a\":\"b\"}");
     private final HttpData badTestDataMultiJsonLines = HttpData.ofUtf8("{\"a\":\"b\"}{\"c\":\"d\"}");
     private final HttpData badTestDataNonJson = HttpData.ofUtf8("non json content");
@@ -40,56 +58,170 @@ class JsonCodecTest {
 
     @Test
     public void testParseSuccess() throws IOException {
-        // When
-        List<List<String>> res = objectUnderTest.parse(goodTestData);
+        List<String> res = objectUnderTest.parse(GOOD_TEST_DATA);
 
         // Then
-        assertEquals(1, res.size());
-        assertEquals(2, res.get(0).size());
-        assertEquals("{\"a\":\"b\"}", res.get(0).get(0));
+        assertEquals(2, res.size());
+        assertEquals("{\"a\":\"b\"}", res.get(0));
+        assertEquals("{\"c\":\"d\"}", res.get(1));
     }
 
     @Test
     public void testParseSuccessWithMaxSize() throws IOException {
         // When
-        List<List<String>> res = objectUnderTest.parse(goodLargeTestData, 30);
+        List<String> res = objectUnderTest.parse(GOOD_LARGE_TEST_DATA);
 
-        assertEquals(3, res.size());
+        assertEquals(5, res.size());
 
         // Then
-        assertEquals(2, res.get(0).size());
-        assertEquals("{\"a1\":\"b1\"}", res.get(0).get(0));
-        assertEquals("{\"a2\":\"b2\"}", res.get(0).get(1));
-        assertEquals(2, res.get(1).size());
-        assertEquals("{\"a3\":\"b3\"}", res.get(1).get(0));
-        assertEquals("{\"a4\":\"b4\"}", res.get(1).get(1));
-        assertEquals(1, res.get(2).size());
-        assertEquals("{\"a5\":\"b5\"}", res.get(2).get(0));
+        assertEquals("{\"a1\":\"b1\"}", res.get(0));
+        assertEquals("{\"a2\":\"b2\"}", res.get(1));
+        assertEquals("{\"a3\":\"b3\"}", res.get(2));
+        assertEquals("{\"a4\":\"b4\"}", res.get(3));
+        assertEquals("{\"a5\":\"b5\"}", res.get(4));
     }
+
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -2, Integer.MIN_VALUE})
+    void serialize_with_invalid_splitLength(final int splitLength) {
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        assertThrows(IllegalArgumentException.class, () -> objectUnderTest.serialize(JSON_BODIES_LIST, serializedBodyConsumer, splitLength));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 24})
+    void serialize_with_split_length_leading_to_groups_of_one(final int splitLength) throws IOException {
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(JSON_BODIES_LIST, serializedBodyConsumer, splitLength);
+
+        final ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(5)).accept(actualSerializedBodyCaptor.capture());
+
+        final List<String> allActualSerializedBodies = actualSerializedBodyCaptor.getAllValues();
+        assertThat(allActualSerializedBodies.size(), equalTo(5));
+        assertThat(allActualSerializedBodies.get(0), equalTo("[{\"a1\":\"b1\"}]"));
+        assertThat(allActualSerializedBodies.get(1), equalTo("[{\"a2\":\"b2\"}]"));
+        assertThat(allActualSerializedBodies.get(2), equalTo("[{\"a3\":\"b3\"}]"));
+        assertThat(allActualSerializedBodies.get(3), equalTo("[{\"a4\":\"b4\"}]"));
+        assertThat(allActualSerializedBodies.get(4), equalTo("[{\"a5\":\"b5\"}]"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {25, 30, 36})
+    void serialize_with_split_length_leading_to_groups_of_two(final int splitLength) throws IOException {
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(JSON_BODIES_LIST, serializedBodyConsumer, splitLength);
+
+        final ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(3)).accept(actualSerializedBodyCaptor.capture());
+
+        final List<String> allActualSerializedBodies = actualSerializedBodyCaptor.getAllValues();
+        assertThat(allActualSerializedBodies.size(), equalTo(3));
+        assertThat(allActualSerializedBodies.get(0), equalTo("[{\"a1\":\"b1\"},{\"a2\":\"b2\"}]"));
+        assertThat(allActualSerializedBodies.get(1), equalTo("[{\"a3\":\"b3\"},{\"a4\":\"b4\"}]"));
+        assertThat(allActualSerializedBodies.get(2), equalTo("[{\"a5\":\"b5\"}]"));
+
+        assertThat(allActualSerializedBodies.get(0).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+        assertThat(allActualSerializedBodies.get(1).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+        assertThat(allActualSerializedBodies.get(2).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {37, 48})
+    void serialize_with_split_length_leading_to_groups_up_to_three(final int splitLength) throws IOException {
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(JSON_BODIES_LIST, serializedBodyConsumer, splitLength);
+
+        final ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(2)).accept(actualSerializedBodyCaptor.capture());
+
+        final List<String> allActualSerializedBodies = actualSerializedBodyCaptor.getAllValues();
+        assertThat(allActualSerializedBodies.size(), equalTo(2));
+        assertThat(allActualSerializedBodies.get(0), equalTo("[{\"a1\":\"b1\"},{\"a2\":\"b2\"},{\"a3\":\"b3\"}]"));
+        assertThat(allActualSerializedBodies.get(1), equalTo("[{\"a4\":\"b4\"},{\"a5\":\"b5\"}]"));
+
+        assertThat(allActualSerializedBodies.get(0).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+        assertThat(allActualSerializedBodies.get(1).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, Integer.MAX_VALUE})
+    void serialize_with_split_size_that_does_not_split(final int splitLength) throws IOException {
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(JSON_BODIES_LIST, serializedBodyConsumer, splitLength);
+
+        final ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(1)).accept(actualSerializedBodyCaptor.capture());
+
+        final String actualSerializedBody = actualSerializedBodyCaptor.getValue();
+        assertThat(actualSerializedBody, equalTo("[{\"a1\":\"b1\"},{\"a2\":\"b2\"},{\"a3\":\"b3\"},{\"a4\":\"b4\"},{\"a5\":\"b5\"}]"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {58, 68})
+    void serialize_with_split_length_unicode(final int splitLength) throws IOException {
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(JSON_BODIES_UNICODE_MIXED_LIST, serializedBodyConsumer, splitLength);
+
+        final ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(2)).accept(actualSerializedBodyCaptor.capture());
+
+        final List<String> allActualSerializedBodies = actualSerializedBodyCaptor.getAllValues();
+        assertThat(allActualSerializedBodies.size(), equalTo(2));
+        assertThat(allActualSerializedBodies.get(0), equalTo("[{\"ὊὊὊ1\":\"ὊὊὊ1\"},{\"ὊὊὊ2\":\"ὊὊὊ2\"}]"));
+        assertThat(allActualSerializedBodies.get(1), equalTo("[{\"a3\":\"b3\"},{\"ὊὊὊ4\":\"ὊὊὊ4\"}]"));
+
+        assertThat(allActualSerializedBodies.get(0).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+        assertThat(allActualSerializedBodies.get(1).getBytes(StandardCharsets.UTF_8).length, lessThanOrEqualTo(splitLength));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GoodTestData.class)
+    void parse_and_serialize_symmetry(final HttpData httpData) throws IOException {
+        final List<String> parsedList = objectUnderTest.parse(httpData);
+
+        final Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(parsedList, serializedBodyConsumer);
+        final ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(1)).accept(actualSerializedBodyCaptor.capture());
+        final String actualString = actualSerializedBodyCaptor.getValue();
+
+        final String expectedJsonString = httpData.toStringUtf8().replace(" ", "");
+        assertThat(actualString, equalTo(expectedJsonString));
+    }
+
 
     @ParameterizedTest
     @ArgumentsSource(JsonArrayWithKnownFirstArgumentsProvider.class)
     public void parse_should_return_lists_smaller_than_provided_length(
             final String inputJsonArray, final String knownFirstPart, final int maxSize, final List<List<String>> expectedChunks, final List<Boolean> exceedsMaxSize) throws IOException {
-        final int knownSingleBodySize = knownFirstPart.getBytes(Charset.defaultCharset()).length;
-        final List<List<String>> chunkedBodies = objectUnderTest.parse(HttpData.ofUtf8(inputJsonArray),
-                maxSize);
+        List<String> individualJsonLines = objectUnderTest.parse(HttpData.ofUtf8(inputJsonArray));
+
+        Consumer<String> serializedBodyConsumer = mock(Consumer.class);
+        objectUnderTest.serialize(individualJsonLines, serializedBodyConsumer, maxSize);
+        ArgumentCaptor<String> actualSerializedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serializedBodyConsumer, times(expectedChunks.size())).accept(actualSerializedBodyCaptor.capture());
+
+        List<String> chunkedBodies = actualSerializedBodyCaptor.getAllValues();
 
         assertThat(chunkedBodies, notNullValue());
         assertThat(chunkedBodies.size(), equalTo(expectedChunks.size()));
 
         for (int i = 0; i < expectedChunks.size(); i++) {
-            final String reconstructed = chunkedBodies.get(i).stream().collect(Collectors.joining(",", "[", "]"));
+            final String reconstructed = chunkedBodies.get(i);
             if (exceedsMaxSize.get(i)) {
                 assertThat(reconstructed.getBytes(Charset.defaultCharset()).length,
-                    greaterThanOrEqualTo(maxSize));
+                        greaterThanOrEqualTo(maxSize));
             } else {
                 assertThat(reconstructed.getBytes(Charset.defaultCharset()).length,
-                    lessThanOrEqualTo(maxSize));
+                        lessThanOrEqualTo(maxSize));
             }
-            
+
+            List<String> reParsedToCompare = objectUnderTest.parse(HttpData.ofUtf8(reconstructed));
+
             for (int j = 0; j < expectedChunks.get(i).size(); j++) {
-                assertThat(chunkedBodies.get(i).get(j), equalTo(expectedChunks.get(i).get(j)));
+                assertThat(reParsedToCompare.get(j), equalTo(expectedChunks.get(i).get(j)));
             }
         }
     }
@@ -109,6 +241,17 @@ class JsonCodecTest {
         assertThrows(IOException.class, () -> objectUnderTest.parse(badTestDataNonJson));
     }
 
+    static class GoodTestData implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(GOOD_TEST_DATA),
+                    arguments(GOOD_LARGE_TEST_DATA),
+                    arguments(GOOD_LARGE_TEST_DATA_UNICODE)
+            );
+        }
+    }
+
     static class JsonArrayWithKnownFirstArgumentsProvider implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
@@ -126,7 +269,7 @@ class JsonCodecTest {
             String chunk31 = "{\"ὊὊὊ1\":\"ὊὊὊ01\"}";
             String chunk32 = "{\"ὊὊὊ2\":\"ὊὊὊO2\"}";
             String chunk33 = "{\"ὊὊὊ3\":\"ὊὊὊO3\"}";
-            String chunk34 = "{\"ὊὊὊ4\":\"ὊὊὊO4\"}"; 
+            String chunk34 = "{\"ὊὊὊ4\":\"ὊὊὊO4\"}";
             // Fourth test, only first chunk larger than maxSize, output has 3 lists, with first chunk larger than maxSize and others smaller
             String chunk41 = "{\"aaaaaaaaaaa1\":\"aaaaaaaaaaa1\"}";
             String chunk42 = "{\"aaa2\":\"aaa2\"}";
@@ -149,12 +292,12 @@ class JsonCodecTest {
             final int maxSize5 = chunk51.getBytes(Charset.defaultCharset()).length * 2 + 3;
             final int maxSize6 = chunk61.getBytes(Charset.defaultCharset()).length * 2 + 3;
             return Stream.of(
-                    arguments("["+chunk11+","+chunk12+","+chunk13+","+chunk14+"]", chunk11, maxSize1, List.of(List.of(chunk11), List.of(chunk12, chunk13), List.of(chunk14)), List.of(false, false, false)),
-                    arguments("["+chunk21+","+chunk22+","+chunk23+","+chunk24+"]", chunk21, maxSize2, List.of(List.of(chunk21, chunk22), List.of(chunk23, chunk24)), List.of(false, false)),
-                    arguments("["+chunk31+","+chunk32+","+chunk33+","+chunk34+"]", chunk31, maxSize3, List.of(List.of(chunk31), List.of(chunk32), List.of(chunk33), List.of(chunk34)), List.of(true, true, true, true)),
-                    arguments("["+chunk41+","+chunk42+","+chunk43+","+chunk44+"]", chunk41, maxSize4, List.of(List.of(chunk41), List.of(chunk42, chunk43), List.of(chunk44)), List.of(true, false, false)),
-                    arguments("["+chunk51+","+chunk52+","+chunk53+","+chunk54+"]", chunk51, maxSize5, List.of(List.of(chunk51), List.of(chunk52), List.of(chunk53,chunk54)), List.of(false, true, false)),
-                    arguments("["+chunk61+","+chunk62+","+chunk63+","+chunk64+"]", chunk61, maxSize6, List.of(List.of(chunk61,chunk62), List.of(chunk63), List.of(chunk64)), List.of(false, false, true))
+                    arguments("[" + chunk11 + "," + chunk12 + "," + chunk13 + "," + chunk14 + "]", chunk11, maxSize1, List.of(List.of(chunk11), List.of(chunk12, chunk13), List.of(chunk14)), List.of(false, false, false)),
+                    arguments("[" + chunk21 + "," + chunk22 + "," + chunk23 + "," + chunk24 + "]", chunk21, maxSize2, List.of(List.of(chunk21, chunk22), List.of(chunk23, chunk24)), List.of(false, false)),
+                    arguments("[" + chunk31 + "," + chunk32 + "," + chunk33 + "," + chunk34 + "]", chunk31, maxSize3, List.of(List.of(chunk31), List.of(chunk32), List.of(chunk33), List.of(chunk34)), List.of(true, true, true, true)),
+                    arguments("[" + chunk41 + "," + chunk42 + "," + chunk43 + "," + chunk44 + "]", chunk41, maxSize4, List.of(List.of(chunk41), List.of(chunk42, chunk43), List.of(chunk44)), List.of(true, false, false)),
+                    arguments("[" + chunk51 + "," + chunk52 + "," + chunk53 + "," + chunk54 + "]", chunk51, maxSize5, List.of(List.of(chunk51), List.of(chunk52), List.of(chunk53, chunk54)), List.of(false, true, false)),
+                    arguments("[" + chunk61 + "," + chunk62 + "," + chunk63 + "," + chunk64 + "]", chunk61, maxSize6, List.of(List.of(chunk61, chunk62), List.of(chunk63), List.of(chunk64)), List.of(false, false, true))
             );
         }
     }


### PR DESCRIPTION
### Description

This refactors the code by placing all logic for serializing the data into the Codec itself. In so doing, it allows for improved testing such as symmetric testing. It also decouples the serialization format from the HTTP server. This also uses the Jackson library for the serialization which yields more accurate JSON.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
