### PR TITLE
Adding support for compression config per KDS stream.

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisStreamConfig.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisStreamConfig.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import software.amazon.kinesis.common.InitialPositionInStream;
 
 import java.time.Duration;
@@ -38,4 +39,9 @@ public class KinesisStreamConfig {
     public InitialPositionInStream getInitialPosition() {
         return initialPosition.getPositionInStream();
     }
+
+    @Getter
+    @JsonProperty("compression")
+    private CompressionOption compression = CompressionOption.NONE;
+
 }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.kinesis.source.converter;
 
+import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventMetadata;
@@ -31,11 +32,12 @@ public class KinesisRecordConverter {
         this.codec = codec;
     }
 
-    public List<Record<Event>> convert(List<KinesisClientRecord> kinesisClientRecords,
+    public List<Record<Event>> convert(final DecompressionEngine decompressionEngine,
+                                       List<KinesisClientRecord> kinesisClientRecords,
                                        final String streamName) throws IOException {
         List<Record<Event>> records = new ArrayList<>();
         for (KinesisClientRecord kinesisClientRecord : kinesisClientRecords) {
-            processRecord(kinesisClientRecord, record -> {
+            processRecord(decompressionEngine, kinesisClientRecord, record -> {
                 records.add(record);
                 Event event = record.getData();
                 EventMetadata eventMetadata = event.getMetadata();
@@ -52,11 +54,14 @@ public class KinesisRecordConverter {
         return records;
     }
 
-    private void processRecord(KinesisClientRecord record, Consumer<Record<Event>> eventConsumer) throws IOException {
+    private void processRecord(final DecompressionEngine decompressionEngine,
+                               KinesisClientRecord record,
+                               Consumer<Record<Event>> eventConsumer) throws IOException {
         // Read bytebuffer
         byte[] arr = new byte[record.data().remaining()];
         record.data().get(arr);
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(arr);
-        codec.parse(byteArrayInputStream, eventConsumer);
+
+        codec.parse(decompressionEngine.createInputStream(byteArrayInputStream), eventConsumer);
     }
 }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
@@ -161,7 +161,9 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
 
             // Track the records for checkpoint purpose
             kinesisCheckpointerTracker.addRecordForCheckpoint(extendedSequenceNumber, processRecordsInput.checkpointer());
-            List<Record<Event>> records = kinesisRecordConverter.convert(processRecordsInput.records(), streamIdentifier.streamName());
+            List<Record<Event>> records = kinesisRecordConverter.convert(
+                    kinesisStreamConfig.getCompression().getDecompressionEngine(),
+                    processRecordsInput.records(), streamIdentifier.streamName());
 
             int eventCount = 0;
             for (Record<Event> record: records) {

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfigTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfigTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.opensearch.dataprepper.pipeline.parser.DataPrepperDurationDeserializer;
+import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.kinesis.common.InitialPositionInStream;
 
@@ -156,6 +157,7 @@ public class KinesisSourceConfigTest {
             assertTrue(kinesisStreamConfig.getName().contains("stream"));
             assertEquals(kinesisStreamConfig.getInitialPosition(), InitialPositionInStream.TRIM_HORIZON);
             assertEquals(kinesisStreamConfig.getCheckPointInterval(), expectedCheckpointIntervals.get(kinesisStreamConfig.getName()));
+            assertEquals(kinesisStreamConfig.getCompression(), CompressionOption.GZIP);
         }
     }
 }

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverterTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverterTest.java
@@ -13,13 +13,16 @@ package org.opensearch.dataprepper.plugins.kinesis.source.converter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.codec.json.NdjsonInputCodec;
 import org.opensearch.dataprepper.plugins.codec.json.NdjsonInputConfig;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -40,6 +43,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class KinesisRecordConverterTest {
     private static final String streamId = "stream-1";
@@ -48,13 +52,15 @@ public class KinesisRecordConverterTest {
     void testRecordConverter() throws IOException {
         InputCodec codec = mock(InputCodec.class);
         KinesisRecordConverter kinesisRecordConverter = new KinesisRecordConverter(codec);
+        DecompressionEngine decompressionEngine = CompressionOption.NONE.getDecompressionEngine();
         doNothing().when(codec).parse(any(InputStream.class), any(Consumer.class));
 
         String sample_record_data = "sample record data";
         KinesisClientRecord kinesisClientRecord = KinesisClientRecord.builder()
                 .data(ByteBuffer.wrap(sample_record_data.getBytes()))
                 .build();
-        kinesisRecordConverter.convert(List.of(kinesisClientRecord), streamId);
+
+        kinesisRecordConverter.convert(decompressionEngine, List.of(kinesisClientRecord), streamId);
         verify(codec, times(1)).parse(any(InputStream.class), any(Consumer.class));
     }
 
@@ -89,7 +95,11 @@ public class KinesisRecordConverterTest {
                 .subSequenceNumber(subsequenceNumber)
                 .partitionKey(partitionKey)
                 .build();
-        List<Record<Event>> events = kinesisRecordConverter.convert(List.of(kinesisClientRecord), streamId);
+        DecompressionEngine decompressionEngine = mock(DecompressionEngine.class);
+        InputStream inputStream = new ByteArrayInputStream(writer.toString().getBytes());
+        when(decompressionEngine.createInputStream(any(InputStream.class))).thenReturn(inputStream);
+
+        List<Record<Event>> events = kinesisRecordConverter.convert(decompressionEngine, List.of(kinesisClientRecord), streamId);
 
         assertEquals(events.size(), numRecords);
         events.forEach(eventRecord -> {

--- a/data-prepper-plugins/kinesis-source/src/test/resources/pipeline_with_checkpoint_enabled.yaml
+++ b/data-prepper-plugins/kinesis-source/src/test/resources/pipeline_with_checkpoint_enabled.yaml
@@ -4,12 +4,15 @@ source:
       - stream_name: "stream-1"
         initial_position: "EARLIEST"
         checkpoint_interval: "20s"
+        compression: "gzip"
       - stream_name: "stream-2"
         initial_position: "EARLIEST"
         checkpoint_interval: "PT15M"
+        compression: "gzip"
       - stream_name: "stream-3"
         initial_position: "EARLIEST"
         checkpoint_interval: "PT2H"
+        compression: "gzip"
     codec:
       ndjson:
     aws:


### PR DESCRIPTION
### Description
This PR is to add support for compression type per stream. For records added by CloudWatch, customers should have an option to enable this configuration which will enable to decompress the records and allow to parse. 
 
### Issues Resolved
Resolves #1082 
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
