### PR TITLE
Fixes Jaeger Hotrod demo failure on OpenSearch 2.16.0

### DIFF
--- a/examples/jaeger-hotrod/README.md
+++ b/examples/jaeger-hotrod/README.md
@@ -7,7 +7,7 @@ This demo will use the revered [Jaeger HotROD](https://github.com/jaegertracing/
 
 #### Demo
 ```
-docker-compose up -d --build
+docker compose up -d
 ``` 
 
 The above command will start the Jaeger HotROD sample, Jaeger Agent, OpenTelemetry Collector, Data Prepper, OpenSearch and OpenSearch Dashboards. Wait for few minutes for all the containers to come up, the DataPrepper container will restart until OpenSearch becomes available.
@@ -15,5 +15,6 @@ The above command will start the Jaeger HotROD sample, Jaeger Agent, OpenTelemet
 After the Docker image is running, do the following.
 
 * Open the HotROD app at [http://localhost:8080](http://localhost:8080). Press the buttons in the UI to simulate requests. 
-* Load the OpenSearch Dashboards trace analytics dashboard at [http://localhost:5601/app/observability-dashboards#/trace_analytics/home](http://localhost:5601/app/observability-dashboards#/trace_analytics/home). If that link does not work, you may still be using On OpenSearch 1.1.0 or below. You will need to use [http://localhost:5601/app/trace-analytics-dashboards#/](http://localhost:5601/app/trace-analytics-dashboards#/) instead. You can view traces and the service map here.
+* Log in to the OpenSearch Dashboards Web UI at [http://localhost:5601](http://localhost:5601) using the username `admin` and the password `yourStrongPassword123!`.
+* Load the OpenSearch Dashboards trace analytics dashboard at [http://localhost:5601/app/observability-traces#/services](http://localhost:5601/app/observability-traces#/services). If that link does not work, you may still be using On OpenSearch 1.1.0 or below. You will need to use [http://localhost:5601/app/trace-analytics-dashboards#/](http://localhost:5601/app/trace-analytics-dashboards#/) instead. You can view traces and the service map here.
 

--- a/examples/jaeger-hotrod/docker-compose.yml
+++ b/examples/jaeger-hotrod/docker-compose.yml
@@ -1,28 +1,24 @@
-version: "3.7"
 services:
   data-prepper:
     restart: unless-stopped
-    container_name: data-prepper
     image: opensearchproject/data-prepper:2
     volumes:
-      - ../trace_analytics_no_ssl_2x.yml:/usr/share/data-prepper/pipelines/pipelines.yaml
+      - ./pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml
       - ../data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
-      - ../demo/root-ca.pem:/usr/share/data-prepper/root-ca.pem
+      - opensearch-config:/usr/share/opensearch-test/:ro
     ports:
       - "21890:21890"
     networks:
       - my_network
     depends_on:
-      - "opensearch"
+      - opensearch
   otel-collector:
-    container_name: otel-collector
     image: otel/opentelemetry-collector:0.64.1
     command: [ "--config=/etc/otel-collector-config.yml" ]
     working_dir: "/project"
     volumes:
       - ${PWD}/:/project
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
-      - ../demo/demo-data-prepper.crt:/etc/demo-data-prepper.crt
     ports:
       - "14250:14250"
     depends_on:
@@ -30,7 +26,6 @@ services:
     networks:
       - my_network
   jaeger-agent:
-    container_name: jaeger-agent
     image: jaegertracing/jaeger-agent:1.51.0
     command: [ "--reporter.grpc.host-port=otel-collector:14250" ]
     ports:
@@ -40,6 +35,8 @@ services:
       - "5778:5778/tcp"
     networks:
       - my_network
+    depends_on:
+      - otel-collector
   jaeger-hot-rod:
     image: jaegertracing/example-hotrod:1.41.0
     command: [ "all" ]
@@ -54,11 +51,14 @@ services:
       - my_network
   opensearch:
     container_name: node-0.example.com
-    image: opensearchproject/opensearch:2.9.0
+    image: opensearchproject/opensearch:2.16.0
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
+    volumes:
+      - opensearch-config:/usr/share/opensearch/config/
     ulimits:
       memlock:
         soft: -1
@@ -67,17 +67,15 @@ services:
         soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
         hard: 65536
     ports:
-      - 9200:9200
-      - 9600:9600 # required for Performance Analyzer
+      - "9200:9200"
+      - "9600:9600" # required for Performance Analyzer
     networks:
       - my_network
   dashboards:
-    image: opensearchproject/opensearch-dashboards:2.9.0
+    image: opensearchproject/opensearch-dashboards:2.16.0
     container_name: opensearch-dashboards
     ports:
-      - 5601:5601
-    expose:
-      - "5601"
+      - "5601:5601"
     environment:
       OPENSEARCH_HOSTS: '["https://node-0.example.com:9200"]'
     depends_on:
@@ -86,3 +84,5 @@ services:
       - my_network
 networks:
   my_network:
+volumes:
+  opensearch-config:

--- a/examples/jaeger-hotrod/pipelines.yaml
+++ b/examples/jaeger-hotrod/pipelines.yaml
@@ -1,0 +1,37 @@
+entry-pipeline:
+  delay: "100"
+  source:
+    otel_trace_source:
+      ssl: false
+  sink:
+    - pipeline:
+        name: "raw-pipeline"
+    - pipeline:
+        name: "service-map-pipeline"
+raw-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - otel_trace_raw:
+  sink:
+    - opensearch:
+        hosts: [ "https://node-0.example.com:9200" ]
+        cert: "/usr/share/opensearch-test/root-ca.pem"
+        username: "admin"
+        password: "yourStrongPassword123!"
+        index_type: trace-analytics-raw
+service-map-pipeline:
+  delay: "100"
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - service_map_stateful:
+  sink:
+    - opensearch:
+        hosts: ["https://node-0.example.com:9200"]
+        cert: "/usr/share/opensearch-test/root-ca.pem"
+        username: "admin"
+        password: "yourStrongPassword123!"
+        index_type: trace-analytics-service-map


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 
- Fixes Jaeger Hotrod demo failure on OpenSearch 2.16.0. 
- Apparently, the old version of OpenSearch is using `admin` as the default password for the `admin` account, which is very dangerous. The new version of OpenSearch corrects this problem and requires the initial password to be greater than 8 digits.
- In Docker Compose 2.29.2, the `version` field is deprecated. The Compose Spec is now dynamically updated at https://github.com/compose-spec/compose-spec .
- The content of `../demo/root-ca.pem` is exactly the same as the content of `/usr/share/opensearch/config/root-ca.pem` of the OpenSearch master node. Whether in the new version or the old version, there is no point in manually writing `root-ca.pem`, which will only confuse users.
- IntelliJ IDEA always recommends to quote all PORT mappings, otherwise there will be a warning.
- Mounting `../demo/demo-data-prepper.crt` to `/etc/demo-data-prepper.crt` does not make any sense because SSL is turned off for otel-collector and data-prepper.
- That being said, there are still some unanswered questions about the current PR. `node-0.example.com` is actually the default `hostname` for OpenSearch Docker Image, which surprised me. I don't understand why this is done.🤔
- Use the `admin` and `opensearchNode1Test` accounts and passwords to log in to `localhost:5601` for testing.
- ![image](https://github.com/user-attachments/assets/1f0e5d0e-d88e-48a9-9172-eccb2f2b1305)
- ![image](https://github.com/user-attachments/assets/7142d0f0-832b-4a34-be98-b13c46fd3bba)
- ![image](https://github.com/user-attachments/assets/e4438a17-ad25-4d53-b0e2-3b00db9d9bff)
- ![image](https://github.com/user-attachments/assets/7e3abfec-7ee3-4416-9cc1-5d18d6a27d2d)




### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]

- Fixes #2273 .
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
