### PR TITLE
Documentation improvements for a number of Data Prepper processors.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/ConditionalRoute.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/ConditionalRoute.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 @JsonPropertyOrder
 @JsonClassDescription("The key-value pair defines routing condition, where the key is the name of a route and the " +
-        "value is a Data Prepper expression representing the routing condition.")
+        "value is an expression representing the routing condition.")
 @JsonSerialize(using = ConditionalRoute.ConditionalRouteSerializer.class)
 @JsonDeserialize(using = ConditionalRoute.ConditionalRouteDeserializer.class)
 public class ConditionalRoute {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOption.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOption.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.model.event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -44,5 +45,10 @@ public enum HandleFailedEventsOption {
     @JsonCreator
     static HandleFailedEventsOption fromOptionValue(final String option) {
         return OPTIONS_MAP.get(option.toLowerCase());
+    }
+
+    @JsonValue
+    public String toOptionValue() {
+        return option;
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOptionTest.java
@@ -5,29 +5,84 @@
 
 package org.opensearch.dataprepper.model.event;
 
-import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class HandleFailedEventsOptionTest {
     @ParameterizedTest
+    @ArgumentsSource(EnumToShouldLogArgumentsProvider.class)
+    void shouldLog_returns_expected_value(final HandleFailedEventsOption option, final boolean shouldLog) {
+        assertThat(option.shouldLog(), equalTo(shouldLog));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(EnumToShouldShouldDropArgumentsProvider.class)
+    void shouldDropEvent_returns_expected_value(final HandleFailedEventsOption option, final boolean shouldDrop) {
+        assertThat(option.shouldDropEvent(), equalTo(shouldDrop));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(EnumToOptionValueArgumentsProvider.class)
+    void toOptionValue_returns_expected_value(final HandleFailedEventsOption option, final String optionValue) {
+        assertThat(option.toOptionValue(), equalTo(optionValue));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(EnumToOptionValueArgumentsProvider.class)
+    void fromOptionValue_returns_expected_option(final HandleFailedEventsOption option, final String optionValue) {
+        assertThat(HandleFailedEventsOption.fromOptionValue(optionValue), equalTo(option));
+    }
+
+    @ParameterizedTest
     @EnumSource(HandleFailedEventsOption.class)
-    void fromOptionValue(final HandleFailedEventsOption option) {
-        assertThat(HandleFailedEventsOption.fromOptionValue(option.name()), CoreMatchers.is(option));
+    void toOptionValue_returns_non_null_for_all(final HandleFailedEventsOption option) {
+        assertThat(option.toOptionValue(), notNullValue());
+    }
 
-        if (option == HandleFailedEventsOption.SKIP || option == HandleFailedEventsOption.SKIP_SILENTLY) {
-            assertThat(option.shouldDropEvent(), equalTo(false));
-        } else {
-            assertThat(option.shouldDropEvent(), equalTo(true));
+    private static class EnumToOptionValueArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(HandleFailedEventsOption.SKIP, "skip"),
+                    arguments(HandleFailedEventsOption.SKIP_SILENTLY, "skip_silently"),
+                    arguments(HandleFailedEventsOption.DROP, "drop"),
+                    arguments(HandleFailedEventsOption.DROP_SILENTLY, "drop_silently")
+            );
         }
+    }
 
-        if (option == HandleFailedEventsOption.SKIP_SILENTLY || option == HandleFailedEventsOption.DROP_SILENTLY) {
-            assertThat(option.shouldLog(), equalTo(false));
-        } else {
-            assertThat(option.shouldLog(), equalTo(true));
+    private static class EnumToShouldShouldDropArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(HandleFailedEventsOption.SKIP, false),
+                    arguments(HandleFailedEventsOption.SKIP_SILENTLY, false),
+                    arguments(HandleFailedEventsOption.DROP, true),
+                    arguments(HandleFailedEventsOption.DROP_SILENTLY, true)
+            );
+        }
+    }
+
+    private static class EnumToShouldLogArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(HandleFailedEventsOption.SKIP, true),
+                    arguments(HandleFailedEventsOption.DROP, true),
+                    arguments(HandleFailedEventsOption.SKIP_SILENTLY, false),
+                    arguments(HandleFailedEventsOption.DROP_SILENTLY, false)
+            );
         }
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -19,14 +19,16 @@ import java.time.Duration;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `aggregate` processor groups events based on the values of identification_keys. " +
+@JsonClassDescription("The <code>aggregate</code> processor groups events based on the values of identification_keys. " +
         "Then, the processor performs an action on each group, helping reduce unnecessary log volume and " +
         "creating aggregated logs over time.")
 public class AggregateProcessorConfig {
 
     static int DEFAULT_GROUP_DURATION_SECONDS = 180;
 
-    @JsonPropertyDescription("An unordered list by which to group events. Events with the same values as these keys are put into the same group. If an event does not contain one of the identification_keys, then the value of that key is considered to be equal to null. At least one identification_key is required (for example, [\"sourceIp\", \"destinationIp\", \"port\"].")
+    @JsonPropertyDescription("An unordered list by which to group events. Events with the same values as these keys are put into the same group. " +
+            "If an event does not contain one of the <code>identification_keys</code>, then the value of that key is considered to be equal to <code>null</code>. " +
+            "At least one <code>identification_key</code> is required. And example configuration is [\"sourceIp\", \"destinationIp\", \"port\"].")
     @JsonProperty("identification_keys")
     @NotEmpty
     private List<String> identificationKeys;
@@ -41,12 +43,12 @@ public class AggregateProcessorConfig {
     @UsesDataPrepperPlugin(pluginType = AggregateAction.class)
     private PluginModel aggregateAction;
 
-    @JsonPropertyDescription("When local_mode is set to true, the aggregation is performed locally on each Data Prepper node instead of forwarding events to a specific node based on the identification_keys using a hash function. Default is false.")
+    @JsonPropertyDescription("When <code>local_mode<code> is set to true, the aggregation is performed locally on each node instead of forwarding events to a specific node based on the <code>identification_keys</code> using a hash function. Default is false.")
     @JsonProperty("local_mode")
     @NotNull
     private Boolean localMode = false;
 
-    @JsonPropertyDescription("A boolean indicating if the unaggregated events should be forwarded to the next processor/sink in the chain.")
+    @JsonPropertyDescription("A boolean indicating if the unaggregated events should be forwarded to the next processor or sink in the chain.")
     @JsonProperty("output_unaggregated_events")
     private Boolean outputUnaggregatedEvents = false;
 
@@ -54,7 +56,7 @@ public class AggregateProcessorConfig {
     @JsonProperty("aggregated_events_tag")
     private String aggregatedEventsTag;
 
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
     @JsonProperty("aggregate_when")
     private String whenCondition;
 

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/DelayProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/DelayProcessor.java
@@ -61,7 +61,7 @@ public class DelayProcessor implements Processor<Record<?>, Record<?>> {
             "Typically, you should use this only for testing, experimenting, and debugging.")
     public static class Configuration {
         @JsonProperty("for")
-        @JsonPropertyDescription("The duration of time to delay. Defaults to `1s`.")
+        @JsonPropertyDescription("The duration of time to delay. Defaults to <code>1s</code>.")
         private Duration delayFor = Duration.ofSeconds(1);
 
         public Duration getDelayFor() {

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
@@ -43,7 +43,7 @@ public class StringProcessor implements Processor<Record<Event>, Record<Event>> 
     private final boolean upperCase;
 
     @JsonPropertyOrder
-    @JsonClassDescription("The `string_converter` processor converts a string to uppercase or lowercase.")
+    @JsonClassDescription("The <code>string_converter</code> processor converts a string to uppercase or lowercase.")
     public static class Configuration {
         @JsonPropertyDescription("Whether to convert to uppercase (<code>true</code>) or lowercase (<code>false</code>).")
         private boolean upperCase = true;

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -18,7 +18,7 @@ import java.util.Locale;
 import java.time.format.DateTimeFormatter;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `date` processor adds a default timestamp to an event, parses timestamp fields, " +
+@JsonClassDescription("The <code>date</code> processor adds a default timestamp to an event, parses timestamp fields, " +
         "and converts timestamp information to the International Organization for Standardization (ISO) 8601 format. " +
         "This timestamp information can be used as an event timestamp.")
 public class DateProcessorConfig {
@@ -34,10 +34,13 @@ public class DateProcessorConfig {
         @JsonPropertyDescription("Represents the event key against which to match patterns. " +
                 "Required if <code>match</code> is configured.")
         private String key;
+
         @JsonProperty("patterns")
         @JsonPropertyDescription("A list of possible patterns that the timestamp value of the key can have. The patterns " +
                 "are based on a sequence of letters and symbols. The <code>patterns</code> support all the patterns listed in the " +
                 "Java DateTimeFormatter (https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) reference. " +
+                "To match ISO 8601 formatted strings, use, <code>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</code>. " +
+                "To match Apache Common Log Format, use <code>dd/MMM/yyyy:HH:mm:ss Z</code>. " +
                 "The timestamp value also supports <code>epoch_second</code>, <code>epoch_milli</code>, and <code>epoch_nano</code> values, " +
                 "which represent the timestamp as the number of seconds, milliseconds, and nanoseconds since the epoch. " +
                 "Epoch values always use the UTC time zone.")
@@ -110,7 +113,9 @@ public class DateProcessorConfig {
 
     @JsonProperty("match")
     @JsonPropertyDescription("The date match configuration. " +
-            "This option cannot be defined at the same time as <code>from_time_received</code>. There is no default value.")
+            "This option cannot be defined at the same time as <code>from_time_received</code>. " +
+            "The date processor will use the first pattern that matches each event's timestamp field. " +
+            "You must provide at least one pattern unless you have <code>from_time_received</code>.")
     private List<DateMatch> match;
 
     @JsonProperty("destination")

--- a/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressProcessorConfig.java
+++ b/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressProcessorConfig.java
@@ -18,7 +18,7 @@ import org.opensearch.dataprepper.plugins.processor.decompress.encoding.DecoderE
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `decompress` processor decompresses any Base64-encoded " +
+@JsonClassDescription("The <code>decompress</code> processor decompresses any Base64-encoded " +
         "compressed fields inside of an event.")
 public class DecompressProcessorConfig {
 
@@ -28,16 +28,16 @@ public class DecompressProcessorConfig {
     @NotNull
     private List<String> keys;
 
-    @JsonPropertyDescription("The type of decompression to use for the keys in the event. Only gzip is supported.")
+    @JsonPropertyDescription("The type of decompression to use for the keys in the event. Only <code>gzip</code> is supported.")
     @JsonProperty("type")
     @NotNull
     private DecompressionType decompressionType;
 
-    @JsonPropertyDescription("A conditional expression that determines when the decompress processor will run on certain events.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>'/is_compressed == true'</code>, that determines when the decompress processor will run on certain events.")
     @JsonProperty("decompress_when")
     private String decompressWhen;
 
-    @JsonPropertyDescription("A list of strings with which to tag events when the processor fails to decompress the keys inside an event. Defaults to _decompression_failure.")
+    @JsonPropertyDescription("A list of strings with which to tag events when the processor fails to decompress the keys inside an event. Defaults to <code>_decompression_failure</code>.")
     @JsonProperty("tags_on_failure")
     private List<String> tagsOnFailure = List.of("_decompression_failure");
 

--- a/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressionType.java
+++ b/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressionType.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.decompress;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.plugins.codec.GZipDecompressionEngine;
 
@@ -35,6 +36,11 @@ public enum DecompressionType implements DecompressionEngineFactory {
     @JsonCreator
     static DecompressionType fromOptionValue(final String option) {
         return OPTIONS_MAP.get(option);
+    }
+
+    @JsonValue
+    public String getOptionValue() {
+        return option;
     }
 
     @Override

--- a/data-prepper-plugins/decompress-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressionTypeTest.java
+++ b/data-prepper-plugins/decompress-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressionTypeTest.java
@@ -34,6 +34,12 @@ public class DecompressionTypeTest {
         assertThat(enumValue.getDecompressionEngine(), instanceOf(decompressionEngineClass));
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(EnumToStringNameArgumentsProvider.class)
+    void getOptionValue_returns_data_type_name(final DecompressionType decompressionType, final String optionValue) {
+        assertThat(decompressionType.getOptionValue(), equalTo(optionValue));
+    }
+
     private static class EnumToStringNameArgumentsProvider implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -10,23 +10,31 @@ import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 import java.util.Map;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `dissect` processor extracts values from an event and maps them to individual fields " +
-        "based on user-defined `dissect` patterns. The processor is well suited for field extraction from log " +
+@JsonClassDescription("The <code>dissect</code> processor extracts values from an event and maps them to individual fields " +
+        "based on user-defined <code>dissect</code> patterns. The processor is well suited for field extraction from log " +
         "messages with a known structure.")
 public class DissectProcessorConfig {
     @NotNull
     @JsonProperty("map")
-    @JsonPropertyDescription("Defines the <code>dissect</code> patterns for specific keys. For details on how to define fields " +
-            "in the <code>dissect</code> pattern, see (https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations).")
+    @JsonPropertyDescription("Defines the <code>dissect</code> patterns for specific keys. " +
+            "Each key is a field name, and the value is the dissect pattern to use for dissecting it. " +
+            "For details on how to define fields " +
+            "in the <code>dissect</code> pattern, see (https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations). " +
+            "An example dissect pattern is <code>%{Date} %{Time} %{Log_Type}: %{Message}</code>, which will dissect into four fields.")
     private Map<String, String> map;
+
     @JsonProperty("target_types")
-    @JsonPropertyDescription("Specifies the data types for extract fields. Valid options are <code>integer</code>, " +
-            "<code>double</code>, <code>string</code>, <code>long</code>, <code>big_decimal</code>, and <code>boolean</code>. By default, all fields are of the <code>string</code> type.")
+    @JsonPropertyDescription("Specifies the data types for extract fields. " +
+            "Each key is a field name, and the value is the data type to use for that field. " +
+            "Valid data types are <code>integer</code>, <code>double</code>, <code>string</code>, <code>long</code>, <code>big_decimal</code>, and <code>boolean</code>. " +
+            "By default, all fields are treated as <code>string</code>.")
     private Map<String, TargetType> targetTypes;
+
     @JsonProperty("dissect_when")
     @JsonPropertyDescription("Specifies a condition for performing the <code>dissect</code> operation using a " +
-            "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Data Prepper Expression Syntax</a>. " +
-            "If specified, the <code>dissect</code> operation will only run when the expression evaluates to true.")
+            "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>. " +
+            "If specified, the <code>dissect</code> operation will only run when the expression evaluates to true. " +
+            "For example, <code>'/some_value == \"log\"'</code>.")
     private String dissectWhen;
 
     public String getDissectWhen(){

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
@@ -22,7 +22,7 @@ public class DropEventProcessorConfig {
     @NotEmpty
     private String dropWhen;
 
-    @JsonPropertyDescription("Specifies how exceptions are handled when an exception occurs while evaluating an event. Default value is <code>drop</code>, which drops the event so that it is not sent to further processors or sinks.")
+    @JsonPropertyDescription("Specifies how exceptions are handled when an exception occurs while evaluating an event. Default value is <code>skip</code>, which drops the event so that it is not sent to further processors or sinks.")
     @JsonProperty("handle_failed_events")
     private HandleFailedEventsOption handleFailedEventsOption = HandleFailedEventsOption.SKIP;
 

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
@@ -13,15 +13,16 @@ import jakarta.validation.constraints.NotEmpty;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `drop_events` processor drops all the events that are passed into it.")
+@JsonClassDescription("The <code>drop_events</code> processor conditionally drops events.")
 public class DropEventProcessorConfig {
 
-    @JsonPropertyDescription("Accepts a Data Prepper conditional expression string following the <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Data Prepper Expression Syntax</a>. Configuring drop_events with drop_when: true drops all the events received.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/log_type == \"DEBUG\"'</code>. " +
+            "The <code>drop_when</code> processor will drop all events where the condition evaluates to true. Those events will not go to any further processors or sinks.")
     @JsonProperty("drop_when")
     @NotEmpty
     private String dropWhen;
 
-    @JsonPropertyDescription("Specifies how exceptions are handled when an exception occurs while evaluating an event. Default value is 'drop', which drops the event so that it is not sent to OpenSearch. Available options are 'drop', 'drop_silently', 'skip', and 'skip_silently'.")
+    @JsonPropertyDescription("Specifies how exceptions are handled when an exception occurs while evaluating an event. Default value is <code>drop</code>, which drops the event so that it is not sent to further processors or sinks.")
     @JsonProperty("handle_failed_events")
     private HandleFailedEventsOption handleFailedEventsOption = HandleFailedEventsOption.SKIP;
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
@@ -23,15 +23,17 @@ public class EntryConfig {
     @NotEmpty
     private String source;
 
-    @JsonPropertyDescription("The key of the target field in which to save the geolocation data. Default is geo.")
+    @JsonPropertyDescription("The key of the target field in which to set the geolocation data. Default is <code>geo</code>.")
     @JsonProperty("target")
     private String target = DEFAULT_TARGET;
 
-    @JsonPropertyDescription("The list of geolocation fields to include in the target object. By default, this is all the fields provided by the configured databases.")
+    @JsonPropertyDescription("The list of geolocation fields to include in the target object. By default, this is all the fields provided by the configured databases. " +
+            "For example, if you wish to only obtain the actual location, you can specify <code>location</code>.")
     @JsonProperty("include_fields")
     private List<String> includeFields;
 
-    @JsonPropertyDescription("The list of geolocation fields to exclude from the target object.")
+    @JsonPropertyDescription("The list of geolocation fields to exclude from the target object. " +
+            "For example, you can exclude ASN fields by including <code>asn</code>, <code>asn_organization</code>, <code>network</code>, <code>ip</code>.")
     @JsonProperty("exclude_fields")
     private List<String> excludeFields;
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -19,7 +19,7 @@ import java.util.List;
  * An implementation class of GeoIP Processor configuration
  */
 @JsonPropertyOrder
-@JsonClassDescription("The `geoip` processor enriches events with geographic information extracted from IP addresses " +
+@JsonClassDescription("The <code>geoip</code> processor enriches events with geographic information extracted from IP addresses " +
         "contained in the events.")
 public class GeoIPProcessorConfig {
 
@@ -31,21 +31,20 @@ public class GeoIPProcessorConfig {
     private List<EntryConfig> entries;
 
     @JsonProperty("tags_on_engine_failure")
-    @JsonPropertyDescription("The tags to add to the event metadata if the geoip processor is unable to enrich an event due to an engine failure.")
+    @JsonPropertyDescription("The tags to add to the event metadata if the <code>geoip</code> processor is unable to enrich an event due to an engine failure.")
     private List<String> tagsOnEngineFailure;
 
     @JsonProperty("tags_on_ip_not_found")
-    @JsonPropertyDescription("The tags to add to the event metadata if the geoip processor is unable to find a location for the IP address.")
+    @JsonPropertyDescription("The tags to add to the event metadata if the <code>geoip</code> processor is unable to find a location for a valid IP address.")
     private List<String> tagsOnIPNotFound;
 
     @JsonProperty("tags_on_no_valid_ip")
-    @JsonPropertyDescription("The tags to add to the event metadata if the source field is not a valid IP address. This includes the localhost IP address.")
+    @JsonPropertyDescription("The tags to add to the event metadata if the source field is not a valid IP address. A source field may not be valid because it is incorrectly formatted or is the loopback/localhost IP address.")
     private List<String> tagsOnNoValidIp;
 
     @JsonProperty("geoip_when")
-    @JsonPropertyDescription("Specifies a condition for including Events in the <code>geoip</code> processor using a Data Prepper [conditional expression]" +
-            "(https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/)." +
-            " If specified, the <code>geoip</code> processor will only run when the expression evaluates to true.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/srcaddr != \"8.8.8.8\"'</code>. " +
+            "If specified, the <code>geoip</code> processor will only run on events when the expression evaluates to true. ")
     private String whenCondition;
 
     /**

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `grok` processor uses pattern matching to structure and extract important keys from " +
+@JsonClassDescription("The <code>grok</code> processor uses pattern matching to structure and extract important keys from " +
         "unstructured data.")
 public class GrokProcessorConfig {
 
@@ -50,52 +50,68 @@ public class GrokProcessorConfig {
     @JsonPropertyDescription("Specifies whether to match all patterns (<code>false</code>) or stop once the first successful " +
             "match is found (<code>true</code>). Default is <code>true</code>.")
     private boolean breakOnMatch = DEFAULT_BREAK_ON_MATCH;
+
     @JsonProperty(KEEP_EMPTY_CAPTURES)
     @JsonPropertyDescription("Enables the preservation of <code>null</code> captures from the processed output. Default is <code>false</code>.")
     private boolean keepEmptyCaptures = DEFAULT_KEEP_EMPTY_CAPTURES;
+
     @JsonProperty(MATCH)
-    @JsonPropertyDescription("Specifies which keys should match specific patterns. Default is an empty response body.")
+    @JsonPropertyDescription("Specifies which keys should match specific patterns. " +
+            "Each key is a source field. The value is a list of possible grok patterns to match on. " +
+            "The <code>grok</code> processor will extract values from the first match for each field. " +
+            "Default is an empty response body.")
     private Map<String, List<String>> match = Collections.emptyMap();
+
     @JsonProperty(NAMED_CAPTURES_ONLY)
     @JsonPropertyDescription("Specifies whether to keep only named captures. Default is <code>true</code>.")
     private boolean namedCapturesOnly = DEFAULT_NAMED_CAPTURES_ONLY;
+
     @JsonProperty(KEYS_TO_OVERWRITE)
     @JsonPropertyDescription("Specifies which existing keys will be overwritten if there is a capture with the same key value. " +
-            "Default is <code>[]</code>.")
+            "Default is an empty list.")
     private List<String> keysToOverwrite = Collections.emptyList();
+
     @JsonProperty(PATTERNS_DIRECTORIES)
     @JsonPropertyDescription("Specifies which directory paths contain the custom pattern files. Default is an empty list.")
     private List<String> patternsDirectories = Collections.emptyList();
+
     @JsonProperty(PATTERNS_FILES_GLOB)
     @JsonPropertyDescription("Specifies which pattern files to use from the directories specified for " +
             "<code>pattern_directories</code>. Default is <code>*</code>.")
     private String patternsFilesGlob = DEFAULT_PATTERNS_FILES_GLOB;
+
     @JsonProperty(PATTERN_DEFINITIONS)
     @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
             "Default is an empty response body.")
     private Map<String, String> patternDefinitions = Collections.emptyMap();
+
     @JsonProperty(TIMEOUT_MILLIS)
     @JsonPropertyDescription("The maximum amount of time during which matching occurs. " +
-            "Setting to <code>0</code> prevents any matching from occurring. Default is <code>30,000</code>.")
+            "Setting to <code>0</code> prevents any matching from occurring. Default is <code>30000</code>.")
     private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+
     @JsonProperty(TARGET_KEY)
-    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code>.")
+    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code> which will write captures into the root of the event.")
     private String targetKey = DEFAULT_TARGET_KEY;
+
     @JsonProperty(GROK_WHEN)
-    @JsonPropertyDescription("Specifies under what condition the <code>grok</code> processor should perform matching. " +
-            "Default is no condition.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/test != false'</code>. " +
+            "If specified, the <code>grok</code> processor will only run on events when the expression evaluates to true. ")
     private String grokWhen;
+
     @JsonProperty(TAGS_ON_MATCH_FAILURE)
     @JsonPropertyDescription("A <code>List</code> of <code>String</code>s that specifies the tags to be set in the event when grok fails to " +
             "match or an unknown exception occurs while matching. This tag may be used in conditional expressions in " +
             "other parts of the configuration")
     private List<String> tagsOnMatchFailure = Collections.emptyList();
+
     @JsonProperty(TAGS_ON_TIMEOUT)
-    @JsonPropertyDescription("A <code>List</code> of <code>String</code>s that specifies the tags to be set in the event when grok match times out.")
+    @JsonPropertyDescription("The tags to add to the event metadata if the grok match times out.")
     private List<String> tagsOnTimeout = Collections.emptyList();
+
     @JsonProperty(INCLUDE_PERFORMANCE_METADATA)
-    @JsonPropertyDescription("A <code>Boolean</code> on whether to include performance metadata into event metadata, " +
-            "e.g. _total_grok_patterns_attempted, _total_grok_processing_time.")
+    @JsonPropertyDescription("A boolean value to determine whether or not to performance metadata into event metadata. " +
+            "If set to true, the events coming out of grok will have new fields such as <code>_total_grok_patterns_attempted</code> and <code>_total_grok_processing_time</code>.")
     private boolean includePerformanceMetadata = false;
 
     public boolean isBreakOnMatch() {

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -110,8 +110,9 @@ public class GrokProcessorConfig {
     private List<String> tagsOnTimeout = Collections.emptyList();
 
     @JsonProperty(INCLUDE_PERFORMANCE_METADATA)
-    @JsonPropertyDescription("A boolean value to determine whether or not to performance metadata into event metadata. " +
-            "If set to true, the events coming out of grok will have new fields such as <code>_total_grok_patterns_attempted</code> and <code>_total_grok_processing_time</code>.")
+    @JsonPropertyDescription("A boolean value to determine whether to include performance metadata into event metadata. " +
+            "If set to true, the events coming out of grok will have new fields such as <code>_total_grok_patterns_attempted</code> and <code>_total_grok_processing_time</code>." +
+            "You can use this metadata to perform performance testing and tuning of your grok patterns. By default, it is not included.")
     private boolean includePerformanceMetadata = false;
 
     public boolean isBreakOnMatch() {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -20,7 +20,7 @@ import org.opensearch.dataprepper.plugins.processor.obfuscation.action.Obfuscati
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `obfuscate` process enables obfuscation of fields inside your documents in order to " +
+@JsonClassDescription("The <code>obfuscate</code> process enables obfuscation of fields inside your documents in order to " +
         "protect sensitive data.")
 public class ObfuscationProcessorConfig {
 
@@ -41,24 +41,23 @@ public class ObfuscationProcessorConfig {
     private String target;
 
     @JsonProperty("action")
-    @JsonPropertyDescription("The obfuscation action. Available actions include 'hash' and 'mask'.")
+    @JsonPropertyDescription("The obfuscation action. Available actions include <code>hash</code> and <code>mask</code>.")
     @UsesDataPrepperPlugin(pluginType = ObfuscationAction.class)
     private PluginModel action;
 
     @JsonProperty("obfuscate_when")
-    @JsonPropertyDescription("Specifies under what condition the Obfuscate processor should perform matching. " +
-            "Default is no condition.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/is_testing_data == true'</code>. " +
+            "If specified, the <code>obfuscate</code> processor will only run on events when the expression evaluates to true. ")
     private String obfuscateWhen;
 
     @JsonProperty("tags_on_match_failure")
-    @JsonPropertyDescription("The tag to add to an event if the obfuscate processor fails to match the pattern.")
+    @JsonPropertyDescription("The tag to add to an event if the <code>obfuscate</code> processor fails to match the pattern.")
     private List<String> tagsOnMatchFailure;
 
     @JsonProperty("single_word_only")
     @JsonPropertyDescription("When set to <code>true</code>, a word boundary <code>\b</code> is added to the pattern, " +
             "which causes obfuscation to be applied only to words that are standalone in the input text. " +
-            "By default, it is false, meaning obfuscation patterns are applied to all occurrences. " +
-            "Can be used for Data Prepper 2.8 or greater.")
+            "By default, it is false, meaning obfuscation patterns are applied to all occurrences.")
     private boolean singleWordOnly = false;
 
     public ObfuscationProcessorConfig() {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionConfig.java
@@ -28,13 +28,13 @@ public class OneWayHashActionConfig {
     private String salt;
 
     @JsonProperty("format")
-    @Pattern(regexp = "SHA-512", message = "Valid values: SHA-512")
-    @JsonPropertyDescription("Format of one way hash to generate. Default to SHA-512.")
+    @Pattern(regexp = "SHA-512", message = "Valid values: <code>SHA-512</code>")
+    @JsonPropertyDescription("Format of one way hash to generate. Default to <code>SHA-512</code>.")
     private String format = "SHA-512";
 
     @JsonProperty("salt_key")
     @JsonPropertyDescription("A key to compute salt based on a value provided as part of a record. " +
-        "If key or value was not found in the record(s), a salt defined in the pipeline configuration will be used instead.")
+        "If key or value was not found in the event, a salt defined in the pipeline configuration will be used instead.")
     @EventKeyConfiguration(EventKeyFactory.EventAction.GET)
     private EventKey saltKey;
  

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `otel_metrics` processor serializes a collection of `ExportMetricsServiceRequest` records " +
-        "sent from the [OTel metrics source](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/) into a collection of string records.")
+@JsonClassDescription("The <code>otel_metrics</code> processor serializes a collection of <code>ExportMetricsServiceRequest</code> records " +
+        "sent from the <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/\">OTel metrics source</a> into a collection of string records.")
 public class OtelMetricsRawProcessorConfig {
 
     @JsonProperty("flatten_attributes")
@@ -27,7 +27,7 @@ public class OtelMetricsRawProcessorConfig {
     @JsonPropertyDescription("Whether or not to calculate exponential histogram buckets.")
     private Boolean calculateExponentialHistogramBuckets = true;
 
-    @JsonPropertyDescription("Maximum allowed scale in exponential histogram calculation.")
+    @JsonPropertyDescription("Maximum allowed scale in exponential histogram calculation. By default, the maximum allowed scale is <code>10</code>.")
     private Integer exponentialHistogramMaxAllowedScale = DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE;
 
     public Boolean getCalculateExponentialHistogramBuckets() {

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -13,24 +13,27 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.time.Duration;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `otel_trace` processor completes trace-group-related fields in all incoming Data Prepper " +
-        "span records by state caching the root span information for each `traceId`.")
+@JsonClassDescription("The <code>otel_traces</code> processor completes trace-group-related fields in all incoming " +
+        "span records by state caching the root span information for each <code>traceId</code>.")
 public class OtelTraceRawProcessorConfig {
     static final long DEFAULT_TG_FLUSH_INTERVAL_SEC = 180L;
     static final Duration DEFAULT_TRACE_ID_TTL = Duration.ofSeconds(15L);
     static final long MAX_TRACE_ID_CACHE_SIZE = 1_000_000L;
+
     @JsonProperty("trace_flush_interval")
     @JsonPropertyDescription("Represents the time interval in seconds to flush all the descendant spans without any " +
-            "root span. Default is 180.")
+            "root span. Default is <code>180</code>.")
     private long traceFlushInterval = DEFAULT_TG_FLUSH_INTERVAL_SEC;
 
     @JsonProperty("trace_group_cache_ttl")
-    @JsonPropertyDescription("Represents the time-to-live to cache a trace group details. Default is 15 seconds.")
+    @JsonPropertyDescription("Represents the time-to-live to cache a trace group details. " +
+            "The value may be an ISO 8601 notation such as <code>PT1M30S</code> or a duration and unit such as <code>45s</code>" +
+            "Default is 15 seconds.")
     private Duration traceGroupCacheTimeToLive = DEFAULT_TRACE_ID_TTL;
 
     @JsonProperty("trace_group_cache_max_size")
     @JsonPropertyDescription("Represents the maximum size of the cache to store the trace group details from root spans. " +
-            "Default is 1000000.")
+            "Default is <code>1000000</code>.")
     private long traceGroupCacheMaxSize = MAX_TRACE_ID_CACHE_SIZE;
 
     public long getTraceFlushIntervalSeconds() {

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `service_map` processor uses OpenTelemetry data to create a distributed service map for " +
+@JsonClassDescription("The <code>service_map</code> processor uses OpenTelemetry data to create a distributed service map for " +
         "visualization in OpenSearch Dashboards.")
 public class ServiceMapProcessorConfig {
     private static final String WINDOW_DURATION = "window_duration";
@@ -20,7 +20,7 @@ public class ServiceMapProcessorConfig {
 
     @JsonProperty(WINDOW_DURATION)
     @JsonPropertyDescription("Represents the fixed time window, in seconds, " +
-            "during which service map relationships are evaluated. Default value is 180.")
+            "during which service map relationships are evaluated. Default value is <code>180</code>.")
     private int windowDuration = DEFAULT_WINDOW_DURATION;
 
     public int getWindowDuration() {

--- a/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
+++ b/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
@@ -19,21 +19,21 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `split_event` processor is used to split events based on a delimiter and " +
+@JsonClassDescription("The <code>split_event</code> processor is used to split events based on a delimiter and " +
         "generates multiple events from a user-specified field.")
 public class SplitEventProcessorConfig {
     @NotEmpty
     @NotNull
     @JsonProperty("field")
-    @JsonPropertyDescription("The event field to be split")
+    @JsonPropertyDescription("The event field to be split.")
     private String field;
 
     @JsonProperty("delimiter_regex")
-    @JsonPropertyDescription("The regular expression used as the delimiter for splitting the field")
+    @JsonPropertyDescription("The regular expression used as the delimiter for splitting the field.")
     private String delimiterRegex;
 
     @Size(min = 1, max = 1)
-    @JsonPropertyDescription("The delimiter used for splitting the field. If not specified, the default delimiter is used")
+    @JsonPropertyDescription("The delimiter used for splitting the field. If not specified, the default delimiter is used.")
     private String delimiter;
 
     public String getField() {

--- a/data-prepper-plugins/trace-peer-forwarder-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/TracePeerForwarderProcessorConfig.java
+++ b/data-prepper-plugins/trace-peer-forwarder-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/TracePeerForwarderProcessorConfig.java
@@ -3,6 +3,6 @@ package org.opensearch.dataprepper.plugins.processor;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 
 @JsonClassDescription("The <code>trace_peer_forwarder</code> processor is used with peer forwarder to reduce by half " +
-        "the number of events forwarded in a <a href=\"https://opensearch.org/docs/latest/data-prepper/common-use-cases/trace-analytics/\">Trace Analytics</a> pipeline. ")
+        "the number of events forwarded in a <a href=\"https://opensearch.org/docs/latest/data-prepper/common-use-cases/trace-analytics/\">Trace Analytics</a> pipeline.")
 public class TracePeerForwarderProcessorConfig {
 }

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -17,7 +17,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `truncate` processor truncates a key’s value at the beginning, the end, " +
+@JsonClassDescription("The <code>truncate</code> processor truncates a key's value at the beginning, the end, " +
         "or on both sides of the value string, based on the processor’s configuration.")
 public class TruncateProcessorConfig {
     public static class Entry {
@@ -27,7 +27,7 @@ public class TruncateProcessorConfig {
         private List<String> sourceKeys;
 
         @JsonProperty("start_at")
-        @JsonPropertyDescription("Where in the string value to start truncation. " +
+        @JsonPropertyDescription("The index into the string value to start truncation. " +
                 "Default is <code>0</code>, which specifies to start truncation at the beginning of each key's value.")
         private Integer startAt;
 
@@ -37,11 +37,12 @@ public class TruncateProcessorConfig {
         private Integer length;
 
         @JsonProperty("recursive")
-        @JsonPropertyDescription("Recursively truncates the fields. If the value of a field is a map (json object), then it recursively applies truncate operation on the fields in the map.")
+        @JsonPropertyDescription("Recursively truncates the fields. If the value of a field is a map, then it recursively applies truncate operation on the fields in the map.")
         private Boolean recurse = false;
 
         @JsonProperty("truncate_when")
-        @JsonPropertyDescription("A condition that, when met, determines when the truncate operation is performed.")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/test != false'</code>. " +
+                "If specified, the <code>truncate</code> processor will only run on events when the expression evaluates to true. ")
         private String truncateWhen;
 
         public Entry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen, final Boolean recurse) {

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorConfig.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorConfig.java
@@ -18,8 +18,8 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `user_agent` processor parses any user agent (UA) string in an event and then adds the " +
-        "parsing results to the event’s write data.")
+@JsonClassDescription("The <code>user_agent</code> processor parses any user agent (UA) string in an event and then adds the " +
+        "parsed results to the event.")
 public class UserAgentProcessorConfig {
 
     private static final int DEFAULT_CACHE_SIZE = 1000;

--- a/data-prepper-plugins/write-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/write_json/WriteJsonProcessorConfig.java
+++ b/data-prepper-plugins/write-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/write_json/WriteJsonProcessorConfig.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotNull;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `write_json` processor converts an object in an event into a JSON string.")
+@JsonClassDescription("The <code>write_json</code> processor converts an object in an event into a JSON string.")
 public class WriteJsonProcessorConfig {
     @JsonProperty("source")
     @JsonPropertyDescription("Specifies the name of the field in the event containing the message or object to be parsed.")


### PR DESCRIPTION
### Description

Updates some enumerations used in processors to support the `@JsonValue` annotation. Corrects `@JsonClassDescription` to use HTML rather than Markdown. Various unit test improvements for modified unit tests.

This follows on other PRs such as:

* #5019
* #4985

In particular, for #4985, I missed the `@JsonClassDescription` headers.
 
### Issues Resolved

None
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
