### PR TITLE
Updates to JSON schema and Data Prepper documentation.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
@@ -95,7 +95,7 @@ public enum DataType {
     }
 
     @JsonCreator
-    static DataType fromTypeName(final String option) {
+    public static DataType fromTypeName(final String option) {
         return TYPES_MAP.get(option);
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
@@ -6,14 +6,21 @@
 package org.opensearch.dataprepper.model.event;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -39,26 +46,55 @@ class DataTypeTest {
         assertThat(DataType.isSameType(object, type), equalTo(expectedResult));
     }
 
+    @ParameterizedTest
+    @EnumSource(DataType.class)
+    void getTypeName_returns_non_empty_string_for_all_types(final DataType dataType) {
+        assertThat(dataType.getTypeName(), notNullValue());
+        assertThat(dataType.getTypeName(), not(emptyString()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DataTypeToKnownString.class)
+    void getTypeName_returns_expected_name(final DataType dataType, final String expectedString) {
+        assertThat(dataType.getTypeName(), equalTo(expectedString));
+    }
+
     private static Stream<Arguments> getSameTypeTestData() {
         int[] testArray = {1,2};
         List<Integer> testList = new ArrayList<>();
         return Stream.of(
-            Arguments.of(2, "integer", true),
-            Arguments.of("testString", "string", true),
-            Arguments.of(2L, "long", true),
-            Arguments.of(2.0, "double", true),
-            Arguments.of(BigDecimal.valueOf(2.34567), "big_decimal", true),
-            Arguments.of(true, "boolean", true),
-            Arguments.of(Map.of("k","v"), "map", true),
-            Arguments.of(testArray, "array", true),
-            Arguments.of(testList, "array", true),
-            Arguments.of(2.0, "integer", false),
-            Arguments.of(2, "string", false),
-            Arguments.of("testString", "long", false),
-            Arguments.of("testString", "double", false),
-            Arguments.of(2, "boolean", false),
-            Arguments.of(2L, "map", false),
-            Arguments.of(2, "array", false)
+            arguments(2, "integer", true),
+            arguments("testString", "string", true),
+            arguments(2L, "long", true),
+            arguments(2.0, "double", true),
+            arguments(BigDecimal.valueOf(2.34567), "big_decimal", true),
+            arguments(true, "boolean", true),
+            arguments(Map.of("k","v"), "map", true),
+            arguments(testArray, "array", true),
+            arguments(testList, "array", true),
+            arguments(2.0, "integer", false),
+            arguments(2, "string", false),
+            arguments("testString", "long", false),
+            arguments("testString", "double", false),
+            arguments(2, "boolean", false),
+            arguments(2L, "map", false),
+            arguments(2, "array", false)
         );
+    }
+
+    static class DataTypeToKnownString implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(DataType.STRING, "string"),
+                    arguments(DataType.BOOLEAN, "boolean"),
+                    arguments(DataType.INTEGER, "integer"),
+                    arguments(DataType.LONG, "long"),
+                    arguments(DataType.DOUBLE, "double"),
+                    arguments(DataType.BIG_DECIMAL, "big_decimal"),
+                    arguments(DataType.MAP, "map"),
+                    arguments(DataType.ARRAY, "array")
+            );
+        }
     }
 }

--- a/data-prepper-plugin-schema-cli/src/main/java/org/opensearch/dataprepper/schemas/DataPrepperPluginSchemaExecute.java
+++ b/data-prepper-plugin-schema-cli/src/main/java/org/opensearch/dataprepper/schemas/DataPrepperPluginSchemaExecute.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.github.victools.jsonschema.module.jackson.JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE;
 import static com.github.victools.jsonschema.module.jackson.JacksonOption.RESPECT_JSONPROPERTY_ORDER;
 import static com.github.victools.jsonschema.module.jackson.JacksonOption.RESPECT_JSONPROPERTY_REQUIRED;
 
