### PR TITLE
Move CsvMapper and Schema creation to constructor

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -46,6 +46,9 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
 
     private final ExpressionEvaluator expressionEvaluator;
 
+    private final CsvMapper mapper;
+    private final CsvSchema schema;
+
     @DataPrepperPluginConstructor
     public CsvProcessor(final PluginMetrics pluginMetrics,
                         final CsvProcessorConfig config,
@@ -61,13 +64,12 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                     String.format("csv_when value of %s is not a valid expression statement. " +
                             "See https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/ for valid expression syntax.", config.getCsvWhen()));
         }
+        this.mapper = createCsvMapper();
+        this.schema = createCsvSchema();
     }
 
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
-        final CsvMapper mapper = createCsvMapper();
-        final CsvSchema schema = createCsvSchema();
-
         for (final Record<Event> record : records) {
 
             final Event event = record.getData();

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
@@ -117,6 +117,7 @@ class CsvProcessorTest {
     @Test
     void test_when_delimiterIsTab_then_parsedCorrectly() {
         when(processorConfig.getDelimiter()).thenReturn("\t");
+        csvProcessor = createObjectUnderTest();
 
         Record<Event> eventUnderTest = createMessageEvent("1\t2\t3");
         final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
@@ -293,6 +294,7 @@ class CsvProcessorTest {
     @Test
     void test_when_differentQuoteCharacter_then_parsesCorrectly() {
         when(processorConfig.getQuoteCharacter()).thenReturn("\'");
+        csvProcessor = createObjectUnderTest();
 
         final Record<Event> eventUnderTest = createMessageEvent("'1','2','3'");
         final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));


### PR DESCRIPTION
### Description
The CSV Processor is creating CsvMapper and CsvSchema for every record processed which is expensive as it can have a negative impact on the performance. The internal data structures consume memory, so creating a new instance on every request can increase the overall memory footprint.

Move CsvMapper and Schema creation to constructor.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
