### PR TITLE
ENH: add missing spaces in descriptions, reorder fields

### DIFF
--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -18,8 +18,8 @@ public class DissectProcessorConfig {
     @JsonProperty("map")
     @JsonPropertyDescription("Defines the <code>dissect</code> patterns for specific keys. " +
             "Each key is a field name, and the value is the dissect pattern to use for dissecting it. " +
-            "For details on how to define fields " +
-            "in the <code>dissect</code> pattern, see (https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations). " +
+            "For details on how to define fields in the <code>dissect</code> pattern, see " + 
+            "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations>here</a>. " +
             "An example dissect pattern is <code>%{Date} %{Time} %{Log_Type}: %{Message}</code>, which will dissect into four fields.")
     private Map<String, String> map;
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -129,7 +129,7 @@ public class KeyValueProcessorConfig {
     @JsonProperty("whitespace")
     @JsonPropertyDescription("Specifies whether to be lenient or strict with the acceptance of " +
             "unnecessary white space surrounding the configured value-split sequence. " +
-            "In this case, strict means that whitespace is trimmed and lenient means it is retained in the key name and in the value." +
+            "In this case, strict means that whitespace is trimmed and lenient means it is retained in the key name and in the value. " +
             "Default is <code>lenient</code>.")
     @NotNull
     private WhitespaceOption whitespace = DEFAULT_WHITESPACE;
@@ -183,7 +183,7 @@ public class KeyValueProcessorConfig {
     @JsonProperty("strict_grouping")
     @JsonPropertyDescription("When enabled, groups with unmatched end characters yield errors. " +
             "The event is ignored after the errors are logged. " +
-            "Specifies whether strict grouping should be enabled when the <code>value_grouping</code>" +
+            "Specifies whether strict grouping should be enabled when the <code>value_grouping</code> " +
             "or <code>string_literal_character</code> options are used. Default is <code>false</code>.")
     private boolean strictGrouping = false;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -61,6 +61,11 @@ public class ListToMapProcessorConfig {
             "placed in the root node.")
     private String target = null;
 
+    @JsonProperty("use_source_key")
+    @JsonPropertyDescription("When <code>true</code>, keys in the generated map will use original keys from the source. " +
+            "Default is <code>false</code>.")
+    private boolean useSourceKey = false;
+
     @JsonProperty("key")
     @JsonPropertyDescription("The key of the fields to be extracted as keys in the generated mappings. Must be " +
             "specified if <code>use_source_key</code> is <code>false</code>.")
@@ -72,11 +77,6 @@ public class ListToMapProcessorConfig {
             "When not specified, objects contained in the source list retain their original value when mapped.")
     private String valueKey = null;
 
-    @JsonProperty("use_source_key")
-    @JsonPropertyDescription("When <code>true</code>, keys in the generated map will use original keys from the source. " +
-            "Default is <code>false</code>.")
-    private boolean useSourceKey = false;
-
     @JsonProperty("extract_value")
     @JsonPropertyDescription("When <code>true</code>, object values from the source list will be extracted and added to " +
             "the generated map. When <code>false</code>, object values from the source list are added to the generated map " +
@@ -86,7 +86,8 @@ public class ListToMapProcessorConfig {
     @NotNull
     @JsonProperty("flatten")
     @JsonPropertyDescription("When <code>true</code>, values in the generated map output flatten into single items based on " +
-            "the <code>flattened_element</code>. Otherwise, objects mapped to values from the generated map appear as lists.")
+            "the <code>flattened_element</code>. Otherwise, objects mapped to values from the generated map appear as lists. " +
+            "Default is <code>false</code>.")
     private boolean flatten = false;
 
     @NotNull


### PR DESCRIPTION
### Description
1. Added an embed into `map` field of the `dissect` processor. It previously had the whole link not hyperlinked.
2. Added missing spaces into the `whitespace` and `strict_grouping` fields of the key-value processor.
3. Added the specification of default value being `false` in the `flatten` field description of the `list to map` processor.
4. Reordered `use_source_key` and `key` fields of the `list to map` processor to be next to each other since they are associated.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
