### PR TITLE
Make acknowledgment_timeout configurable for s3 scan source, configure timeout to 10 minutes for MongoDB L2 transform

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/resources/org/opensearch/dataprepper/transforms/templates/documentdb-template.yaml
+++ b/data-prepper-plugins/mongodb/src/main/resources/org/opensearch/dataprepper/transforms/templates/documentdb-template.yaml
@@ -66,6 +66,7 @@
       delete_s3_objects_on_read: true
       disable_s3_metadata_in_event: true
       scan:
+        acknowledgment_timeout: "PT10M"
         folder_partitions:
           depth: "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>"
           max_objects_per_ownership: 50
@@ -75,7 +76,7 @@
               filter:
                 include_prefix: ["<<FUNCTION_NAME:getSourceCoordinationIdentifierEnvVariable,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>"]
         scheduling:
-          interval: "60s"
+          interval: "20s"
   processor: "<<$.<<pipeline-name>>.processor>>"
   sink: "<<$.<<pipeline-name>>.sink>>"
   routes: "<<$.<<pipeline-name>>.routes>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptions.java
@@ -22,6 +22,9 @@ import java.util.stream.Stream;
  */
 public class S3ScanScanOptions {
 
+    @JsonProperty("acknowledgment_timeout")
+    private Duration acknowledgmentTimeout = Duration.ofHours(2);
+
     @JsonProperty("folder_partitions")
     @Valid
     private FolderPartitioningOptions folderPartitioningOptions;
@@ -84,4 +87,6 @@ public class S3ScanScanOptions {
     }
 
     public FolderPartitioningOptions getPartitioningOptions() { return folderPartitioningOptions; }
+
+    public Duration getAcknowledgmentTimeout() { return acknowledgmentTimeout; }
 }


### PR DESCRIPTION
### Description
If there is some reason that causes partition for s3 scan to not be given up, or if the acknowledgment is never received for a partition, s3 scan defaults to a 2 hour acknowledgment wait before reprocessing. For mongodb pipelines, this can cause high delay for some records, and these pipelines are meant to be low latency.

This change adds an `acknowledgment_timeout` parameter to S3 scan, and sets it to 10 minutes in the DocumentDB L2 transform.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
