### PR TITLE
Providing an option for the plugins to use Spring DI

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -72,4 +72,16 @@ public @interface DataPrepperPlugin {
      * @since 1.2
      */
     Class<?> pluginConfigurationType() default PluginSetting.class;
+
+    /**
+     * Optional Packages to scan for Data Prepper DI components.
+     * Plugins provide this list if they want to use Dependency Injection in its module.
+     * Providing this value, implicitly assumes and initiates plugin specific isolated ApplictionContext.
+     * <p>
+     * The package names that spring context scans will be picked up by these marker classes.
+     *
+     * @return Array of packages to scan
+     * @since 2.2
+     */
+    Class[] packagesToScanForDI() default {};
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -76,12 +76,12 @@ public @interface DataPrepperPlugin {
     /**
      * Optional Packages to scan for Data Prepper DI components.
      * Plugins provide this list if they want to use Dependency Injection in its module.
-     * Providing this value, implicitly assumes and initiates plugin specific isolated ApplictionContext.
+     * Providing this value, implicitly assumes and initiates plugin specific isolated ApplicationContext.
      * <p>
      * The package names that spring context scans will be picked up by these marker classes.
      *
-     * @return Array of packages to scan
+     * @return Array of classes to use for package scan.
      * @since 2.2
      */
-    Class[] packagesToScanForDI() default {};
+    Class[] packagesToScan() default {};
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
@@ -15,7 +15,10 @@ import org.opensearch.dataprepper.core.event.EventFactoryApplicationContextMarke
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.plugins.TestObjectPlugin;
+import org.opensearch.dataprepper.plugins.test.TestComponent;
+import org.opensearch.dataprepper.plugins.test.TestDISource;
 import org.opensearch.dataprepper.plugins.test.TestPlugin;
 import org.opensearch.dataprepper.validation.LoggingPluginErrorsHandler;
 import org.opensearch.dataprepper.validation.PluginErrorCollector;
@@ -30,6 +33,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -94,6 +99,23 @@ class DefaultPluginFactoryIT {
 
         assertThat(configuration.getRequiredString(), equalTo(requiredStringValue));
         assertThat(configuration.getOptionalString(), equalTo(optionalStringValue));
+    }
+
+    @Test
+    void loadPlugin_should_return_a_new_plugin_instance_with_DI_context_initialized() {
+
+        final Map<String, Object> pluginSettingMap = new HashMap<>();
+        final PluginSetting pluginSetting = new PluginSetting("test_di_source", pluginSettingMap);
+        pluginSetting.setPipelineName(pipelineName);
+
+        final Source sourcePlugin = createObjectUnderTest().loadPlugin(Source.class, pluginSetting);
+
+        assertThat(sourcePlugin, instanceOf(TestDISource.class));
+        TestDISource plugin = (TestDISource) sourcePlugin;
+        // Testing the auto wired been with the Dependency Injection
+        assertNotNull(plugin.getTestComponent());
+        assertInstanceOf(TestComponent.class, plugin.getTestComponent());
+        assertThat(plugin.getTestComponent().getIdentifier(), equalTo("test-component"));
     }
 
     @Test

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -116,8 +116,15 @@ public class DefaultPluginFactory implements PluginFactory {
         final PluginConfigObservable pluginConfigObservable = pluginConfigurationObservableFactory
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
-        BeanFactory beanFactory =
-                pluginBeanFactoryProvider.initializePluginSpecificIsolatedContextCombinedWithShared(pluginAnnotation);
+        BeanFactory beanFactory;
+        if(pluginAnnotation.packagesToScanForDI().length>0) {
+            // If packages to scan is provided in this plugin annotation, which indicates
+            // that this plugin is interested in using Dependency Injection isolated for its module
+            beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(pluginAnnotation);
+        }else{
+            beanFactory = pluginBeanFactoryProvider.get();
+        }
+
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)
                 .withPipelineDescription(pluginSetting)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.annotation.DependsOn;
 
 import javax.inject.Inject;
@@ -115,13 +116,15 @@ public class DefaultPluginFactory implements PluginFactory {
         final PluginConfigObservable pluginConfigObservable = pluginConfigurationObservableFactory
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
+        BeanFactory beanFactory =
+                pluginBeanFactoryProvider.initializePluginSpecificIsolatedContextCombinedWithShared(pluginAnnotation);
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)
                 .withPipelineDescription(pluginSetting)
                 .withPluginConfiguration(configuration)
                 .withPluginFactory(this)
                 .withSinkContext(sinkContext)
-                .withBeanFactory(pluginBeanFactoryProvider.get())
+                .withBeanFactory(beanFactory)
                 .withPluginConfigurationObservable(pluginConfigObservable)
                 .withTypeArgumentSuppliers(applicationContextToTypedSuppliers.getArgumentsSuppliers())
                 .build();

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -116,8 +116,8 @@ public class DefaultPluginFactory implements PluginFactory {
         final PluginConfigObservable pluginConfigObservable = pluginConfigurationObservableFactory
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
-        Class[] scanForDIMarkers = pluginAnnotation.packagesToScanForDI();
-        BeanFactory beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(scanForDIMarkers);
+        Class[] markersToScanForDI = pluginAnnotation.packagesToScanForDI();
+        BeanFactory beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(markersToScanForDI);
 
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -116,7 +116,7 @@ public class DefaultPluginFactory implements PluginFactory {
         final PluginConfigObservable pluginConfigObservable = pluginConfigurationObservableFactory
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
-        Class[] markersToScanForDI = pluginAnnotation.packagesToScanForDI();
+        Class[] markersToScanForDI = pluginAnnotation.packagesToScan();
         BeanFactory beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(markersToScanForDI);
 
         return new ComponentPluginArgumentsContext.Builder()

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -116,15 +116,8 @@ public class DefaultPluginFactory implements PluginFactory {
         final PluginConfigObservable pluginConfigObservable = pluginConfigurationObservableFactory
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
-        BeanFactory beanFactory;
         Class[] scanForDIMarkers = pluginAnnotation.packagesToScanForDI();
-        if(scanForDIMarkers.length>0) {
-            // If packages to scan is provided in this plugin annotation, which indicates
-            // that this plugin is interested in using Dependency Injection isolated for its module
-            beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(scanForDIMarkers);
-        }else{
-            beanFactory = pluginBeanFactoryProvider.get();
-        }
+        BeanFactory beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(scanForDIMarkers);
 
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -117,7 +117,7 @@ public class DefaultPluginFactory implements PluginFactory {
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
         Class[] markersToScanForDI = pluginAnnotation.packagesToScan();
-        BeanFactory beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(markersToScanForDI);
+        BeanFactory beanFactory = pluginBeanFactoryProvider.createPluginSpecificContext(markersToScanForDI);
 
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -116,8 +116,8 @@ public class DefaultPluginFactory implements PluginFactory {
         final PluginConfigObservable pluginConfigObservable = pluginConfigurationObservableFactory
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
-        Class[] markersToScanForDI = pluginAnnotation.packagesToScan();
-        BeanFactory beanFactory = pluginBeanFactoryProvider.createPluginSpecificContext(markersToScanForDI);
+        Class[] markersToScan = pluginAnnotation.packagesToScan();
+        BeanFactory beanFactory = pluginBeanFactoryProvider.createPluginSpecificContext(markersToScan);
 
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -117,10 +117,11 @@ public class DefaultPluginFactory implements PluginFactory {
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
         BeanFactory beanFactory;
-        if(pluginAnnotation.packagesToScanForDI().length>0) {
+        Class[] scanForDIMarkers = pluginAnnotation.packagesToScanForDI();
+        if(scanForDIMarkers.length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module
-            beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(pluginAnnotation);
+            beanFactory = pluginBeanFactoryProvider.initializePluginSpecificIsolatedContext(scanForDIMarkers);
         }else{
             beanFactory = pluginBeanFactoryProvider.get();
         }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -64,16 +64,16 @@ class PluginBeanFactoryProvider implements Provider<BeanFactory> {
     }
 
     public BeanFactory initializePluginSpecificIsolatedContext(Class[] markersToScanForDI) {
-        AnnotationConfigApplicationContext pluginDIContext = new AnnotationConfigApplicationContext();
+        AnnotationConfigApplicationContext isolatedPluginApplicationContext = new AnnotationConfigApplicationContext();
         if(markersToScanForDI!=null && markersToScanForDI.length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module
             Arrays.stream(markersToScanForDI)
                     .map(Class::getPackageName)
-                    .forEach(pluginDIContext::scan);
-            pluginDIContext.refresh();
+                    .forEach(isolatedPluginApplicationContext::scan);
+            isolatedPluginApplicationContext.refresh();
         }
-        pluginDIContext.setParent(sharedPluginApplicationContext);
-        return pluginDIContext.getBeanFactory();
+        isolatedPluginApplicationContext.setParent(sharedPluginApplicationContext);
+        return isolatedPluginApplicationContext.getBeanFactory();
     }
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -64,12 +64,12 @@ class PluginBeanFactoryProvider implements Provider<BeanFactory> {
         return isolatedPluginApplicationContext.getBeanFactory();
     }
 
-    public BeanFactory initializePluginSpecificIsolatedContext(Class[] scanForDIMarkers) {
+    public BeanFactory initializePluginSpecificIsolatedContext(Class[] markersToScanForDI) {
         AnnotationConfigApplicationContext pluginDIContext = new AnnotationConfigApplicationContext();
-        if(scanForDIMarkers.length>0) {
+        if(markersToScanForDI.length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module
-            Arrays.stream(scanForDIMarkers)
+            Arrays.stream(markersToScanForDI)
                     .map(Class::getPackageName)
                     .forEach(pluginDIContext::scan);
             pluginDIContext.refresh();

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -60,13 +60,12 @@ class PluginBeanFactoryProvider implements Provider<BeanFactory> {
      * @return BeanFactory A BeanFactory that inherits from {@link PluginBeanFactoryProvider#sharedPluginApplicationContext}
      */
     public BeanFactory get() {
-        final GenericApplicationContext isolatedPluginApplicationContext = new GenericApplicationContext(sharedPluginApplicationContext);
-        return isolatedPluginApplicationContext.getBeanFactory();
+        return initializePluginSpecificIsolatedContext(new Class[]{});
     }
 
     public BeanFactory initializePluginSpecificIsolatedContext(Class[] markersToScanForDI) {
         AnnotationConfigApplicationContext pluginDIContext = new AnnotationConfigApplicationContext();
-        if(markersToScanForDI.length>0) {
+        if(markersToScanForDI!=null && markersToScanForDI.length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module
             Arrays.stream(markersToScanForDI)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugin;
 
-import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -65,13 +64,12 @@ class PluginBeanFactoryProvider implements Provider<BeanFactory> {
         return isolatedPluginApplicationContext.getBeanFactory();
     }
 
-
-    public BeanFactory initializePluginSpecificIsolatedContext(DataPrepperPlugin pluginAnnotation) {
+    public BeanFactory initializePluginSpecificIsolatedContext(Class[] scanForDIMarkers) {
         AnnotationConfigApplicationContext pluginDIContext = new AnnotationConfigApplicationContext();
-        if(pluginAnnotation.packagesToScanForDI().length>0) {
+        if(scanForDIMarkers.length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module
-            Arrays.stream(pluginAnnotation.packagesToScanForDI())
+            Arrays.stream(scanForDIMarkers)
                     .map(Class::getPackageName)
                     .forEach(pluginDIContext::scan);
             pluginDIContext.refresh();

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -12,7 +12,6 @@ import org.springframework.context.support.GenericApplicationContext;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -27,7 +26,7 @@ import java.util.Objects;
  * <p><i>publicContext</i> is the root {@link ApplicationContext}</p>
  */
 @Named
-class PluginBeanFactoryProvider implements Provider<BeanFactory> {
+class PluginBeanFactoryProvider {
     private final GenericApplicationContext sharedPluginApplicationContext;
     private final GenericApplicationContext coreApplicationContext;
 
@@ -59,16 +58,12 @@ class PluginBeanFactoryProvider implements Provider<BeanFactory> {
      * instead, a new isolated {@link ApplicationContext} should be created.
      * @return BeanFactory A BeanFactory that inherits from {@link PluginBeanFactoryProvider#sharedPluginApplicationContext}
      */
-    public BeanFactory get() {
-        return initializePluginSpecificIsolatedContext(new Class[]{});
-    }
-
-    public BeanFactory initializePluginSpecificIsolatedContext(Class[] markersToScanForDI) {
+    public BeanFactory createPluginSpecificContext(Class[] markersToScan) {
         AnnotationConfigApplicationContext isolatedPluginApplicationContext = new AnnotationConfigApplicationContext();
-        if(markersToScanForDI!=null && markersToScanForDI.length>0) {
+        if(markersToScan !=null && markersToScan.length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module
-            Arrays.stream(markersToScanForDI)
+            Arrays.stream(markersToScan)
                     .map(Class::getPackageName)
                     .forEach(isolatedPluginApplicationContext::scan);
             isolatedPluginApplicationContext.refresh();

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -13,6 +13,7 @@ import org.springframework.context.support.GenericApplicationContext;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -27,7 +28,7 @@ import java.util.Objects;
  * <p><i>publicContext</i> is the root {@link ApplicationContext}</p>
  */
 @Named
-class PluginBeanFactoryProvider {
+class PluginBeanFactoryProvider implements Provider<BeanFactory> {
     private final GenericApplicationContext sharedPluginApplicationContext;
     private final GenericApplicationContext coreApplicationContext;
 
@@ -59,7 +60,13 @@ class PluginBeanFactoryProvider {
      * instead, a new isolated {@link ApplicationContext} should be created.
      * @return BeanFactory A BeanFactory that inherits from {@link PluginBeanFactoryProvider#sharedPluginApplicationContext}
      */
-    public BeanFactory initializePluginSpecificIsolatedContextCombinedWithShared(DataPrepperPlugin pluginAnnotation) {
+    public BeanFactory get() {
+        final GenericApplicationContext isolatedPluginApplicationContext = new GenericApplicationContext(sharedPluginApplicationContext);
+        return isolatedPluginApplicationContext.getBeanFactory();
+    }
+
+
+    public BeanFactory initializePluginSpecificIsolatedContext(DataPrepperPlugin pluginAnnotation) {
         AnnotationConfigApplicationContext pluginDIContext = new AnnotationConfigApplicationContext();
         if(pluginAnnotation.packagesToScanForDI().length>0) {
             // If packages to scan is provided in this plugin annotation, which indicates

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -210,7 +210,7 @@ class DefaultPluginFactoryTest {
                     equalTo(expectedInstance));
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{TestDISource.class});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{TestDISource.class});
         }
 
         @Test
@@ -227,7 +227,7 @@ class DefaultPluginFactoryTest {
                     equalTo(expectedInstance));
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
         }
 
         @Test
@@ -261,7 +261,7 @@ class DefaultPluginFactoryTest {
             assertThat(plugins, notNullValue());
             assertThat(plugins.size(), equalTo(0));
 
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
             verifyNoInteractions(pluginCreator);
         }
 
@@ -277,7 +277,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 1);
 
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
@@ -306,7 +306,7 @@ class DefaultPluginFactoryTest {
 
             final Object plugin = createObjectUnderTest().loadPlugin(baseClass, pluginSetting, object);
 
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
@@ -341,7 +341,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 3);
 
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
             verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final List<ComponentPluginArgumentsContext> actualPluginArgumentsContextList = pluginArgumentsContextArgCapture.getAllValues();
@@ -377,7 +377,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 1);
 
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
             verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
@@ -419,7 +419,7 @@ class DefaultPluginFactoryTest {
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
             MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).deprecatedName(), equalTo(TEST_SINK_DEPRECATED_NAME));
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
         }
     }
 
@@ -448,7 +448,7 @@ class DefaultPluginFactoryTest {
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
             MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).alternateNames(), equalTo(new String[]{TEST_SINK_ALTERNATE_NAME}));
-            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{});
         }
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -18,6 +18,8 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.plugins.test.TestDISource;
 import org.opensearch.dataprepper.plugins.test.TestSink;
 import org.springframework.beans.factory.BeanFactory;
 
@@ -193,6 +195,25 @@ class DefaultPluginFactoryTest {
         }
 
         @Test
+        void loadPlugin_should_create_a_new_instance_of_the_plugin_with_di_initialized() {
+
+            final TestDISource expectedInstance = mock(TestDISource.class);
+            final Object convertedConfiguration = mock(Object.class);
+            given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
+                    .willReturn(convertedConfiguration);
+            given(firstPluginProvider.findPluginClass(Source.class, pluginName))
+                    .willReturn(Optional.of(TestDISource.class));
+            given(pluginCreator.newPluginInstance(eq(TestDISource.class), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
+                    .willReturn(expectedInstance);
+
+            assertThat(createObjectUnderTest().loadPlugin(Source.class, pluginSetting),
+                    equalTo(expectedInstance));
+            verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
+                    eq(PluginSetting.class), eq(pluginSetting));
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{TestDISource.class});
+        }
+
+        @Test
         void loadPlugin_should_create_a_new_instance_of_the_first_plugin_found() {
 
             final TestSink expectedInstance = mock(TestSink.class);
@@ -206,7 +227,7 @@ class DefaultPluginFactoryTest {
                     equalTo(expectedInstance));
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
         }
 
         @Test
@@ -240,7 +261,7 @@ class DefaultPluginFactoryTest {
             assertThat(plugins, notNullValue());
             assertThat(plugins.size(), equalTo(0));
 
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
             verifyNoInteractions(pluginCreator);
         }
 
@@ -256,7 +277,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 1);
 
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
@@ -285,7 +306,7 @@ class DefaultPluginFactoryTest {
 
             final Object plugin = createObjectUnderTest().loadPlugin(baseClass, pluginSetting, object);
 
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
@@ -320,7 +341,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 3);
 
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
             verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final List<ComponentPluginArgumentsContext> actualPluginArgumentsContextList = pluginArgumentsContextArgCapture.getAllValues();
@@ -356,7 +377,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 1);
 
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
             verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
@@ -398,7 +419,7 @@ class DefaultPluginFactoryTest {
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
             MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).deprecatedName(), equalTo(TEST_SINK_DEPRECATED_NAME));
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
         }
     }
 
@@ -427,7 +448,7 @@ class DefaultPluginFactoryTest {
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
             MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).alternateNames(), equalTo(new String[]{TEST_SINK_ALTERNATE_NAME}));
-            verify(beanFactoryProvider).get();
+            verify(beanFactoryProvider).initializePluginSpecificIsolatedContext(new Class[]{});
         }
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.test.TestComponent;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.support.GenericApplicationContext;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -112,5 +113,6 @@ class PluginBeanFactoryProviderTest {
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
         BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{});
         assertThat(beanFactory, notNullValue());
+        assertThrows(NoSuchBeanDefinitionException.class, ()->beanFactory.getBean(TestComponent.class));
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PluginBeanFactoryProviderTest {
 
@@ -100,7 +101,7 @@ class PluginBeanFactoryProviderTest {
 
     @Test
     void testInitializePluginSpecificIsolatedContext() {
-        doReturn(context).when(context).getParent();
+        when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
         BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{TestComponent.class});
         assertThat(beanFactory, notNullValue());
@@ -109,7 +110,7 @@ class PluginBeanFactoryProviderTest {
 
     @Test
     void testInitializePluginSpecificIsolatedContext_with_empty_array() {
-        doReturn(context).when(context).getParent();
+        when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
         BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{});
         assertThat(beanFactory, notNullValue());

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
@@ -105,4 +105,12 @@ class PluginBeanFactoryProviderTest {
         assertThat(beanFactory, notNullValue());
         assertThat(beanFactory.getBean(TestComponent.class), notNullValue());
     }
+
+    @Test
+    void testInitializePluginSpecificIsolatedContext_with_empty_array() {
+        doReturn(context).when(context).getParent();
+        final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
+        BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{});
+        assertThat(beanFactory, notNullValue());
+    }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugin;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.test.TestComponent;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.support.GenericApplicationContext;
 
@@ -48,14 +49,14 @@ class PluginBeanFactoryProviderTest {
     @Test
     void testPluginBeanFactoryProviderRequiresContext() {
         context = null;
-        assertThrows(NullPointerException.class, () -> createObjectUnderTest());
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
     @Test
     void testPluginBeanFactoryProviderRequiresParentContext() {
         context = mock(GenericApplicationContext.class);
 
-        assertThrows(NullPointerException.class, () -> createObjectUnderTest());
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
     @Test
@@ -94,5 +95,14 @@ class PluginBeanFactoryProviderTest {
         doReturn(context).when(context).getParent();
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
         assertThat(objectUnderTest.getSharedPluginApplicationContext(), sameInstance(objectUnderTest.getSharedPluginApplicationContext()));
+    }
+
+    @Test
+    void testInitializePluginSpecificIsolatedContext() {
+        doReturn(context).when(context).getParent();
+        final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
+        BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{TestComponent.class});
+        assertThat(beanFactory, notNullValue());
+        assertThat(beanFactory.getBean(TestComponent.class), notNullValue());
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
@@ -68,7 +68,7 @@ class PluginBeanFactoryProviderTest {
         final PluginBeanFactoryProvider beanFactoryProvider = createObjectUnderTest();
 
         verify(context).getParent();
-        assertThat(beanFactoryProvider.get(), is(instanceOf(BeanFactory.class)));
+        assertThat(beanFactoryProvider.createPluginSpecificContext(new Class[]{}), is(instanceOf(BeanFactory.class)));
     }
 
     @Test
@@ -76,8 +76,8 @@ class PluginBeanFactoryProviderTest {
         doReturn(context).when(context).getParent();
 
         final PluginBeanFactoryProvider beanFactoryProvider = createObjectUnderTest();
-        final BeanFactory isolatedBeanFactoryA = beanFactoryProvider.get();
-        final BeanFactory isolatedBeanFactoryB = beanFactoryProvider.get();
+        final BeanFactory isolatedBeanFactoryA = beanFactoryProvider.createPluginSpecificContext(new Class[]{});
+        final BeanFactory isolatedBeanFactoryB = beanFactoryProvider.createPluginSpecificContext(new Class[]{});
 
         verify(context).getParent();
         assertThat(isolatedBeanFactoryA, not(sameInstance(isolatedBeanFactoryB)));
@@ -100,19 +100,19 @@ class PluginBeanFactoryProviderTest {
     }
 
     @Test
-    void testInitializePluginSpecificIsolatedContext() {
+    void testCreatePluginSpecificContext() {
         when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
-        BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{TestComponent.class});
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{TestComponent.class});
         assertThat(beanFactory, notNullValue());
         assertThat(beanFactory.getBean(TestComponent.class), notNullValue());
     }
 
     @Test
-    void testInitializePluginSpecificIsolatedContext_with_empty_array() {
+    void testCreatePluginSpecificContext_with_empty_array() {
         when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
-        BeanFactory beanFactory = objectUnderTest.initializePluginSpecificIsolatedContext(new Class[]{});
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{});
         assertThat(beanFactory, notNullValue());
         assertThrows(NoSuchBeanDefinitionException.class, ()->beanFactory.getBean(TestComponent.class));
     }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestComponent.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestComponent.java
@@ -1,0 +1,7 @@
+package org.opensearch.dataprepper.plugins.test;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestComponent {
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestComponent.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestComponent.java
@@ -4,4 +4,7 @@ import javax.inject.Named;
 
 @Named
 public class TestComponent {
+    public String getIdentifier() {
+        return "test-component";
+    }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestComponent.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestComponent.java
@@ -1,7 +1,7 @@
 package org.opensearch.dataprepper.plugins.test;
 
-import org.springframework.stereotype.Component;
+import javax.inject.Named;
 
-@Component
+@Named
 public class TestComponent {
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestDISource.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestDISource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.test;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.Source;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@DataPrepperPlugin(name = "test_di_source",
+        alternateNames = { "test_source_alternate_name1", "test_source_alternate_name2" },
+        deprecatedName = "test_source_deprecated_name",
+        pluginType = Source.class,
+        packagesToScan = {TestDISource.class})
+public class TestDISource extends TestSource {
+    public static final List<Record<String>> TEST_DATA = Stream.of("TEST")
+            .map(Record::new).collect(Collectors.toList());
+
+    private final TestComponent testComponent;
+
+
+    public TestDISource(TestComponent testComponent) {
+        this.testComponent = testComponent;
+    }
+
+    @Override
+    public void start(Buffer<Record<String>> buffer) {
+        final Iterator<Record<String>> iterator = TEST_DATA.iterator();
+            while (iterator.hasNext()) {
+                try {
+                    buffer.write(iterator.next(), 1_000);
+                } catch (TimeoutException e) {
+                    throw new RuntimeException("Timed out writing to buffer");
+                }
+            }
+    }
+
+    @Override
+    public void stop() {}
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestDISource.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestDISource.java
@@ -12,20 +12,12 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.plugin.TestPluggableInterface;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 @DataPrepperPlugin(name = "test_di_source",
         alternateNames = { "test_source_alternate_name1", "test_source_alternate_name2" },
         deprecatedName = "test_source_deprecated_name",
         pluginType = Source.class,
         packagesToScan = {TestDISource.class})
 public class TestDISource implements Source<Record<String>>, TestPluggableInterface {
-    public static final List<Record<String>> TEST_DATA = Stream.of("TEST")
-            .map(Record::new).collect(Collectors.toList());
 
     private final TestComponent testComponent;
 
@@ -36,14 +28,6 @@ public class TestDISource implements Source<Record<String>>, TestPluggableInterf
 
     @Override
     public void start(Buffer<Record<String>> buffer) {
-        final Iterator<Record<String>> iterator = TEST_DATA.iterator();
-            while (iterator.hasNext()) {
-                try {
-                    buffer.write(iterator.next(), 1_000);
-                } catch (TimeoutException e) {
-                    throw new RuntimeException("Timed out writing to buffer");
-                }
-            }
     }
 
     public TestComponent getTestComponent() {

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestDISource.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestDISource.java
@@ -6,9 +6,11 @@
 package org.opensearch.dataprepper.plugins.test;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.plugin.TestPluggableInterface;
 
 import java.util.Iterator;
 import java.util.List;
@@ -21,13 +23,13 @@ import java.util.stream.Stream;
         deprecatedName = "test_source_deprecated_name",
         pluginType = Source.class,
         packagesToScan = {TestDISource.class})
-public class TestDISource extends TestSource {
+public class TestDISource implements Source<Record<String>>, TestPluggableInterface {
     public static final List<Record<String>> TEST_DATA = Stream.of("TEST")
             .map(Record::new).collect(Collectors.toList());
 
     private final TestComponent testComponent;
 
-
+    @DataPrepperPluginConstructor
     public TestDISource(TestComponent testComponent) {
         this.testComponent = testComponent;
     }
@@ -42,6 +44,10 @@ public class TestDISource extends TestSource {
                     throw new RuntimeException("Timed out writing to buffer");
                 }
             }
+    }
+
+    public TestComponent getTestComponent() {
+        return testComponent;
     }
 
     @Override


### PR DESCRIPTION
### Description
Optional feature for the plugins to use Spring Dependency Injection in its own isolated context. 

How does it work?
- DataPrepper plugin annotation is enhanced to accept the marker classes to indicate the packages that these marker classes belong are the root for the plugin classes to be considered under its isolated spring context
- Plugin can pass more than one marker class to combine its spring context along with other code
- This is an optional entry. If not provided, everything will work as it was before.
- When given, the framework will initialize Spring DI over plugin classes and also inject any required beans to the plugin constructor while it gets instantiated.
 
### Issues Resolved
Resolves #929 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
