### PR TITLE
Add retry to make sure source is not shutdown when exceptions are thrown on the main thread

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfig.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfig.java
@@ -24,6 +24,8 @@ public class KinesisSourceConfig {
     static final Duration DEFAULT_TIME_OUT_IN_MILLIS = Duration.ofMillis(1000);
     static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 100;
     static final Duration DEFAULT_SHARD_ACKNOWLEDGEMENT_TIMEOUT = Duration.ofMinutes(10);
+    static final Duration DEFAULT_INITIALIZATION_BACKOFF_TIME = Duration.ofMillis(1000);
+    static final int DEFAULT_MAX_INITIALIZATION_ATTEMPTS = Integer.MAX_VALUE;
 
     @Getter
     @JsonProperty("streams")
@@ -69,6 +71,14 @@ public class KinesisSourceConfig {
     public Duration getShardAcknowledgmentTimeout() {
         return shardAcknowledgmentTimeout;
     }
+
+    @Getter
+    @JsonProperty("max_initialization_attempts")
+    private int maxInitializationAttempts = DEFAULT_MAX_INITIALIZATION_ATTEMPTS;
+
+    @Getter
+    @JsonProperty("initialization_backoff_time")
+    private Duration initializationBackoffTime = DEFAULT_INITIALIZATION_BACKOFF_TIME;
 }
 
 

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisServiceTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisServiceTest.java
@@ -75,6 +75,7 @@ public class KinesisServiceTest {
     private static final int NUMBER_OF_RECORDS_TO_ACCUMULATE = 10;
     private static final int DEFAULT_MAX_RECORDS = 10000;
     private static final int IDLE_TIME_BETWEEN_READS_IN_MILLIS = 250;
+    private static final int DEFAULT_INITIALIZATION_ATTEMPTS = 10;
     private static final String awsAccountId = "123456789012";
     private static final String streamArnFormat = "arn:aws:kinesis:us-east-1:%s:stream/%s";
     private static final Instant streamCreationTime = Instant.now();
@@ -189,6 +190,7 @@ public class KinesisServiceTest {
         streamConfigs.add(kinesisStreamConfig);
         when(kinesisSourceConfig.getStreams()).thenReturn(streamConfigs);
         when(kinesisSourceConfig.getNumberOfRecordsToAccumulate()).thenReturn(NUMBER_OF_RECORDS_TO_ACCUMULATE);
+        when(kinesisSourceConfig.getMaxInitializationAttempts()).thenReturn(DEFAULT_INITIALIZATION_ATTEMPTS);
 
         PluginModel pluginModel = mock(PluginModel.class);
         when(pluginModel.getPluginName()).thenReturn(codec_plugin_name);

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfigTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfigTest.java
@@ -75,6 +75,8 @@ public class KinesisSourceConfigTest {
         assertThat(kinesisSourceConfig, notNullValue());
         assertEquals(KinesisSourceConfig.DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE, kinesisSourceConfig.getNumberOfRecordsToAccumulate());
         assertEquals(KinesisSourceConfig.DEFAULT_TIME_OUT_IN_MILLIS, kinesisSourceConfig.getBufferTimeout());
+        assertEquals(KinesisSourceConfig.DEFAULT_MAX_INITIALIZATION_ATTEMPTS, kinesisSourceConfig.getMaxInitializationAttempts());
+        assertEquals(KinesisSourceConfig.DEFAULT_INITIALIZATION_BACKOFF_TIME, kinesisSourceConfig.getInitializationBackoffTime());
         assertTrue(kinesisSourceConfig.isAcknowledgments());
         assertEquals(KinesisSourceConfig.DEFAULT_SHARD_ACKNOWLEDGEMENT_TIMEOUT, kinesisSourceConfig.getShardAcknowledgmentTimeout());
         assertThat(kinesisSourceConfig.getAwsAuthenticationConfig(), notNullValue());
@@ -104,6 +106,8 @@ public class KinesisSourceConfigTest {
         assertThat(kinesisSourceConfig, notNullValue());
         assertEquals(KinesisSourceConfig.DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE, kinesisSourceConfig.getNumberOfRecordsToAccumulate());
         assertEquals(KinesisSourceConfig.DEFAULT_TIME_OUT_IN_MILLIS, kinesisSourceConfig.getBufferTimeout());
+        assertEquals(KinesisSourceConfig.DEFAULT_MAX_INITIALIZATION_ATTEMPTS, kinesisSourceConfig.getMaxInitializationAttempts());
+        assertEquals(KinesisSourceConfig.DEFAULT_INITIALIZATION_BACKOFF_TIME, kinesisSourceConfig.getInitializationBackoffTime());
         assertFalse(kinesisSourceConfig.isAcknowledgments());
         assertEquals(KinesisSourceConfig.DEFAULT_SHARD_ACKNOWLEDGEMENT_TIMEOUT, kinesisSourceConfig.getShardAcknowledgmentTimeout());
         assertThat(kinesisSourceConfig.getAwsAuthenticationConfig(), notNullValue());
@@ -134,6 +138,8 @@ public class KinesisSourceConfigTest {
         assertThat(kinesisSourceConfig, notNullValue());
         assertEquals(KinesisSourceConfig.DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE, kinesisSourceConfig.getNumberOfRecordsToAccumulate());
         assertEquals(KinesisSourceConfig.DEFAULT_TIME_OUT_IN_MILLIS, kinesisSourceConfig.getBufferTimeout());
+        assertEquals(KinesisSourceConfig.DEFAULT_MAX_INITIALIZATION_ATTEMPTS, kinesisSourceConfig.getMaxInitializationAttempts());
+        assertEquals(KinesisSourceConfig.DEFAULT_INITIALIZATION_BACKOFF_TIME, kinesisSourceConfig.getInitializationBackoffTime());
         assertFalse(kinesisSourceConfig.isAcknowledgments());
         assertEquals(KinesisSourceConfig.DEFAULT_SHARD_ACKNOWLEDGEMENT_TIMEOUT, kinesisSourceConfig.getShardAcknowledgmentTimeout());
         assertThat(kinesisSourceConfig.getAwsAuthenticationConfig(), notNullValue());


### PR DESCRIPTION
### Description
It has been observed that If the pipeline role is missing Kinesis permissions, the source throws an exception resulting in a shutdown of the pipeline.
The fix is to add retry based on 2 configurations in KinesisSource:
  - max_initialization_attempts - to allow the customer to continue retry to initialize the source 
  - initialization_backoff_time - wait between retry calls 

This should help to make sure that the pipeline is not terminated when permissions are missing. With updated permissions, the pipeline should continue to initialize and function properly.
 
### Issues Resolved
Resolves #1082 
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
