### PR TITLE
Update rds template with new s3 sink client options

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
@@ -48,6 +48,9 @@
         codec:
           event_json:
         default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.rds.aws.sts_role_arn>>"
+        client:
+          max_connections: 100
+          acquire_timeout: 20s
 "<<pipeline-name>>-s3":
   workers: "<<$.<<pipeline-name>>.workers>>"
   delay: "<<$.<<pipeline-name>>.delay>>"


### PR DESCRIPTION
### Description
Update rds template with new s3 sink client options from #4959 . This is supposed to help resolve the error mentioned in #4949 in RDS source performance testing.

Default is 50 for `max_connections` and 10s for `acquire_timeout`. Doubling both here.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
