### PR TITLE
Add alternate name for Plugin

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -33,6 +33,8 @@ import java.lang.annotation.Target;
 public @interface DataPrepperPlugin {
     String DEFAULT_DEPRECATED_NAME = "";
 
+    String DEFAULT_ALTERNATE_NAME = "";
+
     /**
      *
      * @return Name of the plugin which should be unique for the type
@@ -45,6 +47,12 @@ public @interface DataPrepperPlugin {
      * @since 2.2
      */
     String deprecatedName() default DEFAULT_DEPRECATED_NAME;
+
+    /**
+     *
+     * @return Alternate name of the plugin which should be unique for the type
+     */
+    String alternateName() default DEFAULT_ALTERNATE_NAME;
 
     /**
      * The class type for this plugin.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -52,7 +52,7 @@ public @interface DataPrepperPlugin {
      *
      * @return Alternate name of the plugin which should be unique for the type
      */
-    String alternateName() default DEFAULT_ALTERNATE_NAME;
+    String[] alternateNames() default {};
 
     /**
      * The class type for this plugin.

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ClasspathPluginProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ClasspathPluginProvider.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_ALTERNATE_NAME;
 import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_DEPRECATED_NAME;
 
 /**
@@ -78,6 +79,7 @@ public class ClasspathPluginProvider implements PluginProvider {
             supportTypeToPluginTypeMap.put(supportedType, concretePluginClass);
 
             addOptionalDeprecatedPluginName(pluginsMap, concretePluginClass);
+            addOptionalAlternatePluginName(pluginsMap, concretePluginClass);
         }
 
         return pluginsMap;
@@ -93,6 +95,20 @@ public class ClasspathPluginProvider implements PluginProvider {
         if (!deprecatedPluginName.equals(DEFAULT_DEPRECATED_NAME)) {
             final Map<Class<?>, Class<?>> supportTypeToPluginTypeMap =
                     pluginsMap.computeIfAbsent(deprecatedPluginName, k -> new HashMap<>());
+            supportTypeToPluginTypeMap.put(supportedType, concretePluginClass);
+        }
+    }
+
+    private void addOptionalAlternatePluginName(
+            final Map<String, Map<Class<?>, Class<?>>> pluginsMap,
+            final Class<?> concretePluginClass) {
+        final DataPrepperPlugin dataPrepperPluginAnnotation = concretePluginClass.getAnnotation(DataPrepperPlugin.class);
+        final String alternatePluginName = dataPrepperPluginAnnotation.alternateName();
+        final Class<?> supportedType = dataPrepperPluginAnnotation.pluginType();
+
+        if (!alternatePluginName.equals(DEFAULT_ALTERNATE_NAME)) {
+            final Map<Class<?>, Class<?>> supportTypeToPluginTypeMap =
+                    pluginsMap.computeIfAbsent(alternatePluginName, k -> new HashMap<>());
             supportTypeToPluginTypeMap.put(supportedType, concretePluginClass);
         }
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ClasspathPluginProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ClasspathPluginProvider.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_ALTERNATE_NAME;
@@ -70,45 +72,34 @@ public class ClasspathPluginProvider implements PluginProvider {
 
         final Map<String, Map<Class<?>, Class<?>>> pluginsMap = new HashMap<>(dataPrepperPluginClasses.size());
         for (final Class<?> concretePluginClass : dataPrepperPluginClasses) {
-            final DataPrepperPlugin dataPrepperPluginAnnotation = concretePluginClass.getAnnotation(DataPrepperPlugin.class);
-            final String pluginName = dataPrepperPluginAnnotation.name();
-            final Class<?> supportedType = dataPrepperPluginAnnotation.pluginType();
-
-            final Map<Class<?>, Class<?>> supportTypeToPluginTypeMap =
-                    pluginsMap.computeIfAbsent(pluginName, k -> new HashMap<>());
-            supportTypeToPluginTypeMap.put(supportedType, concretePluginClass);
-
-            addOptionalDeprecatedPluginName(pluginsMap, concretePluginClass);
-            addOptionalAlternatePluginName(pluginsMap, concretePluginClass);
+            // plugin name
+            addPossiblePluginName(pluginsMap, concretePluginClass, DataPrepperPlugin::name, name -> true);
+            // deprecated plugin name
+            addPossiblePluginName(pluginsMap, concretePluginClass, DataPrepperPlugin::deprecatedName,
+                    deprecatedPluginName -> !deprecatedPluginName.equals(DEFAULT_DEPRECATED_NAME));
+            // alternate plugin names
+            for (final String alternateName: concretePluginClass.getAnnotation(DataPrepperPlugin.class).alternateNames()) {
+                addPossiblePluginName(pluginsMap, concretePluginClass, DataPrepperPlugin -> alternateName,
+                        alternatePluginName -> !alternatePluginName.equals(DEFAULT_ALTERNATE_NAME));
+            }
         }
 
         return pluginsMap;
     }
 
-    private void addOptionalDeprecatedPluginName(
+    private void addPossiblePluginName(
             final Map<String, Map<Class<?>, Class<?>>> pluginsMap,
-            final Class<?> concretePluginClass) {
+            final Class<?> concretePluginClass,
+            final Function<DataPrepperPlugin, String> possiblePluginNameFunction,
+            final Predicate<String> possiblePluginNamePredicate
+            ) {
         final DataPrepperPlugin dataPrepperPluginAnnotation = concretePluginClass.getAnnotation(DataPrepperPlugin.class);
-        final String deprecatedPluginName = dataPrepperPluginAnnotation.deprecatedName();
+        final String possiblePluginName = possiblePluginNameFunction.apply(dataPrepperPluginAnnotation);
         final Class<?> supportedType = dataPrepperPluginAnnotation.pluginType();
 
-        if (!deprecatedPluginName.equals(DEFAULT_DEPRECATED_NAME)) {
+        if (possiblePluginNamePredicate.test(possiblePluginName)) {
             final Map<Class<?>, Class<?>> supportTypeToPluginTypeMap =
-                    pluginsMap.computeIfAbsent(deprecatedPluginName, k -> new HashMap<>());
-            supportTypeToPluginTypeMap.put(supportedType, concretePluginClass);
-        }
-    }
-
-    private void addOptionalAlternatePluginName(
-            final Map<String, Map<Class<?>, Class<?>>> pluginsMap,
-            final Class<?> concretePluginClass) {
-        final DataPrepperPlugin dataPrepperPluginAnnotation = concretePluginClass.getAnnotation(DataPrepperPlugin.class);
-        final String alternatePluginName = dataPrepperPluginAnnotation.alternateName();
-        final Class<?> supportedType = dataPrepperPluginAnnotation.pluginType();
-
-        if (!alternatePluginName.equals(DEFAULT_ALTERNATE_NAME)) {
-            final Map<Class<?>, Class<?>> supportTypeToPluginTypeMap =
-                    pluginsMap.computeIfAbsent(alternatePluginName, k -> new HashMap<>());
+                    pluginsMap.computeIfAbsent(possiblePluginName, k -> new HashMap<>());
             supportTypeToPluginTypeMap.put(supportedType, concretePluginClass);
         }
     }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ClasspathPluginProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ClasspathPluginProviderTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_ALTERNATE_NAME;
 import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_DEPRECATED_NAME;
 
 class ClasspathPluginProviderTest {
@@ -100,6 +101,27 @@ class ClasspathPluginProviderTest {
                 .willReturn(new HashSet<>(List.of(TestSource.class)));
 
         final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest().findPluginClass(Source.class, "test_source_deprecated_name");
+        assertThat(optionalPlugin, notNullValue());
+        assertThat(optionalPlugin.isPresent(), equalTo(true));
+        assertThat(optionalPlugin.get(), equalTo(TestSource.class));
+    }
+
+    @Test
+    void findPlugin_should_return_empty_for_default_alternate_name() {
+        given(reflections.getTypesAnnotatedWith(DataPrepperPlugin.class))
+                .willReturn(new HashSet<>(List.of(TestSource.class)));
+
+        final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest().findPluginClass(Source.class, DEFAULT_ALTERNATE_NAME);
+        assertThat(optionalPlugin, notNullValue());
+        assertThat(optionalPlugin.isPresent(), equalTo(false));
+    }
+
+    @Test
+    void findPlugin_should_return_plugin_if_found_for_alternate_name_and_type_using_pluginType() {
+        given(reflections.getTypesAnnotatedWith(DataPrepperPlugin.class))
+                .willReturn(new HashSet<>(List.of(TestSource.class)));
+
+        final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest().findPluginClass(Source.class, "test_source_alternate_name");
         assertThat(optionalPlugin, notNullValue());
         assertThat(optionalPlugin.isPresent(), equalTo(true));
         assertThat(optionalPlugin.get(), equalTo(TestSource.class));

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ClasspathPluginProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ClasspathPluginProviderTest.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.plugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.model.source.Source;
@@ -28,7 +30,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
-import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_ALTERNATE_NAME;
 import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_DEPRECATED_NAME;
 
 class ClasspathPluginProviderTest {
@@ -111,17 +112,19 @@ class ClasspathPluginProviderTest {
         given(reflections.getTypesAnnotatedWith(DataPrepperPlugin.class))
                 .willReturn(new HashSet<>(List.of(TestSource.class)));
 
-        final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest().findPluginClass(Source.class, DEFAULT_ALTERNATE_NAME);
+        final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest()
+                .findPluginClass(Source.class, UUID.randomUUID().toString());
         assertThat(optionalPlugin, notNullValue());
         assertThat(optionalPlugin.isPresent(), equalTo(false));
     }
 
-    @Test
-    void findPlugin_should_return_plugin_if_found_for_alternate_name_and_type_using_pluginType() {
+    @ParameterizedTest
+    @ValueSource(strings = {"test_source_alternate_name1", "test_source_alternate_name2"})
+    void findPlugin_should_return_plugin_if_found_for_alternate_name_and_type_using_pluginType(final String alternateSourceName) {
         given(reflections.getTypesAnnotatedWith(DataPrepperPlugin.class))
                 .willReturn(new HashSet<>(List.of(TestSource.class)));
 
-        final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest().findPluginClass(Source.class, "test_source_alternate_name");
+        final Optional<Class<? extends Source>> optionalPlugin = createObjectUnderTest().findPluginClass(Source.class, alternateSourceName);
         assertThat(optionalPlugin, notNullValue());
         assertThat(optionalPlugin.isPresent(), equalTo(true));
         assertThat(optionalPlugin.get(), equalTo(TestSource.class));

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -401,4 +401,33 @@ class DefaultPluginFactoryTest {
             verify(beanFactoryProvider).get();
         }
     }
+
+    @Nested
+    class WithAlternatePluginName {
+        private static final String TEST_SINK_ALTERNATE_NAME = "test_sink_alternate_name";
+        private Class expectedPluginClass;
+
+        @BeforeEach
+        void setUp() {
+            expectedPluginClass = TestSink.class;
+            given(pluginSetting.getName()).willReturn(TEST_SINK_ALTERNATE_NAME);
+
+            given(firstPluginProvider.findPluginClass(baseClass, TEST_SINK_ALTERNATE_NAME))
+                    .willReturn(Optional.of(expectedPluginClass));
+        }
+
+        @Test
+        void loadPlugin_should_create_a_new_instance_of_the_first_plugin_found_with_correct_name_and_alternate_name() {
+            final TestSink expectedInstance = mock(TestSink.class);
+            final Object convertedConfiguration = mock(Object.class);
+            given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
+                    .willReturn(convertedConfiguration);
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(TEST_SINK_ALTERNATE_NAME)))
+                    .willReturn(expectedInstance);
+
+            assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
+            MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).alternateName(), equalTo(TEST_SINK_ALTERNATE_NAME));
+            verify(beanFactoryProvider).get();
+        }
+    }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -426,7 +426,7 @@ class DefaultPluginFactoryTest {
                     .willReturn(expectedInstance);
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
-            MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).alternateName(), equalTo(TEST_SINK_ALTERNATE_NAME));
+            MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).alternateNames(), equalTo(new String[]{TEST_SINK_ALTERNATE_NAME}));
             verify(beanFactoryProvider).get();
         }
     }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSink.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSink.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.time.Instant;
 
-@DataPrepperPlugin(name = "test_sink", alternateNames = { "test_sink_alternate_name" }, deprecatedName = "test_sink_deprecated_name", pluginType = Sink.class)
+@DataPrepperPlugin(name = "test_sink", alternateNames = "test_sink_alternate_name", deprecatedName = "test_sink_deprecated_name", pluginType = Sink.class)
 public class TestSink implements Sink<Record<String>> {
     public boolean isShutdown = false;
     private final List<Record<String>> collectedRecords;

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSink.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSink.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.time.Instant;
 
-@DataPrepperPlugin(name = "test_sink", alternateName = "test_sink_alternate_name", deprecatedName = "test_sink_deprecated_name", pluginType = Sink.class)
+@DataPrepperPlugin(name = "test_sink", alternateNames = { "test_sink_alternate_name" }, deprecatedName = "test_sink_deprecated_name", pluginType = Sink.class)
 public class TestSink implements Sink<Record<String>> {
     public boolean isShutdown = false;
     private final List<Record<String>> collectedRecords;

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSink.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSink.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.time.Instant;
 
-@DataPrepperPlugin(name = "test_sink", deprecatedName = "test_sink_deprecated_name", pluginType = Sink.class)
+@DataPrepperPlugin(name = "test_sink", alternateName = "test_sink_alternate_name", deprecatedName = "test_sink_deprecated_name", pluginType = Sink.class)
 public class TestSink implements Sink<Record<String>> {
     public boolean isShutdown = false;
     private final List<Record<String>> collectedRecords;

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSource.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSource.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@DataPrepperPlugin(name = "test_source", alternateName = "test_source_alternate_name", deprecatedName = "test_source_deprecated_name", pluginType = Source.class)
+@DataPrepperPlugin(name = "test_source", alternateNames = { "test_source_alternate_name1", "test_source_alternate_name2" }, deprecatedName = "test_source_deprecated_name", pluginType = Source.class)
 public class TestSource implements Source<Record<String>> {
     public static final List<Record<String>> TEST_DATA = Stream.of("TEST")
             .map(Record::new).collect(Collectors.toList());

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSource.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestSource.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@DataPrepperPlugin(name = "test_source", deprecatedName = "test_source_deprecated_name", pluginType = Source.class)
+@DataPrepperPlugin(name = "test_source", alternateName = "test_source_alternate_name", deprecatedName = "test_source_deprecated_name", pluginType = Source.class)
 public class TestSource implements Source<Record<String>> {
     public static final List<Record<String>> TEST_DATA = Stream.of("TEST")
             .map(Record::new).collect(Collectors.toList());


### PR DESCRIPTION
### Description
Add alternate name for Plugin
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
