### PR TITLE
Improve validation error messages for unknown property and json mapping exceptions

### DIFF
--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/validation/PluginError.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/validation/PluginError.java
@@ -7,7 +7,8 @@ import lombok.NonNull;
 @Getter
 @Builder
 public class PluginError {
-    static final String PIPELINE_DELIMITER = ":";
+    static final String PIPELINE_DELIMITER = ".";
+    static final String PATH_TO_CAUSE_DELIMITER = ":";
     static final String CAUSED_BY_DELIMITER = " caused by: ";
     private final String pipelineName;
     private final String componentType;
@@ -27,7 +28,7 @@ public class PluginError {
             message.append(PIPELINE_DELIMITER);
         }
         message.append(pluginName);
-        message.append(PIPELINE_DELIMITER);
+        message.append(PATH_TO_CAUSE_DELIMITER);
         message.append(getFlattenedExceptionMessage(CAUSED_BY_DELIMITER));
         return message.toString();
     }
@@ -37,8 +38,10 @@ public class PluginError {
         Throwable throwable = exception;
 
         while (throwable != null) {
-            message.append(delimiter);
-            message.append(throwable.getMessage());
+            if (throwable.getMessage() != null) {
+                message.append(delimiter);
+                message.append(throwable.getMessage());
+            }
             throwable = throwable.getCause();
         }
 

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/validation/PluginErrorTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/validation/PluginErrorTest.java
@@ -25,7 +25,7 @@ class PluginErrorTest {
                 .exception(exception)
                 .build();
         assertThat(pluginError.getErrorMessage(), equalTo(
-                "test-pipeline:test-plugin-type:test-plugin: caused by: test error message"));
+                "test-pipeline.test-plugin-type.test-plugin: caused by: test error message"));
     }
 
     @Test
@@ -38,7 +38,7 @@ class PluginErrorTest {
                 .exception(exception)
                 .build();
         assertThat(pluginError.getErrorMessage(), equalTo(
-                "test-plugin-type:test-plugin: caused by: test error message"));
+                "test-plugin-type.test-plugin: caused by: test error message"));
     }
 
     @Test

