### PR TITLE
Updates JsonPropertyDescription annotations to use HTML

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -52,7 +52,7 @@ public class AggregateProcessorConfig {
     @JsonProperty("aggregated_events_tag")
     private String aggregatedEventsTag;
 
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
     @JsonProperty("aggregate_when")
     private String whenCondition;
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/TailSamplerAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/TailSamplerAggregateActionConfig.java
@@ -18,12 +18,12 @@ public class TailSamplerAggregateActionConfig {
     @NotNull
     private Duration waitPeriod;
     
-    @JsonPropertyDescription("Percent value to use for sampling non error events. 0.0 < percent < 100.0")
+    @JsonPropertyDescription("Percent value to use for sampling non error events. 0.0 &lt; percent &lt; 100.0")
     @JsonProperty("percent")
     @NotNull
     private Integer percent;
     
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the event is an error event or not")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the event is an error event or not")
     @JsonProperty("condition")
     private String condition;
 

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
@@ -45,7 +45,7 @@ public class StringProcessor implements Processor<Record<Event>, Record<Event>> 
     @JsonPropertyOrder
     @JsonClassDescription("The `string_converter` processor converts a string to uppercase or lowercase.")
     public static class Configuration {
-        @JsonPropertyDescription("Whether to convert to uppercase (`true`) or lowercase (`false`).")
+        @JsonPropertyDescription("Whether to convert to uppercase (<code>true</code>) or lowercase (<code>false</code>).")
         private boolean upperCase = true;
 
         public boolean getUpperCase() {

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -21,44 +21,44 @@ public class CsvProcessorConfig {
     static final Boolean DEFAULT_DELETE_HEADERS = true;
 
     @JsonProperty("source")
-    @JsonPropertyDescription("The field in the event that will be parsed. Default value is `message`.")
+    @JsonPropertyDescription("The field in the event that will be parsed. Default value is <code>message</code>.")
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("delimiter")
-    @JsonPropertyDescription("The character separating each column. Default value is `,`.")
+    @JsonPropertyDescription("The character separating each column. Default value is <code>,</code>.")
     private String delimiter = DEFAULT_DELIMITER;
 
     @JsonProperty("delete_header")
-    @JsonPropertyDescription("If specified, the event header (`column_names_source_key`) is deleted after the event " +
+    @JsonPropertyDescription("If specified, the event header (<code>column_names_source_key</code>) is deleted after the event " +
             "is parsed. If there is no event header, no action is taken. Default value is true.")
     private Boolean deleteHeader = DEFAULT_DELETE_HEADERS;
 
     @JsonProperty("quote_character")
     @JsonPropertyDescription("The character used as a text qualifier for a single column of data. " +
-            "Default value is `\"`.")
+            "Default value is <code>\"</code>.")
     private String quoteCharacter = DEFAULT_QUOTE_CHARACTER;
 
     @JsonProperty("column_names_source_key")
     @JsonPropertyDescription("The field in the event that specifies the CSV column names, which will be " +
             "automatically detected. If there need to be extra column names, the column names are automatically " +
-            "generated according to their index. If `column_names` is also defined, the header in " +
-            "`column_names_source_key` can also be used to generate the event fields. " +
+            "generated according to their index. If <code>column_names</code> is also defined, the header in " +
+            "<code>column_names_source_key</code> can also be used to generate the event fields. " +
             "If too few columns are specified in this field, the remaining column names are automatically generated. " +
             "If too many column names are specified in this field, the CSV processor omits the extra column names.")
     private String columnNamesSourceKey;
 
     @JsonProperty("column_names")
     @JsonPropertyDescription("User-specified names for the CSV columns. " +
-            "Default value is `[column1, column2, ..., columnN]` if there are no columns of data in the CSV " +
-            "record and `column_names_source_key` is not defined. If `column_names_source_key` is defined, " +
-            "the header in `column_names_source_key` generates the event fields. If too few columns are specified " +
+            "Default value is <code>[column1, column2, ..., columnN]</code> if there are no columns of data in the CSV " +
+            "record and <code>column_names_source_key</code> is not defined. If <code>column_names_source_key</code> is defined, " +
+            "the header in <code>column_names_source_key</code> generates the event fields. If too few columns are specified " +
             "in this field, the remaining column names are automatically generated. " +
             "If too many column names are specified in this field, the CSV processor omits the extra column names.")
     private List<String> columnNames;
 
     @JsonProperty("csv_when")
-    @JsonPropertyDescription("Allows you to specify a Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-            "such as `/some-key == \"test\"`, that will be evaluated to determine whether " +
+    @JsonPropertyDescription("Allows you to specify a Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether " +
             "the processor should be applied to the event.")
     private String csvWhen;
 

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -32,13 +32,13 @@ public class DateProcessorConfig {
     public static class DateMatch {
         @JsonProperty("key")
         @JsonPropertyDescription("Represents the event key against which to match patterns. " +
-                "Required if `match` is configured. ")
+                "Required if <code>match</code> is configured.")
         private String key;
         @JsonProperty("patterns")
         @JsonPropertyDescription("A list of possible patterns that the timestamp value of the key can have. The patterns " +
-                "are based on a sequence of letters and symbols. The `patterns` support all the patterns listed in the " +
+                "are based on a sequence of letters and symbols. The <code>patterns</code> support all the patterns listed in the " +
                 "Java DateTimeFormatter (https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) reference. " +
-                "The timestamp value also supports `epoch_second`, `epoch_milli`, and `epoch_nano` values, " +
+                "The timestamp value also supports <code>epoch_second</code>, <code>epoch_milli</code>, and <code>epoch_nano</code> values, " +
                 "which represent the timestamp as the number of seconds, milliseconds, and nanoseconds since the epoch. " +
                 "Epoch values always use the UTC time zone.")
         private List<String> patterns;
@@ -98,29 +98,29 @@ public class DateProcessorConfig {
     }
 
     @JsonProperty("from_time_received")
-    @JsonPropertyDescription("When `true`, the timestamp from the event metadata, " +
+    @JsonPropertyDescription("When <code>true</code>, the timestamp from the event metadata, " +
             "which is the time at which the source receives the event, is added to the event data. " +
-            "This option cannot be defined at the same time as `match`. Default is `false`.")
+            "This option cannot be defined at the same time as <code>match</code>. Default is <code>false</code>.")
     private Boolean fromTimeReceived = DEFAULT_FROM_TIME_RECEIVED;
 
     @JsonProperty("to_origination_metadata")
-    @JsonPropertyDescription("When `true`, the matched time is also added to the event's metadata as an instance of " +
-            "`Instant`. Default is `false`.")
+    @JsonPropertyDescription("When <code>true</code>, the matched time is also added to the event's metadata as an instance of " +
+            "<code>Instant</code>. Default is <code>false</code>.")
     private Boolean toOriginationMetadata = DEFAULT_TO_ORIGINATION_METADATA;
 
     @JsonProperty("match")
     @JsonPropertyDescription("The date match configuration. " +
-            "This option cannot be defined at the same time as `from_time_received`. There is no default value.")
+            "This option cannot be defined at the same time as <code>from_time_received</code>. There is no default value.")
     private List<DateMatch> match;
 
     @JsonProperty("destination")
     @JsonPropertyDescription("The field used to store the timestamp parsed by the date processor. " +
-            "Can be used with both `match` and `from_time_received`. Default is `@timestamp`.")
+            "Can be used with both <code>match</code> and <code>from_time_received</code>. Default is <code>@timestamp</code>.")
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty("output_format")
     @JsonPropertyDescription("Determines the format of the timestamp added to an event. " +
-            "Default is `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`.")
+            "Default is <code>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</code>.")
     private String outputFormat = DEFAULT_OUTPUT_FORMAT;
 
     @JsonProperty("source_timezone")
@@ -131,23 +131,23 @@ public class DateProcessorConfig {
     private String sourceTimezone = DEFAULT_SOURCE_TIMEZONE;
 
     @JsonProperty("destination_timezone")
-    @JsonPropertyDescription("The time zone used for storing the timestamp in the `destination` field. " +
+    @JsonPropertyDescription("The time zone used for storing the timestamp in the <code>destination</code> field. " +
             "A list of all the available time zones is contained in the TZ database name column of " +
             "(https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).")
     private String destinationTimezone = DEFAULT_DESTINATION_TIMEZONE;
 
     @JsonProperty("locale")
-    @JsonPropertyDescription("The location used for parsing dates. Commonly used for parsing month names (`MMM`). " +
-            "The value can contain language, country, or variant fields in IETF BCP 47, such as `en-US`, " +
+    @JsonPropertyDescription("The location used for parsing dates. Commonly used for parsing month names (<code>MMM</code>). " +
+            "The value can contain language, country, or variant fields in IETF BCP 47, such as <code>en-US</code>, " +
             "or a string representation of the " +
-            "locale (https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) object, such as `en_US`. " +
+            "locale (https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) object, such as <code>en_US</code>. " +
             "A full list of locale fields, including language, country, and variant, can be found in " +
             "(https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry). " +
-            "Default is `Locale.ROOT`.")
+            "Default is <code>Locale.ROOT</code>.")
     private String locale;
 
     @JsonProperty("date_when")
-    @JsonPropertyDescription("Specifies under what condition the `date` processor should perform matching. " +
+    @JsonPropertyDescription("Specifies under what condition the <code>date</code> processor should perform matching. " +
             "Default is no condition.")
     private String dateWhen;
 

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -16,17 +16,17 @@ import java.util.Map;
 public class DissectProcessorConfig {
     @NotNull
     @JsonProperty("map")
-    @JsonPropertyDescription("Defines the `dissect` patterns for specific keys. For details on how to define fields " +
-            "in the `dissect` pattern, see (https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations).")
+    @JsonPropertyDescription("Defines the <code>dissect</code> patterns for specific keys. For details on how to define fields " +
+            "in the <code>dissect</code> pattern, see (https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations).")
     private Map<String, String> map;
     @JsonProperty("target_types")
-    @JsonPropertyDescription("Specifies the data types for extract fields. Valid options are `integer`, " +
-            "`double`, `string`, `long`, `big_decimal`, and `boolean`. By default, all fields are of the `string` type.")
+    @JsonPropertyDescription("Specifies the data types for extract fields. Valid options are <code>integer</code>, " +
+            "<code>double</code>, <code>string</code>, <code>long</code>, <code>big_decimal</code>, and <code>boolean</code>. By default, all fields are of the <code>string</code> type.")
     private Map<String, TargetType> targetTypes;
     @JsonProperty("dissect_when")
-    @JsonPropertyDescription("Specifies a condition for performing the `dissect` operation using a Data Prepper [conditional expression]" +
-            "(https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/). " +
-            "If specified, the `dissect` operation will only run when the expression evaluates to true.")
+    @JsonPropertyDescription("Specifies a condition for performing the <code>dissect</code> operation using a " +
+            "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Data Prepper Expression Syntax</a>. " +
+            "If specified, the <code>dissect</code> operation will only run when the expression evaluates to true.")
     private String dissectWhen;
 
     public String getDissectWhen(){

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
@@ -16,7 +16,7 @@ import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 @JsonClassDescription("The `drop_events` processor drops all the events that are passed into it.")
 public class DropEventProcessorConfig {
 
-    @JsonPropertyDescription("Accepts a Data Prepper conditional expression string following the [Data Prepper Expression Syntax](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/). Configuring drop_events with drop_when: true drops all the events received.")
+    @JsonPropertyDescription("Accepts a Data Prepper conditional expression string following the <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Data Prepper Expression Syntax</a>. Configuring drop_events with drop_when: true drops all the events received.")
     @JsonProperty("drop_when")
     @NotEmpty
     private String dropWhen;

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -24,39 +24,39 @@ public class FlattenProcessorConfig {
 
     @NotNull
     @JsonProperty("source")
-    @JsonPropertyDescription("The source key on which to perform the operation. If set to an empty string (`\"\"`), " +
+    @JsonPropertyDescription("The source key on which to perform the operation. If set to an empty string (<code>\"\"</code>), " +
             "then the processor uses the root of the event as the source.")
     private String source;
 
     @NotNull
     @JsonProperty("target")
-    @JsonPropertyDescription("The target key to put into the flattened fields. If set to an empty string (`\"\"`), " +
+    @JsonPropertyDescription("The target key to put into the flattened fields. If set to an empty string (<code>\"\"</code>) " +
             "then the processor uses the root of the event as the target.")
     private String target;
 
     @JsonProperty("remove_processed_fields")
-    @JsonPropertyDescription("When `true`, the processor removes all processed fields from the source. Default is `false`.")
+    @JsonPropertyDescription("When <code>true</code>, the processor removes all processed fields from the source. Default is <code>false</code>.")
     private boolean removeProcessedFields = false;
 
     @JsonProperty("remove_list_indices")
-    @JsonPropertyDescription("When `true`, the processor converts the fields from the source map into lists and " +
-            "puts the lists into the target field. Default is `false`.")
+    @JsonPropertyDescription("When <code>true</code>, the processor converts the fields from the source map into lists and " +
+            "puts the lists into the target field. Default is <code>false</code>.")
     private boolean removeListIndices = false;
 
     @JsonProperty("remove_brackets")
-    @JsonPropertyDescription("When `true`, the processor also removes brackets around the indices. Can only be " +
-            "set to `true` when `remove_list_indices` is `true`.")
+    @JsonPropertyDescription("When <code>true</code>, the processor also removes brackets around the indices. Can only be " +
+            "set to <code>true</code> when <code>remove_list_indices</code> is <code>true</code>.")
     private boolean removeBrackets = false;
 
     @JsonProperty("exclude_keys")
     @JsonPropertyDescription("The keys from the source field that should be excluded from processing. " +
-            "Default is an empty list (`[]`).")
+            "Default is an empty list (<code>[]</code>).")
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonProperty("flatten_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-            "such as `/some-key == \"test\"'`, that determines whether the `flatten` processor will be run on the " +
-            "event. Default is `null`, which means that all events will be processed unless otherwise stated.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"'</code>, that determines whether the <code>flatten</code> processor will be run on the " +
+            "event. Default is <code>null</code>, which means that all events will be processed unless otherwise stated.")
     private String flattenWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -43,9 +43,9 @@ public class GeoIPProcessorConfig {
     private List<String> tagsOnNoValidIp;
 
     @JsonProperty("geoip_when")
-    @JsonPropertyDescription("Specifies a condition for including Events in the `geoip` processor using a Data Prepper [conditional expression]" +
+    @JsonPropertyDescription("Specifies a condition for including Events in the <code>geoip</code> processor using a Data Prepper [conditional expression]" +
             "(https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/)." +
-            " If specified, the `geoip` processor will only run when the expression evaluates to true.")
+            " If specified, the <code>geoip</code> processor will only run when the expression evaluates to true.")
     private String whenCondition;
 
     /**

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -47,28 +47,28 @@ public class GrokProcessorConfig {
     static final String DEFAULT_TARGET_KEY = null;
 
     @JsonProperty(BREAK_ON_MATCH)
-    @JsonPropertyDescription("Specifies whether to match all patterns (`false`) or stop once the first successful " +
-            "match is found (`true`). Default is `true`.")
+    @JsonPropertyDescription("Specifies whether to match all patterns (<code>false</code>) or stop once the first successful " +
+            "match is found (<code>true</code>). Default is <code>true</code>.")
     private boolean breakOnMatch = DEFAULT_BREAK_ON_MATCH;
     @JsonProperty(KEEP_EMPTY_CAPTURES)
-    @JsonPropertyDescription("Enables the preservation of `null` captures from the processed output. Default is `false`.")
+    @JsonPropertyDescription("Enables the preservation of <code>null</code> captures from the processed output. Default is <code>false</code>.")
     private boolean keepEmptyCaptures = DEFAULT_KEEP_EMPTY_CAPTURES;
     @JsonProperty(MATCH)
     @JsonPropertyDescription("Specifies which keys should match specific patterns. Default is an empty response body.")
     private Map<String, List<String>> match = Collections.emptyMap();
     @JsonProperty(NAMED_CAPTURES_ONLY)
-    @JsonPropertyDescription("Specifies whether to keep only named captures. Default is `true`.")
+    @JsonPropertyDescription("Specifies whether to keep only named captures. Default is <code>true</code>.")
     private boolean namedCapturesOnly = DEFAULT_NAMED_CAPTURES_ONLY;
     @JsonProperty(KEYS_TO_OVERWRITE)
     @JsonPropertyDescription("Specifies which existing keys will be overwritten if there is a capture with the same key value. " +
-            "Default is `[]`.")
+            "Default is <code>[]</code>.")
     private List<String> keysToOverwrite = Collections.emptyList();
     @JsonProperty(PATTERNS_DIRECTORIES)
     @JsonPropertyDescription("Specifies which directory paths contain the custom pattern files. Default is an empty list.")
     private List<String> patternsDirectories = Collections.emptyList();
     @JsonProperty(PATTERNS_FILES_GLOB)
     @JsonPropertyDescription("Specifies which pattern files to use from the directories specified for " +
-            "`pattern_directories`. Default is `*`.")
+            "<code>pattern_directories</code>. Default is <code>*</code>.")
     private String patternsFilesGlob = DEFAULT_PATTERNS_FILES_GLOB;
     @JsonProperty(PATTERN_DEFINITIONS)
     @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
@@ -76,25 +76,25 @@ public class GrokProcessorConfig {
     private Map<String, String> patternDefinitions = Collections.emptyMap();
     @JsonProperty(TIMEOUT_MILLIS)
     @JsonPropertyDescription("The maximum amount of time during which matching occurs. " +
-            "Setting to `0` prevents any matching from occurring. Default is `30,000`.")
+            "Setting to <code>0</code> prevents any matching from occurring. Default is <code>30,000</code>.")
     private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
     @JsonProperty(TARGET_KEY)
-    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is `null`.")
+    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code>.")
     private String targetKey = DEFAULT_TARGET_KEY;
     @JsonProperty(GROK_WHEN)
-    @JsonPropertyDescription("Specifies under what condition the `grok` processor should perform matching. " +
+    @JsonPropertyDescription("Specifies under what condition the <code>grok</code> processor should perform matching. " +
             "Default is no condition.")
     private String grokWhen;
     @JsonProperty(TAGS_ON_MATCH_FAILURE)
-    @JsonPropertyDescription("A `List` of `String`s that specifies the tags to be set in the event when grok fails to " +
+    @JsonPropertyDescription("A <code>List</code> of <code>String</code>s that specifies the tags to be set in the event when grok fails to " +
             "match or an unknown exception occurs while matching. This tag may be used in conditional expressions in " +
             "other parts of the configuration")
     private List<String> tagsOnMatchFailure = Collections.emptyList();
     @JsonProperty(TAGS_ON_TIMEOUT)
-    @JsonPropertyDescription("A `List` of `String`s that specifies the tags to be set in the event when grok match times out.")
+    @JsonPropertyDescription("A <code>List</code> of <code>String</code>s that specifies the tags to be set in the event when grok match times out.")
     private List<String> tagsOnTimeout = Collections.emptyList();
     @JsonProperty(INCLUDE_PERFORMANCE_METADATA)
-    @JsonPropertyDescription("A `Boolean` on whether to include performance metadata into event metadata, " +
+    @JsonPropertyDescription("A <code>Boolean</code> on whether to include performance metadata into event metadata, " +
             "e.g. _total_grok_patterns_attempted, _total_grok_processing_time.")
     private boolean includePerformanceMetadata = false;
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -40,25 +40,25 @@ public class KeyValueProcessorConfig {
     static final boolean DEFAULT_RECURSIVE = false;
 
     @NotEmpty
-    @JsonPropertyDescription("The message field to be parsed. Optional. Default value is `message`.")
+    @JsonPropertyDescription("The message field to be parsed. Optional. Default value is <code>message</code>.")
     private String source = DEFAULT_SOURCE;
 
     @JsonPropertyDescription("The destination field for the parsed source. The parsed source overwrites the " +
-            "preexisting data for that key. Optional. If `destination` is set to `null`, the parsed fields will be " +
-            "written to the root of the event. Default value is `parsed_message`.")
+            "preexisting data for that key. Optional. If <code>destination</code> is set to <code>null</code>, the parsed fields will be " +
+            "written to the root of the event. Default value is <code>parsed_message</code>.")
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty("field_delimiter_regex")
     @JsonPropertyDescription("A regular expression specifying the delimiter that separates key-value pairs. " +
-            "Special regular expression characters such as `[` and `]` must be escaped with `\\\\`. " +
-            "Cannot be defined at the same time as `field_split_characters`. Optional. " +
-            "If this option is not defined, `field_split_characters` is used.")
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
+            "Cannot be defined at the same time as <code>field_split_characters</code>. Optional. " +
+            "If this option is not defined, <code>field_split_characters</code> is used.")
     private String fieldDelimiterRegex;
 
     @JsonProperty("field_split_characters")
     @JsonPropertyDescription("A string of characters specifying the delimiter that separates key-value pairs. " +
-            "Special regular expression characters such as `[` and `]` must be escaped with `\\\\`. " +
-            "Cannot be defined at the same time as `field_delimiter_regex`. Optional. Default value is `&`.")
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
+            "Cannot be defined at the same time as <code>field_delimiter_regex</code>. Optional. Default value is <code>&amp;</code>.")
     private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
     @JsonProperty("include_keys")
@@ -77,27 +77,27 @@ public class KeyValueProcessorConfig {
     @JsonPropertyDescription("A map specifying the default keys and their values that should be added " +
             "to the event in case these keys do not exist in the source field being parsed. " +
             "If the default key already exists in the message, the value is not changed. " +
-            "The `include_keys` filter will be applied to the message before `default_values`.")
+            "The <code>include_keys</code> filter will be applied to the message before <code>default_values</code>.")
     @NotNull
     private Map<String, Object> defaultValues = DEFAULT_DEFAULT_VALUES;
 
     @JsonProperty("key_value_delimiter_regex")
-    @JsonPropertyDescription("A regular expression specifying the delimiter that separates the key and value " +
-            "within a key-value pair. Special regular expression characters such as `[` and `]` must be escaped with " +
-            "`\\\\`. This option cannot be defined at the same time as `value_split_characters`. Optional. " +
-            "If this option is not defined, `value_split_characters` is used.")
+    @JsonPropertyDescription("A regular expression specifying the delimiter that separates the key and value" +
+            "within a key-value pair. Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with " +
+            "<code>\\\\</code>. This option cannot be defined at the same time as <code>value_split_characters</code>. Optional. " +
+            "If this option is not defined, <code>value_split_characters</code> is used.")
     private String keyValueDelimiterRegex;
 
     @JsonProperty("value_split_characters")
     @JsonPropertyDescription("A string of characters specifying the delimiter that separates the key and value within " +
-            "a key-value pair. Special regular expression characters such as `[` and `]` must be escaped with `\\\\`. " +
-            "Cannot be defined at the same time as `key_value_delimiter_regex`. Optional. Default value is `=`.")
+            "a key-value pair. Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
+            "Cannot be defined at the same time as <code>key_value_delimiter_regex</code>. Optional. Default value is <code>=</code>.")
     private String valueSplitCharacters = DEFAULT_VALUE_SPLIT_CHARACTERS;
 
     @JsonProperty("non_match_value")
     @JsonPropertyDescription("When a key-value pair cannot be successfully split, the key-value pair is " +
-            "placed in the `key` field, and the specified value is placed in the `value` field. " +
-            "Optional. Default value is `null`.")
+            "placed in the <code>key</code> field, and the specified value is placed in the <code>value</code> field. " +
+            "Optional. Default value is <code>null</code>.")
     private Object nonMatchValue = DEFAULT_NON_MATCH_VALUE;
 
     @JsonPropertyDescription("A prefix to append before all keys. Optional. Default value is an empty string.")
@@ -106,14 +106,14 @@ public class KeyValueProcessorConfig {
 
     @JsonProperty("delete_key_regex")
     @JsonPropertyDescription("A regular expression specifying the characters to delete from the key. " +
-            "Special regular expression characters such as `[` and `]` must be escaped with `\\\\`. Cannot be an " +
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. Cannot be an " +
             "empty string. Optional. No default value.")
     @NotNull
     private String deleteKeyRegex = DEFAULT_DELETE_KEY_REGEX;
 
     @JsonProperty("delete_value_regex")
     @JsonPropertyDescription("A regular expression specifying the characters to delete from the value. " +
-            "Special regular expression characters such as `[` and `]` must be escaped with `\\\\`. " +
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "Cannot be an empty string. Optional. No default value.")
     @NotNull
     private String deleteValueRegex = DEFAULT_DELETE_VALUE_REGEX;
@@ -125,78 +125,78 @@ public class KeyValueProcessorConfig {
 
     @JsonProperty("whitespace")
     @JsonPropertyDescription("Specifies whether to be lenient or strict with the acceptance of " +
-            "unnecessary white space surrounding the configured value-split sequence. Default is `lenient`.")
+            "unnecessary white space surrounding the configured value-split sequence. Default is <code>lenient</code>.")
     @NotNull
     private String whitespace = DEFAULT_WHITESPACE;
 
     @JsonProperty("skip_duplicate_values")
-    @JsonPropertyDescription("A Boolean option for removing duplicate key-value pairs. When set to `true`, " +
-            "only one unique key-value pair will be preserved. Default is `false`.")
+    @JsonPropertyDescription("A Boolean option for removing duplicate key-value pairs. When set to <code>true</code>, " +
+            "only one unique key-value pair will be preserved. Default is <code>false</code>.")
     @NotNull
     private boolean skipDuplicateValues = DEFAULT_SKIP_DUPLICATE_VALUES;
 
     @JsonProperty("remove_brackets")
     @JsonPropertyDescription("Specifies whether to treat square brackets, angle brackets, and parentheses " +
-            "as value “wrappers” that should be removed from the value. Default is `false`.")
+            "as value “wrappers” that should be removed from the value. Default is <code>false</code>.")
     @NotNull
     private boolean removeBrackets = DEFAULT_REMOVE_BRACKETS;
 
     @JsonProperty("value_grouping")
     @JsonPropertyDescription("Specifies whether to group values using predefined value grouping delimiters: " +
-            "`{...}`, `[...]`, `<...>`, `(...)`, `\"...\"`, `'...'`, `http://... (space)`, and `https:// (space)`. " +
+            "<code>{...}</code>, <code>[...]</code>, <code>&lt;...&gt;</code>, <code>(...)</code>, <code>\"...\"</code>, <code>'...'</code>, <code>http://... (space)</code>, and <code>https:// (space)</code>. " +
             "If this flag is enabled, then the content between the delimiters is considered to be one entity and " +
-            "is not parsed for key-value pairs. Default is `false`. If `value_grouping` is `true`, then " +
-            "`{\"key1=[a=b,c=d]&key2=value2\"}` parses to `{\"key1\": \"[a=b,c=d]\", \"key2\": \"value2\"}`.")
+            "is not parsed for key-value pairs. Default is <code>false</code>. If <code>value_grouping</code> is <code>true</code>, then " +
+            "<code>{\"key1=[a=b,c=d]&amp;key2=value2\"}</code> parses to <code>{\"key1\": \"[a=b,c=d]\", \"key2\": \"value2\"}</code>.")
     private boolean valueGrouping = DEFAULT_VALUE_GROUPING;
 
     @JsonProperty("recursive")
     @JsonPropertyDescription("Specifies whether to recursively obtain additional key-value pairs from values. " +
-            "The extra key-value pairs will be stored as sub-keys of the root key. Default is `false`. " +
+            "The extra key-value pairs will be stored as sub-keys of the root key. Default is <code>false</code>. " +
             "The levels of recursive parsing must be defined by different brackets for each level: " +
-            "`[]`, `()`, and `<>`, in this order. Any other configurations specified will only be applied " +
+            "<code>[]</code>, <code>()</code>, and <code>&lt;&gt;</code>, in this order. Any other configurations specified will only be applied " +
             "to the outmost keys.\n" +
-            "When `recursive` is `true`:\n" +
-            "`remove_brackets` cannot also be `true`;\n" +
-            "`skip_duplicate_values` will always be `true`;\n" +
-            "`whitespace` will always be `\"strict\"`.")
+            "When <code>recursive</code> is <code>true</code>:\n" +
+            "<code>remove_brackets</code> cannot also be <code>true</code>;\n" +
+            "<code>skip_duplicate_values</code> will always be <code>true</code>;\n" +
+            "<code>whitespace</code> will always be <code>\"strict\"</code>.")
     @NotNull
     private boolean recursive = DEFAULT_RECURSIVE;
 
     @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("When a `kv` operation causes a runtime exception within the processor, " +
+    @JsonPropertyDescription("When a <code>kv</code> operation causes a runtime exception within the processor, " +
             "the operation is safely stopped without crashing the processor, and the event is tagged " +
             "with the provided tags.")
     private List<String> tagsOnFailure;
 
     @JsonProperty("overwrite_if_destination_exists")
     @JsonPropertyDescription("Specifies whether to overwrite existing fields if there are key conflicts " +
-            "when writing parsed fields to the event. Default is `true`.")
+            "when writing parsed fields to the event. Default is <code>true</code>.")
     private boolean overwriteIfDestinationExists = true;
 
     @JsonProperty("drop_keys_with_no_value")
-    @JsonPropertyDescription("Specifies whether keys should be dropped if they have a null value. Default is `false`. " +
-            "If `drop_keys_with_no_value` is set to `true`, " +
-            "then `{\"key1=value1&key2\"}` parses to `{\"key1\": \"value1\"}`.")
+    @JsonPropertyDescription("Specifies whether keys should be dropped if they have a null value. Default is <code>false</code>. " +
+            "If <code>drop_keys_with_no_value</code> is set to <code>true</code>, " +
+            "then <code>{\"key1=value1&amp;key2\"}</code> parses to <code>{\"key1\": \"value1\"}</code>.")
     private boolean dropKeysWithNoValue = false;
 
     @JsonProperty("key_value_when")
-    @JsonPropertyDescription("Allows you to specify a Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-            "such as `/some-key == \"test\"`, that will be evaluated to determine whether " +
+    @JsonPropertyDescription("Allows you to specify a Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether " +
             "the processor should be applied to the event.")
     private String keyValueWhen;
 
     @JsonProperty("strict_grouping")
     @JsonPropertyDescription("When enabled, groups with unmatched end characters yield errors. " +
             "The event is ignored after the errors are logged. " +
-            "Specifies whether strict grouping should be enabled when the `value_grouping` " +
-            "or `string_literal_character` options are used. Default is `false`.")
+            "Specifies whether strict grouping should be enabled when the <code>value_grouping</code>" +
+            "or <code>string_literal_character</code> options are used. Default is <code>false</code>.")
     private boolean strictGrouping = false;
 
     @JsonProperty("string_literal_character")
     @JsonPropertyDescription("When this option is used, any text contained within the specified quotation " +
             "mark character will be ignored and excluded from key-value parsing. " +
-            "Can be set to either a single quotation mark (`'`) or a double quotation mark (`\"`). " +
-            "Default is `null`.")
+            "Can be set to either a single quotation mark (<code>'</code>) or a double quotation mark (<code>\"</code>). " +
+            "Default is <code>null</code>.")
     @Size(min = 0, max = 1, message = "string_literal_character may only have character")
     private String stringLiteralCharacter = null;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -22,14 +22,14 @@ import java.util.stream.Stream;
 public class AddEntryProcessorConfig {
     public static class Entry {
 
-        @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include `my_key`, " +
-                "`myKey`, and `object/sub_Key`. The key can also be a format expression, for example, `${/key1}` to " +
-                "use the value of field `key1` as the key.")
+        @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include <code>my_key</code>, " +
+                "<code>myKey</code>, and <code>object/sub_Key</code>. The key can also be a format expression, for example, <code>${/key1}</code> to " +
+                "use the value of field <code>key1</code> as the key.")
         private String key;
 
         @JsonProperty("metadata_key")
         @JsonPropertyDescription("The key for the new metadata attribute. The argument must be a literal string key " +
-                "and not a JSON Pointer. Either one string key or `metadata_key` is required.")
+                "and not a JSON Pointer. Either one string key or <code>metadata_key</code> is required.")
         private String metadataKey;
 
         @JsonPropertyDescription("The value of the new entry to be added, which can be used with any of the " +
@@ -37,31 +37,31 @@ public class AddEntryProcessorConfig {
         private Object value;
 
         @JsonPropertyDescription("A format string to use as the value of the new entry, for example, " +
-                "`${key1}-${key2}`, where `key1` and `key2` are existing keys in the event. Required if neither " +
-                "`value` nor `value_expression` is specified.")
+                "<code>${key1}-${key2}</code>, where <code>key1</code> and <code>key2</code> are existing keys in the event. Required if neither" +
+                "<code>value</code> nor <code>value_expression</code> is specified.")
         private String format;
 
         @JsonProperty("value_expression")
-        @JsonPropertyDescription("An expression string to use as the value of the new entry. For example, `/key` " +
+        @JsonPropertyDescription("An expression string to use as the value of the new entry. For example, <code>/key</code> " +
                 "is an existing key in the event with a type of either a number, a string, or a Boolean. " +
                 "Expressions can also contain functions returning number/string/integer. For example, " +
-                "`length(/key)` will return the length of the key in the event when the key is a string. For more " +
-                "information about keys, see [Expression syntax](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/).")
+                "<code>length(/key)</code> will return the length of the key in the event when the key is a string. For more " +
+                "information about keys, see <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Expression syntax</a>.")
         private String valueExpression;
 
         @JsonProperty("add_when")
-        @JsonPropertyDescription("A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-                "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be run on the event.")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
         private String addWhen;
 
         @JsonProperty("overwrite_if_key_exists")
-        @JsonPropertyDescription("When set to `true`, the existing value is overwritten if `key` already exists " +
-                "in the event. The default value is `false`.")
+        @JsonPropertyDescription("When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists " +
+                "in the event. The default value is <code>false</code>.")
         private boolean overwriteIfKeyExists = false;
 
         @JsonProperty("append_if_key_exists")
-        @JsonPropertyDescription("When set to `true`, the existing value will be appended if a `key` already " +
-                "exists in the event. An array will be created if the existing value is not an array. Default is `false`.")
+        @JsonPropertyDescription("When set to <code>true</code>, the existing value will be appended if a <code>key</code> already " +
+                "exists in the event. An array will be created if the existing value is not an array. Default is <code>false</code>.")
         private boolean appendIfKeyExists = false;
 
         public String getKey() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -38,7 +38,7 @@ public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     private int scale = 0;
 
     @JsonProperty("convert_when")
-    @JsonPropertyDescription("Specifies a condition using a [Data Prepper expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) for performing the convert_entry_type operation. If specified, the convert_entry_type operation runs only when the expression evaluates to true.")
+    @JsonPropertyDescription("Specifies a condition using a <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Data Prepper expression</a> for performing the convert_entry_type operation. If specified, the convert_entry_type operation runs only when the expression evaluates to true.")
     private String convertWhen;
 
     @JsonProperty("null_values")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -34,13 +34,13 @@ public class CopyValueProcessorConfig {
         private String toKey;
 
         @JsonProperty("copy_when")
-        @JsonPropertyDescription("A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-                "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be run on the event.")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
         private String copyWhen;
 
         @JsonProperty("overwrite_if_to_key_exists")
-        @JsonPropertyDescription("When set to `true`, the existing value is overwritten if `key` already exists in " +
-                "the event. The default value is `false`.")
+        @JsonPropertyDescription("When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists in " +
+                "the event. The default value is <code>false</code>.")
         private boolean overwriteIfToKeyExists = false;
 
         public String getFromKey() {
@@ -84,7 +84,7 @@ public class CopyValueProcessorConfig {
     private String toList;
 
     @JsonProperty("overwrite_if_to_list_exists")
-    @JsonPropertyDescription("When set to `true`, the existing value is overwritten if `key` already exists in the event. The default value is `false`.")
+    @JsonPropertyDescription("When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists in the event. The default value is <code>false</code>.")
     private boolean overwriteIfToListExists = false;
 
     @AssertTrue(message = "Both from_list and to_list should be specified when copying entries between lists.")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -30,7 +30,7 @@ public class DeleteEntryProcessorConfig {
     private List<@NotNull @NotEmpty EventKey> withKeys;
 
     @JsonProperty("delete_when")
-    @JsonPropertyDescription("Specifies under what condition the `delete_entries` processor should perform deletion. " +
+    @JsonPropertyDescription("Specifies under what condition the <code>delete_entries</code> processor should perform deletion. " +
             "Default is no condition.")
     private String deleteWhen;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -47,7 +47,7 @@ public class ListToMapProcessorConfig {
     @NotEmpty
     @NotNull
     @JsonProperty("source")
-    @JsonPropertyDescription("The list of objects with `key` fields to be converted into keys for the generated map.")
+    @JsonPropertyDescription("The list of objects with <code>key</code> fields to be converted into keys for the generated map.")
     private String source;
 
     @JsonProperty("target")
@@ -57,41 +57,41 @@ public class ListToMapProcessorConfig {
 
     @JsonProperty("key")
     @JsonPropertyDescription("The key of the fields to be extracted as keys in the generated mappings. Must be " +
-            "specified if `use_source_key` is `false`.")
+            "specified if <code>use_source_key</code> is <code>false</code>.")
     private String key;
 
     @JsonProperty("value_key")
-    @JsonPropertyDescription("When specified, values given a `value_key` in objects contained in the source list " +
+    @JsonPropertyDescription("When specified, values given a <code>value_key</code> in objects contained in the source list " +
             "will be extracted and converted into the value specified by this option based on the generated map. " +
             "When not specified, objects contained in the source list retain their original value when mapped.")
     private String valueKey = null;
 
     @JsonProperty("use_source_key")
-    @JsonPropertyDescription("When `true`, keys in the generated map will use original keys from the source. " +
-            "Default is `false`.")
+    @JsonPropertyDescription("When <code>true</code>, keys in the generated map will use original keys from the source. " +
+            "Default is <code>false</code>.")
     private boolean useSourceKey = false;
 
     @JsonProperty("extract_value")
-    @JsonPropertyDescription("When `true`, object values from the source list will be extracted and added to " +
-            "the generated map. When `false`, object values from the source list are added to the generated map " +
-            "as they appear in the source list. Default is `false`")
+    @JsonPropertyDescription("When <code>true</code>, object values from the source list will be extracted and added to " +
+            "the generated map. When <code>false</code>, object values from the source list are added to the generated map " +
+            "as they appear in the source list. Default is <code>false</code>")
     private boolean extractValue = false;
 
     @NotNull
     @JsonProperty("flatten")
-    @JsonPropertyDescription("When `true`, values in the generated map output flatten into single items based on " +
-            "the `flattened_element`. Otherwise, objects mapped to values from the generated map appear as lists.")
+    @JsonPropertyDescription("When <code>true</code>, values in the generated map output flatten into single items based on " +
+            "the <code>flattened_element</code>. Otherwise, objects mapped to values from the generated map appear as lists.")
     private boolean flatten = false;
 
     @NotNull
     @JsonProperty("flattened_element")
-    @JsonPropertyDescription("The element to keep, either `first` or `last`, when `flatten` is set to `true`.")
+    @JsonPropertyDescription("The element to keep, either <code>first</code> or <code>last</code>, when <code>flatten</code> is set to <code>true</code>.")
     private FlattenedElement flattenedElement = FlattenedElement.FIRST;
 
     @JsonProperty("list_to_map_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-            "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be " +
-            "run on the event. Default is `null`. All events will be processed unless otherwise stated.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+            "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
     private String listToMapWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -27,7 +27,7 @@ public class MapToListProcessorConfig {
     @NotNull
     @JsonProperty("source")
     @JsonPropertyDescription("The source map used to perform the mapping operation. When set to an empty " +
-            "string (`\"\"`), it will use the root of the event as the `source`.")
+            "string (<code>\"\"</code>), it will use the root of the event as the <code>source</code>.")
     private String source;
 
     @NotEmpty
@@ -37,32 +37,32 @@ public class MapToListProcessorConfig {
     private String target;
 
     @JsonProperty("key_name")
-    @JsonPropertyDescription("The name of the field in which to store the original key. Default is `key`.")
+    @JsonPropertyDescription("The name of the field in which to store the original key. Default is <code>key</code>.")
     private String keyName = DEFAULT_KEY_NAME;
 
     @JsonProperty("value_name")
-    @JsonPropertyDescription("The name of the field in which to store the original value. Default is `value`.")
+    @JsonPropertyDescription("The name of the field in which to store the original value. Default is <code>value</code>.")
     private String valueName = DEFAULT_VALUE_NAME;
 
     @JsonProperty("map_to_list_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-            "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will " +
-            "be run on the event. Default is `null`. All events will be processed unless otherwise stated.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will " +
+            "be run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
     private String mapToListWhen;
 
     @JsonProperty("exclude_keys")
     @JsonPropertyDescription("The keys in the source map that will be excluded from processing. Default is an " +
-            "empty list (`[]`).")
+            "empty list (<code>[]</code>).")
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonProperty("remove_processed_fields")
-    @JsonPropertyDescription("When `true`, the processor will remove the processed fields from the source map. " +
-            "Default is `false`.")
+    @JsonPropertyDescription("When <code>true</code>, the processor will remove the processed fields from the source map. " +
+            "Default is <code>false</code>.")
     private boolean removeProcessedFields = DEFAULT_REMOVE_PROCESSED_FIELDS;
 
     @JsonProperty("convert_field_to_list")
-    @JsonPropertyDescription("If `true`, the processor will convert the fields from the source map into lists and " +
-            "place them in fields in the target list. Default is `false`.")
+    @JsonPropertyDescription("If <code>true</code>, the processor will convert the fields from the source map into lists and " +
+            "place them in fields in the target list. Default is <code>false</code>.")
     private boolean convertFieldToList = false;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -41,9 +41,9 @@ public class RenameKeyProcessorConfig {
         private boolean overwriteIfToKeyExists = false;
 
         @JsonProperty("rename_when")
-        @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-                "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be " +
-                "run on the event. Default is `null`. All events will be processed unless otherwise stated.")
+        @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+                "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
         private String renameWhen;
 
         public EventKey getFromKey() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
@@ -24,9 +24,9 @@ public class SelectEntriesProcessorConfig {
     private List<String> includeKeys;
 
     @JsonProperty("select_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-            "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be " +
-            "run on the event. Default is `null`. All events will be processed unless otherwise stated.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+            "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
     private String selectWhen;
 
     public List<String> getIncludeKeys() {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/ReplaceStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/ReplaceStringProcessorConfig.java
@@ -22,13 +22,13 @@ public class ReplaceStringProcessorConfig implements StringProcessorConfig<Repla
         private EventKey source;
         @JsonPropertyDescription("The substring to be replaced in the source.")
         private String from;
-        @JsonPropertyDescription("The string to be replaced for each match of `from`.")
+        @JsonPropertyDescription("The string to be replaced for each match of <code>from</code>.")
         private String to;
 
         @JsonProperty("replace_when")
-        @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-                "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be " +
-                "run on the event. Default is `null`. All events will be processed unless otherwise stated.")
+        @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+                "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
         private String replaceWhen;
 
         public EventKey getSource() {
@@ -55,7 +55,7 @@ public class ReplaceStringProcessorConfig implements StringProcessorConfig<Repla
         public Entry() {}
     }
 
-    @JsonPropertyDescription("List of entries. Valid values are `source`, `from`, and `to`, and `substitute_when`.")
+    @JsonPropertyDescription("List of entries. Valid values are <code>source</code>, <code>from</code>, and <code>to</code>, and <code>substitute_when</code>.")
     private List<Entry> entries;
 
     public List<Entry> getEntries() {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -30,18 +30,18 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         private EventKey source;
 
         @JsonProperty("delimiter_regex")
-        @JsonPropertyDescription("The regex string responsible for the split. Cannot be defined at the same time as `delimiter`. " +
-                "At least `delimiter` or `delimiter_regex` must be defined.")
+        @JsonPropertyDescription("The regex string responsible for the split. Cannot be defined at the same time as <code>delimiter</code>. " +
+                "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
         private String delimiterRegex;
 
         @Size(min = 1, max = 1)
         @JsonPropertyDescription("The separator character responsible for the split. " +
-                "Cannot be defined at the same time as `delimiter_regex`. " +
-                "At least `delimiter` or `delimiter_regex` must be defined.")
+                "Cannot be defined at the same time as <code>delimiter_regex</code>. " +
+                "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
         private String delimiter;
 
         @JsonProperty("split_when")
-        @JsonPropertyDescription("Specifies under what condition the `split_string` processor should perform splitting. " +
+        @JsonPropertyDescription("Specifies under what condition the <code>split_string</code> processor should perform splitting. " +
                 "Default is no condition.")
         private String splitWhen;
 
@@ -75,7 +75,7 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         return entries;
     }
 
-    @JsonPropertyDescription("List of entries. Valid values are `source`, `delimiter`, and `delimiter_regex`.")
+    @JsonPropertyDescription("List of entries. Valid values are <code>source</code>, <code>delimiter</code>, and <code>delimiter_regex</code>.")
     @NotNull
     private List<@Valid Entry> entries;
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
@@ -21,18 +21,18 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
     public static class Entry {
         @JsonPropertyDescription("The key to modify.")
         private EventKey source;
-        @JsonPropertyDescription("The Regex String to be replaced. Special regex characters such as `[` and `]` must " +
-                "be escaped using `\\\\` when using double quotes and `\\ ` when using single quotes. " +
-                "See [Java Patterns](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html) " +
+        @JsonPropertyDescription("The Regex String to be replaced. Special regex characters such as <code>[</code> and <code>]</code> must " +
+                "be escaped using <code>\\\\</code> when using double quotes and <code>\\</code> when using single quotes. " +
+                "See <a href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html\">Java Patterns</a>" +
                 "for more information.")
         private String from;
-        @JsonPropertyDescription("The String to be substituted for each match of `from`.")
+        @JsonPropertyDescription("The String to be substituted for each match of <code>from</code>.")
         private String to;
 
         @JsonProperty("substitute_when")
-        @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), " +
-                "such as `/some-key == \"test\"'`, that will be evaluated to determine whether the processor will be " +
-                "run on the event. Default is `null`. All events will be processed unless otherwise stated.")
+        @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+                "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
         private String substituteWhen;
 
         public EventKey getSource() {
@@ -59,7 +59,7 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
         public Entry() {}
     }
 
-    @JsonPropertyDescription("List of entries. Valid values are `source`, `from`, and `to`, and `substitute_when`.")
+    @JsonPropertyDescription("List of entries. Valid values are <code>source</code>, <code>from</code>, and <code>to</code>, and <code>substitute_when</code>.")
     @NotNull
     private List<Entry> entries;
 

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -35,7 +35,7 @@ public class ObfuscationProcessorConfig {
     @JsonProperty("target")
     @JsonPropertyDescription("The new field in which to store the obfuscated value. " +
             "This leaves the original source field unchanged. " +
-            "When no `target` is provided, the source field updates with the obfuscated value.")
+            "When no <code>target</code> is provided, the source field updates with the obfuscated value.")
     private String target;
 
     @JsonProperty("action")
@@ -52,7 +52,7 @@ public class ObfuscationProcessorConfig {
     private List<String> tagsOnMatchFailure;
 
     @JsonProperty("single_word_only")
-    @JsonPropertyDescription("When set to `true`, a word boundary `\b` is added to the pattern, " +
+    @JsonPropertyDescription("When set to <code>true</code>, a word boundary <code>\b</code> is added to the pattern, " +
             "which causes obfuscation to be applied only to words that are standalone in the input text. " +
             "By default, it is false, meaning obfuscation patterns are applied to all occurrences. " +
             "Can be used for Data Prepper 2.8 or greater.")

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionConfig.java
@@ -33,8 +33,8 @@ public class OneWayHashActionConfig {
     private String format = "SHA-512";
 
     @JsonProperty("salt_key")
-    @JsonPropertyDescription("A key to compute salt based on a value provided as part of a record." + 
-        "If key or value was not found in the record(s), a salt defined in the pipeline configuration will be used instead.")    
+    @JsonPropertyDescription("A key to compute salt based on a value provided as part of a record. " +
+        "If key or value was not found in the record(s), a salt defined in the pipeline configuration will be used instead.")
     @EventKeyConfiguration(EventKeyFactory.EventAction.GET)
     private EventKey saltKey;
  

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class OtelMetricsRawProcessorConfig {
 
     @JsonProperty("flatten_attributes")
-    @JsonPropertyDescription("Whether or not to flatten the `attributes` field in the JSON data.")
+    @JsonPropertyDescription("Whether or not to flatten the <code>attributes</code> field in the JSON data.")
     boolean flattenAttributesFlag = true;
 
     @JsonPropertyDescription("Whether or not to calculate histogram buckets.")

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -37,7 +37,7 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     private String pointer;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
     private String parseWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
@@ -38,7 +38,7 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     private String pointer;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
     private String parseWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -32,7 +32,7 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
     private String pointer;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
     private String parseWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/FileParameterConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/FileParameterConfig.java
@@ -19,7 +19,7 @@ public class FileParameterConfig {
     private String fileName;
 
     @JsonProperty("aws")
-    @JsonPropertyDescription("The AWS configuration when the file is an S3 object. ")
+    @JsonPropertyDescription("The AWS configuration when the file is an S3 object.")
     @Valid
     private S3ObjectConfig awsConfig;
 

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TargetsParameterConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TargetsParameterConfig.java
@@ -30,15 +30,15 @@ public class TargetsParameterConfig {
     @JsonProperty("map")
     @JsonPropertyDescription("A list of key-value pairs that define the translations. Each key represents a possible " +
             "value in the source field, and the corresponding value represents what it should be translated to. " +
-            "For examples, see [map option](#map-option). At least one of `map` and `regex` should be configured.")
+            "For examples, see <a href=\"#map-option\">map option</a>. At least one of <code>map</code> and <code>regex</code> should be configured.")
     private Map<String, Object> map;
     @JsonProperty("translate_when")
-    @JsonPropertyDescription("Uses a [Data Prepper expression]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/) " +
+    @JsonPropertyDescription("Uses a <a href=\"{{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/\">Data Prepper expression</a> " +
             "to specify a condition for performing the translation. When specified, the expression will only translate when the condition is met.")
     private String translateWhen;
     @JsonProperty("regex")
-    @JsonPropertyDescription("A map of keys that defines the translation map. For more options, see [regex option](#regex-option). " +
-            "At least one of `map` and `regex` should be configured.")
+    @JsonPropertyDescription("A map of keys that defines the translation map. For more options, see <a href=\"#regex-option\">regex option</a>. " +
+            "At least one of <code>map</code> and <code>regex</code> should be configured.")
     private RegexParameterConfiguration regexParameterConfig;
     @JsonProperty("default")
     @JsonPropertyDescription("The default value to use when no match is found during translation.")

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfig.java
@@ -23,12 +23,12 @@ import java.util.Objects;
 public class TranslateProcessorConfig {
 
     @JsonProperty("file")
-    @JsonPropertyDescription("Points to the file that contains mapping configurations. For more information, see [file](#file).")
+    @JsonPropertyDescription("Points to the file that contains mapping configurations. For more information, see <a href=\"#file\">file</a>.")
     @Valid
     private FileParameterConfig fileParameterConfig;
 
     @JsonProperty("mappings")
-    @JsonPropertyDescription("Defines inline mappings. For more information, see [mappings](#mappings).")
+    @JsonPropertyDescription("Defines inline mappings. For more information, see <a href=\"#mappings\">mappings</a>.")
     @Valid
     private List<MappingsParameterConfig> mappingsParameterConfigs = new ArrayList<>();
 

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -28,7 +28,7 @@ public class TruncateProcessorConfig {
 
         @JsonProperty("start_at")
         @JsonPropertyDescription("Where in the string value to start truncation. " +
-                "Default is `0`, which specifies to start truncation at the beginning of each key's value.")
+                "Default is <code>0</code>, which specifies to start truncation at the beginning of each key's value.")
         private Integer startAt;
 
         @JsonProperty("length")

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorConfig.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorConfig.java
@@ -33,20 +33,20 @@ public class UserAgentProcessorConfig {
 
     @NotNull
     @JsonProperty("target")
-    @JsonPropertyDescription("The field to which the parsed event will write. Default is `user_agent`.")
+    @JsonPropertyDescription("The field to which the parsed event will write. Default is <code>user_agent</code>.")
     private String target = "user_agent";
 
     @NotNull
     @JsonProperty("exclude_original")
-    @JsonPropertyDescription("Determines whether to exclude the original UA string from the parsing result. Defaults to `false`. ")
+    @JsonPropertyDescription("Determines whether to exclude the original UA string from the parsing result. Defaults to <code>false</code>.")
     private boolean excludeOriginal = false;
 
     @JsonProperty("cache_size")
-    @JsonPropertyDescription("The cache size of the parser in megabytes. Defaults to `1000`.")
+    @JsonPropertyDescription("The cache size of the parser in megabytes. Defaults to <code>1000</code>.")
     private int cacheSize = DEFAULT_CACHE_SIZE;
 
     @JsonProperty("tags_on_parse_failure")
-    @JsonPropertyDescription("The tag to add to an event if the `user_agent` processor fails to parse the UA string.")
+    @JsonPropertyDescription("The tag to add to an event if the <code>user_agent</code> processor fails to parse the UA string.")
     private List<String> tagsOnParseFailure;
 
     public EventKey getSource() {


### PR DESCRIPTION
### Description

This PR updates `@JsonPropertyDescription` annotations to use HTML. It replaces the Markdown with HTML formatting.
 
### Issues Resolved
Resolves #4984
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
