### PR TITLE
Fix the build break for kinesis source

### DIFF
--- a/data-prepper-plugins/kinesis-source/build.gradle
+++ b/data-prepper-plugins/kinesis-source/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-test-event')
     testImplementation project(':data-prepper-core')
+    testImplementation project(':data-prepper-event')
     testImplementation project(':data-prepper-plugin-framework')
     testImplementation project(':data-prepper-pipeline-parser')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'


### PR DESCRIPTION
### Description

This PR is to fix the build break for `kinesis-source` plugin.

```
> Task :data-prepper-plugins:kinesis-source:compileTestJava FAILED
/Users/dlv/Documents/Development/opensearch/data-prepper/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigTest.java:43: error: cannot access EventConfigurationContainer
        final DataPrepperConfiguration dataPrepperConfiguration = OBJECT_MAPPER.readValue(configurationFile, DataPrepperConfiguration.class);
                                                                               ^
  class file for org.opensearch.dataprepper.core.event.EventConfigurationContainer not found
Note: Some input files use or override a deprecated API.
```
 
### Issues Resolved
Resolves #1082
 
### Check List
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
