### PR TITLE
Adding a metadata attribute for sequence number of record

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
@@ -43,6 +43,7 @@ public class KinesisRecordConverter {
                         streamName.toLowerCase());
                 eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_PARTITION_KEY_METADATA_ATTRIBUTE, kinesisClientRecord.partitionKey());
                 eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_SEQUENCE_NUMBER_METADATA_ATTRIBUTE, kinesisClientRecord.sequenceNumber());
+                eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_SUB_SEQUENCE_NUMBER_METADATA_ATTRIBUTE, kinesisClientRecord.subSequenceNumber());
                 final Instant externalOriginationTime = kinesisClientRecord.approximateArrivalTimestamp();
                 event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
                 event.getMetadata().setExternalOriginationTime(externalOriginationTime);

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
@@ -42,6 +42,7 @@ public class KinesisRecordConverter {
                 eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_STREAM_NAME_METADATA_ATTRIBUTE,
                         streamName.toLowerCase());
                 eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_PARTITION_KEY_METADATA_ATTRIBUTE, kinesisClientRecord.partitionKey());
+                eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_SEQUENCE_NUMBER_METADATA_ATTRIBUTE, kinesisClientRecord.sequenceNumber());
                 final Instant externalOriginationTime = kinesisClientRecord.approximateArrivalTimestamp();
                 event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
                 event.getMetadata().setExternalOriginationTime(externalOriginationTime);

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/MetadataKeyAttributes.java
@@ -14,4 +14,5 @@ public class MetadataKeyAttributes {
     public static final String KINESIS_STREAM_NAME_METADATA_ATTRIBUTE = "stream_name";
     public static final String KINESIS_PARTITION_KEY_METADATA_ATTRIBUTE = "partition_key";
     public static final String KINESIS_SEQUENCE_NUMBER_METADATA_ATTRIBUTE = "sequence_number";
+    public static final String KINESIS_SUB_SEQUENCE_NUMBER_METADATA_ATTRIBUTE = "sub_sequence_number";
 }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/MetadataKeyAttributes.java
@@ -13,4 +13,5 @@ package org.opensearch.dataprepper.plugins.kinesis.source.converter;
 public class MetadataKeyAttributes {
     public static final String KINESIS_STREAM_NAME_METADATA_ATTRIBUTE = "stream_name";
     public static final String KINESIS_PARTITION_KEY_METADATA_ATTRIBUTE = "partition_key";
+    public static final String KINESIS_SEQUENCE_NUMBER_METADATA_ATTRIBUTE = "sequence_number";
 }


### PR DESCRIPTION
### Description
This PR is to add a metadata attribute `sequence_number` such that a combination of the `partition_key` and `sequence_number` can be used as the `document_id` for each record. 
 
### Issues Resolved
Resolves #1082 
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
