### PR TITLE
Refactoring chunking in the HTTP source to improve the performance.

### DIFF
--- a/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/Codec.java
+++ b/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/codec/Codec.java
@@ -24,31 +24,25 @@ public interface Codec<T> {
     T parse(HttpData httpData) throws IOException;
 
     /**
-     * Serializes parsed data back into a UTF-8 string.
+     * Validates the content of the HTTP request.
+     *
+     * @param content The content of the original HTTP request
+     * @throws IOException A failure validating data.
+     */
+    void validate(HttpData content) throws IOException;
+
+    /*
+     * Serializes the HttpData and split into multiple bodies based on splitLength.
+     * <p>
+     * The serialized bodies are passed to the serializedBodyConsumer.
      * <p>
      * This API will split into multiple bodies based on splitLength. Note that if a single
      * item is larger than this, it will be output and exceed that length.
      *
-     * @param parsedData The parsed data
+     * @param content The content of the original HTTP request
      * @param serializedBodyConsumer A {@link Consumer} to accept each serialized body
      * @param splitLength The length at which to split serialized bodies.
      * @throws IOException A failure writing data.
      */
-    void serialize(final T parsedData,
-                   final Consumer<String> serializedBodyConsumer,
-                   final int splitLength) throws IOException;
-
-
-    /**
-     * Serializes parsed data back into a UTF-8 string.
-     * <p>
-     * This API will not split the data into chunks.
-     *
-     * @param parsedData The parsed data
-     * @param serializedBodyConsumer A {@link Consumer} to accept the serialized body
-     * @throws IOException A failure writing data.
-     */
-    default void serialize(final T parsedData, final Consumer<String> serializedBodyConsumer) throws IOException {
-        serialize(parsedData, serializedBodyConsumer, Integer.MAX_VALUE);
-    }
+    void serializeSplit(HttpData content, Consumer<String> serializedBodyConsumer, int splitLength) throws IOException;
 }

