### PR TITLE
Support secret rotation in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
@@ -37,6 +38,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
     private final RdsSourceConfig sourceConfig;
     private final EventFactory eventFactory;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final PluginConfigObservable pluginConfigObservable;
     private EnhancedSourceCoordinator sourceCoordinator;
     private RdsService rdsService;
 
@@ -45,11 +47,13 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
                      final RdsSourceConfig sourceConfig,
                      final EventFactory eventFactory,
                      final AwsCredentialsSupplier awsCredentialsSupplier,
-                     final AcknowledgementSetManager acknowledgementSetManager) {
+                     final AcknowledgementSetManager acknowledgementSetManager,
+                     final PluginConfigObservable pluginConfigObservable) {
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
         this.eventFactory = eventFactory;
         this.acknowledgementSetManager = acknowledgementSetManager;
+        this.pluginConfigObservable = pluginConfigObservable;
 
         clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig);
     }
@@ -60,7 +64,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
         Objects.requireNonNull(sourceCoordinator);
         sourceCoordinator.createPartition(new LeaderPartition());
 
-        rdsService = new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics, acknowledgementSetManager);
+        rdsService = new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
 
         LOG.info("Start RDS service");
         rdsService.start(buffer);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactory.java
@@ -6,29 +6,44 @@
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import software.amazon.awssdk.services.rds.RdsClient;
 
 public class BinlogClientFactory {
 
-    private final RdsSourceConfig sourceConfig;
     private final RdsClient rdsClient;
     private final DbMetadata dbMetadata;
+    private String username;
+    private String password;
+    private SSLMode sslMode = SSLMode.REQUIRED;
 
     public BinlogClientFactory(final RdsSourceConfig sourceConfig,
                                final RdsClient rdsClient,
                                final DbMetadata dbMetadata) {
-        this.sourceConfig = sourceConfig;
         this.rdsClient = rdsClient;
         this.dbMetadata = dbMetadata;
+        username = sourceConfig.getAuthenticationConfig().getUsername();
+        password = sourceConfig.getAuthenticationConfig().getPassword();
     }
 
     public BinaryLogClient create() {
-        return new BinaryLogClient(
+        BinaryLogClient binaryLogClient = new BinaryLogClient(
                 dbMetadata.getHostName(),
                 dbMetadata.getPort(),
-                sourceConfig.getAuthenticationConfig().getUsername(),
-                sourceConfig.getAuthenticationConfig().getPassword());
+                username,
+                password);
+        binaryLogClient.setSSLMode(sslMode);
+        return binaryLogClient;
+    }
+
+    public void setSSLMode(SSLMode sslMode) {
+        this.sslMode = sslMode;
+    }
+
+    public void setCredentials(String username, String password) {
+        this.username = username;
+        this.password = password;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -117,6 +117,16 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         eventProcessingTimer = pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME);
     }
 
