### PR TITLE
Documentation improvements for a number of Data Prepper processors (group 3)

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/csv/CsvOutputCodecConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/csv/CsvOutputCodecConfig.java
@@ -6,6 +6,7 @@ package org.opensearch.dataprepper.plugins.codec.csv;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
@@ -13,14 +14,16 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `csv` processor parses comma-separated values (CSVs) from the event into columns.")
+@JsonClassDescription("The <code>csv</code> codec parses comma-separated values (CSVs) content into events from that content.")
 public class CsvOutputCodecConfig {
     static final String DEFAULT_DELIMITER = ",";
 
     @JsonProperty("delimiter")
+    @JsonPropertyDescription("The character separating each column. Default value is <code>,</code>.")
     private String delimiter = DEFAULT_DELIMITER;
 
     @JsonProperty("header")
+    @JsonPropertyDescription("User-specified names for the CSV columns.")
     private List<String> header;
 
     @Valid
@@ -32,10 +35,12 @@ public class CsvOutputCodecConfig {
     @Size(max = 0, message = "Header from file is not supported.")
     @JsonProperty("region")
     private String region;
+
     @Valid
     @Size(max = 0, message = "Header from file is not supported.")
     @JsonProperty("bucket_name")
     private String bucketName;
+
     @Valid
     @Size(max = 0, message = "Header from file is not supported.")
     @JsonProperty("fileKey")

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.csv;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.AssertTrue;
@@ -14,6 +15,7 @@ import java.util.List;
 /**
  * Configuration class for {@link CsvProcessor}.
  */
+@JsonClassDescription("The <code>csv</code> processor parses comma-separated values (CSVs) strings into structured data.")
 public class CsvProcessorConfig {
     static final String DEFAULT_SOURCE = "message";
     static final String DEFAULT_DELIMITER = ",";
@@ -40,8 +42,8 @@ public class CsvProcessorConfig {
 
     @JsonProperty("column_names_source_key")
     @JsonPropertyDescription("The field in the event that specifies the CSV column names, which will be " +
-            "automatically detected. If there need to be extra column names, the column names are automatically " +
-            "generated according to their index. If <code>column_names</code> is also defined, the header in " +
+            "automatically detected. If there are additional columns in the <code>source</code>, the column names are automatically " +
+            "generated according to column index. If <code>column_names</code> is also defined, the header in " +
             "<code>column_names_source_key</code> can also be used to generate the event fields. " +
             "If too few columns are specified in this field, the remaining column names are automatically generated. " +
             "If too many column names are specified in this field, the CSV processor omits the extra column names.")
@@ -57,9 +59,8 @@ public class CsvProcessorConfig {
     private List<String> columnNames;
 
     @JsonProperty("csv_when")
-    @JsonPropertyDescription("Allows you to specify a Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether " +
-            "the processor should be applied to the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>csv</code> processor will only run on events when the expression evaluates to true. ")
     private String csvWhen;
 
     @JsonPropertyDescription("If true, the configured source field will be deleted after the CSV data is parsed into separate fields.")

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `flatten` processor transforms nested objects inside of events into flattened structures.")
+@JsonClassDescription("The <code>flatten</code> processor transforms nested objects inside of events into flattened structures.")
 public class FlattenProcessorConfig {
 
     private static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
@@ -35,7 +35,8 @@ public class FlattenProcessorConfig {
     private String target;
 
     @JsonProperty("remove_processed_fields")
-    @JsonPropertyDescription("When <code>true</code>, the processor removes all processed fields from the source. Default is <code>false</code>.")
+    @JsonPropertyDescription("When <code>true</code>, the processor removes all processed fields from the source. " +
+            "The default is <code>false</code> which leaves the source fields.")
     private boolean removeProcessedFields = false;
 
     @JsonProperty("remove_list_indices")
@@ -50,13 +51,12 @@ public class FlattenProcessorConfig {
 
     @JsonProperty("exclude_keys")
     @JsonPropertyDescription("The keys from the source field that should be excluded from processing. " +
-            "Default is an empty list (<code>[]</code>).")
+            "By default no keys are excluded.")
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonProperty("flatten_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"'</code>, that determines whether the <code>flatten</code> processor will be run on the " +
-            "event. Default is <code>null</code>, which means that all events will be processed unless otherwise stated.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>flatten</code> processor will only run on events when the expression evaluates to true. ")
     private String flattenWhen;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -55,10 +55,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     private final Set<String> excludeKeysSet = new HashSet<String>();
     private final HashMap<String, Object> defaultValuesMap = new HashMap<>();
     private final Set<String> defaultValuesSet = new HashSet<String>();
-    private final String lowercaseKey = "lowercase";
-    private final String uppercaseKey = "uppercase";
-    private final String capitalizeKey = "capitalize";
-    private final Set<String> validTransformOptionSet = Set.of("", lowercaseKey, uppercaseKey, capitalizeKey);
     private final String whitespaceStrict = "strict";
     private final String whitespaceLenient = "lenient";
     private final Set<String> validWhitespaceSet = Set.of(whitespaceLenient, whitespaceStrict);
@@ -166,14 +162,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         }
 
         validateKeySets(includeKeysSet, excludeKeysSet, defaultValuesSet);
-
-        if (!validTransformOptionSet.contains(keyValueProcessorConfig.getTransformKey())) {
-            throw new IllegalArgumentException(String.format("The transform_key value: %s is not a valid option", keyValueProcessorConfig.getTransformKey()));
-        }
-
-        if (!(validWhitespaceSet.contains(keyValueProcessorConfig.getWhitespace()))) {
-            throw new IllegalArgumentException(String.format("The whitespace value: %s is not a valid option", keyValueProcessorConfig.getWhitespace()));
-        }
 
         final Pattern boolCheck = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE);
         final Matcher duplicateValueBoolMatch = boolCheck.matcher(String.valueOf(keyValueProcessorConfig.getSkipDuplicateValues()));
@@ -596,14 +584,14 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 value = ((String)value).replaceAll(keyValueProcessorConfig.getDeleteValueRegex(), "");
             }
 
-            if (keyValueProcessorConfig.getWhitespace().equals(whitespaceStrict)) {
+            if (keyValueProcessorConfig.getWhitespace() == WhitespaceOption.STRICT) {
                 String[] whitespace_arr = trimWhitespace(key, value);
                 key = whitespace_arr[0];
                 value = whitespace_arr[1];
             }
 
             if (keyValueProcessorConfig.getTransformKey() != null
-                    && !keyValueProcessorConfig.getTransformKey().isEmpty()) {
+                    && keyValueProcessorConfig.getTransformKey() != TransformOption.NONE) {
                 key = transformKey(key);
             }
 
@@ -636,14 +624,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     }
 
     private String transformKey(String key) {
-        if (keyValueProcessorConfig.getTransformKey().equals(lowercaseKey)) {
-            key = key.toLowerCase();
-        } else if (keyValueProcessorConfig.getTransformKey().equals(capitalizeKey)) {
-            key = key.substring(0, 1).toUpperCase() + key.substring(1);
-        } else if (keyValueProcessorConfig.getTransformKey().equals(uppercaseKey)) {
-            key = key.toUpperCase();
-        }
-        return key;
+        return keyValueProcessorConfig.getTransformKey().getTransformFunction().apply(key);
     }
 
     private boolean validKeyAndValue(String key, Object value) {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 @JsonPropertyOrder
-@JsonClassDescription("You can use the `key_value` processor to parse the specified field into key-value pairs.")
+@JsonClassDescription("You can use the <code>key_value</code> processor to create structured data by parsing key-value pairs from strings.")
 public class KeyValueProcessorConfig {
     static final String DEFAULT_SOURCE = "message";
     static final String DEFAULT_DESTINATION = "parsed_message";
@@ -32,43 +32,43 @@ public class KeyValueProcessorConfig {
     static final String DEFAULT_PREFIX = "";
     static final String DEFAULT_DELETE_KEY_REGEX = "";
     static final String DEFAULT_DELETE_VALUE_REGEX = "";
-    static final String DEFAULT_TRANSFORM_KEY = "";
-    static final String DEFAULT_WHITESPACE = "lenient";
+    static final WhitespaceOption DEFAULT_WHITESPACE = WhitespaceOption.LENIENT;
     static final boolean DEFAULT_SKIP_DUPLICATE_VALUES = false;
     static final boolean DEFAULT_REMOVE_BRACKETS = false;
     static final boolean DEFAULT_VALUE_GROUPING = false;
     static final boolean DEFAULT_RECURSIVE = false;
 
     @NotEmpty
-    @JsonPropertyDescription("The message field to be parsed. Optional. Default value is <code>message</code>.")
+    @JsonPropertyDescription("The source field to parse for key-value pairs. The default value is <code>message</code>.")
     private String source = DEFAULT_SOURCE;
 
-    @JsonPropertyDescription("The destination field for the parsed source. The parsed source overwrites the " +
-            "preexisting data for that key. Optional. If <code>destination</code> is set to <code>null</code>, the parsed fields will be " +
-            "written to the root of the event. Default value is <code>parsed_message</code>.")
+    @JsonPropertyDescription("The destination field for the structured data. The destination will be a structured map with the key value pairs extracted from the source. " +
+            "If <code>destination</code> is set to <code>null</code>, the parsed fields will be written to the root of the event. " +
+            "The default value is <code>parsed_message</code>.")
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty("field_delimiter_regex")
     @JsonPropertyDescription("A regular expression specifying the delimiter that separates key-value pairs. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
-            "Cannot be defined at the same time as <code>field_split_characters</code>. Optional. " +
-            "If this option is not defined, <code>field_split_characters</code> is used.")
+            "This field cannot be defined along with <code>field_split_characters</code>. " +
+            "If this option is not defined, the <code>key_value</code> processor will parse the source using <code>field_split_characters</code>.")
     private String fieldDelimiterRegex;
 
     @JsonProperty("field_split_characters")
     @JsonPropertyDescription("A string of characters specifying the delimiter that separates key-value pairs. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
-            "Cannot be defined at the same time as <code>field_delimiter_regex</code>. Optional. Default value is <code>&amp;</code>.")
+            "This field cannot be defined along with <code>field_delimiter_regex</code>. " +
+            "The default value is <code>&amp;</code>.")
     private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
     @JsonProperty("include_keys")
-    @JsonPropertyDescription("An array specifying the keys that should be added for parsing. " +
+    @JsonPropertyDescription("An array specifying the keys that should be included in the destination field. " +
             "By default, all keys will be added.")
     @NotNull
     private List<String> includeKeys = DEFAULT_INCLUDE_KEYS;
 
     @JsonProperty("exclude_keys")
-    @JsonPropertyDescription("An array specifying the parsed keys that should not be added to the event. " +
+    @JsonPropertyDescription("An array specifying the parsed keys that should be excluded from the destination field. " +
             "By default, no keys will be excluded.")
     @NotNull
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
@@ -76,58 +76,63 @@ public class KeyValueProcessorConfig {
     @JsonProperty("default_values")
     @JsonPropertyDescription("A map specifying the default keys and their values that should be added " +
             "to the event in case these keys do not exist in the source field being parsed. " +
-            "If the default key already exists in the message, the value is not changed. " +
-            "The <code>include_keys</code> filter will be applied to the message before <code>default_values</code>.")
+            "If the key was parsed from the source field that value will remain and the default value is not used. " +
+            "If the default values includes keys which are not part of <code>include_keys</code> those keys and value will be added to the event.")
     @NotNull
     private Map<String, Object> defaultValues = DEFAULT_DEFAULT_VALUES;
 
     @JsonProperty("key_value_delimiter_regex")
-    @JsonPropertyDescription("A regular expression specifying the delimiter that separates the key and value" +
-            "within a key-value pair. Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with " +
-            "<code>\\\\</code>. This option cannot be defined at the same time as <code>value_split_characters</code>. Optional. " +
-            "If this option is not defined, <code>value_split_characters</code> is used.")
+    @JsonPropertyDescription("A regular expression specifying the delimiter that separates keys from their values within a key-value pair. " +
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
+            "This field cannot be defined along with <code>value_split_characters</code>. " +
+            "If this option is not defined, the <code>key_value</code> processor will parse the source using <code>value_split_characters</code>.")
     private String keyValueDelimiterRegex;
 
     @JsonProperty("value_split_characters")
-    @JsonPropertyDescription("A string of characters specifying the delimiter that separates the key and value within " +
-            "a key-value pair. Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
-            "Cannot be defined at the same time as <code>key_value_delimiter_regex</code>. Optional. Default value is <code>=</code>.")
+    @JsonPropertyDescription("A string of characters specifying the delimiter that separates keys from their values within a key-value pair. " +
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
+            "This field cannot be defined along with <code>key_value_delimiter_regex</code>. " +
+            "The default value is <code>=</code>.")
     private String valueSplitCharacters = DEFAULT_VALUE_SPLIT_CHARACTERS;
 
     @JsonProperty("non_match_value")
-    @JsonPropertyDescription("When a key-value pair cannot be successfully split, the key-value pair is " +
-            "placed in the <code>key</code> field, and the specified value is placed in the <code>value</code> field. " +
-            "Optional. Default value is <code>null</code>.")
+    @JsonPropertyDescription("Configures a value to use when the processor cannot split a key-value pair. " +
+            "The value specified in this configuration is the value used in <code>destination</code> map. " +
+            "The default behavior is to drop the key-value pair.")
     private Object nonMatchValue = DEFAULT_NON_MATCH_VALUE;
 
-    @JsonPropertyDescription("A prefix to append before all keys. Optional. Default value is an empty string.")
+    @JsonPropertyDescription("A prefix to append before all keys. By default no prefix is added.")
     @NotNull
     private String prefix = DEFAULT_PREFIX;
 
     @JsonProperty("delete_key_regex")
-    @JsonPropertyDescription("A regular expression specifying the characters to delete from the key. " +
-            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. Cannot be an " +
-            "empty string. Optional. No default value.")
+    @JsonPropertyDescription("A regular expression specifying characters to delete from the key. " +
+            "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
+            "Cannot be an empty string. " +
+            "By default, no characters are deleted from the key.")
     @NotNull
     private String deleteKeyRegex = DEFAULT_DELETE_KEY_REGEX;
 
     @JsonProperty("delete_value_regex")
-    @JsonPropertyDescription("A regular expression specifying the characters to delete from the value. " +
+    @JsonPropertyDescription("A regular expression specifying characters to delete from the value. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
-            "Cannot be an empty string. Optional. No default value.")
+            "Cannot be an empty string. " +
+            "By default, no characters are deleted from the value.")
     @NotNull
     private String deleteValueRegex = DEFAULT_DELETE_VALUE_REGEX;
 
     @JsonProperty("transform_key")
-    @JsonPropertyDescription("When to lowercase, uppercase, or capitalize keys.")
+    @JsonPropertyDescription("Allows transforming the key's name such as making the name all lowercase.")
     @NotNull
-    private String transformKey = DEFAULT_TRANSFORM_KEY;
+    private TransformOption transformKey = TransformOption.NONE;
 
     @JsonProperty("whitespace")
     @JsonPropertyDescription("Specifies whether to be lenient or strict with the acceptance of " +
-            "unnecessary white space surrounding the configured value-split sequence. Default is <code>lenient</code>.")
+            "unnecessary white space surrounding the configured value-split sequence. " +
+            "In this case, strict means that whitespace is trimmed and lenient means it is retained in the key name and in the value." +
+            "Default is <code>lenient</code>.")
     @NotNull
-    private String whitespace = DEFAULT_WHITESPACE;
+    private WhitespaceOption whitespace = DEFAULT_WHITESPACE;
 
     @JsonProperty("skip_duplicate_values")
     @JsonPropertyDescription("A Boolean option for removing duplicate key-value pairs. When set to <code>true</code>, " +
@@ -136,25 +141,27 @@ public class KeyValueProcessorConfig {
     private boolean skipDuplicateValues = DEFAULT_SKIP_DUPLICATE_VALUES;
 
     @JsonProperty("remove_brackets")
-    @JsonPropertyDescription("Specifies whether to treat square brackets, angle brackets, and parentheses " +
-            "as value “wrappers” that should be removed from the value. Default is <code>false</code>.")
+    @JsonPropertyDescription("Specifies whether to treat certain grouping characters as wrapping text that should be removed from values." +
+            "When set to <code>true</code>, the following grouping characters will be removed: square brackets, angle brackets, and parentheses. " +
+            "The default configuration is <code>false</code> which retains those grouping characters.")
     @NotNull
     private boolean removeBrackets = DEFAULT_REMOVE_BRACKETS;
 
     @JsonProperty("value_grouping")
-    @JsonPropertyDescription("Specifies whether to group values using predefined value grouping delimiters: " +
-            "<code>{...}</code>, <code>[...]</code>, <code>&lt;...&gt;</code>, <code>(...)</code>, <code>\"...\"</code>, <code>'...'</code>, <code>http://... (space)</code>, and <code>https:// (space)</code>. " +
+    @JsonPropertyDescription("Specifies whether to group values using predefined grouping delimiters. " +
             "If this flag is enabled, then the content between the delimiters is considered to be one entity and " +
-            "is not parsed for key-value pairs. Default is <code>false</code>. If <code>value_grouping</code> is <code>true</code>, then " +
+            "they are not parsed as key-value pairs. The following characters are used a group delimiters: " +
+            "<code>{...}</code>, <code>[...]</code>, <code>&lt;...&gt;</code>, <code>(...)</code>, <code>\"...\"</code>, <code>'...'</code>, <code>http://... (space)</code>, and <code>https:// (space)</code>. " +
+            "Default is <code>false</code>. For example, if <code>value_grouping</code> is <code>true</code>, then " +
             "<code>{\"key1=[a=b,c=d]&amp;key2=value2\"}</code> parses to <code>{\"key1\": \"[a=b,c=d]\", \"key2\": \"value2\"}</code>.")
     private boolean valueGrouping = DEFAULT_VALUE_GROUPING;
 
     @JsonProperty("recursive")
     @JsonPropertyDescription("Specifies whether to recursively obtain additional key-value pairs from values. " +
-            "The extra key-value pairs will be stored as sub-keys of the root key. Default is <code>false</code>. " +
+            "The extra key-value pairs will be stored as nested objects within the destination object. Default is <code>false</code>. " +
             "The levels of recursive parsing must be defined by different brackets for each level: " +
             "<code>[]</code>, <code>()</code>, and <code>&lt;&gt;</code>, in this order. Any other configurations specified will only be applied " +
-            "to the outmost keys.\n" +
+            "to the outermost keys.\n" +
             "When <code>recursive</code> is <code>true</code>:\n" +
             "<code>remove_brackets</code> cannot also be <code>true</code>;\n" +
             "<code>skip_duplicate_values</code> will always be <code>true</code>;\n" +
@@ -163,9 +170,7 @@ public class KeyValueProcessorConfig {
     private boolean recursive = DEFAULT_RECURSIVE;
 
     @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("When a <code>kv</code> operation causes a runtime exception within the processor, " +
-            "the operation is safely stopped without crashing the processor, and the event is tagged " +
-            "with the provided tags.")
+    @JsonPropertyDescription("The tags to add to the event metadata if the <code>key_value</code> processor fails to parse the source string.")
     private List<String> tagsOnFailure;
 
     @JsonProperty("overwrite_if_destination_exists")
@@ -175,14 +180,13 @@ public class KeyValueProcessorConfig {
 
     @JsonProperty("drop_keys_with_no_value")
     @JsonPropertyDescription("Specifies whether keys should be dropped if they have a null value. Default is <code>false</code>. " +
-            "If <code>drop_keys_with_no_value</code> is set to <code>true</code>, " +
+            "For example, if <code>drop_keys_with_no_value</code> is set to <code>true</code>, " +
             "then <code>{\"key1=value1&amp;key2\"}</code> parses to <code>{\"key1\": \"value1\"}</code>.")
     private boolean dropKeysWithNoValue = false;
 
     @JsonProperty("key_value_when")
-    @JsonPropertyDescription("Allows you to specify a Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether " +
-            "the processor should be applied to the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>key_value</code> processor will only run on events when the expression evaluates to true. ")
     private String keyValueWhen;
 
     @JsonProperty("strict_grouping")
@@ -193,8 +197,8 @@ public class KeyValueProcessorConfig {
     private boolean strictGrouping = false;
 
     @JsonProperty("string_literal_character")
-    @JsonPropertyDescription("When this option is used, any text contained within the specified quotation " +
-            "mark character will be ignored and excluded from key-value parsing. " +
+    @JsonPropertyDescription("When this option is used, any text contained within the specified literal " +
+            "character will be ignored and excluded from key-value parsing. " +
             "Can be set to either a single quotation mark (<code>'</code>) or a double quotation mark (<code>\"</code>). " +
             "Default is <code>null</code>.")
     @Size(min = 0, max = 1, message = "string_literal_character may only have character")
@@ -284,11 +288,11 @@ public class KeyValueProcessorConfig {
         return deleteValueRegex;
     }
 
-    public String getTransformKey() {
+    public TransformOption getTransformKey() {
         return transformKey;
     }
 
-    public String getWhitespace() {
+    public WhitespaceOption getWhitespace() {
         return whitespace;
     }
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/TransformOption.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/TransformOption.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.keyvalue;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum TransformOption {
+    NONE("", key -> key),
+    LOWERCASE("lowercase", String::toLowerCase),
+    UPPERCASE("uppercase", String::toUpperCase),
+    CAPITALIZE("capitalize", key -> key.substring(0, 1).toUpperCase() + key.substring(1));
+
+    private static final Map<String, TransformOption> NAMES_MAP = Arrays.stream(TransformOption.values())
+            .collect(Collectors.toMap(
+                    value -> value.transformName,
+                    value -> value
+            ));
+
+    private final String transformName;
+    private final Function<String, String> transformFunction;
+
+    TransformOption(final String transformName, final Function<String, String> transformFunction) {
+        this.transformName = transformName;
+        this.transformFunction = transformFunction;
+    }
+
+    @JsonValue
+    public String getTransformName() {
+        return transformName;
+    }
+
+    Function<String, String> getTransformFunction() {
+        return transformFunction;
+    }
+
+    @JsonCreator
+    public static TransformOption fromTransformName(final String transformName) {
+        return NAMES_MAP.get(transformName);
+    }
+}

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/WhitespaceOption.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/WhitespaceOption.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.keyvalue;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum WhitespaceOption {
+    LENIENT("lenient"),
+    STRICT("strict");
+
+    private static final Map<String, WhitespaceOption> NAMES_MAP = Arrays.stream(WhitespaceOption.values())
+            .collect(Collectors.toMap(
+                    value -> value.optionName,
+                    value -> value
+            ));
+
+    private final String optionName;
+
+    WhitespaceOption(final String optionName) {
+        this.optionName = optionName;
+    }
+
+    @JsonValue
+    public String getWhitespaceName() {
+        return optionName;
+    }
+
+    @JsonCreator
+    public static WhitespaceOption fromWhitespaceName(final String optionName) {
+        return NAMES_MAP.get(optionName);
+    }
+}

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -778,7 +778,7 @@ public class KeyValueProcessorTests {
 
     @Test
     void testLowercaseTransformKvProcessor() {
-        when(mockConfig.getTransformKey()).thenReturn("lowercase");
+        when(mockConfig.getTransformKey()).thenReturn(TransformOption.LOWERCASE);
 
         final Record<Event> record = getMessage("Key1=value1");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
@@ -790,7 +790,7 @@ public class KeyValueProcessorTests {
 
     @Test
     void testUppercaseTransformKvProcessor() {
-        when(mockConfig.getTransformKey()).thenReturn("uppercase");
+        when(mockConfig.getTransformKey()).thenReturn(TransformOption.UPPERCASE);
 
         final Record<Event> record = getMessage("key1=value1");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
@@ -802,7 +802,7 @@ public class KeyValueProcessorTests {
 
     @Test
     void testCapitalizeTransformKvProcessor() {
-        when(mockConfig.getTransformKey()).thenReturn("capitalize");
+        when(mockConfig.getTransformKey()).thenReturn(TransformOption.CAPITALIZE);
 
         final Record<Event> record = getMessage("key1=value1");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
@@ -814,7 +814,7 @@ public class KeyValueProcessorTests {
 
     @Test
     void testStrictWhitespaceKvProcessor() {
-        when(mockConfig.getWhitespace()).thenReturn("strict");
+        when(mockConfig.getWhitespace()).thenReturn(WhitespaceOption.STRICT);
 
         final Record<Event> record = getMessage("key1  =  value1");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
@@ -934,7 +934,7 @@ public class KeyValueProcessorTests {
     @Test
     void testTransformKeyRecursiveKvProcessor() {
         when(mockConfig.getRecursive()).thenReturn(true);
-        when(mockConfig.getTransformKey()).thenReturn("capitalize");
+        when(mockConfig.getTransformKey()).thenReturn(TransformOption.CAPITALIZE);
 
         final Record<Event> record = getMessage("item1=[item1-subitem1=item1-subitem1-value&item1-subitem2=item1-subitem2-value]&item2=item2-value");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/TransformOptionTest.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/TransformOptionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.keyvalue;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class TransformOptionTest {
+    @ParameterizedTest
+    @EnumSource(TransformOption.class)
+    void fromTransformName_returns_expected_value(final TransformOption transformOption) {
+        assertThat(TransformOption.fromTransformName(transformOption.getTransformName()), equalTo(transformOption));
+    }
+
+    @ParameterizedTest
+    @EnumSource(TransformOption.class)
+    void getTransformName_returns_non_empty_null_for_all_types(final TransformOption transformOption) {
+        assertThat(transformOption.getTransformName(), notNullValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransformOption.class, mode = EnumSource.Mode.EXCLUDE, names = {"NONE"})
+    void getTransformName_returns_non_empty_string_for_all_types_except_none(final TransformOption transformOption) {
+        assertThat(transformOption.getTransformName(), notNullValue());
+        assertThat(transformOption.getTransformName(), not(emptyString()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TransformOptionToKnownName.class)
+    void getTransformName_returns_expected_name(final TransformOption transformOption, final String expectedString) {
+        assertThat(transformOption.getTransformName(), equalTo(expectedString));
+    }
+
+    static class TransformOptionToKnownName implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(TransformOption.NONE, ""),
+                    arguments(TransformOption.UPPERCASE, "uppercase"),
+                    arguments(TransformOption.LOWERCASE, "lowercase"),
+                    arguments(TransformOption.CAPITALIZE, "capitalize")
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TransformationArguments.class)
+    void getTransformFunction_performs_expected_transformation(final TransformOption transformOption, final String inputString, final String outputString) {
+        assertThat(transformOption.getTransformFunction().apply(inputString), equalTo(outputString));
+    }
+
+    static class TransformationArguments implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(TransformOption.NONE, "hello", "hello"),
+                    arguments(TransformOption.NONE, "Hello", "Hello"),
+                    arguments(TransformOption.NONE, "hello world", "hello world"),
+                    arguments(TransformOption.UPPERCASE, "hello", "HELLO"),
+                    arguments(TransformOption.UPPERCASE, "Hello", "HELLO"),
+                    arguments(TransformOption.LOWERCASE, "hello", "hello"),
+                    arguments(TransformOption.LOWERCASE, "Hello", "hello"),
+                    arguments(TransformOption.LOWERCASE, "HELLO", "hello"),
+                    arguments(TransformOption.CAPITALIZE, "hello", "Hello"),
+                    arguments(TransformOption.CAPITALIZE, "hello world", "Hello world")
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/WhitespaceOptionTest.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/WhitespaceOptionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.keyvalue;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class WhitespaceOptionTest {
+    @ParameterizedTest
+    @EnumSource(WhitespaceOption.class)
+    void fromWhitespaceName_returns_expected_value(final WhitespaceOption whitespaceOption) {
+        assertThat(WhitespaceOption.fromWhitespaceName(whitespaceOption.getWhitespaceName()), equalTo(whitespaceOption));
+    }
+
+    @ParameterizedTest
+    @EnumSource(WhitespaceOption.class)
+    void getWhitespaceName_returns_non_empty_string_for_all_types(final WhitespaceOption whitespaceOption) {
+        assertThat(whitespaceOption.getWhitespaceName(), notNullValue());
+        assertThat(whitespaceOption.getWhitespaceName(), not(emptyString()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(WhitespaceOptionToKnownName.class)
+    void getWhitespaceName_returns_expected_name(final WhitespaceOption whitespaceOption, final String expectedString) {
+        assertThat(whitespaceOption.getWhitespaceName(), equalTo(expectedString));
+    }
+
+    static class WhitespaceOptionToKnownName implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(WhitespaceOption.LENIENT, "lenient"),
+                    arguments(WhitespaceOption.STRICT, "strict")
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -19,29 +19,31 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `parse_ion` processor parses [Amazon Ion](https://amazon-ion.github.io/ion-docs/) data.")
+@JsonClassDescription("The <code>parse_ion</code> processor parses <a href=\"https://amazon-ion.github.io/ion-docs/\">Amazon Ion</a> data.")
 public class ParseIonProcessorConfig implements CommonParseConfig {
     static final String DEFAULT_SOURCE = "message";
 
     @NotBlank
     @JsonProperty("source")
-    @JsonPropertyDescription("The field in the event that will be parsed. Default value is message.")
+    @JsonPropertyDescription("The field in the event that will be parsed. The default value is <code>message</code>.")
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("destination")
-    @JsonPropertyDescription("The destination field of the parsed JSON. Defaults to the root of the event. Cannot be an empty string, /, or any white-space-only string because these are not valid event fields.")
+    @JsonPropertyDescription("The destination field of the structured object from the parsed ION. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
 
     @JsonProperty("pointer")
-    @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
+    @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. " +
+            "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>parse_ion</code> processor will only run on events when the expression evaluates to true. ")
     private String parseWhen;
 
     @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event that the processor fails or an unknown exception occurs during parsing.")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
     private List<String> tagsOnFailure;
 
     @JsonProperty("overwrite_if_destination_exists")
@@ -49,12 +51,12 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     private boolean overwriteIfDestinationExists = true;
 
     @JsonProperty
-    @JsonPropertyDescription("If true, the configured source field will be deleted after the JSON data is parsed into separate fields.")
+    @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the ION data is parsed into separate fields.")
     private boolean deleteSource = false;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with ION processing errors. Options include 'skip', " +
-            "which will log the error and send the Event downstream to the next processor, and 'skip_silently', " +
+            "which will log the error and send the event downstream to the next processor, and 'skip_silently', " +
             "which will send the Event downstream to the next processor without logging the error. " +
             "Default is 'skip'.")
     @NotNull

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
@@ -19,30 +19,31 @@ import java.util.Objects;
 import java.util.List;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `parse_json` processor parses JSON data for an event, including any nested fields. " +
-        "The processor extracts the JSON pointer data and adds the input event to the extracted fields.")
+@JsonClassDescription("The <code>parse_json</code> processor parses JSON data from fields in events.")
 public class ParseJsonProcessorConfig implements CommonParseConfig {
     static final String DEFAULT_SOURCE = "message";
 
     @NotBlank
     @JsonProperty("source")
-    @JsonPropertyDescription("The field in the event that will be parsed. Default value is message.")
+    @JsonPropertyDescription("The field in the event that will be parsed. The default value is <code>message</code>.")
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("destination")
-    @JsonPropertyDescription("The destination field of the parsed JSON. Defaults to the root of the event. Cannot be an empty string, /, or any white-space-only string because these are not valid event fields.")
+    @JsonPropertyDescription("The destination field of the structured object from the parsed JSON. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
 
     @JsonProperty("pointer")
-    @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
+    @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. " +
+            "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>parse_json</code> processor will only run on events when the expression evaluates to true. ")
     private String parseWhen;
 
     @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event that the processor fails or an unknown exception occurs during parsing.")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
     private List<String> tagsOnFailure;
 
     @JsonProperty("overwrite_if_destination_exists")
@@ -50,12 +51,12 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     private boolean overwriteIfDestinationExists = true;
 
     @JsonProperty
-    @JsonPropertyDescription("If true, the configured source field will be deleted after the JSON data is parsed into separate fields.")
+    @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the JSON data is parsed into separate fields.")
     private boolean deleteSource = false;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with JSON processing errors. Options include 'skip', " +
-            "which will log the error and send the Event downstream to the next processor, and 'skip_silently', " +
+            "which will log the error and send the event downstream to the next processor, and 'skip_silently', " +
             "which will send the Event downstream to the next processor without logging the error. " +
             "Default is 'skip'.")
     @NotNull

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -14,29 +14,31 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `parse_xml` processor parses XML data for an event.")
+@JsonClassDescription("The <code>parse_xml</code> processor parses XML data for an event.")
 public class ParseXmlProcessorConfig implements CommonParseConfig {
     static final String DEFAULT_SOURCE = "message";
 
     @NotBlank
     @JsonProperty("source")
-    @JsonPropertyDescription("The field in the event that will be parsed. Default value is message.")
+    @JsonPropertyDescription("The field in the event that will be parsed. The default value is <code>message</code>.")
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("destination")
-    @JsonPropertyDescription("The destination field of the parsed JSON. Defaults to the root of the event. Cannot be an empty string, /, or any white-space-only string because these are not valid event fields.")
+    @JsonPropertyDescription("The destination field of the structured object from the parsed XML. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
 
     @JsonProperty("pointer")
-    @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
+    @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. " +
+            "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>parse_xml</code> processor will only run on events when the expression evaluates to true. ")
     private String parseWhen;
 
     @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event that the processor fails or an unknown exception occurs during parsing.")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
     private List<String> tagsOnFailure;
 
     @JsonProperty("overwrite_if_destination_exists")
@@ -44,12 +46,12 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
     private boolean overwriteIfDestinationExists = true;
 
     @JsonProperty
-    @JsonPropertyDescription("If true, the configured source field will be deleted after the JSON data is parsed into separate fields.")
+    @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the XML data is parsed into separate fields.")
     private boolean deleteSource = false;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with XML processing errors. Options include 'skip', " +
-            "which will log the error and send the Event downstream to the next processor, and 'skip_silently', " +
+            "which will log the error and send the event downstream to the next processor, and 'skip_silently', " +
             "which will send the Event downstream to the next processor without logging the error. " +
             "Default is 'skip'.")
     @NotNull

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TargetsParameterConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TargetsParameterConfig.java
@@ -30,14 +30,14 @@ public class TargetsParameterConfig {
     @JsonProperty("map")
     @JsonPropertyDescription("A list of key-value pairs that define the translations. Each key represents a possible " +
             "value in the source field, and the corresponding value represents what it should be translated to. " +
-            "For examples, see <a href=\"#map-option\">map option</a>. At least one of <code>map</code> and <code>regex</code> should be configured.")
+            "At least one of <code>map</code> and <code>regex</code> should be configured.")
     private Map<String, Object> map;
     @JsonProperty("translate_when")
-    @JsonPropertyDescription("Uses a <a href=\"{{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/\">Data Prepper expression</a> " +
+    @JsonPropertyDescription("Uses a <a href=\"{{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/\">conditional expression</a> " +
             "to specify a condition for performing the translation. When specified, the expression will only translate when the condition is met.")
     private String translateWhen;
     @JsonProperty("regex")
-    @JsonPropertyDescription("A map of keys that defines the translation map. For more options, see <a href=\"#regex-option\">regex option</a>. " +
+    @JsonPropertyDescription("A map of keys that defines the translation map. " +
             "At least one of <code>map</code> and <code>regex</code> should be configured.")
     private RegexParameterConfiguration regexParameterConfig;
     @JsonProperty("default")

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfig.java
@@ -19,16 +19,16 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonPropertyOrder
-@JsonClassDescription("The `translate` processor transforms values in events into preconfigured values.")
+@JsonClassDescription("The <code>translate</code> processor transforms values in events into preconfigured values.")
 public class TranslateProcessorConfig {
 
     @JsonProperty("file")
-    @JsonPropertyDescription("Points to the file that contains mapping configurations. For more information, see <a href=\"#file\">file</a>.")
+    @JsonPropertyDescription("Points to the file that contains mapping configurations.")
     @Valid
     private FileParameterConfig fileParameterConfig;
 
     @JsonProperty("mappings")
-    @JsonPropertyDescription("Defines inline mappings. For more information, see <a href=\"#mappings\">mappings</a>.")
+    @JsonPropertyDescription("Defines inline mappings.")
     @Valid
     private List<MappingsParameterConfig> mappingsParameterConfigs = new ArrayList<>();
 


### PR DESCRIPTION
### Description

Adds missing enumerations in the key-value processor to support better documentation. Corrects @JsonClassDescription to use HTML rather than Markdown. This set of changes is for key_value, flatten, translate, parse_json, parse_xml, parse_ion, and csv. Also, this adds documentation to the csv input codec.

Continues the work done in #5019 and #5023.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
