### PR TITLE
Replace deprecated archivePath

### DIFF
--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -52,7 +52,7 @@ subprojects {
     tasks.register('copyDataPrepperArchive', Copy) {
         dependsOn ':release:archives:linux:linuxx64DistTar'
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        from project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archivePath
+        from project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFile.get().asFile
         into("${project.buildDir}/docker/")
     }
 

--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -147,7 +147,7 @@ CopySpec archiveToTar() {
     return copySpec {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         into('lib') {
-            from project(':data-prepper-main').jar.archivePath
+            from project(':data-prepper-main').jar.archiveFile.get().asFile
             from configurations.runtimeClasspath
             //from allDependencyJarsFromMain(project(path: ':data-prepper-main', configuration: 'allDependencyJars')).runtimeClasspath
             //from project(':data-prepper-main').configurations.allDependencyJars

--- a/release/docker/build.gradle
+++ b/release/docker/build.gradle
@@ -10,7 +10,7 @@ plugins {
 docker {
     name "${project.rootProject.name}:${project.version}"
     tag "${project.rootProject.name}", "${project.version}"
-    files project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archivePath
+    files project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFile.get().asFile
     files "${project.projectDir}/config/default-data-prepper-config.yaml", "${project.projectDir}/config/default-keystore.p12"
     files 'adoptium.repo'
     buildArgs(['ARCHIVE_FILE' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get(),


### PR DESCRIPTION
### Description

Fix deprecation warning

```
The AbstractArchiveTask.archivePath property has been deprecated. This is
scheduled to be removed in Gradle 9.0. Please use the archiveFile property
instead. For more information, please refer to
https://docs.gradle.org/8.8/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archivePath
in the Gradle documentation.
```

`.archivePath` has been deprecated and will be removed in Gradle 9.0. Use `.archiveFile.get().asFile` instead.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged] - **did not find a related issue**, consider this to be a minor improvement
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