+    public static BinlogEventListener create(final Buffer<Record<Event>> buffer,
+                                             final RdsSourceConfig sourceConfig,
+                                             final String s3Prefix,
+                                             final PluginMetrics pluginMetrics,
+                                             final BinaryLogClient binaryLogClient,
+                                             final StreamCheckpointer streamCheckpointer,
+                                             final AcknowledgementSetManager acknowledgementSetManager) {
+        return new BinlogEventListener(buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager);
+    }
+
     @Override
     public void onEvent(com.github.shyiko.mysql.binlog.event.Event event) {
         final EventType eventType = event.getHeader().getEventType();

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
@@ -81,7 +81,7 @@ public class StreamScheduler implements Runnable {
                     streamPartition = (StreamPartition) sourcePartition.get();
                     final StreamCheckpointer streamCheckpointer = new StreamCheckpointer(sourceCoordinator, streamPartition, pluginMetrics);
 
-                    streamWorkerTaskRefresher = new StreamWorkerTaskRefresher(
+                    streamWorkerTaskRefresher = StreamWorkerTaskRefresher.create(
                             sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, binlogClientFactory, buffer, acknowledgementSetManager, executorService, pluginMetrics);
 
                     streamWorkerTaskRefresher.initialize(sourceConfig);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -68,6 +68,30 @@ public class StreamWorker {
         }
     }
 
+//    public void refreshConnection(final StreamPartition streamPartition) {
+//        try {
+//            binaryLogClient.disconnect();
+//        } catch (IOException e) {
+//            LOG.error("Binary log client failed to disconnect.", e);
+//            throw new RuntimeException(e);
+//        }
+//
+//        setStartBinlogPosition(streamPartition);
+//
+//        try {
+//            LOG.info("Re-connect to database to read change events.");
+//            binaryLogClient.connect();
+//        } catch (IOException e) {
+//            throw new RuntimeException(e);
+//        } finally {
+//            try {
+//                binaryLogClient.disconnect();
+//            } catch (IOException e) {
+//                LOG.error("Binary log client failed to disconnect.", e);
+//            }
+//        }
+//    }
+
     private boolean shouldWaitForExport(final StreamPartition streamPartition) {
         if (!streamPartition.getProgressState().get().shouldWaitForExport()) {
             LOG.debug("Export is not enabled. Proceed with streaming.");

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -68,30 +68,6 @@ public class StreamWorker {
         }
     }
 
-//    public void refreshConnection(final StreamPartition streamPartition) {
-//        try {
-//            binaryLogClient.disconnect();
-//        } catch (IOException e) {
-//            LOG.error("Binary log client failed to disconnect.", e);
-//            throw new RuntimeException(e);
-//        }
-//
-//        setStartBinlogPosition(streamPartition);
-//
-//        try {
-//            LOG.info("Re-connect to database to read change events.");
-//            binaryLogClient.connect();
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        } finally {
-//            try {
-//                binaryLogClient.disconnect();
-//            } catch (IOException e) {
-//                LOG.error("Binary log client failed to disconnect.", e);
-//            }
-//        }
-//    }
-
     private boolean shouldWaitForExport(final StreamPartition streamPartition) {
         if (!streamPartition.getProgressState().get().shouldWaitForExport()) {
             LOG.debug("Export is not enabled. Proceed with streaming.");

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSourceConfig> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamWorkerTaskRefresher.class);
+    static final String CREDENTIALS_CHANGED = "credentialsChanged";
+    static final String EXECUTOR_REFRESH_ERRORS = "executorRefreshErrors";
+
+    private final EnhancedSourceCoordinator sourceCoordinator;
+    private final StreamPartition streamPartition;
+    private final StreamCheckpointer streamCheckpointer;
+    private final String s3Prefix;
+    private final BinlogClientFactory binlogClientFactory;
+    private final Buffer<Record<Event>> buffer;
+    private final PluginMetrics pluginMetrics;
+    private final AcknowledgementSetManager acknowledgementSetManager;
+    private final Counter credentialsChangeCounter;
+    private final Counter executorRefreshErrorsCounter;
+
+    private ExecutorService executorService;
+    private RdsSourceConfig currentSourceConfig;
+
+    public StreamWorkerTaskRefresher(final EnhancedSourceCoordinator sourceCoordinator,
+                                     final StreamPartition streamPartition,
+                                     final StreamCheckpointer streamCheckpointer,
+                                     final String s3Prefix,
+                                     final BinlogClientFactory binlogClientFactory,
+                                     final Buffer<Record<Event>> buffer,
+                                     final AcknowledgementSetManager acknowledgementSetManager,
+                                     final ExecutorService executorService,
+                                     final PluginMetrics pluginMetrics) {
+        this.sourceCoordinator = sourceCoordinator;
+        this.streamPartition = streamPartition;
+        this.streamCheckpointer = streamCheckpointer;
+        this.s3Prefix = s3Prefix;
+        this.buffer = buffer;
+        this.pluginMetrics = pluginMetrics;
+        this.acknowledgementSetManager = acknowledgementSetManager;
+        this.binlogClientFactory = binlogClientFactory;
+        this.executorService = executorService;
+        this.credentialsChangeCounter = pluginMetrics.counter(CREDENTIALS_CHANGED);
+        this.executorRefreshErrorsCounter = pluginMetrics.counter(EXECUTOR_REFRESH_ERRORS);
+    }
+
+    public void initialize(final RdsSourceConfig sourceConfig) {
+        currentSourceConfig = sourceConfig;
+        refreshTask(sourceConfig);
+    }
+
+    @Override
+    public void update(RdsSourceConfig sourceConfig) {
+        if (basicAuthChanged(sourceConfig.getAuthenticationConfig())) {
+            LOG.info("Database credentials were updated. Refreshing stream worker...");
+            credentialsChangeCounter.increment();
+            try {
+                executorService.shutdownNow();
+                executorService = Executors.newSingleThreadExecutor();
+                binlogClientFactory.setCredentials(
+                        sourceConfig.getAuthenticationConfig().getUsername(), sourceConfig.getAuthenticationConfig().getPassword());
+
+                refreshTask(sourceConfig);
+
+                currentSourceConfig = sourceConfig;
+            } catch (Exception e) {
+                executorRefreshErrorsCounter.increment();
+                LOG.error("Refreshing stream worker failed", e);
+            }
+        }
+        LOG.debug("Database credentials were not changed. Skipping...");
+    }
+
+    private void refreshTask(RdsSourceConfig sourceConfig) {
+        final BinaryLogClient binaryLogClient = binlogClientFactory.create();
+        binaryLogClient.registerEventListener(new BinlogEventListener(
+                buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager));
+        final StreamWorker streamWorker = StreamWorker.create(sourceCoordinator, binaryLogClient, pluginMetrics);
+        executorService.submit(() -> streamWorker.processStream(streamPartition));
+    }
+
+    private boolean basicAuthChanged(final RdsSourceConfig.AuthenticationConfig newAuthConfig) {
+        final RdsSourceConfig.AuthenticationConfig currentAuthConfig = currentSourceConfig.getAuthenticationConfig();
+        return !Objects.equals(currentAuthConfig.getUsername(), newAuthConfig.getUsername()) ||
+                !Objects.equals(currentAuthConfig.getPassword(), newAuthConfig.getPassword());
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -18,6 +18,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManag
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.TlsConfig;
@@ -79,6 +80,9 @@ class RdsServiceTest {
 
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private PluginConfigObservable pluginConfigObservable;
 
     @BeforeEach
     void setUp() {
@@ -186,6 +190,6 @@ class RdsServiceTest {
     }
 
     private RdsService createObjectUnderTest() {
-        return new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics, acknowledgementSetManager);
+        return new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,6 +42,9 @@ class RdsSourceTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
+    @Mock
+    private PluginConfigObservable pluginConfigObservable;
+
     @BeforeEach
     void setUp() {
         when(sourceConfig.getAwsAuthenticationConfig()).thenReturn(awsAuthenticationConfig);
@@ -53,6 +57,7 @@ class RdsSourceTest {
     }
 
     private RdsSource createObjectUnderTest() {
-        return new RdsSource(pluginMetrics, sourceConfig, eventFactory, awsCredentialsSupplier, acknowledgementSetManager);
+        return new RdsSource(
+                pluginMetrics, sourceConfig, eventFactory, awsCredentialsSupplier, acknowledgementSetManager, pluginConfigObservable);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactoryTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientFactoryTest.java
@@ -5,25 +5,24 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 import org.opensearch.dataprepper.plugins.source.rds.model.DbMetadata;
 import software.amazon.awssdk.services.rds.RdsClient;
 
-import java.util.Random;
+import java.util.UUID;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class BinlogClientFactoryTest {
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RdsSourceConfig sourceConfig;
 
     @Mock
@@ -33,28 +32,22 @@ class BinlogClientFactoryTest {
     private DbMetadata dbMetadata;
 
     private BinlogClientFactory binlogClientFactory;
-    private Random random;
-
-    @BeforeEach
-    void setUp() {
-        binlogClientFactory = createBinlogClientFactory();
-        random = new Random();
-    }
 
     @Test
     void test_create() {
-        final RdsSourceConfig.AuthenticationConfig authenticationConfig = mock(RdsSourceConfig.AuthenticationConfig.class);
-        when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
+        final String username = UUID.randomUUID().toString();
+        final String password = UUID.randomUUID().toString();
+        when(sourceConfig.getAuthenticationConfig().getUsername()).thenReturn(username);
+        when(sourceConfig.getAuthenticationConfig().getPassword()).thenReturn(password);
 
+        binlogClientFactory = createObjectUnderTest();
         binlogClientFactory.create();
 
         verify(dbMetadata).getHostName();
         verify(dbMetadata).getPort();
-        verify(authenticationConfig).getUsername();
-        verify(authenticationConfig).getPassword();
     }
 
-    private BinlogClientFactory createBinlogClientFactory() {
+    private BinlogClientFactory createObjectUnderTest() {
         return new BinlogClientFactory(sourceConfig, rdsClient, dbMetadata);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
-import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +16,8 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
@@ -29,7 +30,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -48,7 +50,7 @@ class StreamSchedulerTest {
     private RdsSourceConfig sourceConfig;
 
     @Mock
-    private BinaryLogClient binaryLogClient;
+    private BinlogClientFactory binlogClientFactory;
 
     @Mock
     private PluginMetrics pluginMetrics;
@@ -58,6 +60,12 @@ class StreamSchedulerTest {
 
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private PluginConfigObservable pluginConfigObservable;
+
+    @Mock
+    private StreamWorkerTaskRefresher streamWorkerTaskRefresher;
 
     private String s3Prefix;
     private StreamScheduler objectUnderTest;
@@ -79,7 +87,7 @@ class StreamSchedulerTest {
         Thread.sleep(100);
         executorService.shutdownNow();
 
-        verifyNoInteractions(binaryLogClient);
+        verifyNoInteractions(binlogClientFactory, pluginConfigObservable);
     }
 
     @Test
@@ -87,15 +95,12 @@ class StreamSchedulerTest {
         final StreamPartition streamPartition = mock(StreamPartition.class);
         when(sourceCoordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).thenReturn(Optional.of(streamPartition));
 
-        StreamWorker streamWorker = mock(StreamWorker.class);
-        doNothing().when(streamWorker).processStream(streamPartition);
-        when(sourceConfig.getStream().getNumWorkers()).thenReturn(1);
-
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {
-            try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class)) {
-                streamWorkerMockedStatic.when(() -> StreamWorker.create(sourceCoordinator, binaryLogClient, pluginMetrics))
-                        .thenReturn(streamWorker);
+            try (MockedStatic<StreamWorkerTaskRefresher> streamWorkerTaskRefresherMockedStatic = mockStatic(StreamWorkerTaskRefresher.class)) {
+                streamWorkerTaskRefresherMockedStatic.when(() -> StreamWorkerTaskRefresher.create(eq(sourceCoordinator), eq(streamPartition), any(StreamCheckpointer.class),
+                                eq(s3Prefix), eq(binlogClientFactory), eq(buffer), eq(acknowledgementSetManager), any(ExecutorService.class), eq(pluginMetrics)))
+                        .thenReturn(streamWorkerTaskRefresher);
                 objectUnderTest.run();
             }
 
@@ -105,7 +110,8 @@ class StreamSchedulerTest {
         Thread.sleep(100);
         executorService.shutdownNow();
 
-        verify(streamWorker).processStream(streamPartition);
+        verify(streamWorkerTaskRefresher).initialize(sourceConfig);
+        verify(pluginConfigObservable).addPluginConfigObserver(any(PluginConfigObserver.class));
     }
 
     @Test
@@ -120,6 +126,7 @@ class StreamSchedulerTest {
     }
 
     private StreamScheduler createObjectUnderTest() {
-        return new StreamScheduler(sourceCoordinator, sourceConfig, s3Prefix, binaryLogClient, buffer, pluginMetrics, acknowledgementSetManager);
+        return new StreamScheduler(
+                sourceCoordinator, sourceConfig, s3Prefix, binlogClientFactory, buffer, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
@@ -26,7 +26,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Stre
 
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -70,6 +70,12 @@ class StreamWorkerTaskRefresherTest {
     @Mock
     private ExecutorService executorService;
 
+    @Mock
+    private ExecutorService newExecutorService;
+
+    @Mock
+    private Supplier<ExecutorService> executorServiceSupplier;
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RdsSourceConfig sourceConfig;
 
@@ -91,6 +97,7 @@ class StreamWorkerTaskRefresherTest {
     void setUp() {
         when(pluginMetrics.counter(CREDENTIALS_CHANGED)).thenReturn(credentialsChangeCounter);
         when(pluginMetrics.counter(TASK_REFRESH_ERRORS)).thenReturn(taskRefreshErrorsCounter);
+        when(executorServiceSupplier.get()).thenReturn(executorService).thenReturn(newExecutorService);
         streamWorkerTaskRefresher = createObjectUnderTest();
     }
 
@@ -131,13 +138,10 @@ class StreamWorkerTaskRefresherTest {
 
         when(binlogClientFactory.create()).thenReturn(binlogClient).thenReturn(binlogClient);
 
-        final ExecutorService newExecutorService = mock(ExecutorService.class);
         try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class);
-             MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class);
              MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
             streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
                     .thenReturn(streamWorker);
-            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(newExecutorService);
             binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
                     .thenReturn(binlogEventListener);
             streamWorkerTaskRefresher.initialize(sourceConfig);
@@ -181,10 +185,16 @@ class StreamWorkerTaskRefresherTest {
         verify(executorService, never()).shutdownNow();
     }
 
+    @Test
+    void test_shutdown() {
+        streamWorkerTaskRefresher.shutdown();
+        verify(executorService).shutdownNow();
+    }
+
     private StreamWorkerTaskRefresher createObjectUnderTest() {
         final String s3Prefix = UUID.randomUUID().toString();
 
         return new StreamWorkerTaskRefresher(
-                sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, binlogClientFactory, buffer, acknowledgementSetManager, executorService, pluginMetrics);
+                sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, binlogClientFactory, buffer, executorServiceSupplier, acknowledgementSetManager, pluginMetrics);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.stream.StreamWorkerTaskRefresher.CREDENTIALS_CHANGED;
+import static org.opensearch.dataprepper.plugins.source.rds.stream.StreamWorkerTaskRefresher.TASK_REFRESH_ERRORS;
+
+@ExtendWith(MockitoExtension.class)
+class StreamWorkerTaskRefresherTest {
+
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private StreamPartition streamPartition;
+
+    @Mock
+    private StreamCheckpointer streamCheckpointer;
+
+    @Mock
+    private BinlogClientFactory binlogClientFactory;
+
+    @Mock
+    private BinaryLogClient binlogClient;
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private ExecutorService executorService;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RdsSourceConfig sourceConfig;
+
+    @Mock
+    private StreamWorker streamWorker;
+
+    @Mock
+    private Counter credentialsChangeCounter;
+
+    @Mock
+    private Counter taskRefreshErrorsCounter;
+
+    @Mock
+    private BinlogEventListener binlogEventListener;
+
+    private StreamWorkerTaskRefresher streamWorkerTaskRefresher;
+
+    @BeforeEach
+    void setUp() {
+        when(pluginMetrics.counter(CREDENTIALS_CHANGED)).thenReturn(credentialsChangeCounter);
+        when(pluginMetrics.counter(TASK_REFRESH_ERRORS)).thenReturn(taskRefreshErrorsCounter);
+        streamWorkerTaskRefresher = createObjectUnderTest();
+    }
+
+    @Test
+    void test_initialize_then_process_stream() {
+        when(binlogClientFactory.create()).thenReturn(binlogClient);
+        try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class);
+             MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
+            streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
+                    .thenReturn(streamWorker);
+            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                    .thenReturn(binlogEventListener);
+            streamWorkerTaskRefresher.initialize(sourceConfig);
+        }
+
+        verify(binlogClientFactory).create();
+        verify(binlogClient).registerEventListener(binlogEventListener);
+
+        ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executorService).submit(runnableArgumentCaptor.capture());
+
+        Runnable capturedRunnable = runnableArgumentCaptor.getValue();
+        capturedRunnable.run();
+        verify(streamWorker).processStream(streamPartition);
+    }
+
+    @Test
+    void test_update_when_credentials_changed_then_refresh_task() {
+        final String username = UUID.randomUUID().toString();
+        final String password = UUID.randomUUID().toString();
+        when(sourceConfig.getAuthenticationConfig().getUsername()).thenReturn(username);
+        when(sourceConfig.getAuthenticationConfig().getPassword()).thenReturn(password);
+
+        RdsSourceConfig sourceConfig2 = mock(RdsSourceConfig.class, RETURNS_DEEP_STUBS);
+        final String password2 = UUID.randomUUID().toString();
+        when(sourceConfig2.getAuthenticationConfig().getUsername()).thenReturn(username);
+        when(sourceConfig2.getAuthenticationConfig().getPassword()).thenReturn(password2);
+
+        when(binlogClientFactory.create()).thenReturn(binlogClient).thenReturn(binlogClient);
+
+        final ExecutorService newExecutorService = mock(ExecutorService.class);
+        try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class);
+             MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class);
+             MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
+            streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
+                    .thenReturn(streamWorker);
+            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(newExecutorService);
+            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                    .thenReturn(binlogEventListener);
+            streamWorkerTaskRefresher.initialize(sourceConfig);
+            streamWorkerTaskRefresher.update(sourceConfig2);
+        }
+
+        verify(credentialsChangeCounter).increment();
+        verify(executorService).shutdownNow();
+
+        verify(binlogClientFactory, times(2)).create();
+        verify(binlogClient, times(2)).registerEventListener(binlogEventListener);
+
+        ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(newExecutorService).submit(runnableArgumentCaptor.capture());
+
+        Runnable capturedRunnable = runnableArgumentCaptor.getValue();
+        capturedRunnable.run();
+        verify(streamWorker).processStream(streamPartition);
+    }
+
+    @Test
+    void test_update_when_credentials_unchanged_then_do_nothing() {
+        final String username = UUID.randomUUID().toString();
+        final String password = UUID.randomUUID().toString();
+        when(sourceConfig.getAuthenticationConfig().getUsername()).thenReturn(username);
+        when(sourceConfig.getAuthenticationConfig().getPassword()).thenReturn(password);
+
+        when(binlogClientFactory.create()).thenReturn(binlogClient);
+
+        try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class);
+             MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
+            streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
+                    .thenReturn(streamWorker);
+            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                    .thenReturn(binlogEventListener);
+            streamWorkerTaskRefresher.initialize(sourceConfig);
+            streamWorkerTaskRefresher.update(sourceConfig);
+        }
+
+        verify(credentialsChangeCounter, never()).increment();
+        verify(executorService, never()).shutdownNow();
+    }
+
+    private StreamWorkerTaskRefresher createObjectUnderTest() {
+        final String s3Prefix = UUID.randomUUID().toString();
+
+        return new StreamWorkerTaskRefresher(
+                sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, binlogClientFactory, buffer, acknowledgementSetManager, executorService, pluginMetrics);
+    }
+}


### PR DESCRIPTION
### Description
RDS source uses credentials stored in Secret Manager to connect to the database during stream (CDC). Data Prepper checks the credentials regularly through the Secret Manager extension in case they change. The PR adds a StreamWorkerTaskRefresher to the source plugin to update the stream connection when credentials change is detected.
 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
