### PR TITLE
MAINT: update required properties and property descriptions in some processors

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/DelayProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/DelayProcessor.java
@@ -60,6 +60,7 @@ public class DelayProcessor implements Processor<Record<?>, Record<?>> {
             "Typically, you should use this only for testing, experimenting, and debugging.")
     public static class Configuration {
         @JsonProperty("for")
+        @JsonPropertyDescription("The duration of time to delay. Defaults to `1s`.")
         private Duration delayFor = Duration.ofSeconds(1);
 
         public Duration getDelayFor() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -20,10 +20,12 @@ import java.util.Optional;
 public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     @JsonProperty("key")
     @JsonPropertyDescription("Key whose value needs to be converted to a different type.")
+    @NotEmpty
     private String key;
 
     @JsonProperty("keys")
     @JsonPropertyDescription("List of keys whose value needs to be converted to a different type.")
+    @NotEmpty
     private List<String> keys;
 
     @JsonProperty("type")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -20,12 +20,10 @@ import java.util.Optional;
 public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     @JsonProperty("key")
     @JsonPropertyDescription("Key whose value needs to be converted to a different type.")
-    @NotEmpty
     private String key;
 
     @JsonProperty("keys")
     @JsonPropertyDescription("List of keys whose value needs to be converted to a different type.")
-    @NotEmpty
     private List<String> keys;
 
     @JsonProperty("type")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -25,12 +25,14 @@ public class RenameKeyProcessorConfig {
         @NotEmpty
         @NotNull
         @JsonProperty("from_key")
+        @JsonPropertyDescription("The key of the entry to be renamed.")
         @EventKeyConfiguration({EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.DELETE})
         private EventKey fromKey;
 
         @NotEmpty
         @NotNull
         @JsonProperty("to_key")
+        @JsonPropertyDescription("The new key of the entry.")
         @EventKeyConfiguration(EventKeyFactory.EventAction.PUT)
         private EventKey toKey;
 


### PR DESCRIPTION
### Description
Update required fields and property descriptions in rename key, convert entry type, and delay processors according to the documentation on the Opensearch website.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
