### PR TITLE
Add change to s3 scan source to create partitions after each page of objects listed

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -64,6 +64,12 @@ public interface SourceCoordinator<T> {
     Optional<SourcePartition<T>> getNextPartition(final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier, final boolean forceSupplier);
 
     /**
+     * Can be used to directly create partitions for source coordination, as an alternative to relying on getNextPartition to create partitions.
+     * @param partitionIdentifiers  - The partitions to be created.
+     */
+    void createPartitions(final List<PartitionIdentifier> partitionIdentifiers);
+
+    /**
      * Should be called by the source when it has fully processed a given partition
      * @throws org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotFoundException if the partition key could not be found in the distributed store
      * @throws org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotOwnedException if the partition is not owned by this instance of SourceCoordinator

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -202,7 +202,8 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         return Optional.of(sourcePartition);
     }
 
-    private void createPartitions(final List<PartitionIdentifier> partitionIdentifiers) {
+    @Override
+    public void createPartitions(final List<PartitionIdentifier> partitionIdentifiers) {
         for (final PartitionIdentifier partitionIdentifier : partitionIdentifiers) {
             final Optional<SourcePartitionStoreItem> optionalPartitionItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifierWithPartitionType, partitionIdentifier.getPartitionKey());
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplier.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.s3;
 
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
+import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.FolderPartitioningOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.S3ScanKeyPathOption;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.S3ScanSchedulingOptions;
@@ -50,17 +51,21 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
 
     private final FolderPartitioningOptions folderPartitioningOptions;
 
+    private final SourceCoordinator<S3SourceProgressState> sourceCoordinator;
+
     public S3ScanPartitionCreationSupplier(final S3Client s3Client,
                                            final BucketOwnerProvider bucketOwnerProvider,
                                            final List<ScanOptions> scanOptionsList,
                                            final S3ScanSchedulingOptions schedulingOptions,
-                                           final FolderPartitioningOptions folderPartitioningOptions) {
+                                           final FolderPartitioningOptions folderPartitioningOptions,
+                                           final SourceCoordinator<S3SourceProgressState> sourceCoordinator) {
 
         this.s3Client = s3Client;
         this.bucketOwnerProvider = bucketOwnerProvider;
         this.scanOptionsList = scanOptionsList;
         this.schedulingOptions = schedulingOptions;
         this.folderPartitioningOptions = folderPartitioningOptions;
+        this.sourceCoordinator = sourceCoordinator;
     }
 
     @Override
@@ -73,8 +78,6 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
         if (shouldScanBeSkipped(globalStateMap)) {
             return Collections.emptyList();
         }
-
-        final List<PartitionIdentifier> objectsToProcess = new ArrayList<>();
 
         for (final ScanOptions scanOptions : scanOptionsList) {
             final List<String> excludeItems = new ArrayList<>();
@@ -91,12 +94,12 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
             if (Objects.nonNull(s3ScanKeyPathOption) && Objects.nonNull(s3ScanKeyPathOption.getS3scanIncludePrefixOptions()))
                 s3ScanKeyPathOption.getS3scanIncludePrefixOptions().forEach(includePath -> {
                     listObjectsV2Request.prefix(includePath);
-                    objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
-                            scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap));
+                    createFilteredS3ObjectPartitionsForBucket(excludeItems, listObjectsV2Request,
+                            scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap);
                 });
             else
-                objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
-                        scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap));
+                createFilteredS3ObjectPartitionsForBucket(excludeItems, listObjectsV2Request,
+                        scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap);
 
             globalStateMap.put(scanOptions.getBucketOption().getName(), updatedScanTime.toString());
         }
@@ -104,10 +107,11 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
         globalStateMap.put(SCAN_COUNT, (Integer) globalStateMap.get(SCAN_COUNT) + 1);
         globalStateMap.put(LAST_SCAN_TIME, Instant.now().toEpochMilli());
 
-        return objectsToProcess;
+        // Partitions are created by the supplier, so source coordinator does not need to attempt to create any partitions
+        return Collections.emptyList();
     }
 
-    private List<PartitionIdentifier> listFilteredS3ObjectsForBucket(final List<String> excludeKeyPaths,
+    private void createFilteredS3ObjectPartitionsForBucket(final List<String> excludeKeyPaths,
                                                                      final ListObjectsV2Request.Builder listObjectsV2Request,
                                                                      final String bucket,
                                                                      final LocalDateTime startDateTime,
@@ -115,11 +119,11 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                                                                      final Map<String, Object> globalStateMap) {
         final Instant previousScanTime = globalStateMap.get(bucket) != null ? Instant.parse((String) globalStateMap.get(bucket)) : null;
         final boolean isFirstScan = previousScanTime == null;
-        final List<PartitionIdentifier> allPartitionIdentifiers = new ArrayList<>();
         ListObjectsV2Response listObjectsV2Response = null;
+
         do {
             listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request.fetchOwner(true).continuationToken(Objects.nonNull(listObjectsV2Response) ? listObjectsV2Response.nextContinuationToken() : null).build());
-            allPartitionIdentifiers.addAll(listObjectsV2Response.contents().stream()
+            final List<PartitionIdentifier> partitionsForPage = listObjectsV2Response.contents().stream()
                     .filter(s3Object -> isLastModifiedTimeAfterMostRecentScanForBucket(previousScanTime, s3Object))
                     .map(s3Object -> Pair.of(s3Object.key(), instantToLocalDateTime(s3Object.lastModified())))
                     .filter(keyTimestampPair -> !keyTimestampPair.left().endsWith("/"))
@@ -128,32 +132,17 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                     .filter(keyTimestampPair -> isKeyMatchedBetweenTimeRange(keyTimestampPair.right(), startDateTime, endDateTime, isFirstScan))
                     .map(Pair::left)
                     .map(objectKey -> PartitionIdentifier.builder().withPartitionKey(String.format(BUCKET_OBJECT_PARTITION_KEY_FORMAT, bucket, objectKey)).build())
-                    .collect(Collectors.toList()));
-
+                    .collect(Collectors.toList());
             LOG.info("Found page of {} objects from bucket {}", listObjectsV2Response.keyCount(), bucket);
+
+            if (folderPartitioningOptions != null) {
+                final List<PartitionIdentifier> folderPartitionsForPage = getFolderPartitionIdentifiers(partitionsForPage);
+                sourceCoordinator.createPartitions(folderPartitionsForPage);
+            } else {
+                LOG.info("Creating partitions for {} S3 objects from bucket {}", partitionsForPage.size(), bucket);
+                sourceCoordinator.createPartitions(partitionsForPage);
+            }
         } while (listObjectsV2Response.isTruncated());
-
-        if (folderPartitioningOptions != null) {
-            final Set<PartitionIdentifier> folderPartitions = allPartitionIdentifiers.stream()
-                    .map(partitionIdentifier -> {
-                        final String fullObjectKey = partitionIdentifier.getPartitionKey();
-                        final String prefix = getPrefixWithDepth(fullObjectKey);
-                        if (prefix == null) {
-                            return null;
-                        }
-                        return PartitionIdentifier.builder().withPartitionKey(prefix).build();
-                    })
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-
-            LOG.info("Running in folder_partitions mode at depth {}, found {} unique prefixes from {} objects", folderPartitioningOptions.getFolderDepth(), folderPartitions.size(), allPartitionIdentifiers.size());
-
-            return new ArrayList<>(folderPartitions);
-        } else {
-            LOG.info("Returning partitions for {} S3 objects from bucket {}", allPartitionIdentifiers.size(), bucket);
-        }
-
-        return allPartitionIdentifiers;
     }
 
     private LocalDateTime instantToLocalDateTime(final Instant instant) {
@@ -247,5 +236,24 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
         }
         int actualDepth = min(folderPartitioningOptions.getFolderDepth(), folders.length - 1);
         return String.join("/", Arrays.copyOfRange(folders, 0, actualDepth)) + "/";
+    }
+
+    private List<PartitionIdentifier> getFolderPartitionIdentifiers(final List<PartitionIdentifier> objectPartitionIdentifiers) {
+
+        final Set<PartitionIdentifier> folderPartitions = objectPartitionIdentifiers.stream()
+                .map(partitionIdentifier -> {
+                    final String fullObjectKey = partitionIdentifier.getPartitionKey();
+                    final String prefix = getPrefixWithDepth(fullObjectKey);
+                    if (prefix == null) {
+                        return null;
+                    }
+                    return PartitionIdentifier.builder().withPartitionKey(prefix).build();
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        LOG.info("Running in folder_partitions mode at depth {}, found {} unique prefixes from {} objects", folderPartitioningOptions.getFolderDepth(), folderPartitions.size(), objectPartitionIdentifiers.size());
+
+        return new ArrayList<>(folderPartitions);
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -129,7 +129,7 @@ public class ScanObjectWorker implements Runnable {
         this.folderPartitioningOptions = s3SourceConfig.getS3ScanScanOptions().getPartitioningOptions();
         this.acknowledgmentSetTimeout = s3SourceConfig.getS3ScanScanOptions().getAcknowledgmentTimeout();
 
-        this.partitionCreationSupplier = new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsBuilderList, s3ScanSchedulingOptions, s3SourceConfig.getS3ScanScanOptions().getPartitioningOptions());
+        this.partitionCreationSupplier = new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsBuilderList, s3ScanSchedulingOptions, s3SourceConfig.getS3ScanScanOptions().getPartitioningOptions(), sourceCoordinator);
         this.acknowledgmentsRemainingForPartitions = new ConcurrentHashMap<>();
         this.objectsToDeleteForAcknowledgmentSets = new ConcurrentHashMap<>();
     }


### PR DESCRIPTION
### Description
This changes the S3 scan partition supplier to create partitions directly after each page is listed during the listObjects call to S3. This has a couple of benefits

* Processing objects will start immediately during the scan in a multi-node data prepper environment rather than after the scan is fully complete
* Improves memory usage and fixes out of memory error from storing too many partitions in memory for buckets with many objects.
 
### Issues Resolved
Resolves #4608 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