--- a/data-prepper-plugin-framework/build.gradle
+++ b/data-prepper-plugin-framework/build.gradle
@@ -24,4 +24,5 @@ dependencies {
     }
     implementation libs.reflections.core
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationConverter.java
@@ -32,11 +32,15 @@ class PluginConfigurationConverter {
     private final ObjectMapper objectMapper;
     private final Validator validator;
 
+    private final PluginConfigurationErrorHandler pluginConfigurationErrorHandler;
+
     PluginConfigurationConverter(final Validator validator,
                                  @Named("pluginConfigObjectMapper")
-                                 final ObjectMapper objectMapper) {
+                                 final ObjectMapper objectMapper,
+                                 final PluginConfigurationErrorHandler pluginConfigurationErrorHandler) {
         this.objectMapper = objectMapper;
         this.validator = validator;
+        this.pluginConfigurationErrorHandler = pluginConfigurationErrorHandler;
     }
 
     /**
@@ -80,6 +84,12 @@ class PluginConfigurationConverter {
         Map<String, Object> settingsMap = pluginSetting.getSettings();
         if (settingsMap == null)
             settingsMap = Collections.emptyMap();
-        return objectMapper.convertValue(settingsMap, pluginConfigurationType);
+
+        try {
+            return objectMapper.convertValue(settingsMap, pluginConfigurationType);
+        } catch (final Exception e) {
+            throw pluginConfigurationErrorHandler.handleException(pluginSetting, e);
+        }
     }
+
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationErrorHandler.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationErrorHandler.java
@@ -1,0 +1,91 @@
+package org.opensearch.dataprepper.plugin;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Named
+public class PluginConfigurationErrorHandler {
+
+    static final String UNRECOGNIZED_PROPERTY_EXCEPTION_FORMAT = "Parameter \"%s\" for plugin \"%s\" does not exist. Available options include %s.";
+    static final String JSON_MAPPING_EXCEPTION_FORMAT = "Parameter \"%s\" for plugin \"%s\" is invalid: %s";
+    static final String GENERIC_PLUGIN_EXCEPTION_FORMAT = "Plugin \"%s\" is invalid: %s";
+
+    static final Integer MIN_DISTANCE_TO_RECOMMEND_PROPERTY = 3;
+
+    private final LevenshteinDistance levenshteinDistance;
+
+    @Inject
+    public PluginConfigurationErrorHandler(final LevenshteinDistance levenshteinDistance) {
+        this.levenshteinDistance = levenshteinDistance;
+    }
+
+    public RuntimeException handleException(final PluginSetting pluginSetting, final Exception e) {
+        if (e.getCause() instanceof UnrecognizedPropertyException) {
+            return handleUnrecognizedPropertyException((UnrecognizedPropertyException) e.getCause(), pluginSetting);
+        } else if (e.getCause() instanceof JsonMappingException) {
+            return handleJsonMappingException((JsonMappingException) e.getCause(), pluginSetting);
+        }
+
+        return new InvalidPluginConfigurationException(
+                String.format(GENERIC_PLUGIN_EXCEPTION_FORMAT, pluginSetting.getName(), e.getMessage()));
+    }
+
+    private RuntimeException handleJsonMappingException(final JsonMappingException e, final PluginSetting pluginSetting) {
+        final String parameterPath = getParameterPath(e.getPath());
+
+        final String errorMessage = String.format(JSON_MAPPING_EXCEPTION_FORMAT,
+                parameterPath, pluginSetting.getName(), e.getOriginalMessage());
+
+        return new InvalidPluginConfigurationException(errorMessage);
+    }
+
+    private RuntimeException handleUnrecognizedPropertyException(final UnrecognizedPropertyException e, final PluginSetting pluginSetting) {
+        String errorMessage = String.format(UNRECOGNIZED_PROPERTY_EXCEPTION_FORMAT,
+                getParameterPath(e.getPath()),
+                pluginSetting.getName(),
+                e.getKnownPropertyIds());
+
+        final Optional<String> closestRecommendation = getClosestField(e);
+
+        if (closestRecommendation.isPresent()) {
+            errorMessage += " Did you mean \"" + closestRecommendation.get() + "\"?";
+        }
+
+        return new InvalidPluginConfigurationException(errorMessage);
+    }
+
+    private Optional<String> getClosestField(final UnrecognizedPropertyException e) {
+        String closestMatch = null;
+        int smallestDistance = Integer.MAX_VALUE;
+
+        for (final String field : e.getKnownPropertyIds().stream().map(Object::toString).collect(Collectors.toList())) {
+            int distance = levenshteinDistance.apply(e.getPropertyName(), field);
+
+            if (distance < smallestDistance) {
+                smallestDistance = distance;
+                closestMatch = field;
+            }
+        }
+
+        if (smallestDistance <= MIN_DISTANCE_TO_RECOMMEND_PROPERTY) {
+            return Optional.ofNullable(closestMatch);
+        }
+
+        return Optional.empty();
+    }
+
+    private String getParameterPath(final List<JsonMappingException.Reference> path) {
+        return path.stream()
+                .map(JsonMappingException.Reference::getFieldName)
+                .collect(Collectors.joining("."));
+    }
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginCreator.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginCreator.java
@@ -54,10 +54,10 @@ class PluginCreator {
         } catch (final IllegalAccessException | InstantiationException ex) {
             LOG.error("Encountered exception while instantiating the plugin {}", pluginClass.getSimpleName(), ex);
             throw new InvalidPluginDefinitionException(
-                    "Unable to access or instantiate the plugin '" + pluginClass.getSimpleName() + ".'", ex);
+                    "Unable to access or instantiate the plugin \"" + pluginName + "\".", ex);
         } catch (final InvocationTargetException ex) {
             LOG.error("Encountered exception while instantiating the plugin {}", pluginClass.getSimpleName(), ex);
-            throw new PluginInvocationException("Exception throw from the plugin'" + pluginClass.getSimpleName() + "'." , ex);
+            throw new PluginInvocationException("Exception thrown from plugin \"" + pluginName + "\".", ex.getTargetException());
         }
     }
 

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ValidatorConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ValidatorConfiguration.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugin;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.springframework.context.annotation.Bean;
 
@@ -25,5 +26,10 @@ class ValidatorConfiguration {
                 .messageInterpolator(new ParameterMessageInterpolator())
                 .buildValidatorFactory();
         return validationFactory.getValidator();
+    }
+
+    @Bean
+    LevenshteinDistance levenshteinDistance() {
+        return new LevenshteinDistance();
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginConfigurationErrorHandlerTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginConfigurationErrorHandlerTest.java
@@ -1,0 +1,183 @@
+package org.opensearch.dataprepper.plugin;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugin.PluginConfigurationErrorHandler.GENERIC_PLUGIN_EXCEPTION_FORMAT;
+import static org.opensearch.dataprepper.plugin.PluginConfigurationErrorHandler.JSON_MAPPING_EXCEPTION_FORMAT;
+import static org.opensearch.dataprepper.plugin.PluginConfigurationErrorHandler.MIN_DISTANCE_TO_RECOMMEND_PROPERTY;
+import static org.opensearch.dataprepper.plugin.PluginConfigurationErrorHandler.UNRECOGNIZED_PROPERTY_EXCEPTION_FORMAT;
+
+@ExtendWith(MockitoExtension.class)
+public class PluginConfigurationErrorHandlerTest {
+
+    @Mock
+    private LevenshteinDistance levenshteinDistance;
+
+    private PluginConfigurationErrorHandler createObjectUnderTest() {
+        return new PluginConfigurationErrorHandler(levenshteinDistance);
+    }
+
+    @Test
+    void handle_exception_with_unrecognized_property_exception_throws_expected_exception_without_parameter_recommendation() {
+        final List<Object> knownPropertyIds = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final String pluginName = UUID.randomUUID().toString();
+        final String propertyName = UUID.randomUUID().toString();
+
+        final JsonMappingException.Reference firstPathReference = mock(JsonMappingException.Reference.class);
+        when(firstPathReference.getFieldName()).thenReturn(UUID.randomUUID().toString());
+
+        final JsonMappingException.Reference secondPathReference = mock(JsonMappingException.Reference.class);
+        when(secondPathReference.getFieldName()).thenReturn(UUID.randomUUID().toString());
+
+        final List<JsonMappingException.Reference> path = List.of(firstPathReference, secondPathReference);
+
+        final PluginSetting pluginSetting = mock(PluginSetting.class);
+        when(pluginSetting.getName()).thenReturn(pluginName);
+
+        final RuntimeException exception = mock(RuntimeException.class);
+
+        final UnrecognizedPropertyException unrecognizedPropertyException = mock(UnrecognizedPropertyException.class);
+        when(unrecognizedPropertyException.getKnownPropertyIds()).thenReturn(knownPropertyIds);
+        when(unrecognizedPropertyException.getPropertyName()).thenReturn(propertyName);
+        when(unrecognizedPropertyException.getPath()).thenReturn(path);
+
+        when(exception.getCause()).thenReturn(unrecognizedPropertyException);
+
+        when(levenshteinDistance.apply(eq(propertyName), anyString())).thenReturn(10).thenReturn(MIN_DISTANCE_TO_RECOMMEND_PROPERTY + 1);
+
+        final PluginConfigurationErrorHandler objectUnderTest = createObjectUnderTest();
+
+        final Exception resultingException = objectUnderTest.handleException(pluginSetting, exception);
+        assertThat(resultingException instanceof InvalidPluginConfigurationException, equalTo(true));
+
+        final String expectedErrorMessage = String.format(UNRECOGNIZED_PROPERTY_EXCEPTION_FORMAT,
+                firstPathReference.getFieldName() + "." + secondPathReference.getFieldName(),
+                pluginName,
+                knownPropertyIds);
+
+        assertThat(resultingException.getMessage(), equalTo(expectedErrorMessage));
+    }
+
+    @Test
+    void handle_exception_with_unrecognized_property_exception_throws_expected_exception_with_parameter_recommendation() {
+        final List<Object> knownPropertyIds = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final String pluginName = UUID.randomUUID().toString();
+        final String propertyName = UUID.randomUUID().toString();
+
+        final JsonMappingException.Reference firstPathReference = mock(JsonMappingException.Reference.class);
+        when(firstPathReference.getFieldName()).thenReturn(UUID.randomUUID().toString());
+
+        final JsonMappingException.Reference secondPathReference = mock(JsonMappingException.Reference.class);
+        when(secondPathReference.getFieldName()).thenReturn(UUID.randomUUID().toString());
+
+        final List<JsonMappingException.Reference> path = List.of(firstPathReference, secondPathReference);
+
+        final PluginSetting pluginSetting = mock(PluginSetting.class);
+        when(pluginSetting.getName()).thenReturn(pluginName);
+
+        final RuntimeException exception = mock(RuntimeException.class);
+
+        final UnrecognizedPropertyException unrecognizedPropertyException = mock(UnrecognizedPropertyException.class);
+        when(unrecognizedPropertyException.getKnownPropertyIds()).thenReturn(knownPropertyIds);
+        when(unrecognizedPropertyException.getPropertyName()).thenReturn(propertyName);
+        when(unrecognizedPropertyException.getPath()).thenReturn(path);
+
+        when(exception.getCause()).thenReturn(unrecognizedPropertyException);
+
+        when(levenshteinDistance.apply(eq(propertyName), anyString())).thenReturn(10).thenReturn(MIN_DISTANCE_TO_RECOMMEND_PROPERTY - 1);
+
+        final PluginConfigurationErrorHandler objectUnderTest = createObjectUnderTest();
+
+        final Exception resultingException = objectUnderTest.handleException(pluginSetting, exception);
+        assertThat(resultingException instanceof InvalidPluginConfigurationException, equalTo(true));
+
+        String expectedErrorMessage = String.format(UNRECOGNIZED_PROPERTY_EXCEPTION_FORMAT,
+                firstPathReference.getFieldName() + "." + secondPathReference.getFieldName(),
+                pluginName,
+                knownPropertyIds);
+
+        expectedErrorMessage += " Did you mean \"" + knownPropertyIds.get(1).toString() + "\"?";
+
+
+
+        assertThat(resultingException.getMessage(), equalTo(expectedErrorMessage));
+    }
+
+    @Test
+    void handle_exception_with_json_mapping_exception_returns_expected_error_message() {
+        final String pluginName = UUID.randomUUID().toString();
+
+        final JsonMappingException.Reference firstPathReference = mock(JsonMappingException.Reference.class);
+        when(firstPathReference.getFieldName()).thenReturn(UUID.randomUUID().toString());
+
+        final JsonMappingException.Reference secondPathReference = mock(JsonMappingException.Reference.class);
+        when(secondPathReference.getFieldName()).thenReturn(UUID.randomUUID().toString());
+
+        final List<JsonMappingException.Reference> path = List.of(firstPathReference, secondPathReference);
+
+        final PluginSetting pluginSetting = mock(PluginSetting.class);
+        when(pluginSetting.getName()).thenReturn(pluginName);
+
+        final RuntimeException exception = mock(RuntimeException.class);
+
+        final JsonMappingException jsonMappingException = mock(JsonMappingException.class);
+        when(jsonMappingException.getPath()).thenReturn(path);
+        when(jsonMappingException.getOriginalMessage()).thenReturn(UUID.randomUUID().toString());
+
+        when(exception.getCause()).thenReturn(jsonMappingException);
+
+        final PluginConfigurationErrorHandler objectUnderTest = createObjectUnderTest();
+
+        final Exception resultingException = objectUnderTest.handleException(pluginSetting, exception);
+        assertThat(resultingException instanceof InvalidPluginConfigurationException, equalTo(true));
+
+        final String expectedErrorMessage = String.format(JSON_MAPPING_EXCEPTION_FORMAT,
+                firstPathReference.getFieldName() + "." + secondPathReference.getFieldName(),
+                pluginName,
+                jsonMappingException.getOriginalMessage());
+
+        assertThat(resultingException.getMessage(), equalTo(expectedErrorMessage));
+    }
+
+    @Test
+    void non_handled_exception_throws_generic_invalid_plugin_configuration_exception() {
+        final String pluginName = UUID.randomUUID().toString();
+
+        final PluginSetting pluginSetting = mock(PluginSetting.class);
+        when(pluginSetting.getName()).thenReturn(pluginName);
+
+        final RuntimeException exception = mock(RuntimeException.class);
+        when(exception.getMessage()).thenReturn(UUID.randomUUID().toString());
+
+        final RuntimeException cause = mock(RuntimeException.class);
+        when(exception.getCause()).thenReturn(cause);
+
+        final PluginConfigurationErrorHandler objectUnderTest = createObjectUnderTest();
+
+        final Exception resultingException = objectUnderTest.handleException(pluginSetting, exception);
+        assertThat(resultingException instanceof InvalidPluginConfigurationException, equalTo(true));
+
+        final String expectedErrorMessage = String.format(GENERIC_PLUGIN_EXCEPTION_FORMAT,
+                pluginName,
+                exception.getMessage());
+
+        assertThat(resultingException.getMessage(), equalTo(expectedErrorMessage));
+    }
+}


### PR DESCRIPTION
### Description
This change improves the error messaging for unknown plugin properties and json mapping exceptions

Old error for unknown property

```
    entry-pipeline.processor.parse_json: caused by: Unrecognized field "destiatio" (class org.opensearch.dataprepper.plugins.processor.parse.json.ParseJsonProcessorConfig), not marked as ignorable (8 known properties: "tags_on_failure", "handle_failed_events", "parse_when", "source", "pointer", "destination", "delete_source", "overwrite_if_destination_exists"]) at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: org.opensearch.dataprepper.plugins.processor.parse.json.ParseJsonProcessorConfig["destiatio"]) caused by: Unrecognized field "destiatio" (class org.opensearch.dataprepper.plugins.processor.parse.json.ParseJsonProcessorConfig), not marked as ignorable (8 known properties: "tags_on_failure", "handle_failed_events", "parse_when", "source", "pointer", "destination", "delete_source", "overwrite_if_destination_exists"]) at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: org.opensearch.dataprepper.plugins.processor.parse.json.ParseJsonProcessorConfig["destiatio"])
```

New error for unknown property

```
1. entry-pipeline.processor.parse_json: caused by: Parameter "destintio" for plugin "parse_json" does not exist. Available options include [tags_on_failure, handle_failed_events, parse_when, source, pointer, destination, delete_source, overwrite_if_destination_exists]. Did you mean "destination"?
```


 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
