### PR TITLE
Add OpenTelemetry Metrics example

### DIFF
--- a/examples/metrics-ingestion-otel/README.md
+++ b/examples/metrics-ingestion-otel/README.md
@@ -14,7 +14,7 @@ To run:
 
 1. Run `docker compose up`
 2. Wait for everything to come up.
-3. Log into OpenSearch Dashboards at <http://localhost:5601>.
+3. Log into OpenSearch Dashboards at <http://localhost:5601> using username `admin` and password `Developer@123`.
 4. Create an Index Pattern for index `otel_metrics` choosing `time` as the time field.
 5. Inspect the data in the Discovery plugin.
 

--- a/examples/metrics-ingestion-otel/README.md
+++ b/examples/metrics-ingestion-otel/README.md
@@ -1,0 +1,26 @@
+# DataPrepper Metrics Ingestion from OpenTelemetry Collector
+
+This is an example of using the OpenTelemetry Collector to send metrics data to Data Prepper and then to OpenSearch.
+The Data Prepper OTLP/gRPC endpoint is exposed at port 21891. 
+The same protocol can be used with the OpenTelemetry Collector, which listens at the OTLP default port 4317.
+This setup allows to compare both endpoints.
+The Collector will forward any data to Data Prepper for indexing in OpenSearch.
+
+To generate some demo data, the OpenTelemetry Collector uses its host metrics receiver to acquire cpu and memory metrics on the machine it is running on.
+Additionally, it scrapes the Prometheus metrics endpoint of the Data Prepper instance.
+This also let's you investigate the Data Prepper metrics in OpenSearch.
+
+To run:
+
+1. Run `docker compose up`
+2. Wait for everything to come up.
+3. Log into OpenSearch Dashboards at <http://localhost:5601>.
+4. Create an Index Pattern for index `otel_metrics` choosing `time` as the time field.
+5. Inspect the data in the Discovery plugin.
+
+Useful changes and additions:
+
+1. The OpenTelemetry Collector has its [Logging Exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/loggingexporter/README.md) in use. Changing the `loglevel` to `debug` or setting the `verbosity` to `detailed` will log all data to stdout. This is useful for troubleshooting.
+2. The OpenTelemetry Collector can push its own metrics to Data Prepper. Follow its documentation in [Internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/#use-internal-telemetry-to-monitor-the-collector) for details. These metrics allow comparing the event counts between the Collector and Data Prepper.
+3. The OpenTelemetry Collector can be configured to translate between OTLP/HTTP and OTLP/gRPC. It can be used to proxy between sources only capable of OTLP/HTTP and Data Prepper, which only supports OTLP/gRPC.
+4. The OpenTelemetry Collector can receive data from the Docker host. It can attach metadata describing the containers. Unfortunately, the required processor does not work with MacOS, so this config was not provided in this example.

--- a/examples/metrics-ingestion-otel/docker-compose.yaml
+++ b/examples/metrics-ingestion-otel/docker-compose.yaml
@@ -1,0 +1,69 @@
+version: '3'
+services:
+  data-prepper:
+    image: opensearchproject/data-prepper
+    container_name: data-prepper
+    volumes:
+      - ./metric_pipeline.yaml:/usr/share/data-prepper/pipelines/metric_pipeline.yaml
+      - ../data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
+    ports:
+      - 2021:2021
+      - 21891:21891
+      - 4900:4900
+    expose:
+      - "2021"
+      - "4900"
+      - "21891"
+    networks:
+      - opensearch-net
+    depends_on:
+      - opensearch
+  opensearch:
+    container_name: opensearch
+    image: docker.io/opensearchproject/opensearch:latest
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=Developer@123"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer
+    networks:
+      - opensearch-net
+  dashboards:
+    image: docker.io/opensearchproject/opensearch-dashboards:latest
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601
+    expose:
+      - "5601"
+    environment:
+      OPENSEARCH_HOSTS: '["https://opensearch:9200"]'
+    depends_on:
+      - opensearch
+    networks:
+      - opensearch-net
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    container_name: otel-collector
+    command: ["--config=/etc/otel-collector-config.yml"]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel-collector-config.yml
+    environment:
+      OTEL_RESOURCE_ATTRIBUTES: service.name=otel-collector
+    ports:
+      - 4317:4317
+    depends_on:
+      - data-prepper
+    networks:
+      - opensearch-net
+networks:
+  opensearch-net:

--- a/examples/metrics-ingestion-otel/metric_pipeline.yaml
+++ b/examples/metrics-ingestion-otel/metric_pipeline.yaml
@@ -1,0 +1,13 @@
+metric-pipeline:
+  source:
+    otel_metrics_source:
+      ssl: false
+  processor:
+    - otel_metrics:
+  sink:
+    - opensearch:
+        hosts: [ "https://opensearch:9200" ]
+        insecure: true
+        username: admin
+        password: Developer@123
+        index: otel_metrics

--- a/examples/metrics-ingestion-otel/otel-collector-config.yml
+++ b/examples/metrics-ingestion-otel/otel-collector-config.yml
@@ -1,0 +1,37 @@
+receivers:
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+      memory:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: data-prepper
+          metrics_path: /metrics/sys
+          scrape_interval: 60s
+          static_configs:
+            - targets: ['data-prepper:4900']
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+exporters:
+  otlp/metrics:
+    endpoint: data-prepper:21891
+    tls:
+      insecure: true
+  otlphttp/metrics:
+    metrics_endpoint: http://data-prepper:21891/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
+  logging:
+processors:
+  resourcedetection/env:
+    detectors: [env]
+    timeout: 2s
+    override: false
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp,hostmetrics,prometheus]
+      processors: [resourcedetection/env]
+      exporters: [logging, otlp/metrics]


### PR DESCRIPTION
### Description
Provides a small Docker Compose setup to show metrics ingestion with Data Prepper. This example is similar to the traces and logs examples. It also shows the metrics Data Prepper emits on its metrics endpoint.
 
### Issues Resolved
no issue known
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
