### PR TITLE
Fix a bug with event listener in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -146,6 +146,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
     public void stopClient() {
         try {
             binaryLogClient.disconnect();
+            binaryLogClient.unregisterEventListener(this);
             binlogEventExecutorService.shutdownNow();
             LOG.info("Binary log client disconnected.");
         } catch (Exception e) {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,6 +27,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,6 +36,7 @@ import java.util.concurrent.ThreadFactory;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -101,6 +104,16 @@ class BinlogEventListenerTest {
 
         verifyHandlerCallHelper();
         verify(objectUnderTest).handleTableMapEvent(binlogEvent);
+    }
+
+    @Test
+    void test_stopClient() throws IOException {
+        objectUnderTest.stopClient();
+
+        InOrder inOrder = inOrder(binaryLogClient, eventListnerExecutorService);
+        inOrder.verify(binaryLogClient).disconnect();
+        inOrder.verify(binaryLogClient).unregisterEventListener(objectUnderTest);
+        inOrder.verify(eventListnerExecutorService).shutdownNow();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
Fix a bug by deregistering event listener when binlog client is disconnected.

 
### Issues Resolved
When receiving negative acknowledgment, RDS source plugin will disconnect binlog client and reconnect with latest checkpoint. When reconnected, however, the client cannot process events any more with this error:

`java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@56c0293[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@33d53db2[Wrapped task = org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener$$Lambda$3144/0x000000080161d578@db0faf8]] rejected from java.util.concurrent.ThreadPoolExecutor@53e18682[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 12717915]`

This is because the old event listener is still registered and accepting events but its executor pool has been shutdown.

### Testing
Was able to reproduce the issue by setting ack always to negative and run an RDS source pipeline. Also verified the fix with the same setup.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
