### PR TITLE
Support start_time or range options for the first scan of scheduled s3 scan

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptions.java
@@ -55,9 +55,14 @@ public class S3ScanScanOptions {
         return (startTime != null || endTime != null) && range != null;
     }
 
-    @AssertTrue(message = "start_time, end_time, and range are not valid options when using scheduling with s3 scan")
+    @AssertTrue(message = "end_time is not a valid option when using scheduling with s3 scan. One of start_time or range must be used for scheduled scan.")
     public boolean hasValidTimeOptionsWithScheduling() {
-        return !Objects.nonNull(schedulingOptions) || Stream.of(startTime, endTime, range).noneMatch(Objects::nonNull);
+
+        if (schedulingOptions != null && ((startTime != null && range != null) || endTime != null)) {
+            return false;
+        }
+
+        return true;
     }
 
     public Duration getRange() {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptionsTest.java
@@ -45,4 +45,60 @@ public class S3ScanScanOptionsTest {
         assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3ScanExcludeSuffixOptions().get(0),
                 equalTo(".jpeg"));
     }
+
+    @Test
+    public void s3scan_options_with_scheduled_scan_does_not_allow_end_time() throws JsonProcessingException {
+        final String scanYaml = "        start_time: 2023-01-21T18:00:00\n" +
+                "        end_time: 2023-04-21T18:00:00\n" +
+                "        scheduling: \n" +
+                "          count: 1\n" +
+                "        buckets:\n" +
+                "          - bucket:\n" +
+                "              name: test-s3-source-test-output\n" +
+                "              filter:\n" +
+                "                include_prefix:\n" +
+                "                  - bucket2\n" +
+                "                exclude_suffix:\n" +
+                "                  - .jpeg";
+        final S3ScanScanOptions s3ScanScanOptions = objectMapper.readValue(scanYaml, S3ScanScanOptions.class);
+        assertThat(s3ScanScanOptions.getStartTime(),equalTo(LocalDateTime.parse("2023-01-21T18:00:00")));
+        assertThat(s3ScanScanOptions.getEndTime(),equalTo(LocalDateTime.parse("2023-04-21T18:00:00")));
+        assertThat(s3ScanScanOptions.getBuckets(),instanceOf(List.class));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getName(),equalTo("test-s3-source-test-output"));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3ScanExcludeSuffixOptions(),instanceOf(List.class));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3scanIncludePrefixOptions(),instanceOf(List.class));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3scanIncludePrefixOptions().get(0),
+                equalTo("bucket2"));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3ScanExcludeSuffixOptions().get(0),
+                equalTo(".jpeg"));
+
+        assertThat(s3ScanScanOptions.hasValidTimeOptionsWithScheduling(), equalTo(false));
+    }
+
+    @Test
+    public void s3scan_options_with_scheduled_scan_allows_start_time() throws JsonProcessingException {
+        final String scanYaml = "        start_time: 2023-01-21T18:00:00\n" +
+                "        scheduling: \n" +
+                "          count: 1\n" +
+                "        buckets:\n" +
+                "          - bucket:\n" +
+                "              name: test-s3-source-test-output\n" +
+                "              filter:\n" +
+                "                include_prefix:\n" +
+                "                  - bucket2\n" +
+                "                exclude_suffix:\n" +
+                "                  - .jpeg";
+        final S3ScanScanOptions s3ScanScanOptions = objectMapper.readValue(scanYaml, S3ScanScanOptions.class);
+        assertThat(s3ScanScanOptions.getStartTime(),equalTo(LocalDateTime.parse("2023-01-21T18:00:00")));
+        assertThat(s3ScanScanOptions.getBuckets(),instanceOf(List.class));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getName(),equalTo("test-s3-source-test-output"));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3ScanExcludeSuffixOptions(),instanceOf(List.class));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3scanIncludePrefixOptions(),instanceOf(List.class));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3scanIncludePrefixOptions().get(0),
+                equalTo("bucket2"));
+        assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3ScanExcludeSuffixOptions().get(0),
+                equalTo(".jpeg"));
+
+        assertThat(s3ScanScanOptions.hasValidTimeOptionsWithScheduling(), equalTo(true));
+    }
 }


### PR DESCRIPTION
### Description
This change adds support for start_time and range in scheduled s3 scan to filter on the first scan of the buckets based on the time. Previously scheduled scan would always process all objects on the first scan.

Tested with a pipeline to confirm that only objects within a given start_time and range are processed
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR: https://github.com/opensearch-project/documentation-website/issues/8203
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
