### PR TITLE
Add NotEmpty annotation to grok match parameter

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +49,8 @@ public class GrokProcessorConfig {
     static final String DEFAULT_TARGET_KEY = null;
 
     @JsonProperty(MATCH)
+    @NotEmpty
+    @NotNull
     @JsonPropertyDescription("Specifies which keys should match specific patterns. " +
             "Each key is a source field. The value is a list of possible grok patterns to match on. " +
             "The <code>grok</code> processor will extract values from the first match for each field. " +


### PR DESCRIPTION
### Description
The grok `match` field is currently not validated as required. However, if this parameter is not set, then the grok processor will not do anything, and that is not clear. The `match` field should be required.
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. I will create a PR for documentation following from this.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