--- a/data-prepper-plugins/http-source/build.gradle
+++ b/data-prepper-plugins/http-source/build.gradle
@@ -5,6 +5,7 @@
 
 plugins {
     id 'java'
+    id 'me.champeau.jmh' version '0.7.2'
 }
 
 dependencies {

--- a/data-prepper-plugins/http-source/src/jmh/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceMeasure.java
+++ b/data-prepper-plugins/http-source/src/jmh/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceMeasure.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.loghttp;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+public class LogHTTPServiceMeasure {
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        private HttpData httpData;
+        private Buffer buffer;
+        private LogHTTPService logHTTPService;
+        private ServiceRequestContext serviceRequestContext;
+        private RequestHeaders requestHeaders;
+
+        @Setup
+        public void setUp() throws IOException {
+            byte[] jsonContent = new TestGenerator().createJson(10 * 1024 * 1024);
+            httpData = HttpData.ofUtf8(new String(jsonContent));
+
+            buffer = mock(Buffer.class, withSettings().stubOnly());
+            when(buffer.isByteBuffer()).thenReturn(true);
+            when(buffer.getMaxRequestSize()).thenReturn(Optional.of(512 * 1024));
+            when(buffer.getOptimalRequestSize()).thenReturn(Optional.of(256 * 1024));
+
+            serviceRequestContext = mock(ServiceRequestContext.class);
+            logHTTPService = new LogHTTPService((int) Duration.ofSeconds(10).toMillis(), buffer, PluginMetrics.fromPrefix("testing"));
+
+            requestHeaders = RequestHeaders.builder()
+                    .method(HttpMethod.POST)
+                    .path("/test")
+                    .build();
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 5, time = 10)
+    public HttpResponse measure_doPost(BenchmarkState benchmarkState) throws Exception {
+        AggregatedHttpRequest aggregatedHttpRequest = AggregatedHttpRequest.of(benchmarkState.requestHeaders, benchmarkState.httpData);
+        return benchmarkState.logHTTPService.doPost(benchmarkState.serviceRequestContext, aggregatedHttpRequest);
+    }
+}

--- a/data-prepper-plugins/http-source/src/jmh/java/org/opensearch/dataprepper/plugins/source/loghttp/TestGenerator.java
+++ b/data-prepper-plugins/http-source/src/jmh/java/org/opensearch/dataprepper/plugins/source/loghttp/TestGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.loghttp;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.commons.io.output.CountingOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.Random;
+import java.util.UUID;
+
+public class TestGenerator {
+    private final Random random = new Random();
+
+    public byte[] createJson(final int roughMaximumSize) throws IOException {
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(roughMaximumSize);
+        writeLog(roughMaximumSize, byteArrayOutputStream);
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    private void writeLog(final int roughMaximumSize, final OutputStream fileOutputStream) throws IOException {
+        try (final CountingOutputStream countingOutputStream = new CountingOutputStream(fileOutputStream)) {
+            writeJson(roughMaximumSize, countingOutputStream);
+        }
+    }
+
+    private void writeJson(final int roughMaximumSize, final CountingOutputStream countingOutputStream) throws IOException {
+        final JsonFactory jsonFactory = new JsonFactory();
+        final JsonGenerator jsonGenerator = jsonFactory
+                .createGenerator(countingOutputStream, JsonEncoding.UTF8);
+
+        jsonGenerator.writeStartArray();
+
+        while (countingOutputStream.getCount() < roughMaximumSize) {
+            writeSingleRecord(jsonGenerator);
+            jsonGenerator.flush(); // Need to flush the JsonGenerator in order to get the bytes to write to the counting output stream
+        }
+
+        jsonGenerator.writeEndArray();
+        jsonGenerator.close();
+
+        countingOutputStream.flush();
+    }
+
+    private void writeSingleRecord(final JsonGenerator jsonGenerator) throws IOException {
+        final StringBuilder logStringBuilder = new StringBuilder();
+        logStringBuilder.append(Instant.now());
+        logStringBuilder.append(" ");
+        logStringBuilder.append(UUID.randomUUID());
+        logStringBuilder.append(" ");
+        logStringBuilder.append(UUID.randomUUID());
+        logStringBuilder.append(" ");
+        logStringBuilder.append(random.nextInt(100_000));
+
+        jsonGenerator.writeStartObject();
+
+        jsonGenerator.writeStringField("log", logStringBuilder.toString());
+
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -141,7 +141,7 @@ public class HTTPSource implements Source<Record<Log>> {
 
             final String httpSourcePath = sourceConfig.getPath().replace(PIPELINE_NAME_PLACEHOLDER, pipelineName);
             sb.decorator(httpSourcePath, ThrottlingService.newDecorator(logThrottlingStrategy, logThrottlingRejectHandler));
-            final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, byteDecoder, pluginMetrics);
+            final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, pluginMetrics);
 
             if (CompressionOption.NONE.equals(sourceConfig.getCompression())) {
                 sb.annotatedService(httpSourcePath, logHTTPService, httpRequestExceptionHandler);


### PR DESCRIPTION
### Description

The HTTP source was parsing the entire message and then serializing from strings. This created a bit of memory churn and probably duplicate processing. The new approach is to chunk the message from the start which allows us to stream the reading and perform copies of data. This also has a JMH benchmark added which shows that this new approach doubles the number of operations per second.
 
### Benchmarks

```
./gradlew -p data-prepper-plugins/http-source jmh
```

**With original implementation**

```
Benchmark                              Mode  Cnt   Score   Error  Units
LogHTTPServiceMeasure.measure_doPost  thrpt   25  16.320 ± 0.314  ops/s
```

**With new implementation**

```
Benchmark                              Mode  Cnt   Score   Error  Units
LogHTTPServiceMeasure.measure_doPost  thrpt   25  33.425 ± 1.015  ops/s
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
