### PR TITLE
Add support to parse upto certain depth in parse_json processor 

### DIFF
--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/CommonParseConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/CommonParseConfig.java
@@ -66,4 +66,9 @@ public interface CommonParseConfig {
      * and passing the failed Event downstream to the next processor.
      */
     HandleFailedEventsOption getHandleFailedEventsOption();
+
+    /**
+     * An optional setting used to determine the depth of the input to handle
+     */
+    int getDepth();
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
@@ -35,6 +35,8 @@ public class ParseIonProcessor extends AbstractParseProcessor {
 
     private final Counter parseErrorsCounter;
 
+    private final int depth;
+
     private final HandleFailedEventsOption handleFailedEventsOption;
 
     @DataPrepperPluginConstructor
@@ -44,6 +46,7 @@ public class ParseIonProcessor extends AbstractParseProcessor {
                              final EventKeyFactory eventKeyFactory) {
         super(pluginMetrics, parseIonProcessorConfig, expressionEvaluator, eventKeyFactory);
 
+        this.depth = parseIonProcessorConfig.getDepth();
         // Convert Timestamps to ISO-8601 Z strings
         objectMapper.registerModule(new IonTimestampConverterModule());
 
@@ -51,11 +54,16 @@ public class ParseIonProcessor extends AbstractParseProcessor {
         parseErrorsCounter = pluginMetrics.counter(PARSE_ERRORS);
     }
 
+
     @Override
     protected Optional<HashMap<String, Object>> readValue(String message, Event context) {
         try {
             // We need to do a two-step process here, read the value in, then convert away any Ion types like Timestamp
-            return Optional.of(objectMapper.convertValue(objectMapper.readValue(message, new TypeReference<>() {}), new TypeReference<>() {}));
+            HashMap<String, Object> map = objectMapper.convertValue(objectMapper.readValue(message, new TypeReference<>() {}), new TypeReference<>() {});
+            if (depth == 0) {
+                return Optional.of(map);
+            }
+            return Optional.of(objectMapper.convertValue(convertNestedObjectToString(map, 1, depth), new TypeReference<>() {}));
         } catch (JsonProcessingException e) {
             if (handleFailedEventsOption.shouldLog()) {
                 LOG.error(SENSITIVE, "An exception occurred due to invalid Ion while parsing [{}] due to {}", message, e.getMessage());

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessor.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
@@ -56,10 +57,10 @@ public class ParseIonProcessor extends AbstractParseProcessor {
 
 
     @Override
-    protected Optional<HashMap<String, Object>> readValue(String message, Event context) {
+    protected Optional<Map<String, Object>> readValue(String message, Event context) {
         try {
             // We need to do a two-step process here, read the value in, then convert away any Ion types like Timestamp
-            HashMap<String, Object> map = objectMapper.convertValue(objectMapper.readValue(message, new TypeReference<>() {}), new TypeReference<>() {});
+            final HashMap<String, Object> map = objectMapper.convertValue(objectMapper.readValue(message, new TypeReference<>() {}), new TypeReference<>() {});
             if (depth == 0) {
                 return Optional.of(map);
             }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -39,20 +39,6 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
-    @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
-    private String parseWhen;
-
-    @JsonProperty("depth")
-    @Min(0)
-    @Max(10)
-    @JsonPropertyDescription("Indicates the depth at which the nested values of the event are not parsed any more. Default is 0, which means all levels of nested values are parsed. If the depth is 1, only the top level keys are parsed and all its nested values are represented as strings")
-    private int depth = 0;
-
-    @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event that the processor fails or an unknown exception occurs during parsing.")
-    private List<String> tagsOnFailure;
-
     @JsonProperty("overwrite_if_destination_exists")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
@@ -61,6 +47,14 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the ION data is parsed into separate fields.")
     private boolean deleteSource = false;
 
+    @JsonProperty("tags_on_failure")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event that the processor fails or an unknown exception occurs during parsing.")
+    private List<String> tagsOnFailure;
+
+    @JsonProperty("parse_when")
+    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    private String parseWhen;
+
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with ION processing errors. Options include 'skip', " +
             "which will log the error and send the event downstream to the next processor, and 'skip_silently', " +
@@ -68,6 +62,12 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
             "Default is 'skip'.")
     @NotNull
     private HandleFailedEventsOption handleFailedEventsOption = HandleFailedEventsOption.SKIP;
+
+    @JsonProperty("depth")
+    @Min(0)
+    @Max(10)
+    @JsonPropertyDescription("Indicates the depth at which the nested values of the event are not parsed any more. Default is 0, which means all levels of nested values are parsed. If the depth is 1, only the top level keys are parsed and all its nested values are represented as strings")
+    private int depth = 0;
 
     @Override
     public String getSource() {

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -9,9 +9,11 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 import org.opensearch.dataprepper.plugins.processor.parse.CommonParseConfig;
 
@@ -37,6 +39,20 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
+    @JsonProperty("parse_when")
+    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    private String parseWhen;
+
+    @JsonProperty("depth")
+    @Min(0)
+    @Max(10)
+    @JsonPropertyDescription("Indicates the depth at which the nested values of the event are not parsed any more. Default is 0, which means all levels of nested values are parsed. If the depth is 1, only the top level keys are parsed and all its nested values are represented as strings")
+    private int depth = 0;
+
+    @JsonProperty("tags_on_failure")
+    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event that the processor fails or an unknown exception occurs during parsing.")
+    private List<String> tagsOnFailure;
+
     @JsonProperty("overwrite_if_destination_exists")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
@@ -44,15 +60,6 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     @JsonProperty
     @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the ION data is parsed into separate fields.")
     private boolean deleteSource = false;
-
-    @JsonProperty("tags_on_failure")
-    @JsonPropertyDescription("A list of strings specifying the tags to be set in the event when the processor fails or an unknown exception occurs during parsing.")
-    private List<String> tagsOnFailure;
-
-    @JsonProperty("parse_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
-            "If specified, the <code>parse_ion</code> processor will only run on events when the expression evaluates to true. ")
-    private String parseWhen;
 
     @JsonProperty("handle_failed_events")
     @JsonPropertyDescription("Determines how to handle events with ION processing errors. Options include 'skip', " +
@@ -80,6 +87,11 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     @Override
     public List<String> getTagsOnFailure() {
         return tagsOnFailure;
+    }
+
+    @Override
+    public int getDepth() {
+        return depth;
     }
 
     @Override

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessor.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
@@ -50,9 +51,9 @@ public class ParseJsonProcessor extends AbstractParseProcessor {
     }
 
     @Override
-    protected Optional<HashMap<String, Object>> readValue(String message, Event context) {
+    protected Optional<Map<String, Object>> readValue(String message, Event context) {
         try {
-            HashMap<String, Object> map = objectMapper.readValue(message, new TypeReference<>() {});
+            final HashMap<String, Object> map = objectMapper.readValue(message, new TypeReference<>() {});
             if (depth == 0) {
                 return Optional.of(map);
             }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 import org.opensearch.dataprepper.plugins.processor.parse.CommonParseConfig;
 
@@ -31,6 +33,12 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     @JsonProperty("destination")
     @JsonPropertyDescription("The destination field of the structured object from the parsed JSON. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
+
+    @JsonProperty("depth")
+    @Min(0)
+    @Max(10)
+    @JsonPropertyDescription("Indicates the depth at which the nested values of the event are not parsed any more. Default is 0, which means all levels of nested values are parsed. If the depth is 1, only the top level keys are parsed and all its nested values are represented as strings")
+    private int depth = 0;
 
     @JsonProperty("pointer")
     @JsonPropertyDescription("A JSON pointer to the field to be parsed. There is no pointer by default, meaning the entire source is parsed. The pointer can access JSON array indexes as well. " +
@@ -65,6 +73,11 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     @Override
     public String getSource() {
         return source;
+    }
+
+    @Override
+    public int getDepth() {
+        return depth;
     }
 
     @Override

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessor.java
@@ -16,7 +16,7 @@ import org.opensearch.dataprepper.plugins.processor.parse.AbstractParseProcessor
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
@@ -43,7 +43,7 @@ public class ParseXmlProcessor extends AbstractParseProcessor {
     }
 
     @Override
-    protected Optional<HashMap<String, Object>> readValue(final String message, final Event context) {
+    protected Optional<Map<String, Object>> readValue(final String message, final Event context) {
         try {
             return Optional.of(xmlMapper.readValue(message, new TypeReference<>() {}));
         } catch (JsonProcessingException e) {

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -73,6 +73,9 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
     }
 
     @Override
+    public int getDepth() { return 0; }
+
+    @Override
     public List<String> getTagsOnFailure() {
         return tagsOnFailure;
     }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
@@ -5,7 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.processor.parse.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
@@ -47,6 +50,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class ParseJsonProcessorTest {
     private static final String DEEPLY_NESTED_KEY_NAME = "base";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     protected CommonParseConfig processorConfig;
 
@@ -124,6 +129,44 @@ public class ParseJsonProcessorTest {
         verifyNoInteractions(parseErrorsCounter);
         verifyNoInteractions(handleFailedEventsOption);
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0,1,2,3,4,5,6,7,8,9,10})
+    void test_depth_option_with_same_source_and_destination(int depth) throws Exception {
+        final String source = "root_source";
+        when(processorConfig.getSource()).thenReturn(source);
+        when(processorConfig.getDestination()).thenReturn(source);
+        when(processorConfig.getDepth()).thenReturn(depth);
+        parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
+
+        Map<String, Object> mapValue = new HashMap<>();
+        Map<String, Object> prevMap = null;
+        Object expectedResult = null;
+        // Create a map with 12 nested levels
+        for (int i = 11; i >= 0; i--) {
+            Map<String, Object> m = (prevMap == null) ?
+                    Map.of("key" + i, i, "key" + (100 + i), "value" + i) :
+                    Map.of("key" + i, i, "key" + (100 + i), "value" + i, "key"+(1000+i), prevMap);
+            if (i == depth) {
+                expectedResult = (depth == 0) ? m : objectMapper.writeValueAsString(m);
+            } else if (i < depth) {
+                expectedResult = Map.of("key" + i, i, "key" + (100 + i), "value" + i, "key"+(1000+i), expectedResult);
+            }
+            prevMap = m;
+        }
+
+        mapValue = prevMap;
+        final Map<String, Object> data = Map.of(
+                source, mapValue,
+                "key","value"
+        );
+        final String serializedMessage = objectMapper.writeValueAsString(mapValue);
+        final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
+        Object m1 = parsedEvent.get(source, Object.class);
+        assertThatKeyEquals(parsedEvent, source, expectedResult);
+
+    }
+
 
     @Test
     void test_when_dataFieldEqualToRootField_then_overwritesOriginalFields() {


### PR DESCRIPTION

### Description
parse_json: add ability to only parse upto a user-configured depth with the larger depth values are stored as strings.

With this change an input like
```
"key":"{\"a\": 1, \"b\": {\"c\": 3, \"d\" : {\"e\": \"s5\"}}}"
```
with source as `key` and destination as `key` 
with `depth: 1` would parse the json as

```
{
  "key": {
    "a": 1,
    "b": "{\"c\":3,\"d\":{\"e\":\"s5\"}}"
  }
}
```
with `depth: 2` would parse the json as
```
{
  "key":  {
    "a": 1,
    "b": {
      "c": 3,
      "d": "{\"e\":\"s5\"}"
    }
  }
}

```

and with `depth:0` (which is default) would parse it as

```
{
  "key": {
    "a": 1,
    "b": {
      "c": 3,
      "d": {
        "e": "s5"
      }
    }
  }
}

```
 
### Issues Resolved
Resolves #4695
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [X ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
