### PR TITLE
Adding ttl_delete parameter to metadata for DynamoDB

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
@@ -21,4 +21,5 @@ public class MetadataKeyAttributes {
     static final String DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE = "dynamodb_event_name";
 
     static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
+    static final String DDB_STREAM_EVENT_USER_IDENTITY = "ttl_delete";
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
@@ -21,5 +21,5 @@ public class MetadataKeyAttributes {
     static final String DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE = "dynamodb_event_name";
 
     static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
-    static final String DDB_STREAM_EVENT_USER_IDENTITY = "ttl_delete";
+    static final String DDB_STREAM_EVENT_IS_TTL_DELETE = "ttl_delete";
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -13,6 +13,8 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
+import software.amazon.awssdk.services.dynamodb.model.Identity;
+import software.amazon.awssdk.services.dynamodb.model.OperationType;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -26,7 +28,7 @@ import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.Metad
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.SORT_KEY_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_USER_IDENTITY;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_IS_TTL_DELETE;
 
 /**
  * Base Record Processor definition.
@@ -40,6 +42,8 @@ public abstract class RecordConverter {
     private final BufferAccumulator<Record<Event>> bufferAccumulator;
 
     private final TableInfo tableInfo;
+    static final String TTL_USER_PRINCIPAL = "dynamodb.amazonaws.com";
+    static final String TTL_USER_TYPE = "Service";
 
     public RecordConverter(final BufferAccumulator<Record<Event>> bufferAccumulator, TableInfo tableInfo) {
         this.bufferAccumulator = bufferAccumulator;
@@ -86,7 +90,7 @@ public abstract class RecordConverter {
                             final long eventCreationTimeMillis,
                             final long eventVersionNumber,
                             final String eventName,
-                            final Boolean userIdentity) throws Exception {
+                            final Identity userIdentity) throws Exception {
         Event event = JacksonEvent.builder()
                 .withEventType(getEventType())
                 .withData(data)
@@ -98,6 +102,7 @@ public abstract class RecordConverter {
             event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
             event.getMetadata().setExternalOriginationTime(externalOriginationTime);
         }
+
         EventMetadata eventMetadata = event.getMetadata();
 
         eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableInfo.getTableName());
@@ -105,7 +110,13 @@ public abstract class RecordConverter {
         eventMetadata.setAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE, eventName);
         eventMetadata.setAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, mapStreamEventNameToBulkAction(eventName));
         eventMetadata.setAttribute(EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
-        eventMetadata.setAttribute(DDB_STREAM_EVENT_USER_IDENTITY, userIdentity);
+
+        // Only set ttl_delete for stream events, which are of type REMOVE containing a userIdentity
+        final boolean isTtlDelete = OperationType.REMOVE.toString().equals(eventName) &&
+                userIdentity != null &&
+                TTL_USER_PRINCIPAL.equals(userIdentity.principalId()) &&
+                TTL_USER_TYPE.equals(userIdentity.type());
+        eventMetadata.setAttribute(DDB_STREAM_EVENT_IS_TTL_DELETE, isTtlDelete);
 
         String partitionKey = getAttributeValue(keys, tableInfo.getMetadata().getPartitionKeyAttributeName());
         eventMetadata.setAttribute(PARTITION_KEY_METADATA_ATTRIBUTE, partitionKey);
@@ -127,7 +138,7 @@ public abstract class RecordConverter {
                             final Map<String, Object> data,
                             final long timestamp,
                             final long eventVersionNumber) throws Exception {
-        addToBuffer(acknowledgementSet, data, data, timestamp, eventVersionNumber, null, Boolean.FALSE);
+        addToBuffer(acknowledgementSet, data, data, timestamp, eventVersionNumber, null, null);
     }
 
     private String mapStreamEventNameToBulkAction(final String streamEventName) {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -26,6 +26,7 @@ import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.Metad
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.SORT_KEY_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_USER_IDENTITY;
 
 /**
  * Base Record Processor definition.
@@ -76,6 +77,7 @@ public abstract class RecordConverter {
      * @param keys                    A map to hold the keys (partition key and sort key)
      * @param eventCreationTimeMillis Creation timestamp of the event
      * @param eventName               Event name
+     * @param userIdentity            UserIdentity for TTL based deletes
      * @throws Exception Exception if failed to write to buffer.
      */
     public void addToBuffer(final AcknowledgementSet acknowledgementSet,
@@ -83,7 +85,8 @@ public abstract class RecordConverter {
                             final Map<String, Object> keys,
                             final long eventCreationTimeMillis,
                             final long eventVersionNumber,
-                            final String eventName) throws Exception {
+                            final String eventName,
+                            final Boolean userIdentity) throws Exception {
         Event event = JacksonEvent.builder()
                 .withEventType(getEventType())
                 .withData(data)
@@ -102,6 +105,7 @@ public abstract class RecordConverter {
         eventMetadata.setAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE, eventName);
         eventMetadata.setAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, mapStreamEventNameToBulkAction(eventName));
         eventMetadata.setAttribute(EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
+        eventMetadata.setAttribute(DDB_STREAM_EVENT_USER_IDENTITY, userIdentity);
 
         String partitionKey = getAttributeValue(keys, tableInfo.getMetadata().getPartitionKeyAttributeName());
         eventMetadata.setAttribute(PARTITION_KEY_METADATA_ATTRIBUTE, partitionKey);
@@ -123,7 +127,7 @@ public abstract class RecordConverter {
                             final Map<String, Object> data,
                             final long timestamp,
                             final long eventVersionNumber) throws Exception {
-        addToBuffer(acknowledgementSet, data, data, timestamp, eventVersionNumber, null);
+        addToBuffer(acknowledgementSet, data, data, timestamp, eventVersionNumber, null, Boolean.FALSE);
     }
 
     private String mapStreamEventNameToBulkAction(final String streamEventName) {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -80,7 +80,6 @@ public class StreamRecordConverter extends RecordConverter {
         int eventCount = 0;
         for (Record record : records) {
             final long bytes = record.dynamodb().sizeBytes();
-            final Boolean userIdentity = record.userIdentity() != null && "dynamodb.amazonaws.com".equals(record.userIdentity().principalId());
             Map<String, Object> data;
             Map<String, Object> keys;
             try {
@@ -99,7 +98,7 @@ public class StreamRecordConverter extends RecordConverter {
             try {
                 bytesReceivedSummary.record(bytes);
                 final long eventCreationTimeMillis = calculateTieBreakingVersionFromTimestamp(record.dynamodb().approximateCreationDateTime());
-                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), eventCreationTimeMillis, record.eventNameAsString(), userIdentity);
+                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), eventCreationTimeMillis, record.eventNameAsString(), record.userIdentity());
                 bytesProcessedSummary.record(bytes);
                 eventCount++;
             } catch (Exception e) {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -80,6 +80,7 @@ public class StreamRecordConverter extends RecordConverter {
         int eventCount = 0;
         for (Record record : records) {
             final long bytes = record.dynamodb().sizeBytes();
+            final Boolean userIdentity = record.userIdentity() != null && "dynamodb.amazonaws.com".equals(record.userIdentity().principalId());
             Map<String, Object> data;
             Map<String, Object> keys;
             try {
@@ -98,7 +99,7 @@ public class StreamRecordConverter extends RecordConverter {
             try {
                 bytesReceivedSummary.record(bytes);
                 final long eventCreationTimeMillis = calculateTieBreakingVersionFromTimestamp(record.dynamodb().approximateCreationDateTime());
-                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), eventCreationTimeMillis, record.eventNameAsString());
+                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), eventCreationTimeMillis, record.eventNameAsString(), userIdentity);
                 bytesProcessedSummary.record(bytes);
                 eventCount++;
             } catch (Exception e) {

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -28,6 +28,8 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.OperationType;
 import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
 import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
+import software.amazon.awssdk.services.dynamodb.model.Identity;
+
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -57,6 +59,7 @@ import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.Metad
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.SORT_KEY_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_USER_IDENTITY;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.StreamRecordConverter.BYTES_PROCESSED;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.StreamRecordConverter.BYTES_RECEIVED;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.StreamRecordConverter.CHANGE_EVENTS_PROCESSED_COUNT;
@@ -211,6 +214,7 @@ class StreamRecordConverterTest {
         assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
         assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo("INSERT"));
         assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(record.dynamodb().approximateCreationDateTime().toEpochMilli()));
+        assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_USER_IDENTITY), equalTo(Boolean.FALSE));
 
         assertThat(event.get(partitionKeyAttrName, String.class), notNullValue());
         assertThat(event.get(sortKeyAttrName, String.class), notNullValue());
@@ -355,7 +359,7 @@ class StreamRecordConverterTest {
 
         final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
         final Map<String, AttributeValue> oldImage = Map.of(oldImageKey, AttributeValue.builder().s(oldImageValue).build());
-        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, oldImage, OperationType.REMOVE));
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, oldImage, OperationType.REMOVE, null));
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
         final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
@@ -397,7 +401,7 @@ class StreamRecordConverterTest {
         final String newImageValue = UUID.randomUUID().toString();
 
         final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
-        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, null, OperationType.REMOVE));
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, null, OperationType.REMOVE, null));
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
         final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