@@ -52,7 +53,7 @@ public class DataPrepperPluginSchemaExecute implements Runnable {
     @Override
     public void run() {
         final List<Module> modules = List.of(
-                new CustomJacksonModule(RESPECT_JSONPROPERTY_REQUIRED, RESPECT_JSONPROPERTY_ORDER),
+                new CustomJacksonModule(RESPECT_JSONPROPERTY_REQUIRED, RESPECT_JSONPROPERTY_ORDER, FLATTENED_ENUMS_FROM_JSONVALUE),
                 new JakartaValidationModule(JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED,
                         JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS)
         );

--- a/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterTest.java
+++ b/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterTest.java
@@ -10,6 +10,7 @@ import com.github.victools.jsonschema.generator.Module;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.EventKey;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,6 +23,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,6 +66,18 @@ class JsonSchemaConverterTest {
         assertThat(propertiesNode.has("custom_test_attribute"), is(true));
     }
 
+    @Test
+    void testConvertIntoJsonSchemaWithEventKey() throws JsonProcessingException {
+        final JsonSchemaConverter jsonSchemaConverter = createObjectUnderTest(Collections.emptyList(), pluginProvider);
+        final ObjectNode jsonSchemaNode = jsonSchemaConverter.convertIntoJsonSchema(
+                SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON, TestConfig.class);
+        final JsonNode propertiesNode = jsonSchemaNode.at("/properties");
+        assertThat(propertiesNode, instanceOf(ObjectNode.class));
+        assertThat(propertiesNode.has("testAttributeEventKey"), is(equalTo(true)));
+        assertThat(propertiesNode.get("testAttributeEventKey"), is(notNullValue()));
+        assertThat(propertiesNode.get("testAttributeEventKey").get("type"), is(equalTo(TextNode.valueOf("string"))));
+    }
+
     @JsonClassDescription("test config")
     static class TestConfig {
         private String testAttributeWithGetter;
@@ -77,5 +91,7 @@ class JsonSchemaConverterTest {
         public String getTestAttributeWithGetter() {
             return testAttributeWithGetter;
         }
+
+        private EventKey testAttributeEventKey;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `add_entries` processor adds entries to an event.")
+@JsonClassDescription("The <code>add_entries</code> processor adds entries to an event.")
 public class AddEntryProcessorConfig {
     public static class Entry {
 
@@ -29,7 +29,7 @@ public class AddEntryProcessorConfig {
 
         @JsonProperty("metadata_key")
         @JsonPropertyDescription("The key for the new metadata attribute. The argument must be a literal string key " +
-                "and not a JSON Pointer. Either one string key or <code>metadata_key</code> is required.")
+                "and not a JSON Pointer. Either one of <code>key</code> or <code>metadata_key</code> is required.")
         private String metadataKey;
 
         @JsonPropertyDescription("The value of the new entry to be added, which can be used with any of the " +

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -15,30 +15,30 @@ import java.util.List;
 import java.util.Optional;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `convert_entry_type` processor converts a value type associated with the specified key in " +
-        "a event to the specified type. It is a casting processor that changes the types of some fields in events.")
+@JsonClassDescription("The <code>convert_entry_type</code> processor converts a value associated with the specified key in " +
+        "a event to the specified type. It is a casting processor that changes the types of specified fields in events.")
 public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     @JsonProperty("key")
     @JsonPropertyDescription("Key whose value needs to be converted to a different type.")
     private String key;
 
     @JsonProperty("keys")
-    @JsonPropertyDescription("List of keys whose value needs to be converted to a different type.")
+    @JsonPropertyDescription("List of keys whose values needs to be converted to a different type.")
     private List<String> keys;
 
     @JsonProperty("type")
-    @JsonPropertyDescription("Target type for the key-value pair. Possible values are integer, long, double, big_decimal, string, and boolean. Default value is integer.")
+    @JsonPropertyDescription("Target type for the values. Default value is <code>integer.</code>")
     private TargetType type = TargetType.INTEGER;
 
     /**
      * Optional scale value used only in the case of BigDecimal converter
      */
     @JsonProperty("scale")
-    @JsonPropertyDescription("Modifies the scale of the big_decimal when converting to a big_decimal. The default value is 0.")
+    @JsonPropertyDescription("Modifies the scale of the <code>big_decimal</code> when converting to a <code>big_decimal</code>. The default value is 0.")
     private int scale = 0;
 
     @JsonProperty("convert_when")
-    @JsonPropertyDescription("Specifies a condition using a <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Data Prepper expression</a> for performing the convert_entry_type operation. If specified, the convert_entry_type operation runs only when the expression evaluates to true.")
+    @JsonPropertyDescription("Specifies a condition using a <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> for performing the <code>convert_entry_type</code> operation. If specified, the <code>convert_entry_type</code> operation runs only when the expression evaluates to true. Example: <code>/mykey != \"---\"</code>")
     private String convertWhen;
 
     @JsonProperty("null_values")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -17,8 +17,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `copy_values` processor copies values within an event and is a [mutate event]" +
-        "(https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/mutate-event/) processor.")
+@JsonClassDescription("The <code>copy_values</code> processor copies values within an event to other fields within the event.")
 public class CopyValueProcessorConfig {
     public static class Entry {
         @NotEmpty

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -18,20 +18,20 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `delete_entries` processor deletes entries, such as key-value pairs, from an event. " +
-        "You can define the keys you want to delete in the `with-keys` field following `delete_entries` in the YAML " +
-        "configuration file. Those keys and their values are deleted.")
+@JsonClassDescription("The <code>delete_entries</code> processor deletes fields from events. " +
+        "You can define the keys you want to delete in the <code>with_keys</code> configuration." +
+        "Those keys and their values are deleted from events.")
 public class DeleteEntryProcessorConfig {
     @NotEmpty
     @NotNull
     @JsonProperty("with_keys")
     @EventKeyConfiguration(EventKeyFactory.EventAction.DELETE)
-    @JsonPropertyDescription("An array of keys for the entries to be deleted.")
+    @JsonPropertyDescription("A list of keys to be deleted.")
     private List<@NotNull @NotEmpty EventKey> withKeys;
 
     @JsonProperty("delete_when")
     @JsonPropertyDescription("Specifies under what condition the <code>delete_entries</code> processor should perform deletion. " +
-            "Default is no condition.")
+            "By default, keys are always deleted. Example: <code>/mykey == \"---\"</code>")
     private String deleteWhen;
 
     public List<EventKey> getWithKeys() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `list_to_map` processor converts a list of objects from an event, " +
-        "where each object contains a `key` field, into a map of target keys.")
+@JsonClassDescription("The <code>list_to_map</code> processor converts a list of objects from an event, " +
+        "where each object contains a <code>key</code> field, into a map of target keys.")
 public class ListToMapProcessorConfig {
     enum FlattenedElement {
         FIRST("first"),
@@ -89,9 +89,9 @@ public class ListToMapProcessorConfig {
     private FlattenedElement flattenedElement = FlattenedElement.FIRST;
 
     @JsonProperty("list_to_map_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
             "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
-            "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
+            "run on the event. By default, all events will be processed unless otherwise stated.")
     private String listToMapWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `map_to_list` processor converts a map of key-value pairs to a list of objects. " +
+@JsonClassDescription("The <code>map_to_list</code> processor converts a map of key-value pairs to a list of objects. " +
         "Each object contains the key and value in separate fields.")
 public class MapToListProcessorConfig {
     private static final String DEFAULT_KEY_NAME = "key";
@@ -45,9 +45,9 @@ public class MapToListProcessorConfig {
     private String valueName = DEFAULT_VALUE_NAME;
 
     @JsonProperty("map_to_list_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
             "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will " +
-            "be run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
+            "be run on the event. By default, all events will be processed unless otherwise stated.")
     private String mapToListWhen;
 
     @JsonProperty("exclude_keys")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -19,7 +19,7 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `rename_keys` processor renames keys in an event.")
+@JsonClassDescription("The <code>rename_keys</code> processor renames keys in an event.")
 public class RenameKeyProcessorConfig {
     public static class Entry {
         @NotEmpty
@@ -41,9 +41,9 @@ public class RenameKeyProcessorConfig {
         private boolean overwriteIfToKeyExists = false;
 
         @JsonProperty("rename_when")
-        @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
                 "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
-                "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
+                "run on the event. By default, all events will be processed unless otherwise stated.")
         private String renameWhen;
 
         public EventKey getFromKey() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
@@ -15,7 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `select_entries` processor selects entries from a Data Prepper event.")
+@JsonClassDescription("The <code>select_entries</code> processor selects entries from an event.")
 public class SelectEntriesProcessorConfig {
     @NotEmpty
     @NotNull
@@ -24,7 +24,7 @@ public class SelectEntriesProcessorConfig {
     private List<String> includeKeys;
 
     @JsonProperty("select_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
             "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
             "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
     private String selectWhen;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.opensearch.dataprepper.model.event.DataType;
 import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
 import org.opensearch.dataprepper.typeconverter.BooleanConverter;
@@ -27,9 +28,9 @@ public enum TargetType {
     LONG(DataType.LONG, new LongConverter()),
     BIG_DECIMAL(DataType.BIG_DECIMAL, new BigDecimalConverter());
 
-    private static final Map<String, TargetType> OPTIONS_MAP = Arrays.stream(TargetType.values())
+    private static final Map<DataType, TargetType> OPTIONS_MAP = Arrays.stream(TargetType.values())
             .collect(Collectors.toMap(
-                    value -> value.dataType.getTypeName(),
+                    value -> value.dataType,
                     value -> value
             ));
 
@@ -51,6 +52,11 @@ public enum TargetType {
 
     @JsonCreator
     static TargetType fromOptionValue(final String option) {
-        return OPTIONS_MAP.get(option.toLowerCase());
+        return OPTIONS_MAP.get(DataType.fromTypeName(option));
+    }
+
+    @JsonValue
+    public String getOptionValue() {
+        return dataType.getTypeName();
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetTypeTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetTypeTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -25,10 +26,18 @@ class TargetTypeTest {
     void fromTypeName_returns_expected_value(final TargetType targetType) {
         assertThat(TargetType.fromOptionValue(targetType.getDataType().getTypeName()), equalTo(targetType));
     }
+
     @ParameterizedTest
     @ArgumentsSource(DataTypeToTargetTypeArgumentsProvider.class)
     void fromTypeName_returns_expected_value_based_on_DataType(final String typeName, final TargetType targetType) {
         assertThat(TargetType.fromOptionValue(typeName), equalTo(targetType));
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(DataTypeToTargetTypeArgumentsProvider.class)
+    void getOptionValue_returns_data_type_name(final String typeName, final TargetType targetType) throws JsonProcessingException {
+        assertThat(targetType.getOptionValue(), equalTo(typeName));
     }
 
     static class DataTypeToTargetTypeArgumentsProvider implements ArgumentsProvider {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessor.java
@@ -18,7 +18,7 @@ import java.util.Locale;
  * This processor takes in a key and changes its value to a lowercase string. If the value is not a string,
  * no action is performed.
  */
-@DataPrepperPlugin(name = "lowercase_string", pluginType = Processor.class, pluginConfigurationType = WithKeysConfig.class)
+@DataPrepperPlugin(name = "lowercase_string", pluginType = Processor.class, pluginConfigurationType = LowercaseStringProcessorConfig.class)
 public class LowercaseStringProcessor extends AbstractStringProcessor<EventKey> {
     @DataPrepperPluginConstructor
     public LowercaseStringProcessor(final PluginMetrics pluginMetrics, final WithKeysConfig config) {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessorConfig.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutatestring;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder
+@JsonClassDescription("Makes all characters in strings lowercase.")
+public class LowercaseStringProcessorConfig extends WithKeysConfig {
+}

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/ReplaceStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/ReplaceStringProcessorConfig.java
@@ -14,11 +14,11 @@ import org.opensearch.dataprepper.model.event.EventKey;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `replace_string` processor replaces all occurrence of substring in key’s value with a " +
+@JsonClassDescription("The <code>replace_string</code> processor replaces all occurrence of substring in key’s value with a " +
         "replacement string.")
 public class ReplaceStringProcessorConfig implements StringProcessorConfig<ReplaceStringProcessorConfig.Entry> {
     public static class Entry {
-        @JsonPropertyDescription("The key to modify.")
+        @JsonPropertyDescription("The key of the field to modify.")
         private EventKey source;
         @JsonPropertyDescription("The substring to be replaced in the source.")
         private String from;
@@ -26,9 +26,9 @@ public class ReplaceStringProcessorConfig implements StringProcessorConfig<Repla
         private String to;
 
         @JsonProperty("replace_when")
-        @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
                 "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
-                "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
+                "run on the event. By default, all events will be processed unless otherwise stated.")
         private String replaceWhen;
 
         public EventKey getSource() {
@@ -55,7 +55,7 @@ public class ReplaceStringProcessorConfig implements StringProcessorConfig<Repla
         public Entry() {}
     }
 
-    @JsonPropertyDescription("List of entries. Valid values are <code>source</code>, <code>from</code>, and <code>to</code>, and <code>substitute_when</code>.")
+    @JsonPropertyDescription("List of entries. Each entry defines a replacement.")
     private List<Entry> entries;
 
     public List<Entry> getEntries() {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -19,14 +19,13 @@ import org.opensearch.dataprepper.model.event.EventKey;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `split_string` processor splits a field into an array using a delimiting character and is a " +
-        "[mutate string](https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/mutate-string-processors#mutate-string-processors) processor.")
+@JsonClassDescription("The <code>split_string</code> processor splits a field into an array using a delimiting character.")
 public class SplitStringProcessorConfig implements StringProcessorConfig<SplitStringProcessorConfig.Entry> {
     public static class Entry {
 
         @NotEmpty
         @NotNull
-        @JsonPropertyDescription("The key to split.")
+        @JsonPropertyDescription("The key name of the field to split.")
         private EventKey source;
 
         @JsonProperty("delimiter_regex")
@@ -75,7 +74,7 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         return entries;
     }
 
-    @JsonPropertyDescription("List of entries. Valid values are <code>source</code>, <code>delimiter</code>, and <code>delimiter_regex</code>.")
+    @JsonPropertyDescription("List of entries. Each entry defines a split.")
     @NotNull
     private List<@Valid Entry> entries;
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
@@ -15,24 +15,24 @@ import org.opensearch.dataprepper.model.event.EventKey;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `substitute_string` processor matches a key’s value against a regular expression and " +
+@JsonClassDescription("The <code>substitute_string</code> processor matches a key’s value against a regular expression and " +
         "replaces all matches with a replacement string.")
 public class SubstituteStringProcessorConfig implements StringProcessorConfig<SubstituteStringProcessorConfig.Entry> {
     public static class Entry {
-        @JsonPropertyDescription("The key to modify.")
+        @JsonPropertyDescription("The key of the field to modify.")
         private EventKey source;
-        @JsonPropertyDescription("The Regex String to be replaced. Special regex characters such as <code>[</code> and <code>]</code> must " +
+        @JsonPropertyDescription("The regular expression to match on for replacement. Special regex characters such as <code>[</code> and <code>]</code> must " +
                 "be escaped using <code>\\\\</code> when using double quotes and <code>\\</code> when using single quotes. " +
                 "See <a href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html\">Java Patterns</a>" +
                 "for more information.")
         private String from;
-        @JsonPropertyDescription("The String to be substituted for each match of <code>from</code>.")
+        @JsonPropertyDescription("The string to be substituted for each match of <code>from</code>.")
         private String to;
 
         @JsonProperty("substitute_when")
-        @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
                 "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
-                "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
+                "run on the event. By default, all events will be processed unless otherwise stated.")
         private String substituteWhen;
 
         public EventKey getSource() {
@@ -59,7 +59,7 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
         public Entry() {}
     }
 
-    @JsonPropertyDescription("List of entries. Valid values are <code>source</code>, <code>from</code>, and <code>to</code>, and <code>substitute_when</code>.")
+    @JsonPropertyDescription("List of entries. Each entry defines a substitution.")
     @NotNull
     private List<Entry> entries;
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/TrimStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/TrimStringProcessor.java
@@ -16,7 +16,7 @@ import org.opensearch.dataprepper.model.processor.Processor;
  * This processor takes in a key and changes its value to a string with the leading and trailing spaces trimmed.
  * If the value is not a string, no action is performed.
  */
-@DataPrepperPlugin(name = "trim_string", pluginType = Processor.class, pluginConfigurationType = WithKeysConfig.class)
+@DataPrepperPlugin(name = "trim_string", pluginType = Processor.class, pluginConfigurationType = TrimStringProcessorConfig.class)
 public class TrimStringProcessor extends AbstractStringProcessor<EventKey> {
     @DataPrepperPluginConstructor
     public TrimStringProcessor(final PluginMetrics pluginMetrics, final WithKeysConfig config) {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/TrimStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/TrimStringProcessorConfig.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutatestring;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder
+@JsonClassDescription("Trims strings by removing whitespace from the beginning and end of the strings.")
+public class TrimStringProcessorConfig extends WithKeysConfig {
+}

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/UppercaseStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/UppercaseStringProcessorConfig.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutatestring;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder
+@JsonClassDescription("Makes all characters in strings uppercase.")
+public class UppercaseStringProcessorConfig extends WithKeysConfig {
+}

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/WithKeysConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/WithKeysConfig.java
@@ -5,33 +5,24 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutatestring;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.model.event.EventKey;
 
 import java.util.List;
 
-@JsonPropertyOrder
-@JsonClassDescription("This processor is a [mutate string]" +
-        "(https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/mutate-string-processors#mutate-string-processors) processor.")
-public class WithKeysConfig implements StringProcessorConfig<EventKey> {
+public abstract class WithKeysConfig implements StringProcessorConfig<EventKey> {
 
     @NotNull
     @NotEmpty
     @JsonProperty("with_keys")
-    @JsonPropertyDescription("A list of keys to trim the white space from.")
+    @JsonPropertyDescription("A list of keys to modify.")
     private List<EventKey> withKeys;
 
     @Override
     public List<EventKey> getIterativeConfig() {
-        return withKeys;
-    }
-
-    public List<EventKey> getWithKeys() {
         return withKeys;
     }
 }


### PR DESCRIPTION
### Description

Support `@JsonValue` for determining enumeration values in the JSON Schema. Provide a JSON schema type of string for `EventKey` objects. Documentation wording improvements to the mutate event and mutate string processors.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
