### PR TITLE
Support BigDecimal data type in expressions

### DIFF
--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -292,6 +292,7 @@ EscapeSequence
 DataTypes
     : INTEGER
     | BOOLEAN
+    | BIG_DECIMAL
     | LONG
     | MAP
     | ARRAY
@@ -339,6 +340,7 @@ EXPONENTLETTER
     ;
 
 INTEGER: 'integer';
+BIG_DECIMAL: 'big_decimal';
 BOOLEAN: 'boolean';
 LONG   : 'long';
 DOUBLE : 'double';

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LiteralTypeConversionsConfiguration.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LiteralTypeConversionsConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 
 import javax.inject.Named;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -26,6 +27,7 @@ class LiteralTypeConversionsConfiguration {
             Long.class, Function.identity(),
             ArrayList.class, Function.identity(),
             LinkedHashMap.class, Function.identity(),
+            BigDecimal.class, Function.identity(),
             Double.class, o -> ((Double) o).floatValue()
         );
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -12,7 +12,6 @@ import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.Serializable;
-import java.math.BigDecimal;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -22,6 +22,7 @@ import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import org.opensearch.dataprepper.expression.util.TestObject;
 import org.opensearch.dataprepper.model.event.Event;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,6 +112,19 @@ class ParseTreeCoercionServiceTest {
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
         assertThat(result, instanceOf(Float.class));
         assertThat(result, equalTo(testFloat));
+    }
+
+    @Test
+    void testCoerceTerminalNodeBigDecimalType() {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.JsonPointer);
+        final BigDecimal testBigDecimal = new BigDecimal(new Random().nextFloat());
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("/key");
+
+        final Event testEvent = createTestEvent(Map.of("key", testBigDecimal));
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        assertThat(result, instanceOf(BigDecimal.class));
+        assertThat(result, equalTo(testBigDecimal));
     }
 
     @ParameterizedTest

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/TypeOfOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/TypeOfOperatorTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,7 @@ class TypeOfOperatorTest {
         List<Integer> testArrayList = new ArrayList<Integer>();
         testArrayList.add(1);
         testArrayList.add(2);
+        BigDecimal bigDecimalValue = new BigDecimal(1.222);
         return Stream.of(
             Arguments.of(2, "integer", true),
             Arguments.of("testString", "string", true),
@@ -86,6 +88,8 @@ class TypeOfOperatorTest {
             Arguments.of("testString", "double", false),
             Arguments.of(2, "boolean", false),
             Arguments.of(2L, "map", false),
+            Arguments.of(2L, "big_decimal", false),
+            Arguments.of(bigDecimalValue, "big_decimal", true),
             Arguments.of(2, "array", false)
         );
     }


### PR DESCRIPTION
### Description
Support BigDecimal data type in expressions
 
### Issues Resolved
Resolves #4817 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
