### PR TITLE
MAINT: use tmp folder for default db path for service-map

### DIFF
--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.validation.constraints.NotEmpty;
 
 @JsonPropertyOrder
 @JsonClassDescription("The <code>service_map</code> processor uses OpenTelemetry data to create a distributed service map for " +
@@ -16,14 +17,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class ServiceMapProcessorConfig {
     private static final String WINDOW_DURATION = "window_duration";
     static final int DEFAULT_WINDOW_DURATION = 180;
-    static final String DEFAULT_DB_PATH = "/tmp/data/service-map/";
+    static final String DEFAULT_DB_PATH = "data/service-map/";
+    static final String DB_PATH = "db_path";
 
     @JsonProperty(WINDOW_DURATION)
     @JsonPropertyDescription("Represents the fixed time window, in seconds, " +
             "during which service map relationships are evaluated. Default value is <code>180</code>.")
     private int windowDuration = DEFAULT_WINDOW_DURATION;
 
+    @NotEmpty
+    @JsonProperty(DB_PATH)
+    @JsonPropertyDescription("Represents folder path for database storing transient data off-heap " +
+            "when processing service-map data. Default value is <code>data/service-map/</code>")
+    private String dbPath = DEFAULT_DB_PATH;
+
     public int getWindowDuration() {
         return windowDuration;
+    }
+
+    public String getDbPath() {
+        return dbPath;
     }
 }

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
@@ -27,7 +27,7 @@ public class ServiceMapProcessorConfig {
 
     @NotEmpty
     @JsonProperty(DB_PATH)
-    @JsonPropertyDescription("Represents folder path for database storing transient data off-heap " +
+    @JsonPropertyDescription("Represents folder path for creating database files storing transient data off heap memory" +
             "when processing service-map data. Default value is <code>data/service-map/</code>")
     private String dbPath = DEFAULT_DB_PATH;
 

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfig.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class ServiceMapProcessorConfig {
     private static final String WINDOW_DURATION = "window_duration";
     static final int DEFAULT_WINDOW_DURATION = 180;
-    static final String DEFAULT_DB_PATH = "data/service-map/";
+    static final String DEFAULT_DB_PATH = "/tmp/data/service-map/";
 
     @JsonProperty(WINDOW_DURATION)
     @JsonPropertyDescription("Represents the fixed time window, in seconds, " +

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
@@ -84,7 +84,7 @@ public class ServiceMapStatefulProcessor extends AbstractProcessor<Record<Event>
             final PluginMetrics pluginMetrics,
             final PipelineDescription pipelineDescription) {
         this((long) serviceMapProcessorConfig.getWindowDuration() * TO_MILLIS,
-                new File(ServiceMapProcessorConfig.DEFAULT_DB_PATH),
+                new File(serviceMapProcessorConfig.getDbPath()),
                 Clock.systemUTC(),
                 pipelineDescription.getNumberOfProcessWorkers(),
                 pluginMetrics);

--- a/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfigTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapProcessorConfigTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
 import java.util.Random;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,6 +24,7 @@ class ServiceMapProcessorConfigTest {
     @Test
     void testDefaultConfig() {
         assertThat(serviceMapProcessorConfig.getWindowDuration(), equalTo(DEFAULT_WINDOW_DURATION));
+        assertThat(serviceMapProcessorConfig.getDbPath(), equalTo(ServiceMapProcessorConfig.DEFAULT_DB_PATH));
     }
 
     @Test
@@ -33,6 +35,12 @@ class ServiceMapProcessorConfigTest {
                 serviceMapProcessorConfig,
                 "windowDuration",
                 windowDuration);
-        assertThat(serviceMapProcessorConfig.getWindowDuration(), equalTo(windowDuration));
+        final String testDbPath = UUID.randomUUID().toString();
+        ReflectivelySetField.setField(
+                ServiceMapProcessorConfig.class,
+                serviceMapProcessorConfig,
+                "dbPath",
+                testDbPath);
+        assertThat(serviceMapProcessorConfig.getDbPath(), equalTo(testDbPath));
     }
 }


### PR DESCRIPTION
### Description
Change default DB path for service map to be under /tmp since it is only used for off-heap memory
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