@@ -442,7 +446,7 @@ class StreamRecordConverterTest {
 
         final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
         final Map<String, AttributeValue> oldImage = Map.of(oldImageKey, AttributeValue.builder().s(oldImageValue).build());
-        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, oldImage, OperationType.REMOVE));
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, oldImage, OperationType.REMOVE, null));
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
         final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
@@ -476,6 +480,39 @@ class StreamRecordConverterTest {
         verify(bytesProcessedSummary).record(record.dynamodb().sizeBytes());
     }
 
+    @Test
+    void test_writeSingleRecordToBuffer_with_userIdentity() throws Exception {
+
+        when(streamConfig.getStreamViewForRemoves()).thenReturn(StreamViewType.OLD_IMAGE);
+
+        final Identity userIdentity = Identity.builder()
+                .principalId("dynamodb.amazonaws.com")
+                .type("Service")
+                .build();
+
+        final String newImageKey = UUID.randomUUID().toString();
+        final String newImageValue = UUID.randomUUID().toString();
+
+        final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, null, OperationType.REMOVE, userIdentity));
+        final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
+        doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
+
+        objectUnderTest.writeToBuffer(null, records);
+
+        verify(bufferAccumulator).add(any(Record.class));
+        verify(bufferAccumulator).flush();
+        verify(changeEventSuccessCounter).increment(anyDouble());
+        assertThat(recordArgumentCaptor.getValue().getData(), notNullValue());
+        JacksonEvent event = (JacksonEvent) recordArgumentCaptor.getValue().getData();
+
+        assertThat(event.getMetadata(), notNullValue());
+        assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_USER_IDENTITY), equalTo(Boolean.TRUE));
+
+    }
+
     private List<software.amazon.awssdk.services.dynamodb.model.Record> buildRecords(int count, final Instant creationTime) {
         return buildRecords(count, creationTime, Collections.emptyMap());
     }
