### PR TITLE
Support convert entry type on arrays

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -19,7 +19,6 @@ import org.opensearch.dataprepper.typeconverter.TypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -84,7 +83,7 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
                     if (keyVal != null) {
                         if (!nullValues.contains(keyVal.toString())) {
                             try {
-                                if (keyVal instanceof ArrayList || keyVal.getClass().isArray()) {
+                                if (keyVal instanceof List || keyVal.getClass().isArray()) {
                                     Stream<Object> inputStream;
                                     if (keyVal.getClass().isArray()) {
                                         inputStream = Arrays.stream((Object[])keyVal);

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
@@ -84,14 +85,14 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
                         if (!nullValues.contains(keyVal.toString())) {
                             try {
                                 if (keyVal instanceof ArrayList || keyVal.getClass().isArray()) {
-                                    ArrayList<Object> inputList;
+                                    Stream<Object> inputStream;
                                     if (keyVal.getClass().isArray()) {
-                                        inputList = (ArrayList<Object>)Arrays.asList((Object[])keyVal);
+                                        inputStream = Arrays.stream((Object[])keyVal);
                                     } else {
-                                        inputList = (ArrayList<Object>)keyVal;
+                                        inputStream = ((List<Object>)keyVal).stream();
                                     }
-                                    recordEvent.put(key, inputList.stream().
-                                            map(i -> converter.convert(i, converterArguments)).collect(Collectors.toList()));
+                                    List<?> replacementList = inputStream.map(i -> converter.convert(i, converterArguments)).collect(Collectors.toList());
+                                    recordEvent.put(key, replacementList);
                                 } else {
                                     recordEvent.put(key, converter.convert(keyVal, converterArguments));
                                 }

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -20,11 +20,13 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.record.Record;
 
+import java.util.ArrayList;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -109,6 +111,30 @@ public class ConvertEntryTypeProcessorTests {
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(testValue.toString());
         assertThat(event.get(TEST_KEY, Integer.class), equalTo(testValue));
+    }
+
+    @Test
+    void testArrayOfStringsToIntegerConvertEntryTypeProcessor() {
+        when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("integer"));
+        typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+
+        Random random = new Random();
+        Integer testValue1 = random.nextInt();
+        Integer testValue2 = random.nextInt();
+        Integer testValue3 = random.nextInt();
+        List<String> inputList = new ArrayList<>();
+        inputList.add(testValue1.toString());
+        inputList.add(testValue2.toString());
+        inputList.add(testValue3.toString());
+        String[] inputArray = {testValue1.toString(), testValue2.toString(), testValue3.toString()};
+        List<Integer> expectedResult = new ArrayList<>();
+        expectedResult.add(testValue1);
+        expectedResult.add(testValue2);
+        expectedResult.add(testValue3);
+        Event event = executeAndGetProcessedEvent(inputList);
+        assertThat(event.get(TEST_KEY, List.class), equalTo(expectedResult));
+        event = executeAndGetProcessedEvent(inputArray);
+        assertThat(event.get(TEST_KEY, List.class), equalTo(expectedResult));
     }
 
     @Test

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -122,18 +122,33 @@ public class ConvertEntryTypeProcessorTests {
         Integer testValue1 = random.nextInt();
         Integer testValue2 = random.nextInt();
         Integer testValue3 = random.nextInt();
-        List<String> inputList = new ArrayList<>();
-        inputList.add(testValue1.toString());
-        inputList.add(testValue2.toString());
-        inputList.add(testValue3.toString());
         String[] inputArray = {testValue1.toString(), testValue2.toString(), testValue3.toString()};
         List<Integer> expectedResult = new ArrayList<>();
         expectedResult.add(testValue1);
         expectedResult.add(testValue2);
         expectedResult.add(testValue3);
-        Event event = executeAndGetProcessedEvent(inputList);
-        assertThat(event.get(TEST_KEY, List.class), equalTo(expectedResult));
         event = executeAndGetProcessedEvent(inputArray);
+        assertThat(event.get(TEST_KEY, List.class), equalTo(expectedResult));
+    }
+
+    @Test
+    void testArrayListOfStringsToIntegerConvertEntryTypeProcessor() {
+        when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("integer"));
+        typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+
+        Random random = new Random();
+        Integer testValue1 = random.nextInt();
+        Integer testValue2 = random.nextInt();
+        Integer testValue3 = random.nextInt();
+        List<String> inputList = new ArrayList<>();
+        inputList.add(testValue1.toString());
+        inputList.add(testValue2.toString());
+        inputList.add(testValue3.toString());
+        List<Integer> expectedResult = new ArrayList<>();
+        expectedResult.add(testValue1);
+        expectedResult.add(testValue2);
+        expectedResult.add(testValue3);
+        Event event = executeAndGetProcessedEvent(inputList);
         assertThat(event.get(TEST_KEY, List.class), equalTo(expectedResult));
     }
 

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -127,7 +127,7 @@ public class ConvertEntryTypeProcessorTests {
         expectedResult.add(testValue1);
         expectedResult.add(testValue2);
         expectedResult.add(testValue3);
-        event = executeAndGetProcessedEvent(inputArray);
+        Event event = executeAndGetProcessedEvent(inputArray);
         assertThat(event.get(TEST_KEY, List.class), equalTo(expectedResult));
     }
 


### PR DESCRIPTION
### Description
Support convert entry type on arrays. Each array element is converted to target type.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
