### PR TITLE
Shorten S3 prefix to meet the requirement of RDS export API

### DIFF
--- a/data-prepper-pipeline-parser/build.gradle
+++ b/data-prepper-pipeline-parser/build.gradle
@@ -12,6 +12,7 @@ group = 'org.opensearch.dataprepper.core'
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:blocking-buffer')
+    implementation project(':data-prepper-plugins:rds-source')
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'org.apache.commons:commons-collections4:4.4'

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -27,6 +27,7 @@ import org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager;
 import org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager;
 import org.opensearch.dataprepper.plugins.source.rds.stream.BinlogClientFactory;
 import org.opensearch.dataprepper.plugins.source.rds.stream.StreamScheduler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.IdentifierShortener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -45,6 +46,7 @@ public class RdsService {
      */
     public static final int DATA_LOADER_MAX_JOB_COUNT = 1;
     public static final String S3_PATH_DELIMITER = "/";
+    public static final int MAX_SOURCE_IDENTIFIER_LENGTH = 15;
 
     private final RdsClient rdsClient;
     private final S3Client s3Client;
@@ -162,10 +164,13 @@ public class RdsService {
 
         final String s3PathPrefix;
         if (sourceCoordinator.getPartitionPrefix() != null ) {
-            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + sourceCoordinator.getPartitionPrefix();
+            // The prefix will be used in RDS export, which has a limit of 60 characters.
+            s3PathPrefix = s3UserPathPrefix + S3_PATH_DELIMITER + IdentifierShortener.shortenIdentifier(sourceCoordinator.getPartitionPrefix(), MAX_SOURCE_IDENTIFIER_LENGTH);
         } else {
             s3PathPrefix = s3UserPathPrefix;
         }
         return s3PathPrefix;
     }
+
+
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -34,7 +34,7 @@ public class LeaderScheduler implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(LeaderScheduler.class);
     private static final int DEFAULT_EXTEND_LEASE_MINUTES = 3;
     private static final Duration DEFAULT_LEASE_INTERVAL = Duration.ofMinutes(1);
-    private static final String S3_EXPORT_PREFIX = "rds-export";
+    private static final String S3_EXPORT_PREFIX = "rds";
     private final EnhancedSourceCoordinator sourceCoordinator;
     private final RdsSourceConfig sourceConfig;
     private final String s3Prefix;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/IdentifierShortener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/IdentifierShortener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class IdentifierShortener {
+
+    public static String shortenIdentifier(final String identifier, final int maxLength) {
+        if (identifier.length() <= maxLength) {
+            return identifier;
+        }
+
+        try {
+            // Create SHA-256 hash
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedhash = digest.digest(identifier.getBytes(StandardCharsets.UTF_8));
+
+            // Convert byte array to Base64 string
+            String base64Hash = Base64.getUrlEncoder().withoutPadding().encodeToString(encodedhash);
+
+            // Return the first maxLength characters
+            return base64Hash.substring(0, Math.min(base64Hash.length(), maxLength));
+        } catch (final NoSuchAlgorithmException e) {
+            return identifier.substring(0, maxLength);
+        }
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -25,6 +25,7 @@ import org.opensearch.dataprepper.plugins.source.rds.export.DataFileScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.export.ExportScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.leader.LeaderScheduler;
 import org.opensearch.dataprepper.plugins.source.rds.stream.StreamScheduler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.IdentifierShortener;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
@@ -46,6 +47,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.RdsService.MAX_SOURCE_IDENTIFIER_LENGTH;
 import static org.opensearch.dataprepper.plugins.source.rds.RdsService.S3_PATH_DELIMITER;
 
 @ExtendWith(MockitoExtension.class)
@@ -150,7 +152,7 @@ class RdsServiceTest {
             rdsService.start(buffer);
         }
 
-        assertThat(s3PrefixArray[0], equalTo(s3Prefix + S3_PATH_DELIMITER + partitionPrefix));
+        assertThat(s3PrefixArray[0], equalTo(s3Prefix + S3_PATH_DELIMITER + IdentifierShortener.shortenIdentifier(partitionPrefix, MAX_SOURCE_IDENTIFIER_LENGTH)));
         verify(executor).submit(any(LeaderScheduler.class));
         verify(executor).submit(any(StreamScheduler.class));
         verify(executor, never()).submit(any(ExportScheduler.class));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/IdentifierShortenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/IdentifierShortenerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.Mockito.mockStatic;
+
+class IdentifierShortenerTest {
+
+    @Test
+    void shortenIdentifier_when_input_is_shorter_than_max_then_return_original_input() {
+        final int maxLength = 10;
+        final String testInput = UUID.randomUUID().toString().substring(0, maxLength);
+
+        final String result = IdentifierShortener.shortenIdentifier(testInput, maxLength);
+
+        assertThat(result, equalTo(testInput));
+    }
+
+    @Test
+    void shortenIdentifier_when_input_is_longer_than_max_then_return_shortened_result() {
+        final int maxLength = 5;
+        final String testInput = UUID.randomUUID().toString();
+        assertThat(testInput.length(), greaterThan(maxLength));
+
+        final String result = IdentifierShortener.shortenIdentifier(testInput, maxLength);
+
+        assertThat(result.length(), lessThanOrEqualTo(maxLength));
+    }
+
+    @Test
+    void shortenIdentifier_when_NoSuchAlgorithmException_then_return_shortened_result() {
+        final int maxLength = 5;
+        final String testInput = UUID.randomUUID().toString();
+        assertThat(testInput.length(), greaterThan(maxLength));
+
+        try (MockedStatic<MessageDigest> messageDigestMockedStatic = mockStatic(MessageDigest.class)) {
+            messageDigestMockedStatic.when(() -> MessageDigest.getInstance("SHA-256"))
+                    .thenThrow(new NoSuchAlgorithmException());
+            final String result = IdentifierShortener.shortenIdentifier(testInput, maxLength);
+            assertThat(result, equalTo(testInput.substring(0, maxLength)));
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Description
RDS startExportTask API requires S3 prefix fewer than 60 characters. The S3 prefix for export defined by pipeline is `user-defined_prefix/source_identifier/rds-export`. The source identifier along often exceed the limit. 

This PR shortens source identifier to 15 chars and change `rds-export` to just `rds`. This leaves about 40 chars for user defined prefix.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