@@ -486,20 +523,34 @@ class StreamRecordConverterTest {
             final Map<String, AttributeValue> additionalData) {
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            records.add(buildRecord(creationTime, additionalData, null, OperationType.INSERT));
+            records.add(buildRecord(creationTime, additionalData, null, OperationType.INSERT, null));
+        }
+
+        return records;
+    }
+
+    private List<software.amazon.awssdk.services.dynamodb.model.Record> buildRecords(
+            int count,
+            final Instant creationTime,
+            final Map<String, AttributeValue> additionalData,
+            final Identity userIdentity) {
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            records.add(buildRecord(creationTime, additionalData, null, OperationType.INSERT, userIdentity));
         }
 
         return records;
     }
 
     private software.amazon.awssdk.services.dynamodb.model.Record buildRecord(final Instant creationTime) {
-        return buildRecord(creationTime, Collections.emptyMap(), null, OperationType.INSERT);
+        return buildRecord(creationTime, Collections.emptyMap(), null, OperationType.INSERT, null);
     }
 
     private software.amazon.awssdk.services.dynamodb.model.Record buildRecord(final Instant creationTime,
                                                                               Map<String, AttributeValue> additionalData,
                                                                               Map<String, AttributeValue> oldImage,
-                                                                              final OperationType operationType) {
+                                                                              final OperationType operationType,
+                                                                              final Identity userIdentity) {
         Map<String, AttributeValue> keysData = Map.of(
                 partitionKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build(),
                 sortKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build());
@@ -526,6 +577,7 @@ class StreamRecordConverterTest {
         software.amazon.awssdk.services.dynamodb.model.Record record = software.amazon.awssdk.services.dynamodb.model.Record.builder()
                 .dynamodb(streamRecord)
                 .eventName(operationType)
+                .userIdentity(userIdentity)
                 .build();
         return record;
     }


### PR DESCRIPTION
### Description
This change allows users to identify the source of a REMOVE event from DynamoDB streams,  if it was a manual delete or a TTL delete.
 
### Issues Resolved
Resolves #4560 
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
 - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
