### PR TITLE
Additional logging when shutting down the pipeline.

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
@@ -137,7 +137,7 @@ public class Pipeline {
         this.sinkExecutorService = PipelineThreadPoolExecutor.newFixedThreadPool(processorThreads,
                 new PipelineThreadFactory(format("%s-sink-worker", name)), this);
 
-        this.pipelineShutdown = new PipelineShutdown(buffer);
+        this.pipelineShutdown = new PipelineShutdown(name, buffer);
     }
 
     AcknowledgementSetManager getAcknowledgementSetManager() {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineShutdownTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineShutdownTest.java
@@ -17,6 +17,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Random;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,17 +38,19 @@ class PipelineShutdownTest {
 
     private Duration bufferDrainTimeout;
     private Random random;
+    private String pipelineName;
 
     @BeforeEach
     void setUp() {
         random = new Random();
+        pipelineName = UUID.randomUUID().toString();
         bufferDrainTimeout = Duration.ofSeconds(random.nextInt(100) + 1_000);
 
         when(buffer.getDrainTimeout()).thenReturn(bufferDrainTimeout);
     }
 
     private PipelineShutdown createObjectUnderTest() {
-        return new PipelineShutdown(buffer, clock);
+        return new PipelineShutdown(pipelineName, buffer, clock);
     }
 
     @Test


### PR DESCRIPTION
### Description

When shutting down a pipeline, it is hard to know what the shutdown timing will be. This PR adds additional logging.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
