### PR TITLE
FIX: annotation and documentation gap in processors

### DIFF
--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -17,14 +17,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "sent from the <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/\">OTel metrics source</a> into a collection of string records.")
 public class OtelMetricsRawProcessorConfig {
 
-    @JsonProperty("flatten_attributes")
-    @JsonPropertyDescription("Whether or not to flatten the <code>attributes</code> field in the JSON data.")
+    @JsonProperty(value = "flatten_attributes", defaultValue = "true")
+    @JsonPropertyDescription("Whether or not to flatten the <code>attributes</code> field in the JSON data. Default value is <code>true</code>.")
     boolean flattenAttributesFlag = true;
 
-    @JsonPropertyDescription("Whether or not to calculate histogram buckets.")
+    @JsonProperty(defaultValue = "true")
+    @JsonPropertyDescription("Whether or not to calculate histogram buckets. Default value is <code>true</code>.")
     private Boolean calculateHistogramBuckets = true;
 
-    @JsonPropertyDescription("Whether or not to calculate exponential histogram buckets.")
+    @JsonProperty(defaultValue = "true")
+    @JsonPropertyDescription("Whether or not to calculate exponential histogram buckets. Default value is <code>true</code>.")
     private Boolean calculateExponentialHistogramBuckets = true;
 
     @JsonPropertyDescription("Maximum allowed scale in exponential histogram calculation. By default, the maximum allowed scale is <code>10</code>.")

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -27,7 +27,7 @@ public class OtelTraceRawProcessorConfig {
 
     @JsonProperty("trace_group_cache_ttl")
     @JsonPropertyDescription("Represents the time-to-live to cache a trace group details. " +
-            "The value may be an ISO 8601 notation such as <code>PT1M30S</code> or a duration and unit such as <code>45s</code>" +
+            "The value may be an ISO 8601 notation such as <code>PT1M30S</code> or a duration and unit such as <code>45s</code>. " +
             "Default is 15 seconds.")
     private Duration traceGroupCacheTimeToLive = DEFAULT_TRACE_ID_TTL;
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 import org.opensearch.dataprepper.plugins.processor.parse.CommonParseConfig;
 
@@ -29,6 +30,7 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("destination")
+    @Pattern(regexp = "^(?!\\s*$)(?!^/$).+", message = "Cannot be an empty string, <code>/</code>, or any whitespace-only string")
     @JsonPropertyDescription("The destination field of the structured object from the parsed ION. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
 
@@ -37,7 +39,7 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
-    @JsonProperty("overwrite_if_destination_exists")
+    @JsonProperty(value = "overwrite_if_destination_exists", defaultValue = "true")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 import org.opensearch.dataprepper.plugins.processor.parse.CommonParseConfig;
 
@@ -29,6 +30,7 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("destination")
+    @Pattern(regexp = "^(?!\\s*$)(?!^/$).+", message = "Cannot be an empty string, <code>/</code>, or any whitespace-only string")
     @JsonPropertyDescription("The destination field of the structured object from the parsed JSON. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
 
@@ -37,7 +39,7 @@ public class ParseJsonProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
-    @JsonProperty("overwrite_if_destination_exists")
+    @JsonProperty(value = "overwrite_if_destination_exists", defaultValue = "true")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/xml/ParseXmlProcessorConfig.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 import org.opensearch.dataprepper.plugins.processor.parse.CommonParseConfig;
 
@@ -24,6 +25,7 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty("destination")
+    @Pattern(regexp = "^(?!\\s*$)(?!^/$).+", message = "Cannot be an empty string, <code>/</code>, or any whitespace-only string")
     @JsonPropertyDescription("The destination field of the structured object from the parsed XML. Defaults to the root of the event. Cannot be an empty string, <code>/</code>, or any whitespace-only string because these are not valid event fields.")
     private String destination;
 
@@ -32,7 +34,7 @@ public class ParseXmlProcessorConfig implements CommonParseConfig {
             "If the JSON pointer is invalid then the entire source data is parsed into the outgoing event. If the key that is pointed to already exists in the event and the destination is the root, then the pointer uses the entire path of the key.")
     private String pointer;
 
-    @JsonProperty("overwrite_if_destination_exists")
+    @JsonProperty(value = "overwrite_if_destination_exists", defaultValue = "true")
     @JsonPropertyDescription("Overwrites the destination if set to true. Set to false to prevent changing a destination value that exists. Defaults to true.")
     private boolean overwriteIfDestinationExists = true;
 


### PR DESCRIPTION
### Description
This PR covers:
* parse_json
* parse_ion
* parse_xml
* otel_metrics
* otel_trace
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
