### PR TITLE
Update the test logging to include the failed assertion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,10 @@ subprojects {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.current()
         }
+        testLogging {
+            exceptionFormat "full"
+            showStackTraces false
+        }
         reports {
             junitXml.required
             html.required


### PR DESCRIPTION
### Description

The current output of failures shows where the assertion failed. But, it does not show what was wrong with the assertion.

For example, we see logs like this:

```
AbstractSinkTest > testSinkNotReady() FAILED
    org.opentest4j.AssertionFailedError at AbstractSinkTest.java:84
```

This change outputs the actual cause without adding the whole stack trace either.

Here is some sample code:

```
public class ForceFail {
    @Test
    void always_fails() {
        assertThat(true, equalTo(false));
    }
}
```
 
The logging includes:

```
> Task :data-prepper-api:test

ForceFail > always_fails() FAILED
    java.lang.AssertionError:
    Expected: <false>
         but: was <true>

1133 tests completed, 1 failed, 2 skipped
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
