### PR TITLE
Fix service map tests

### DIFF
--- a/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -130,6 +130,7 @@ public class ServiceMapStatefulProcessorTest {
     @Test
     public void testDataPrepperConstructor() {
         when(pipelineDescription.getNumberOfProcessWorkers()).thenReturn(4);
+        when(serviceMapProcessorConfig.getDbPath()).thenReturn(ServiceMapProcessorConfig.DEFAULT_DB_PATH);
         //Nothing is accessible to validate, so just verify that no exception is thrown.
         final ServiceMapStatefulProcessor serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(
                 serviceMapProcessorConfig, pluginMetrics, pipelineDescription);
@@ -426,6 +427,7 @@ public class ServiceMapStatefulProcessorTest {
     @Test
     public void testGetIdentificationKeys() {
         when(pipelineDescription.getNumberOfProcessWorkers()).thenReturn(4);
+        when(serviceMapProcessorConfig.getDbPath()).thenReturn(ServiceMapProcessorConfig.DEFAULT_DB_PATH);
         final ServiceMapStatefulProcessor serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(
                 serviceMapProcessorConfig, pluginMetrics, pipelineDescription);
         final Collection<String> expectedIdentificationKeys = serviceMapStatefulProcessor.getIdentificationKeys();


### PR DESCRIPTION
### Description
This fixes the build that is currently failing with:
```
ServiceMapStatefulProcessorTest > testDataPrepperConstructor() FAILED
    java.lang.NullPointerException

ServiceMapStatefulProcessorTest > testGetIdentificationKeys() FAILED
    java.lang.NullPointerException
```

Testing: `./gradlew :data-prepper-plugins:service-map-stateful:test` is passing after the change.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
