### PR TITLE
Adds config transformation template for RDS source

### DIFF
--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -403,15 +403,28 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
     }
 
     /**
-     * Calculate s3 folder scan depth for DocDB and RDS source pipeline
+     * Calculate s3 folder scan depth for DocDB source pipeline
      * @param s3Prefix: s3 prefix defined in the source configuration
      * @return s3 folder scan depth
      */
     public String calculateDepth(String s3Prefix) {
-        if (s3Prefix == null) {
-            return Integer.toString(4);
+        return Integer.toString(getDepth(s3Prefix, 4));
+    }
+
+    /**
+     * Calculate s3 folder scan depth for RDS source pipeline
+     * @param s3Prefix: s3 prefix defined in the source configuration
+     * @return s3 folder scan depth
+     */
+    public String calculateDepthForRdsSource(String s3Prefix) {
+        return Integer.toString(getDepth(s3Prefix, 3));
+    }
+
+    private int getDepth(String s3Prefix, int baseDepth) {
+        if(s3Prefix == null){
+            return baseDepth;
         }
-        return Integer.toString(s3Prefix.split("/").length + 4);
+        return s3Prefix.split("/").length + baseDepth;
     }
 
     public String getSourceCoordinationIdentifierEnvVariable(String s3Prefix){

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -403,28 +403,15 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
     }
 
     /**
-     * Calculate s3 folder scan depth for DocDB source pipeline
+     * Calculate s3 folder scan depth for DocDB and RDS source pipeline
      * @param s3Prefix: s3 prefix defined in the source configuration
      * @return s3 folder scan depth
      */
     public String calculateDepth(String s3Prefix) {
-        return Integer.toString(getDepth(s3Prefix, 4));
-    }
-
-    /**
-     * Calculate s3 folder scan depth for RDS source pipeline
-     * @param s3Prefix: s3 prefix defined in the source configuration
-     * @return s3 folder scan depth
-     */
-    public String calculateDepthForRdsSource(String s3Prefix) {
-        return Integer.toString(getDepth(s3Prefix, 3));
-    }
-
-    private int getDepth(String s3Prefix, int baseDepth) {
-        if(s3Prefix == null){
-            return baseDepth;
+        if (s3Prefix == null) {
+            return Integer.toString(4);
         }
-        return s3Prefix.split("/").length + baseDepth;
+        return Integer.toString(s3Prefix.split("/").length + 4);
     }
 
     public String getSourceCoordinationIdentifierEnvVariable(String s3Prefix){
@@ -443,7 +430,7 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
     public String getIncludePrefixForRdsSource(String s3Prefix) {
         String envSourceCoordinationIdentifier = System.getenv(SOURCE_COORDINATION_IDENTIFIER_ENVIRONMENT_VARIABLE);
         if (s3Prefix == null && envSourceCoordinationIdentifier == null) {
-            return "";
+            return S3_BUFFER_PREFIX;
         } else if (s3Prefix == null) {
             return envSourceCoordinationIdentifier + S3_BUFFER_PREFIX;
         } else if (envSourceCoordinationIdentifier == null) {

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -77,6 +77,7 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
     private static final String SINK_SUBPIPELINE_PLUGIN_NAME = "pipeline";
     private static final String SUBPIPELINE_PATH = "$.source.pipeline";
 
+    private static final String S3_BUFFER_PREFIX = "/buffer";
 
     Configuration parseConfigWithJsonNode = Configuration.builder()
             .jsonProvider(new JacksonJsonNodeJsonProvider())
@@ -402,15 +403,28 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
     }
 
     /**
-     * Specific to DocDB depth field.
-     * @param s3Prefix
-     * @return
+     * Calculate s3 folder scan depth for DocDB source pipeline
+     * @param s3Prefix: s3 prefix defined in the source configuration
+     * @return s3 folder scan depth
      */
     public String calculateDepth(String s3Prefix) {
+        return Integer.toString(getDepth(s3Prefix, 4));
+    }
+
+    /**
+     * Calculate s3 folder scan depth for RDS source pipeline
+     * @param s3Prefix: s3 prefix defined in the source configuration
+     * @return s3 folder scan depth
+     */
+    public String calculateDepthForRdsSource(String s3Prefix) {
+        return Integer.toString(getDepth(s3Prefix, 3));
+    }
+
+    private int getDepth(String s3Prefix, int baseDepth) {
         if(s3Prefix == null){
-            return Integer.toString(4);
+            return baseDepth;
         }
-        return Integer.toString(s3Prefix.split("/").length + 4);
+        return s3Prefix.split("/").length + baseDepth;
     }
 
     public String getSourceCoordinationIdentifierEnvVariable(String s3Prefix){
@@ -419,6 +433,23 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
             return envSourceCoordinationIdentifier;
         }
         return s3Prefix+"/"+envSourceCoordinationIdentifier;
+    }
+
+    /**
+     * Get the include_prefix in s3 scan source. This is a function specific to RDS source.
+     * @param s3Prefix: s3 prefix defined in the source configuration
+     * @return the actual include_prefix
+     */
+    public String getIncludePrefixForRdsSource(String s3Prefix) {
+        String envSourceCoordinationIdentifier = System.getenv(SOURCE_COORDINATION_IDENTIFIER_ENVIRONMENT_VARIABLE);
+        if (s3Prefix == null && envSourceCoordinationIdentifier == null) {
+            return "";
+        } else if (s3Prefix == null) {
+            return envSourceCoordinationIdentifier + S3_BUFFER_PREFIX;
+        } else if (envSourceCoordinationIdentifier == null) {
+            return s3Prefix + S3_BUFFER_PREFIX;
+        }
+        return s3Prefix + "/" + envSourceCoordinationIdentifier + S3_BUFFER_PREFIX;
     }
 
     public String getAccountIdFromRole(final String roleArn) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -162,7 +163,7 @@ public class RdsService {
 
         final String s3PathPrefix;
         if (sourceCoordinator.getPartitionPrefix() != null ) {
-            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + sourceCoordinator.getPartitionPrefix();
+            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + sourceCoordinator.getPartitionPrefix() + S3_PATH_DELIMITER + Instant.now().toEpochMilli();
         } else {
             s3PathPrefix = s3UserPathPrefix;
         }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -156,17 +156,16 @@ public class RdsService {
     private String getS3PathPrefix() {
         final String s3UserPathPrefix;
         if (sourceConfig.getS3Prefix() != null && !sourceConfig.getS3Prefix().isBlank()) {
-            s3UserPathPrefix = sourceConfig.getS3Prefix() + S3_PATH_DELIMITER;
+            s3UserPathPrefix = sourceConfig.getS3Prefix();
         } else {
             s3UserPathPrefix = "";
         }
 
         final String s3PathPrefix;
-        final Instant now = Instant.now();
         if (sourceCoordinator.getPartitionPrefix() != null ) {
-            s3PathPrefix = s3UserPathPrefix + sourceCoordinator.getPartitionPrefix() + S3_PATH_DELIMITER + now.toEpochMilli() + S3_PATH_DELIMITER;
+            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + sourceCoordinator.getPartitionPrefix();
         } else {
-            s3PathPrefix = s3UserPathPrefix + now.toEpochMilli() + S3_PATH_DELIMITER;
+            s3PathPrefix = s3UserPathPrefix;
         }
         return s3PathPrefix;
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -163,7 +162,7 @@ public class RdsService {
 
         final String s3PathPrefix;
         if (sourceCoordinator.getPartitionPrefix() != null ) {
-            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + sourceCoordinator.getPartitionPrefix() + S3_PATH_DELIMITER + Instant.now().toEpochMilli();
+            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + sourceCoordinator.getPartitionPrefix();
         } else {
             s3PathPrefix = s3UserPathPrefix;
         }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -51,7 +51,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
         this.eventFactory = eventFactory;
         this.acknowledgementSetManager = acknowledgementSetManager;
 
-        clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig.getAwsAuthenticationConfig());
+        clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig);
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceConfig.java
@@ -7,12 +7,15 @@ package org.opensearch.dataprepper.plugins.source.rds;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.ExportConfig;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.TlsConfig;
+import software.amazon.awssdk.regions.Region;
 
 import java.time.Duration;
 import java.util.List;
@@ -21,6 +24,7 @@ import java.util.List;
  * Configuration for RDS Source
  */
 public class RdsSourceConfig {
+    private static final int DEFAULT_S3_FOLDER_PARTITION_COUNT = 100;
 
     /**
      * Identifier for RDS instance/cluster or Aurora cluster
@@ -71,6 +75,14 @@ public class RdsSourceConfig {
 
     @JsonProperty("s3_region")
     private String s3Region;
+
+    /**
+     * The number of folder partitions in S3 buffer
+     */
+    @JsonProperty("partition_count")
+    @Min(1)
+    @Max(1000)
+    private int s3FolderPartitionCount = DEFAULT_S3_FOLDER_PARTITION_COUNT;
 
     @JsonProperty("export")
     @Valid
@@ -132,8 +144,12 @@ public class RdsSourceConfig {
         return s3Prefix;
     }
 
-    public String getS3Region() {
-        return s3Region;
+    public Region getS3Region() {
+        return s3Region != null ? Region.of(s3Region) : null;
+    }
+
+    public int getPartitionCount() {
+        return s3FolderPartitionCount;
     }
 
     public ExportConfig getExport() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/ExportConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/ExportConfig.java
@@ -14,6 +14,9 @@ public class ExportConfig {
     @NotNull
     private String kmsKeyId;
 
+    /**
+     * The ARN of the IAM role that will be passed to RDS for export.
+     */
     @JsonProperty("iam_role_arn")
     @NotNull
     private String iamRoleArn;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/ExportConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/ExportConfig.java
@@ -14,7 +14,15 @@ public class ExportConfig {
     @NotNull
     private String kmsKeyId;
 
+    @JsonProperty("iam_role_arn")
+    @NotNull
+    private String iamRoleArn;
+
     public String getKmsKeyId() {
         return kmsKeyId;
+    }
+
+    public String getIamRoleArn() {
+        return iamRoleArn;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
@@ -13,9 +13,10 @@ public class StreamConfig {
 
     private static final int DEFAULT_NUM_WORKERS = 1;
 
+    // TODO: Restricted max to 1 here until we have a proper method to process the stream events in parallel.
     @JsonProperty("workers")
     @Min(1)
-    @Max(1000)
+    @Max(1)
     private int numWorkers = DEFAULT_NUM_WORKERS;
 
     public int getNumWorkers() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/configuration/StreamConfig.java
@@ -11,22 +11,12 @@ import jakarta.validation.constraints.Min;
 
 public class StreamConfig {
 
-    private static final int DEFAULT_S3_FOLDER_PARTITION_COUNT = 100;
     private static final int DEFAULT_NUM_WORKERS = 1;
-
-    @JsonProperty("partition_count")
-    @Min(1)
-    @Max(1000)
-    private int s3FolderPartitionCount = DEFAULT_S3_FOLDER_PARTITION_COUNT;
 
     @JsonProperty("workers")
     @Min(1)
     @Max(1000)
     private int numWorkers = DEFAULT_NUM_WORKERS;
-
-    public int getPartitionCount() {
-        return s3FolderPartitionCount;
-    }
 
     public int getNumWorkers() {
         return numWorkers;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverter.java
@@ -5,52 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.converter;
 
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventMetadata;
-import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
-import org.opensearch.dataprepper.model.record.Record;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public class ExportRecordConverter extends RecordConverter {
 
-import java.util.List;
-import java.util.stream.Collectors;
+    public ExportRecordConverter(final String s3Prefix, final int partitionCount) {
+        super(s3Prefix, partitionCount);
+    }
 
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
-
-public class ExportRecordConverter {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ExportRecordConverter.class);
-
-    static final String EXPORT_EVENT_TYPE = "EXPORT";
-
-    public Event convert(final Record<Event> record,
-                         final String databaseName,
-                         final String tableName,
-                         final List<String> primaryKeys,
-                         final long eventCreateTimeEpochMillis,
-                         final long eventVersionNumber) {
-        Event event = record.getData();
-
-        EventMetadata eventMetadata = event.getMetadata();
-        eventMetadata.setAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE, databaseName);
-        eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
-        eventMetadata.setAttribute(BULK_ACTION_METADATA_ATTRIBUTE, OpenSearchBulkActions.INDEX.toString());
-        eventMetadata.setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, EXPORT_EVENT_TYPE);
-
-        final String primaryKeyValue = primaryKeys.stream()
-                .map(key -> event.get(key, String.class))
-                .collect(Collectors.joining("|"));
-        eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, primaryKeyValue);
-
-        eventMetadata.setAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreateTimeEpochMillis);
-        eventMetadata.setAttribute(EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
-
-        return event;
+    @Override
+    String getIngestionType() {
+        return EXPORT_INGESTION_TYPE;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.converter;
+
+import com.github.shyiko.mysql.binlog.event.EventType;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+
+public abstract class RecordConverter {
+
+    private final String s3Prefix;
+    private final List<String> folderNames;
+
+    static final String S3_BUFFER_PREFIX = "buffer";
+    static final String S3_PATH_DELIMITER = "/";
+    static final String EXPORT_INGESTION_TYPE = "EXPORT";
+    static final String STREAM_INGESTION_TYPE = "STREAM";
+
+
+    public RecordConverter(final String s3Prefix, final int partitionCount) {
+        this.s3Prefix = s3Prefix;
+        S3PartitionCreator s3PartitionCreator = new S3PartitionCreator(partitionCount);
+        folderNames = s3PartitionCreator.createPartitions();
+    }
+
+    public Event convert(final Event event,
+                         final String databaseName,
+                         final String tableName,
+                         final OpenSearchBulkActions bulkAction,
+                         final List<String> primaryKeys,
+                         final long eventCreateTimeEpochMillis,
+                         final long eventVersionNumber,
+                         final EventType eventType) {
+
+        EventMetadata eventMetadata = event.getMetadata();
+
+        // Only set external origination time for stream events, not export
+        if (STREAM_INGESTION_TYPE.equals(getIngestionType())) {
+            final Instant externalOriginationTime = Instant.ofEpochMilli(eventCreateTimeEpochMillis);
+            event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
+            eventMetadata.setExternalOriginationTime(externalOriginationTime);
+        }
+
+        eventMetadata.setAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE, databaseName);
+        eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
+        eventMetadata.setAttribute(BULK_ACTION_METADATA_ATTRIBUTE, bulkAction.toString());
+        setIngestionTypeMetadata(event);
+        if (eventType != null) {
+            eventMetadata.setAttribute(CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE, eventType.toString());
+        }
+
+        final String primaryKeyValue = primaryKeys.stream()
+                .map(key -> event.get(key, String.class))
+                .collect(Collectors.joining("|"));
+        eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, primaryKeyValue);
+        final String s3PartitionKey = s3Prefix + S3_PATH_DELIMITER + S3_BUFFER_PREFIX + S3_PATH_DELIMITER + hashKeyToPartition(primaryKeyValue);
+        eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, s3PartitionKey);
+
+        eventMetadata.setAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreateTimeEpochMillis);
+        eventMetadata.setAttribute(EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
+
+        return event;
+    }
+
+    abstract String getIngestionType();
+
+    private void setIngestionTypeMetadata(final Event event) {
+        event.getMetadata().setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, getIngestionType());
+    }
+
+    private String hashKeyToPartition(final String key) {
+        return folderNames.get(hashKeyToIndex(key));
+    }
+
+    private int hashKeyToIndex(final String key) {
+        try {
+            // Create a SHA-256 hash instance
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            // Hash the key
+            byte[] hashBytes = digest.digest(key.getBytes());
+            // Convert the hash to an integer
+            int hashValue = bytesToInt(hashBytes);
+            // Map the hash value to an index in the list
+            return Math.abs(hashValue) % folderNames.size();
+        } catch (final NoSuchAlgorithmException e) {
+            return -1;
+        }
+    }
+
+    private int bytesToInt(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).getInt();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
@@ -73,6 +73,7 @@ public abstract class RecordConverter {
                 .map(key -> event.get(key, String.class))
                 .collect(Collectors.joining("|"));
         eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, primaryKeyValue);
+
         final String s3PartitionKey = s3Prefix + S3_PATH_DELIMITER + S3_BUFFER_PREFIX + S3_PATH_DELIMITER + hashKeyToPartition(primaryKeyValue);
         eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, s3PartitionKey);
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverter.java
@@ -5,107 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.converter;
 
-import com.github.shyiko.mysql.binlog.event.EventType;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventMetadata;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.nio.ByteBuffer;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
-
 /**
  * Convert binlog row data into JacksonEvent
  */
-public class StreamRecordConverter {
+public class StreamRecordConverter extends RecordConverter {
 
-    private static final Logger LOG = LoggerFactory.getLogger(StreamRecordConverter.class);
-
-    private final List<String> folderNames;
-
-    static final String S3_PATH_DELIMITER = "/";
-
-    static final String STREAM_EVENT_TYPE = "STREAM";
-
-    public StreamRecordConverter(final int partitionCount) {
-        S3PartitionCreator s3PartitionCreator = new S3PartitionCreator(partitionCount);
-        folderNames = s3PartitionCreator.createPartitions();
+    public StreamRecordConverter(final String s3Prefix, final int partitionCount) {
+        super(s3Prefix, partitionCount);
     }
 
-    public Event convert(final Map<String, Object> rowData,
-                         final String databaseName,
-                         final String tableName,
-                         final EventType eventType,
-                         final OpenSearchBulkActions bulkAction,
-                         final List<String> primaryKeys,
-                         final String s3Prefix,
-                         final long eventCreateTimeEpochMillis,
-                         final long eventVersionNumber) {
-        final Event event = JacksonEvent.builder()
-                .withEventType("event")
-                .withData(rowData)
-                .build();
-
-        EventMetadata eventMetadata = event.getMetadata();
-
-        // Only set external origination time for stream events, not export
-        final Instant externalOriginationTime = Instant.ofEpochMilli(eventCreateTimeEpochMillis);
-        event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
-        eventMetadata.setExternalOriginationTime(externalOriginationTime);
-
-        eventMetadata.setAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE, databaseName);
-        eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
-        eventMetadata.setAttribute(BULK_ACTION_METADATA_ATTRIBUTE, bulkAction.toString());
-        eventMetadata.setAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE, STREAM_EVENT_TYPE);
-        eventMetadata.setAttribute(CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE, eventType.toString());
-
-        final String primaryKeyValue = primaryKeys.stream()
-                .map(rowData::get)
-                .map(String::valueOf)
-                .collect(Collectors.joining("|"));
-        eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, primaryKeyValue);
-        eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, s3Prefix + S3_PATH_DELIMITER + hashKeyToPartition(primaryKeyValue));
-
-        eventMetadata.setAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreateTimeEpochMillis);
-        eventMetadata.setAttribute(EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
-
-        return event;
-    }
-
-    private String hashKeyToPartition(final String key) {
-        return folderNames.get(hashKeyToIndex(key));
-    }
-    private int hashKeyToIndex(final String key) {
-        try {
-            // Create a SHA-256 hash instance
-            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            // Hash the key
-            byte[] hashBytes = digest.digest(key.getBytes());
-            // Convert the hash to an integer
-            int hashValue = bytesToInt(hashBytes);
-            // Map the hash value to an index in the list
-            return Math.abs(hashValue) % folderNames.size();
-        } catch (final NoSuchAlgorithmException e) {
-            return -1;
-        }
-    }
-    private int bytesToInt(byte[] bytes) {
-        return ByteBuffer.wrap(bytes).getInt();
+    @Override
+    String getIngestionType() {
+        return STREAM_INGESTION_TYPE;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter;
@@ -121,12 +122,14 @@ public class DataFileLoader implements Runnable {
                     final long snapshotTime = progressState.getSnapshotTime();
                     final long eventVersionNumber = snapshotTime - VERSION_OVERLAP_TIME_FOR_EXPORT.toMillis();
                     final Event transformedEvent = recordConverter.convert(
-                            record,
+                            event,
                             progressState.getSourceDatabase(),
                             progressState.getSourceTable(),
+                            OpenSearchBulkActions.INDEX,
                             primaryKeys,
                             snapshotTime,
-                            eventVersionNumber);
+                            eventVersionNumber,
+                            null);
 
                     if (acknowledgementSet != null) {
                         acknowledgementSet.add(transformedEvent);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
@@ -74,6 +74,7 @@ public class DataFileScheduler implements Runnable {
 
     public DataFileScheduler(final EnhancedSourceCoordinator sourceCoordinator,
                              final RdsSourceConfig sourceConfig,
+                             final String s3Prefix,
                              final S3Client s3Client,
                              final EventFactory eventFactory,
                              final Buffer<Record<Event>> buffer,
@@ -83,7 +84,7 @@ public class DataFileScheduler implements Runnable {
         this.sourceConfig = sourceConfig;
         codec = new ParquetInputCodec(eventFactory);
         objectReader = new S3ObjectReader(s3Client);
-        recordConverter = new ExportRecordConverter();
+        recordConverter = new ExportRecordConverter(s3Prefix, sourceConfig.getPartitionCount());
         executor = Executors.newFixedThreadPool(DATA_LOADER_MAX_JOB_COUNT);
         this.buffer = buffer;
         this.pluginMetrics = pluginMetrics;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -133,7 +133,7 @@ public class LeaderScheduler implements Runnable {
 
     private void createExportPartition(RdsSourceConfig sourceConfig) {
         ExportProgressState progressState = new ExportProgressState();
-        progressState.setIamRoleArn(sourceConfig.getAwsAuthenticationConfig().getAwsStsRoleArn());
+        progressState.setIamRoleArn(sourceConfig.getExport().getIamRoleArn());
         progressState.setBucket(sourceConfig.getS3Bucket());
         // This prefix is for data exported from RDS
         progressState.setPrefix(getS3PrefixForExport(s3Prefix));

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -27,13 +27,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.plugins.source.rds.RdsService.S3_PATH_DELIMITER;
+
 public class LeaderScheduler implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(LeaderScheduler.class);
     private static final int DEFAULT_EXTEND_LEASE_MINUTES = 3;
     private static final Duration DEFAULT_LEASE_INTERVAL = Duration.ofMinutes(1);
+    private static final String S3_EXPORT_PREFIX = "rds-export";
     private final EnhancedSourceCoordinator sourceCoordinator;
     private final RdsSourceConfig sourceConfig;
+    private final String s3Prefix;
     private final SchemaManager schemaManager;
     private final DbMetadata dbMetadata;
 
@@ -42,10 +46,12 @@ public class LeaderScheduler implements Runnable {
 
     public LeaderScheduler(final EnhancedSourceCoordinator sourceCoordinator,
                            final RdsSourceConfig sourceConfig,
+                           final String s3Prefix,
                            final SchemaManager schemaManager,
                            final DbMetadata dbMetadata) {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
+        this.s3Prefix = s3Prefix;
         this.schemaManager = schemaManager;
         this.dbMetadata = dbMetadata;
     }
@@ -129,12 +135,17 @@ public class LeaderScheduler implements Runnable {
         ExportProgressState progressState = new ExportProgressState();
         progressState.setIamRoleArn(sourceConfig.getAwsAuthenticationConfig().getAwsStsRoleArn());
         progressState.setBucket(sourceConfig.getS3Bucket());
-        progressState.setPrefix(sourceConfig.getS3Prefix());
+        // This prefix is for data exported from RDS
+        progressState.setPrefix(getS3PrefixForExport(s3Prefix));
         progressState.setTables(sourceConfig.getTableNames());
         progressState.setKmsKeyId(sourceConfig.getExport().getKmsKeyId());
         progressState.setPrimaryKeyMap(getPrimaryKeyMap());
         ExportPartition exportPartition = new ExportPartition(sourceConfig.getDbIdentifier(), sourceConfig.isCluster(), progressState);
         sourceCoordinator.createPartition(exportPartition);
+    }
+
+    private String getS3PrefixForExport(final String givenS3Prefix) {
+        return givenS3Prefix + S3_PATH_DELIMITER + S3_EXPORT_PREFIX;
     }
 
     private Map<String, List<String>> getPrimaryKeyMap() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
@@ -86,6 +87,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
 
     public BinlogEventListener(final Buffer<Record<Event>> buffer,
                                final RdsSourceConfig sourceConfig,
+                               final String s3Prefix,
                                final PluginMetrics pluginMetrics,
                                final BinaryLogClient binaryLogClient,
                                final StreamCheckpointer streamCheckpointer,
@@ -93,8 +95,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         this.buffer = buffer;
         this.binaryLogClient = binaryLogClient;
         tableMetadataMap = new HashMap<>();
-        recordConverter = new StreamRecordConverter(sourceConfig.getPartitionCount());
-        s3Prefix = sourceConfig.getS3Prefix();
+        recordConverter = new StreamRecordConverter(s3Prefix, sourceConfig.getPartitionCount());
+        this.s3Prefix = s3Prefix;
         tableNames = sourceConfig.getTableNames();
         isAcknowledgmentsEnabled = sourceConfig.isAcknowledgmentsEnabled();
         this.pluginMetrics = pluginMetrics;
@@ -244,16 +246,20 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                 rowDataMap.put(columnNames.get(i), rowDataArray[i]);
             }
 
+            final Event dataPrepperEvent = JacksonEvent.builder()
+                    .withEventType("event")
+                    .withData(rowDataMap)
+                    .build();
+
             final Event pipelineEvent = recordConverter.convert(
-                    rowDataMap,
+                    dataPrepperEvent,
                     tableMetadata.getDatabaseName(),
                     tableMetadata.getTableName(),
-                    event.getHeader().getEventType(),
                     bulkAction,
                     primaryKeys,
-                    s3Prefix,
                     eventTimestampMillis,
-                    eventTimestampMillis);
+                    eventTimestampMillis,
+                    event.getHeader().getEventType());
             pipelineEvents.add(pipelineEvent);
         }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -93,7 +93,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         this.buffer = buffer;
         this.binaryLogClient = binaryLogClient;
         tableMetadataMap = new HashMap<>();
-        recordConverter = new StreamRecordConverter(sourceConfig.getStream().getPartitionCount());
+        recordConverter = new StreamRecordConverter(sourceConfig.getPartitionCount());
         s3Prefix = sourceConfig.getS3Prefix();
         tableNames = sourceConfig.getTableNames();
         isAcknowledgmentsEnabled = sourceConfig.isAcknowledgmentsEnabled();

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -52,6 +52,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
 
     static final Duration BUFFER_TIMEOUT = Duration.ofSeconds(60);
     static final int DEFAULT_BUFFER_BATCH_SIZE = 1_000;
+    static final String DATA_PREPPER_EVENT_TYPE = "event";
     static final String CHANGE_EVENTS_PROCESSED_COUNT = "changeEventsProcessed";
     static final String CHANGE_EVENTS_PROCESSING_ERROR_COUNT = "changeEventsProcessingErrors";
     static final String BYTES_RECEIVED = "bytesReceived";
@@ -247,7 +248,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             }
 
             final Event dataPrepperEvent = JacksonEvent.builder()
-                    .withEventType("event")
+                    .withEventType(DATA_PREPPER_EVENT_TYPE)
                     .withData(rowDataMap)
                     .build();
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
@@ -33,6 +33,7 @@ public class StreamScheduler implements Runnable {
 
     private final EnhancedSourceCoordinator sourceCoordinator;
     private final RdsSourceConfig sourceConfig;
+    private final String s3Prefix;
     private final BinaryLogClient binaryLogClient;
     private final Buffer<Record<Event>> buffer;
     private final PluginMetrics pluginMetrics;
@@ -43,12 +44,14 @@ public class StreamScheduler implements Runnable {
 
     public StreamScheduler(final EnhancedSourceCoordinator sourceCoordinator,
                            final RdsSourceConfig sourceConfig,
+                           final String s3Prefix,
                            final BinaryLogClient binaryLogClient,
                            final Buffer<Record<Event>> buffer,
                            final PluginMetrics pluginMetrics,
                            final AcknowledgementSetManager acknowledgementSetManager) {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
+        this.s3Prefix = s3Prefix;
         this.binaryLogClient = binaryLogClient;
         this.buffer = buffer;
         this.pluginMetrics = pluginMetrics;
@@ -74,7 +77,7 @@ public class StreamScheduler implements Runnable {
                     streamPartition = (StreamPartition) sourcePartition.get();
                     final StreamCheckpointer streamCheckpointer = new StreamCheckpointer(sourceCoordinator, streamPartition, pluginMetrics);
                     binaryLogClient.registerEventListener(new BinlogEventListener(
-                            buffer, sourceConfig, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager));
+                            buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager));
                     final StreamWorker streamWorker = StreamWorker.create(sourceCoordinator, binaryLogClient, pluginMetrics);
                     executorService.submit(() -> streamWorker.processStream((StreamPartition) sourcePartition.get()));
                 }

--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/rules/rds-rule.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/rules/rds-rule.yaml
@@ -1,4 +1,3 @@
 plugin_name: "rds"
 apply_when:
   - "$..source.rds"
-  - "$..source.documentdb.s3_bucket"

--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/rules/rds-rule.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/rules/rds-rule.yaml
@@ -1,0 +1,4 @@
+plugin_name: "rds"
+apply_when:
+  - "$..source.rds"
+  - "$..source.documentdb.s3_bucket"

--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
@@ -67,7 +67,7 @@
       disable_s3_metadata_in_event: true
       scan:
         folder_partitions:
-          depth: "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"
+          depth: "<<FUNCTION_NAME:calculateDepthForRdsSource,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"
           max_objects_per_ownership: 50
         buckets:
           - bucket:

--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
@@ -1,0 +1,81 @@
+"<<pipeline-name>>":
+  workers: "<<$.<<pipeline-name>>.workers>>"
+  delay: "<<$.<<pipeline-name>>.delay>>"
+  buffer: "<<$.<<pipeline-name>>.buffer>>"
+  source:
+    rds: "<<$.<<pipeline-name>>.source.rds>>"
+  routes:
+    - initial_load: 'getMetadata("ingestion_type") == "EXPORT"'
+    - stream_load: 'getMetadata("ingestion_type") == "STREAM"'
+  sink:
+    - s3:
+        routes:
+          - initial_load
+        aws:
+          region:  "<<$.<<pipeline-name>>.source.rds.s3_region>>"
+          sts_role_arn: "<<$.<<pipeline-name>>.source.rds.aws.sts_role_arn>>"
+          sts_external_id: "<<$.<<pipeline-name>>.source.rds.aws.sts_external_id>>"
+          sts_header_overrides: "<<$.<<pipeline-name>>.source.rds.aws.sts_header_overrides>>"
+        bucket: "<<$.<<pipeline-name>>.source.rds.s3_bucket>>"
+        threshold:
+          event_collect_timeout: "120s"
+          maximum_size: "2mb"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        codec:
+          event_json:
+        default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.rds.aws.sts_role_arn>>"
+    - s3:
+        routes:
+          - stream_load
+        aws:
+          region:  "<<$.<<pipeline-name>>.source.rds.s3_region>>"
+          sts_role_arn: "<<$.<<pipeline-name>>.source.rds.aws.sts_role_arn>>"
+          sts_external_id: "<<$.<<pipeline-name>>.source.rds.aws.sts_external_id>>"
+          sts_header_overrides: "<<$.<<pipeline-name>>.source.rds.aws.sts_header_overrides>>"
+        bucket: "<<$.<<pipeline-name>>.source.rds.s3_bucket>>"
+        threshold:
+          event_collect_timeout: "15s"
+          maximum_size: "1mb"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        codec:
+          event_json:
+        default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.rds.aws.sts_role_arn>>"
+"<<pipeline-name>>-s3":
+  workers: "<<$.<<pipeline-name>>.workers>>"
+  delay: "<<$.<<pipeline-name>>.delay>>"
+  buffer: "<<$.<<pipeline-name>>.buffer>>"
+  source:
+    s3:
+      codec:
+        event_json:
+      compression: "none"
+      aws:
+        region:  "<<$.<<pipeline-name>>.source.rds.s3_region>>"
+        sts_role_arn: "<<$.<<pipeline-name>>.source.rds.aws.sts_role_arn>>"
+        sts_external_id: "<<$.<<pipeline-name>>.source.rds.aws.sts_external_id>>"
+        sts_header_overrides: "<<$.<<pipeline-name>>.source.rds.aws.sts_header_overrides>>"
+      acknowledgments: true
+      delete_s3_objects_on_read: true
+      disable_s3_metadata_in_event: true
+      scan:
+        folder_partitions:
+          depth: "<<FUNCTION_NAME:calculateDepthForRdsSource,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"
+          max_objects_per_ownership: 50
+        buckets:
+          - bucket:
+              name: "<<$.<<pipeline-name>>.source.rds.s3_bucket>>"
+              filter:
+                include_prefix: ["<<FUNCTION_NAME:getIncludePrefixForRdsSource,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"]
+        scheduling:
+          interval: "60s"
+  processor: "<<$.<<pipeline-name>>.processor>>"
+  sink: "<<$.<<pipeline-name>>.sink>>"
+  routes: "<<$.<<pipeline-name>>.routes>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.

--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
@@ -67,7 +67,7 @@
       disable_s3_metadata_in_event: true
       scan:
         folder_partitions:
-          depth: "<<FUNCTION_NAME:calculateDepthForRdsSource,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"
+          depth: "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"
           max_objects_per_ownership: 50
         buckets:
           - bucket:

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -150,7 +150,7 @@ class RdsServiceTest {
             rdsService.start(buffer);
         }
 
-        assertThat(s3PrefixArray[0], startsWith(s3Prefix + S3_PATH_DELIMITER + partitionPrefix + S3_PATH_DELIMITER));
+        assertThat(s3PrefixArray[0], equalTo(s3Prefix + S3_PATH_DELIMITER + partitionPrefix));
         verify(executor).submit(any(LeaderScheduler.class));
         verify(executor).submit(any(StreamScheduler.class));
         verify(executor, never()).submit(any(ExportScheduler.class));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
@@ -13,7 +13,6 @@ import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
-import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.List;
 import java.util.Map;
@@ -22,25 +21,33 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter.EXPORT_EVENT_TYPE;
+import static org.hamcrest.Matchers.startsWith;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.ExportRecordConverter.EXPORT_INGESTION_TYPE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_S3_PARTITION_KEY;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.RecordConverter.S3_BUFFER_PREFIX;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.RecordConverter.S3_PATH_DELIMITER;
 
 @ExtendWith(MockitoExtension.class)
 class ExportRecordConverterTest {
 
     private Random random;
+    private String s3Prefix;
     private ExportRecordConverter exportRecordConverter;
 
     @BeforeEach
     void setUp() {
         random = new Random();
+        s3Prefix = UUID.randomUUID().toString();
         exportRecordConverter = createObjectUnderTest();
     }
 
@@ -49,6 +56,7 @@ class ExportRecordConverterTest {
         final String databaseName = UUID.randomUUID().toString();
         final String tableName = UUID.randomUUID().toString();
         final String primaryKeyName = UUID.randomUUID().toString();
+        final List<String> primaryKeys = List.of(primaryKeyName);
         final String primaryKeyValue = UUID.randomUUID().toString();
         final long eventCreateTimeEpochMillis = random.nextLong();
         final long eventVersionNumber = random.nextLong();
@@ -58,24 +66,24 @@ class ExportRecordConverterTest {
                 .withData(Map.of(primaryKeyName, primaryKeyValue))
                 .build();
 
-        Record<Event> testRecord = new Record<>(testEvent);
-
-        ExportRecordConverter exportRecordConverter = new ExportRecordConverter();
         Event actualEvent = exportRecordConverter.convert(
-                testRecord, databaseName, tableName, List.of(primaryKeyName), eventCreateTimeEpochMillis, eventVersionNumber);
+                testEvent, databaseName, tableName, OpenSearchBulkActions.INDEX, primaryKeys,
+                eventCreateTimeEpochMillis, eventVersionNumber, null);
 
         // Assert
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE), equalTo(databaseName));
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), equalTo(tableName));
         assertThat(actualEvent.getMetadata().getAttribute(BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
         assertThat(actualEvent.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(primaryKeyValue));
-        assertThat(actualEvent.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(EXPORT_EVENT_TYPE));
+        assertThat(actualEvent.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(EXPORT_INGESTION_TYPE));
+        assertThat(actualEvent.getMetadata().getAttribute(EVENT_S3_PARTITION_KEY).toString(), startsWith(s3Prefix + S3_PATH_DELIMITER + S3_BUFFER_PREFIX + S3_PATH_DELIMITER));
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(eventCreateTimeEpochMillis));
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_VERSION_FROM_TIMESTAMP), equalTo(eventVersionNumber));
-        assertThat(actualEvent, sameInstance(testRecord.getData()));
+        assertThat(actualEvent.getMetadata().getAttribute(CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE), nullValue());
+        assertThat(actualEvent, sameInstance(testEvent));
     }
 
     private ExportRecordConverter createObjectUnderTest() {
-        return new ExportRecordConverter();
+        return new ExportRecordConverter(s3Prefix, random.nextInt(1000) + 1);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
@@ -8,7 +8,9 @@ package org.opensearch.dataprepper.plugins.source.rds.converter;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 
 import java.util.List;
@@ -17,7 +19,9 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
@@ -26,7 +30,10 @@ import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKe
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.RecordConverter.S3_BUFFER_PREFIX;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.RecordConverter.STREAM_INGESTION_TYPE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.StreamRecordConverter.S3_PATH_DELIMITER;
 
 
@@ -34,11 +41,13 @@ class StreamRecordConverterTest {
 
     private StreamRecordConverter streamRecordConverter;
     private Random random;
+    private String s3Prefix;
 
     @BeforeEach
     void setUp() {
-        streamRecordConverter = createObjectUnderTest();
         random = new Random();
+        s3Prefix = UUID.randomUUID().toString();
+        streamRecordConverter = createObjectUnderTest();
     }
 
     @Test
@@ -49,13 +58,17 @@ class StreamRecordConverterTest {
         final EventType eventType = EventType.EXT_WRITE_ROWS;
         final OpenSearchBulkActions bulkAction = OpenSearchBulkActions.INDEX;
         final List<String> primaryKeys = List.of("key1");
-        final String s3Prefix = UUID.randomUUID().toString();
         final long eventCreateTimeEpochMillis = random.nextLong();
         final long eventVersionNumber = random.nextLong();
 
+        final Event testEvent = TestEventFactory.getTestEventFactory().eventBuilder(EventBuilder.class)
+                .withEventType("event")
+                .withData(rowData)
+                .build();
+
         Event event = streamRecordConverter.convert(
-                rowData, databaseName, tableName, eventType, bulkAction,
-                primaryKeys, s3Prefix, eventCreateTimeEpochMillis, eventVersionNumber);
+                testEvent, databaseName, tableName, bulkAction, primaryKeys,
+                eventCreateTimeEpochMillis, eventVersionNumber, eventType);
 
         assertThat(event.toMap(), is(rowData));
         assertThat(event.getMetadata().getAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE), is(databaseName));
@@ -63,12 +76,14 @@ class StreamRecordConverterTest {
         assertThat(event.getMetadata().getAttribute(CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE), is(eventType.toString()));
         assertThat(event.getMetadata().getAttribute(BULK_ACTION_METADATA_ATTRIBUTE), is(bulkAction.toString()));
         assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), is("value1"));
-        assertThat(event.getMetadata().getAttribute(EVENT_S3_PARTITION_KEY).toString(), startsWith(s3Prefix + S3_PATH_DELIMITER));
+        assertThat(event.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(STREAM_INGESTION_TYPE));
+        assertThat(event.getMetadata().getAttribute(EVENT_S3_PARTITION_KEY).toString(), startsWith(s3Prefix + S3_PATH_DELIMITER + S3_BUFFER_PREFIX + S3_PATH_DELIMITER));
         assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), is(eventCreateTimeEpochMillis));
         assertThat(event.getMetadata().getAttribute(EVENT_VERSION_FROM_TIMESTAMP), is(eventVersionNumber));
+        assertThat(event, sameInstance(testEvent));
     }
 
     private StreamRecordConverter createObjectUnderTest() {
-        return new StreamRecordConverter(new Random().nextInt(1000) + 1);
+        return new StreamRecordConverter(s3Prefix, random.nextInt(1000) + 1);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -130,7 +130,7 @@ class DataFileLoaderTest {
         when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
         when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
         when(event.toJsonString()).thenReturn(randomString);
-        when(recordConverter.convert(any(), any(), any(), any(), anyLong(), anyLong())).thenReturn(event);
+        when(recordConverter.convert(any(), any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(event);
 
         AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
         ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
@@ -180,7 +180,7 @@ class DataFileLoaderTest {
         when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
         when(event.toJsonString()).thenReturn(randomString);
 
-        when(recordConverter.convert(any(), any(), any(), any(), anyLong(), anyLong())).thenReturn(event);
+        when(recordConverter.convert(any(), any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(event);
 
         ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
         AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
@@ -88,10 +88,12 @@ class DataFileSchedulerTest {
     private AtomicInteger activeExportS3ObjectConsumersGauge;
 
     private Random random;
+    private String s3Prefix;
 
     @BeforeEach
     void setUp() {
         random = new Random();
+        s3Prefix = UUID.randomUUID().toString();
         when(pluginMetrics.counter(EXPORT_S3_OBJECTS_PROCESSED_COUNT)).thenReturn(exportFileSuccessCounter);
         when(pluginMetrics.counter(eq(DataFileScheduler.EXPORT_S3_OBJECTS_ERROR_COUNT))).thenReturn(exportFileErrorCounter);
         when(pluginMetrics.gauge(eq(ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE), any(AtomicInteger.class), any()))
@@ -192,6 +194,6 @@ class DataFileSchedulerTest {
     }
 
     private DataFileScheduler createObjectUnderTest() {
-        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Client, eventFactory, buffer, pluginMetrics, acknowledgementSetManager);
+        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Prefix, s3Client, eventFactory, buffer, pluginMetrics, acknowledgementSetManager);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderSchedulerTest.java
@@ -60,10 +60,12 @@ class LeaderSchedulerTest {
     @Mock
     private LeaderProgressState leaderProgressState;
 
+    private String s3Prefix;
     private LeaderScheduler leaderScheduler;
 
     @BeforeEach
     void setUp() {
+        s3Prefix = UUID.randomUUID().toString();
         leaderScheduler = createObjectUnderTest();
 
         AwsAuthenticationConfig awsAuthenticationConfig = mock(AwsAuthenticationConfig.class);
@@ -138,6 +140,6 @@ class LeaderSchedulerTest {
     }
 
     private LeaderScheduler createObjectUnderTest() {
-        return new LeaderScheduler(sourceCoordinator, sourceConfig, schemaManager, dbMetadata);
+        return new LeaderScheduler(sourceCoordinator, sourceConfig, s3Prefix, schemaManager, dbMetadata);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKeyTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/ExportObjectKeyTest.java
@@ -28,8 +28,34 @@ class ExportObjectKeyTest {
     }
 
     @Test
+    void test_fromString_with_path_with_empty_prefix() {
+        final String objectKeyString = "export-task-id/db-name/db-name.table-name/1/file-name.parquet";
+        final ExportObjectKey exportObjectKey = ExportObjectKey.fromString(objectKeyString);
+
+        assertThat(exportObjectKey.getPrefix(), equalTo(""));
+        assertThat(exportObjectKey.getExportTaskId(), equalTo("export-task-id"));
+        assertThat(exportObjectKey.getDatabaseName(), equalTo("db-name"));
+        assertThat(exportObjectKey.getTableName(), equalTo("table-name"));
+        assertThat(exportObjectKey.getNumberedFolder(), equalTo("1"));
+        assertThat(exportObjectKey.getFileName(), equalTo("file-name.parquet"));
+    }
+
+    @Test
+    void test_fromString_with_path_with_multilevel_prefix() {
+        final String objectKeyString = "prefix1/prefix2/prefix3/export-task-id/db-name/db-name.table-name/1/file-name.parquet";
+        final ExportObjectKey exportObjectKey = ExportObjectKey.fromString(objectKeyString);
+
+        assertThat(exportObjectKey.getPrefix(), equalTo("prefix1/prefix2/prefix3"));
+        assertThat(exportObjectKey.getExportTaskId(), equalTo("export-task-id"));
+        assertThat(exportObjectKey.getDatabaseName(), equalTo("db-name"));
+        assertThat(exportObjectKey.getTableName(), equalTo("table-name"));
+        assertThat(exportObjectKey.getNumberedFolder(), equalTo("1"));
+        assertThat(exportObjectKey.getFileName(), equalTo("file-name.parquet"));
+    }
+
+    @Test
     void test_fromString_with_invalid_input_string() {
-        final String objectKeyString = "prefix/export-task-id/db-name/table-name/1/";
+        final String objectKeyString = "export-task-id/db-name/table-name/1";
 
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> ExportObjectKey.fromString(objectKeyString));
         assertThat(exception.getMessage(), containsString("Export object key is not valid: " + objectKeyString));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -26,6 +26,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -72,12 +73,15 @@ class BinlogEventListenerTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private com.github.shyiko.mysql.binlog.event.Event binlogEvent;
 
+    private String s3Prefix;
+
     private BinlogEventListener objectUnderTest;
 
     private Timer eventProcessingTimer;
 
     @BeforeEach
     void setUp() {
+        s3Prefix = UUID.randomUUID().toString();
         eventProcessingTimer = Metrics.timer("test-timer");
         when(pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME)).thenReturn(eventProcessingTimer);
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
@@ -136,7 +140,7 @@ class BinlogEventListenerTest {
     }
 
     private BinlogEventListener createObjectUnderTest() {
-        return new BinlogEventListener(buffer, sourceConfig, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager);
+        return new BinlogEventListener(buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager);
     }
 
     private void verifyHandlerCallHelper() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Stre
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -58,10 +59,12 @@ class StreamSchedulerTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
+    private String s3Prefix;
     private StreamScheduler objectUnderTest;
 
     @BeforeEach
     void setUp() {
+        s3Prefix = UUID.randomUUID().toString();
         objectUnderTest = createObjectUnderTest();
     }
 
@@ -117,6 +120,6 @@ class StreamSchedulerTest {
     }
 
     private StreamScheduler createObjectUnderTest() {
-        return new StreamScheduler(sourceCoordinator, sourceConfig, binaryLogClient, buffer, pluginMetrics, acknowledgementSetManager);
+        return new StreamScheduler(sourceCoordinator, sourceConfig, s3Prefix, binaryLogClient, buffer, pluginMetrics, acknowledgementSetManager);
     }
 }


### PR DESCRIPTION
### Description
This PR adds config transformation template for RDS source:
- Slightly updates RDS source config: moves partition_count to top level; adds role arn for export config
- For the S3 bucket, on top of user provided s3 prefix, add source coordinator prefix as subpath to distinguish between different pipelines. Under the subpath, further splits into two prefixes: `rds-export` for RDS exported data and `buffer` for pipeline generated data. 
- Refactors `ExportRecordConverter` and `StreamRecordConverter` to extract common code
- Adds rule and template for config transformation. The template is mostly adopted from documentdb ([link](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/mongodb/src/main/resources/org/opensearch/dataprepper/transforms/templates/documentdb-template.yaml)), with changes to the functions to get `include_prefix` and `depth`.

### Testing
Tested a pipeline with RDS source and verified the config transformation works and the pipeline processes export and stream data as expected.

 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
