### PR TITLE
Doc improvements: re-ordering; missing annotations; missed enums

### DIFF
--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -106,11 +106,6 @@ public class DateProcessorConfig {
             "This option cannot be defined at the same time as <code>match</code>. Default is <code>false</code>.")
     private Boolean fromTimeReceived = DEFAULT_FROM_TIME_RECEIVED;
 
-    @JsonProperty("to_origination_metadata")
-    @JsonPropertyDescription("When <code>true</code>, the matched time is also added to the event's metadata as an instance of " +
-            "<code>Instant</code>. Default is <code>false</code>.")
-    private Boolean toOriginationMetadata = DEFAULT_TO_ORIGINATION_METADATA;
-
     @JsonProperty("match")
     @JsonPropertyDescription("The date match configuration. " +
             "This option cannot be defined at the same time as <code>from_time_received</code>. " +
@@ -127,6 +122,11 @@ public class DateProcessorConfig {
     @JsonPropertyDescription("Determines the format of the timestamp added to an event. " +
             "Default is <code>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</code>.")
     private String outputFormat = DEFAULT_OUTPUT_FORMAT;
+
+    @JsonProperty("to_origination_metadata")
+    @JsonPropertyDescription("When <code>true</code>, the matched time is also added to the event's metadata as an instance of " +
+            "<code>Instant</code>. Default is <code>false</code>.")
+    private Boolean toOriginationMetadata = DEFAULT_TO_ORIGINATION_METADATA;
 
     @JsonProperty("source_timezone")
     @JsonPropertyDescription("The time zone used to parse dates, including when the zone or offset cannot be extracted " +

--- a/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressProcessorConfig.java
+++ b/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressProcessorConfig.java
@@ -33,13 +33,13 @@ public class DecompressProcessorConfig {
     @NotNull
     private DecompressionType decompressionType;
 
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>'/is_compressed == true'</code>, that determines when the decompress processor will run on certain events.")
-    @JsonProperty("decompress_when")
-    private String decompressWhen;
-
     @JsonPropertyDescription("A list of strings with which to tag events when the processor fails to decompress the keys inside an event. Defaults to <code>_decompression_failure</code>.")
     @JsonProperty("tags_on_failure")
     private List<String> tagsOnFailure = List.of("_decompression_failure");
+
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>'/is_compressed == true'</code>, that determines when the decompress processor will run on certain events.")
+    @JsonProperty("decompress_when")
+    private String decompressWhen;
 
     @JsonIgnore
     private final EncodingType encodingType = EncodingType.BASE64;

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -54,14 +54,14 @@ public class FlattenProcessorConfig {
             "By default no keys are excluded.")
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
+    @JsonProperty("tags_on_failure")
+    @JsonPropertyDescription("A list of tags to add to the event metadata when the event fails to process.")
+    private List<String> tagsOnFailure;
+
     @JsonProperty("flatten_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
             "If specified, the <code>flatten</code> processor will only run on events when the expression evaluates to true. ")
     private String flattenWhen;
-
-    @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of tags to add to the event metadata when the event fails to process.")
-    private List<String> tagsOnFailure;
 
     public String getSource() {
         return source;

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
@@ -5,8 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.geoip.processor;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import org.opensearch.dataprepper.plugins.geoip.GeoIPField;
@@ -15,6 +17,8 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 
+@JsonPropertyOrder
+@JsonClassDescription("Defines a single entry for geolocation.")
 public class EntryConfig {
     static final String DEFAULT_TARGET = "geo";
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -27,7 +27,7 @@ public class GeoIPProcessorConfig {
     @NotNull
     @Size(min = 1)
     @JsonProperty("entries")
-    @JsonPropertyDescription("The list of entries marked for enrichment.")
+    @JsonPropertyDescription("The list of entries for enrichment. Each entry provides a source field with an IP address along with a target for the enriched geolocation data.")
     private List<EntryConfig> entries;
 
     @JsonProperty("tags_on_engine_failure")

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -46,6 +46,17 @@ public class GrokProcessorConfig {
     static final int DEFAULT_TIMEOUT_MILLIS = 30000;
     static final String DEFAULT_TARGET_KEY = null;
 
+    @JsonProperty(MATCH)
+    @JsonPropertyDescription("Specifies which keys should match specific patterns. " +
+            "Each key is a source field. The value is a list of possible grok patterns to match on. " +
+            "The <code>grok</code> processor will extract values from the first match for each field. " +
+            "Default is an empty response body.")
+    private Map<String, List<String>> match = Collections.emptyMap();
+
+    @JsonProperty(TARGET_KEY)
+    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code> which will write captures into the root of the event.")
+    private String targetKey = DEFAULT_TARGET_KEY;
+
     @JsonProperty(BREAK_ON_MATCH)
     @JsonPropertyDescription("Specifies whether to match all patterns (<code>false</code>) or stop once the first successful " +
             "match is found (<code>true</code>). Default is <code>true</code>.")
@@ -54,13 +65,6 @@ public class GrokProcessorConfig {
     @JsonProperty(KEEP_EMPTY_CAPTURES)
     @JsonPropertyDescription("Enables the preservation of <code>null</code> captures from the processed output. Default is <code>false</code>.")
     private boolean keepEmptyCaptures = DEFAULT_KEEP_EMPTY_CAPTURES;
-
-    @JsonProperty(MATCH)
-    @JsonPropertyDescription("Specifies which keys should match specific patterns. " +
-            "Each key is a source field. The value is a list of possible grok patterns to match on. " +
-            "The <code>grok</code> processor will extract values from the first match for each field. " +
-            "Default is an empty response body.")
-    private Map<String, List<String>> match = Collections.emptyMap();
 
     @JsonProperty(NAMED_CAPTURES_ONLY)
     @JsonPropertyDescription("Specifies whether to keep only named captures. Default is <code>true</code>.")
@@ -71,6 +75,11 @@ public class GrokProcessorConfig {
             "Default is an empty list.")
     private List<String> keysToOverwrite = Collections.emptyList();
 
+    @JsonProperty(PATTERN_DEFINITIONS)
+    @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
+            "Default is an empty response body.")
+    private Map<String, String> patternDefinitions = Collections.emptyMap();
+
     @JsonProperty(PATTERNS_DIRECTORIES)
     @JsonPropertyDescription("Specifies which directory paths contain the custom pattern files. Default is an empty list.")
     private List<String> patternsDirectories = Collections.emptyList();
@@ -80,24 +89,10 @@ public class GrokProcessorConfig {
             "<code>pattern_directories</code>. Default is <code>*</code>.")
     private String patternsFilesGlob = DEFAULT_PATTERNS_FILES_GLOB;
 
-    @JsonProperty(PATTERN_DEFINITIONS)
-    @JsonPropertyDescription("Allows for a custom pattern that can be used inline inside the response body. " +
-            "Default is an empty response body.")
-    private Map<String, String> patternDefinitions = Collections.emptyMap();
-
     @JsonProperty(TIMEOUT_MILLIS)
     @JsonPropertyDescription("The maximum amount of time during which matching occurs. " +
             "Setting to <code>0</code> prevents any matching from occurring. Default is <code>30000</code>.")
     private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
-
-    @JsonProperty(TARGET_KEY)
-    @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code> which will write captures into the root of the event.")
-    private String targetKey = DEFAULT_TARGET_KEY;
-
-    @JsonProperty(GROK_WHEN)
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/test != false'</code>. " +
-            "If specified, the <code>grok</code> processor will only run on events when the expression evaluates to true. ")
-    private String grokWhen;
 
     @JsonProperty(TAGS_ON_MATCH_FAILURE)
     @JsonPropertyDescription("A <code>List</code> of <code>String</code>s that specifies the tags to be set in the event when grok fails to " +
@@ -108,6 +103,11 @@ public class GrokProcessorConfig {
     @JsonProperty(TAGS_ON_TIMEOUT)
     @JsonPropertyDescription("The tags to add to the event metadata if the grok match times out.")
     private List<String> tagsOnTimeout = Collections.emptyList();
+
+    @JsonProperty(GROK_WHEN)
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/test != false'</code>. " +
+            "If specified, the <code>grok</code> processor will only run on events when the expression evaluates to true. ")
+    private String grokWhen;
 
     @JsonProperty(INCLUDE_PERFORMANCE_METADATA)
     @JsonPropertyDescription("A boolean value to determine whether to include performance metadata into event metadata. " +

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -20,8 +20,8 @@ import java.util.stream.Stream;
 @JsonPropertyOrder
 @JsonClassDescription("The <code>add_entries</code> processor adds entries to an event.")
 public class AddEntryProcessorConfig {
+    @JsonPropertyOrder
     public static class Entry {
-
         @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include <code>my_key</code>, " +
                 "<code>myKey</code>, and <code>object/sub_Key</code>. The key can also be a format expression, for example, <code>${/key1}</code> to " +
                 "use the value of field <code>key1</code> as the key.")
@@ -49,11 +49,6 @@ public class AddEntryProcessorConfig {
                 "information about keys, see <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Expression syntax</a>.")
         private String valueExpression;
 
-        @JsonProperty("add_when")
-        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
-        private String addWhen;
-
         @JsonProperty("overwrite_if_key_exists")
         @JsonPropertyDescription("When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists " +
                 "in the event. The default value is <code>false</code>.")
@@ -63,6 +58,11 @@ public class AddEntryProcessorConfig {
         @JsonPropertyDescription("When set to <code>true</code>, the existing value will be appended if a <code>key</code> already " +
                 "exists in the event. An array will be created if the existing value is not an array. Default is <code>false</code>.")
         private boolean appendIfKeyExists = false;
+
+        @JsonProperty("add_when")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
+        private String addWhen;
 
         public String getKey() {
             return key;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -30,6 +30,10 @@ public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     @JsonPropertyDescription("Target type for the values. Default value is <code>integer.</code>")
     private TargetType type = TargetType.INTEGER;
 
+    @JsonProperty("null_values")
+    @JsonPropertyDescription("String representation of what constitutes a null value. If the field value equals one of these strings, then the value is considered null and is converted to null.")
+    private List<String> nullValues;
+
     /**
      * Optional scale value used only in the case of BigDecimal converter
      */
@@ -37,17 +41,13 @@ public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     @JsonPropertyDescription("Modifies the scale of the <code>big_decimal</code> when converting to a <code>big_decimal</code>. The default value is 0.")
     private int scale = 0;
 
-    @JsonProperty("convert_when")
-    @JsonPropertyDescription("Specifies a condition using a <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> for performing the <code>convert_entry_type</code> operation. If specified, the <code>convert_entry_type</code> operation runs only when the expression evaluates to true. Example: <code>/mykey != \"---\"</code>")
-    private String convertWhen;
-
-    @JsonProperty("null_values")
-    @JsonPropertyDescription("String representation of what constitutes a null value. If the field value equals one of these strings, then the value is considered null and is converted to null.")
-    private List<String> nullValues;
-
     @JsonProperty("tags_on_failure")
     @JsonPropertyDescription("A list of tags to be added to the event metadata when the event fails to convert.")
     private List<String> tagsOnFailure;
+
+    @JsonProperty("convert_when")
+    @JsonPropertyDescription("Specifies a condition using a <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> for performing the <code>convert_entry_type</code> operation. If specified, the <code>convert_entry_type</code> operation runs only when the expression evaluates to true. Example: <code>/mykey != \"---\"</code>")
+    private String convertWhen;
 
     public String getKey() {
         return key;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -19,6 +19,7 @@ import java.util.List;
 @JsonPropertyOrder
 @JsonClassDescription("The <code>copy_values</code> processor copies values within an event to other fields within the event.")
 public class CopyValueProcessorConfig {
+    @JsonPropertyOrder
     public static class Entry {
         @NotEmpty
         @NotNull
@@ -32,15 +33,15 @@ public class CopyValueProcessorConfig {
         @JsonPropertyDescription("The key of the new entry to be added.")
         private String toKey;
 
-        @JsonProperty("copy_when")
-        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
-        private String copyWhen;
-
         @JsonProperty("overwrite_if_to_key_exists")
         @JsonPropertyDescription("When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists in " +
                 "the event. The default value is <code>false</code>.")
         private boolean overwriteIfToKeyExists = false;
+
+        @JsonProperty("copy_when")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
+        private String copyWhen;
 
         public String getFromKey() {
             return fromKey;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 @JsonClassDescription("The <code>list_to_map</code> processor converts a list of objects from an event, " +
         "where each object contains a <code>key</code> field, into a map of target keys.")
 public class ListToMapProcessorConfig {
-    enum FlattenedElement {
+    public enum FlattenedElement {
         FIRST("first"),
         LAST("last");
 
@@ -41,6 +42,11 @@ public class ListToMapProcessorConfig {
         @JsonCreator
         static FlattenedElement fromOptionValue(final String option) {
             return ACTIONS_MAP.get(option);
+        }
+
+        @JsonValue
+        public String getOptionValue() {
+            return name;
         }
     }
 
@@ -88,15 +94,15 @@ public class ListToMapProcessorConfig {
     @JsonPropertyDescription("The element to keep, either <code>first</code> or <code>last</code>, when <code>flatten</code> is set to <code>true</code>.")
     private FlattenedElement flattenedElement = FlattenedElement.FIRST;
 
+    @JsonProperty("tags_on_failure")
+    @JsonPropertyDescription("A list of tags to add to the event metadata when the event fails to process.")
+    private List<String> tagsOnFailure;
+
     @JsonProperty("list_to_map_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
             "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
             "run on the event. By default, all events will be processed unless otherwise stated.")
     private String listToMapWhen;
-
-    @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of tags to add to the event metadata when the event fails to process.")
-    private List<String> tagsOnFailure;
 
     public String getSource() {
         return source;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -44,17 +44,6 @@ public class MapToListProcessorConfig {
     @JsonPropertyDescription("The name of the field in which to store the original value. Default is <code>value</code>.")
     private String valueName = DEFAULT_VALUE_NAME;
 
-    @JsonProperty("map_to_list_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will " +
-            "be run on the event. By default, all events will be processed unless otherwise stated.")
-    private String mapToListWhen;
-
-    @JsonProperty("exclude_keys")
-    @JsonPropertyDescription("The keys in the source map that will be excluded from processing. Default is an " +
-            "empty list (<code>[]</code>).")
-    private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
-
     @JsonProperty("remove_processed_fields")
     @JsonPropertyDescription("When <code>true</code>, the processor will remove the processed fields from the source map. " +
             "Default is <code>false</code>.")
@@ -65,9 +54,20 @@ public class MapToListProcessorConfig {
             "place them in fields in the target list. Default is <code>false</code>.")
     private boolean convertFieldToList = false;
 
+    @JsonProperty("exclude_keys")
+    @JsonPropertyDescription("The keys in the source map that will be excluded from processing. Default is an " +
+            "empty list (<code>[]</code>).")
+    private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
+
     @JsonProperty("tags_on_failure")
     @JsonPropertyDescription("A list of tags to add to the event metadata when the event fails to process.")
     private List<String> tagsOnFailure;
+
+    @JsonProperty("map_to_list_when")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will " +
+            "be run on the event. By default, all events will be processed unless otherwise stated.")
+    private String mapToListWhen;
 
     public String getSource() {
         return source;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -21,6 +21,7 @@ import java.util.List;
 @JsonPropertyOrder
 @JsonClassDescription("The <code>rename_keys</code> processor renames keys in an event.")
 public class RenameKeyProcessorConfig {
+    @JsonPropertyOrder
     public static class Entry {
         @NotEmpty
         @NotNull

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig_FlattenedElementTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig_FlattenedElementTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ListToMapProcessorConfig_FlattenedElementTest {
+
+    @ParameterizedTest
+    @EnumSource(ListToMapProcessorConfig.FlattenedElement.class)
+    void fromOptionValue_returns_expected_value(final ListToMapProcessorConfig.FlattenedElement flattenedElement) {
+        assertThat(ListToMapProcessorConfig.FlattenedElement.fromOptionValue(flattenedElement.getOptionValue()), equalTo(flattenedElement));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ListToMapProcessorConfig.FlattenedElement.class)
+    void getOptionValue_returns_non_empty_string_for_all_types(final ListToMapProcessorConfig.FlattenedElement flattenedElement) {
+        assertThat(flattenedElement.getOptionValue(), notNullValue());
+        assertThat(flattenedElement.getOptionValue(), not(emptyString()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FlattenedElementToKnownName.class)
+    void getOptionValue_returns_expected_name(final ListToMapProcessorConfig.FlattenedElement flattenedElement, final String expectedString) {
+        assertThat(flattenedElement.getOptionValue(), equalTo(expectedString));
+    }
+
+    static class FlattenedElementToKnownName implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(ListToMapProcessorConfig.FlattenedElement.FIRST, "first"),
+                    arguments(ListToMapProcessorConfig.FlattenedElement.LAST, "last")
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/ReplaceStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/ReplaceStringProcessorConfig.java
@@ -17,6 +17,7 @@ import java.util.List;
 @JsonClassDescription("The <code>replace_string</code> processor replaces all occurrence of substring in key’s value with a " +
         "replacement string.")
 public class ReplaceStringProcessorConfig implements StringProcessorConfig<ReplaceStringProcessorConfig.Entry> {
+    @JsonPropertyOrder
     public static class Entry {
         @JsonPropertyDescription("The key of the field to modify.")
         private EventKey source;

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -21,23 +21,23 @@ import java.util.List;
 @JsonPropertyOrder
 @JsonClassDescription("The <code>split_string</code> processor splits a field into an array using a delimiting character.")
 public class SplitStringProcessorConfig implements StringProcessorConfig<SplitStringProcessorConfig.Entry> {
+    @JsonPropertyOrder
     public static class Entry {
-
         @NotEmpty
         @NotNull
         @JsonPropertyDescription("The key name of the field to split.")
         private EventKey source;
-
-        @JsonProperty("delimiter_regex")
-        @JsonPropertyDescription("The regex string responsible for the split. Cannot be defined at the same time as <code>delimiter</code>. " +
-                "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
-        private String delimiterRegex;
 
         @Size(min = 1, max = 1)
         @JsonPropertyDescription("The separator character responsible for the split. " +
                 "Cannot be defined at the same time as <code>delimiter_regex</code>. " +
                 "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
         private String delimiter;
+
+        @JsonProperty("delimiter_regex")
+        @JsonPropertyDescription("The regex string responsible for the split. Cannot be defined at the same time as <code>delimiter</code>. " +
+                "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
+        private String delimiterRegex;
 
         @JsonProperty("split_when")
         @JsonPropertyDescription("Specifies under what condition the <code>split_string</code> processor should perform splitting. " +

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
@@ -18,14 +18,17 @@ import java.util.List;
 @JsonClassDescription("The <code>substitute_string</code> processor matches a key’s value against a regular expression and " +
         "replaces all matches with a replacement string.")
 public class SubstituteStringProcessorConfig implements StringProcessorConfig<SubstituteStringProcessorConfig.Entry> {
+    @JsonPropertyOrder
     public static class Entry {
         @JsonPropertyDescription("The key of the field to modify.")
         private EventKey source;
+
         @JsonPropertyDescription("The regular expression to match on for replacement. Special regex characters such as <code>[</code> and <code>]</code> must " +
                 "be escaped using <code>\\\\</code> when using double quotes and <code>\\</code> when using single quotes. " +
                 "See <a href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html\">Java Patterns</a>" +
                 "for more information.")
         private String from;
+
         @JsonPropertyDescription("The string to be substituted for each match of <code>from</code>.")
         private String to;
 

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -30,35 +30,35 @@ public class ObfuscationProcessorConfig {
     @NotNull
     private String source;
 
-    @JsonProperty("patterns")
-    @JsonPropertyDescription("A list of regex patterns that allow you to obfuscate specific parts of a field. Only parts that match the regex pattern will obfuscate. When not provided, the processor obfuscates the whole field.")
-    private List<String> patterns;
-    
     @JsonProperty("target")
     @JsonPropertyDescription("The new field in which to store the obfuscated value. " +
             "This leaves the original source field unchanged. " +
             "When no <code>target</code> is provided, the source field updates with the obfuscated value.")
     private String target;
 
+    @JsonProperty("patterns")
+    @JsonPropertyDescription("A list of regex patterns that allow you to obfuscate specific parts of a field. Only parts that match the regex pattern will obfuscate. When not provided, the processor obfuscates the whole field.")
+    private List<String> patterns;
+
     @JsonProperty("action")
     @JsonPropertyDescription("The obfuscation action. Available actions include <code>hash</code> and <code>mask</code>.")
     @UsesDataPrepperPlugin(pluginType = ObfuscationAction.class)
     private PluginModel action;
-
-    @JsonProperty("obfuscate_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/is_testing_data == true'</code>. " +
-            "If specified, the <code>obfuscate</code> processor will only run on events when the expression evaluates to true. ")
-    private String obfuscateWhen;
-
-    @JsonProperty("tags_on_match_failure")
-    @JsonPropertyDescription("The tag to add to an event if the <code>obfuscate</code> processor fails to match the pattern.")
-    private List<String> tagsOnMatchFailure;
 
     @JsonProperty("single_word_only")
     @JsonPropertyDescription("When set to <code>true</code>, a word boundary <code>\b</code> is added to the pattern, " +
             "which causes obfuscation to be applied only to words that are standalone in the input text. " +
             "By default, it is false, meaning obfuscation patterns are applied to all occurrences.")
     private boolean singleWordOnly = false;
+
+    @JsonProperty("tags_on_match_failure")
+    @JsonPropertyDescription("The tag to add to an event if the <code>obfuscate</code> processor fails to match the pattern.")
+    private List<String> tagsOnMatchFailure;
+
+    @JsonProperty("obfuscate_when")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/is_testing_data == true'</code>. " +
+            "If specified, the <code>obfuscate</code> processor will only run on events when the expression evaluates to true. ")
+    private String obfuscateWhen;
 
     public ObfuscationProcessorConfig() {
     }

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskActionConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskActionConfig.java
@@ -5,20 +5,27 @@
 
 package org.opensearch.dataprepper.plugins.processor.obfuscation.action;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 
+@JsonClassDescription("Obfuscates data by masking data. Without any configuration this will replace text with <code>***</code>")
+@JsonPropertyOrder
 public class MaskActionConfig {
 
     @JsonProperty("mask_character")
     @Pattern(regexp = "[*#!%&@]", message = "Valid characters are *, #, $, %, &, ! and @")
+    @JsonPropertyDescription("The character to use to mask text. By default, this is <code>*</code>")
     private String maskCharacter = "*";
 
     @JsonProperty("mask_character_length")
     @Min(1)
     @Max(10)
+    @JsonPropertyDescription("The length of the character mask to apply. By default, this is three characters.")
     private int maskCharacterLength = 3;
 
     public MaskActionConfig() {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionConfig.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.processor.obfuscation.action;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
@@ -15,10 +17,9 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import org.opensearch.dataprepper.model.event.EventKey;
-import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
-import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
-
+@JsonClassDescription("Obfuscates data by performing a one-way hash.")
+@JsonPropertyOrder
 public class OneWayHashActionConfig {
 
     @JsonProperty("salt")
@@ -27,17 +28,17 @@ public class OneWayHashActionConfig {
     @Size(max = 64, message = "Maximum size of salt string is 64")
     private String salt;
 
+    @JsonProperty("salt_key")
+    @JsonPropertyDescription("A key to compute salt based on a value provided as part of a record. " +
+            "If key or value was not found in the event, a salt defined in the pipeline configuration will be used instead.")
+    @EventKeyConfiguration(EventKeyFactory.EventAction.GET)
+    private EventKey saltKey;
+
     @JsonProperty("format")
     @Pattern(regexp = "SHA-512", message = "Valid values: <code>SHA-512</code>")
     @JsonPropertyDescription("Format of one way hash to generate. Default to <code>SHA-512</code>.")
     private String format = "SHA-512";
 
-    @JsonProperty("salt_key")
-    @JsonPropertyDescription("A key to compute salt based on a value provided as part of a record. " +
-        "If key or value was not found in the event, a salt defined in the pipeline configuration will be used instead.")
-    @EventKeyConfiguration(EventKeyFactory.EventAction.GET)
-    private EventKey saltKey;
- 
     public OneWayHashActionConfig(){
 
     }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -37,15 +37,6 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
-    @JsonProperty("parse_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
-            "If specified, the <code>parse_ion</code> processor will only run on events when the expression evaluates to true. ")
-    private String parseWhen;
-
-    @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
-    private List<String> tagsOnFailure;
-
     @JsonProperty("overwrite_if_destination_exists")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
@@ -53,6 +44,15 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     @JsonProperty
     @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the ION data is parsed into separate fields.")
     private boolean deleteSource = false;
+
+    @JsonProperty("tags_on_failure")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
+    private List<String> tagsOnFailure;
+
+    @JsonProperty("parse_when")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>parse_ion</code> processor will only run on events when the expression evaluates to true. ")
+    private String parseWhen;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with ION processing errors. Options include 'skip', " +

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
@@ -37,15 +37,6 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
-    @JsonProperty("parse_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
-            "If specified, the <code>parse_json</code> processor will only run on events when the expression evaluates to true. ")
-    private String parseWhen;
-
-    @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
-    private List<String> tagsOnFailure;
-
     @JsonProperty("overwrite_if_destination_exists")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
@@ -53,6 +44,15 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     @JsonProperty
     @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the JSON data is parsed into separate fields.")
     private boolean deleteSource = false;
+
+    @JsonProperty("tags_on_failure")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
+    private List<String> tagsOnFailure;
+
+    @JsonProperty("parse_when")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
+            "If specified, the <code>parse_json</code> processor will only run on events when the expression evaluates to true. ")
+    private String parseWhen;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with JSON processing errors. Options include 'skip', " +

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -32,6 +32,14 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
+    @JsonProperty("overwrite_if_destination_exists")
+    @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
+    private boolean overwriteIfDestinationExists = true;
+
+    @JsonProperty
+    @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the XML data is parsed into separate fields.")
+    private boolean deleteSource = false;
+
     @JsonProperty("parse_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
             "If specified, the <code>parse_xml</code> processor will only run on events when the expression evaluates to true. ")
@@ -40,14 +48,6 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
     @JsonProperty("tags_on_failure")
     @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
     private List<String> tagsOnFailure;
-
-    @JsonProperty("overwrite_if_destination_exists")
-    @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
-    private boolean overwriteIfDestinationExists = true;
-
-    @JsonProperty
-    @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the XML data is parsed into separate fields.")
-    private boolean deleteSource = false;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with XML processing errors. Options include 'skip', " +

--- a/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
+++ b/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
@@ -28,13 +28,13 @@ public class SplitEventProcessorConfig {
     @JsonPropertyDescription("The event field to be split.")
     private String field;
 
-    @JsonProperty("delimiter_regex")
-    @JsonPropertyDescription("The regular expression used as the delimiter for splitting the field.")
-    private String delimiterRegex;
-
     @Size(min = 1, max = 1)
-    @JsonPropertyDescription("The delimiter used for splitting the field. If not specified, the default delimiter is used.")
+    @JsonPropertyDescription("The delimiter character used for splitting the field. You must provide either the <code>delimiter</code> or the <code>delimiter_regex</code>.")
     private String delimiter;
+
+    @JsonProperty("delimiter_regex")
+    @JsonPropertyDescription("The regular expression used as the delimiter for splitting the field. You must provide either the <code>delimiter</code> or the <code>delimiter_regex</code>.")
+    private String delimiterRegex;
 
     public String getField() {
         return field;


### PR DESCRIPTION
### Description

This fixes many property orders.

First by adding missing `@JsonPropertyOrder` annotations. Second, by re-ordering many properties. The approach I took is to move the most important configurations up front. Then I also grouped others logically. For character vs. regex, I put character configurations first. I moved tags and when statements toward the bottom.

Added some other missing documentation. Also, added a missing enum.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
