### PR TITLE
Json codec changes with specific json input codec config

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -17,8 +17,8 @@ import org.opensearch.dataprepper.model.record.Record;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -27,10 +27,10 @@ public class JsonDecoder implements ByteDecoder {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JsonFactory jsonFactory = new JsonFactory();
     private String keyName;
-    private List<String> includeKeys;
-    private List<String> includeKeysMetadata;
+    private Collection<String> includeKeys;
+    private Collection<String> includeKeysMetadata;
 
-    public JsonDecoder(String keyName, List<String> includeKeys, List<String> includeKeysMetadata) {
+    public JsonDecoder(String keyName, Collection<String> includeKeys, Collection<String> includeKeysMetadata) {
         this.keyName = keyName;
         this.includeKeys = includeKeys;
         this.includeKeysMetadata = includeKeysMetadata;
@@ -56,10 +56,10 @@ public class JsonDecoder implements ByteDecoder {
             if (includeKeys != null && includeKeys.contains(nodeName) ||
                     (includeKeysMetadata != null && includeKeysMetadata.contains(nodeName))) {
                 jsonParser.nextToken();
-                if (includeKeys.contains(nodeName)) {
+                if (includeKeys != null && includeKeys.contains(nodeName)) {
                     includeKeysMap.put(nodeName, jsonParser.getValueAsString());
                 }
-                if (includeKeysMetadata.contains(nodeName)) {
+                if (includeKeysMetadata != null && includeKeysMetadata.contains(nodeName)) {
                     includeMetadataKeysMap.put(nodeName, jsonParser.getValueAsString());
                 }
                 continue;
@@ -77,8 +77,8 @@ public class JsonDecoder implements ByteDecoder {
     private void parseRecordsArray(final JsonParser jsonParser,
                                    final Instant timeReceived,
                                    final Consumer<Record<Event>> eventConsumer,
-                                   Map<String, Object> includeKeysMap,
-                                   Map<String, Object> includeMetadataKeysMap
+                                   final Map<String, Object> includeKeysMap,
+                                   final Map<String, Object> includeMetadataKeysMap
     ) throws IOException {
         while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
             final Map<String, Object> innerJson = objectMapper.readValue(jsonParser, Map.class);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -17,6 +17,8 @@ import org.opensearch.dataprepper.model.record.Record;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -24,6 +26,21 @@ import java.util.function.Consumer;
 public class JsonDecoder implements ByteDecoder {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JsonFactory jsonFactory = new JsonFactory();
+    private String keyName;
+    private List<String> includeKeys;
+    private List<String> includeKeysMetadata;
+
+    public JsonDecoder(String keyName, List<String> includeKeys, List<String> includeKeysMetadata) {
+        this.keyName = keyName;
+        this.includeKeys = includeKeys;
+        this.includeKeysMetadata = includeKeysMetadata;
+    }
+
+    public JsonDecoder() {
+        this.keyName = null;
+        this.includeKeys = null;
+        this.includeKeysMetadata = null;
+    }
 
     public void parse(InputStream inputStream, Instant timeReceived, Consumer<Record<Event>> eventConsumer) throws IOException {
         Objects.requireNonNull(inputStream);
@@ -31,18 +48,50 @@ public class JsonDecoder implements ByteDecoder {
 
         final JsonParser jsonParser = jsonFactory.createParser(inputStream);
 
+        Map<String, Object> includeKeysMap = new HashMap<>();
+        Map<String, Object> includeMetadataKeysMap = new HashMap<>();
         while (!jsonParser.isClosed() && jsonParser.nextToken() != JsonToken.END_OBJECT) {
+            final String nodeName = jsonParser.currentName();
+
+            if (includeKeys != null && includeKeys.contains(nodeName) ||
+                    (includeKeysMetadata != null && includeKeysMetadata.contains(nodeName))) {
+                jsonParser.nextToken();
+                if (includeKeys.contains(nodeName)) {
+                    includeKeysMap.put(nodeName, jsonParser.getValueAsString());
+                }
+                if (includeKeysMetadata.contains(nodeName)) {
+                    includeMetadataKeysMap.put(nodeName, jsonParser.getValueAsString());
+                }
+                continue;
+            }
+
             if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
-                parseRecordsArray(jsonParser, timeReceived, eventConsumer);
+                if (keyName != null && !nodeName.equals(keyName)) {
+                    continue;
+                }
+                parseRecordsArray(jsonParser, timeReceived, eventConsumer, includeKeysMap, includeMetadataKeysMap);
             }
         }
     }
 
-    private void parseRecordsArray(final JsonParser jsonParser, final Instant timeReceived, final Consumer<Record<Event>> eventConsumer) throws IOException {
+    private void parseRecordsArray(final JsonParser jsonParser,
+                                   final Instant timeReceived,
+                                   final Consumer<Record<Event>> eventConsumer,
+                                   Map<String, Object> includeKeysMap,
+                                   Map<String, Object> includeMetadataKeysMap
+    ) throws IOException {
         while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
             final Map<String, Object> innerJson = objectMapper.readValue(jsonParser, Map.class);
 
             final Record<Event> record = createRecord(innerJson, timeReceived);
+            for (final Map.Entry<String, Object> entry : includeKeysMap.entrySet()) {
+                record.getData().put(entry.getKey(), entry.getValue());
+            }
+
+            for (final Map.Entry<String, Object> entry : includeMetadataKeysMap.entrySet()) {
+                record.getData().getMetadata().setAttribute(entry.getKey(), entry.getValue());
+            }
+
             eventConsumer.accept(record);
         }
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
@@ -1,12 +1,20 @@
 package org.opensearch.dataprepper.model.codec;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -14,6 +22,7 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 
@@ -26,7 +35,7 @@ public class JsonDecoderTest {
         return new JsonDecoder();
     }
 
-@BeforeEach
+    @BeforeEach
     void setup() {
         jsonDecoder = createObjectUnderTest();
         receivedRecord = null;
@@ -60,15 +69,93 @@ public class JsonDecoderTest {
         try {
             jsonDecoder.parse(new ByteArrayInputStream(inputString.getBytes()), now, (record) -> {
                 receivedRecord = record;
-                receivedTime = ((DefaultEventHandle)(((Event)record.getData()).getEventHandle())).getInternalOriginationTime();
+                receivedTime = record.getData().getEventHandle().getInternalOriginationTime();
             });
         } catch (Exception e){}
-        
+
         assertNotEquals(receivedRecord, null);
         Map<String, Object> map = receivedRecord.getData().toMap();
         assertThat(map.get("key1"), equalTo(stringValue));
         assertThat(map.get("key2"), equalTo(intValue));
         assertThat(receivedTime, equalTo(now));
+    }
+
+    @Nested
+    class JsonDecoderWithInputConfig {
+        private ObjectMapper objectMapper;
+        final List<String> include_keys = new ArrayList<>();
+
+        @BeforeEach
+        void setup() {
+            objectMapper = new ObjectMapper();
+        }
+        @Test
+        void test_basicJsonDecoder_withInputConfig() throws IOException {
+            Random r = new Random();
+            final Instant now = Instant.now();
+            List<Record<Event>> records = new ArrayList<>();
+            for (int i=0; i<10; i++) {
+                include_keys.add(UUID.randomUUID().toString());
+            }
+            final String key_name = "logEvents";
+            Map<String, Object> jsonObject = generateJsonWithSpecificKeys(include_keys, key_name, 10);
+            jsonDecoder = new JsonDecoder(key_name, include_keys, include_keys);
+            jsonDecoder.parse(createInputStream(jsonObject), now, (record) -> {
+                records.add(record);
+                receivedTime = ((Event)record.getData()).getEventHandle().getInternalOriginationTime();
+            });
+
+            records.forEach(record -> {
+                Map<String, Object> dataMap = record.getData().toMap();
+                Map<String, Object> metadataMap = record.getData().getMetadata().getAttributes();
+
+                for (String include_key: include_keys) {
+                    assertThat(dataMap.get(include_key), equalTo(jsonObject.get(include_key)));
+                    assertThat(metadataMap.get(include_key), equalTo(jsonObject.get(include_key)));
+                }
+            });
+
+            assertThat(receivedTime, equalTo(now));
+        }
+
+        @Test
+        void test_basicJsonDecoder_withInputConfig_withoutEvents() throws IOException {
+            Random r = new Random();
+            final Instant now = Instant.now();
+            List<Record<Event>> records = new ArrayList<>();
+            Map<String, Object> jsonObject = generateJsonWithSpecificKeys(include_keys, "logEvents", 10);
+            jsonDecoder = new JsonDecoder("", include_keys, Collections.emptyList());
+            jsonDecoder.parse(createInputStream(jsonObject), now, (record) -> {
+                records.add(record);
+                receivedTime = ((Event)record.getData()).getEventHandle().getInternalOriginationTime();
+            });
+
+            assertTrue(records.isEmpty());
+        }
+
+        private Map<String, Object> generateJsonWithSpecificKeys(final List<String> outerKeys, final String key, final int numRecords) {
+            final Map<String, Object> jsonObject = new LinkedHashMap<>();
+            final List<Map<String, Object>> innerObjects = new ArrayList<>();
+
+            for (String outerKey: outerKeys) {
+                jsonObject.put(outerKey, UUID.randomUUID().toString());
+            }
+            for (int i=0; i<numRecords; i++) {
+                final Map<String, Object> innerJsonMap = new LinkedHashMap<>();
+                for (int j=0; j<3; j++) {
+                    innerJsonMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+                }
+                innerObjects.add(innerJsonMap);
+            }
+            jsonObject.put(key, innerObjects);
+            return jsonObject;
+        }
+
+        private InputStream createInputStream(final Map<String, ?> jsonRoot) throws JsonProcessingException {
+            final byte[] jsonBytes = objectMapper.writeValueAsBytes(jsonRoot);
+
+            return new ByteArrayInputStream(jsonBytes);
+        }
     }
 
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.codec.json;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.codec.JsonDecoder;
 import org.opensearch.dataprepper.model.event.Event;
@@ -13,13 +14,20 @@ import org.opensearch.dataprepper.model.record.Record;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
  * An implementation of {@link InputCodec} which parses JSON Objects for arrays.
  */
-@DataPrepperPlugin(name = "json", pluginType = InputCodec.class)
+@DataPrepperPlugin(name = "json", pluginType = InputCodec.class, pluginConfigurationType = JsonInputCodecConfig.class)
 public class JsonInputCodec extends JsonDecoder implements InputCodec {
+
+    @DataPrepperPluginConstructor
+    public JsonInputCodec(final JsonInputCodecConfig config) {
+        super(Objects.requireNonNull(config).getKeyName(), config.getIncludeKeys(), config.getIncludeKeysMetadata());
+    }
+
     public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
         parse(inputStream, null, eventConsumer);
     }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public class JsonInputCodecConfig {
+
+    @JsonProperty("key_name")
+    @Size(min = 1, max = 2048)
+    private String keyName;
+
+    public String getKeyName() {
+        return keyName;
+    }
+
+    @JsonProperty("include_keys")
+    private List<String> includeKeys;
+
+    public List<String> getIncludeKeys() {
+        return includeKeys;
+    }
+
+    @JsonProperty("include_keys_metadata")
+    private List<String> includeKeysMetadata;
+
+    public List<String> getIncludeKeysMetadata() {
+        return includeKeysMetadata;
+    }
+}

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
@@ -36,21 +36,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JsonCodecsIT {
 
     private ObjectMapper objectMapper;
     private Consumer<Record<Event>> eventConsumer;
+    private JsonInputCodecConfig jsonInputCodecConfig;
 
     @BeforeEach
     void setUp() {
         objectMapper = new ObjectMapper();
-
+        jsonInputCodecConfig = mock(JsonInputCodecConfig.class);
+        when(jsonInputCodecConfig.getIncludeKeysMetadata()).thenReturn(Collections.emptyList());
+        when(jsonInputCodecConfig.getIncludeKeys()).thenReturn(Collections.emptyList());
+        when(jsonInputCodecConfig.getKeyName()).thenReturn(null);
         eventConsumer = mock(Consumer.class);
     }
 
     private JsonInputCodec createJsonInputCodecObjectUnderTest() {
-        return new JsonInputCodec();
+        return new JsonInputCodec(jsonInputCodecConfig);
     }
 
     private JsonOutputCodec createJsonOutputCodecObjectUnderTest() {

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfigTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.codec.json;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JsonInputCodecConfigTest {
+
+    private JsonInputCodecConfig createObjectUnderTest() {
+        return new JsonInputCodecConfig();
+    }
+
+    @Test
+    public void testJsonInputCodecConfig() {
+        JsonInputCodecConfig jsonInputCodecConfig = createObjectUnderTest();
+        assertTrue(jsonInputCodecConfig.getKeyName().equals(JsonInputCodecConfig.DEFAULT_KEY_NAME));
+        assertNull(jsonInputCodecConfig.getIncludeKeys());
+        assertNull(jsonInputCodecConfig.getIncludeKeysMetadata());
+    }
+}

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfigTest.java
@@ -8,7 +8,6 @@ package org.opensearch.dataprepper.plugins.codec.json;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonInputCodecConfigTest {
 
@@ -19,7 +18,7 @@ public class JsonInputCodecConfigTest {
     @Test
     public void testJsonInputCodecConfig() {
         JsonInputCodecConfig jsonInputCodecConfig = createObjectUnderTest();
-        assertTrue(jsonInputCodecConfig.getKeyName().equals(JsonInputCodecConfig.DEFAULT_KEY_NAME));
+        assertNull(jsonInputCodecConfig.getKeyName());
         assertNull(jsonInputCodecConfig.getIncludeKeys());
         assertNull(jsonInputCodecConfig.getIncludeKeysMetadata());
     }

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/JsonRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/JsonRecordsGenerator.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.codec.json.JsonInputCodec;
+import org.opensearch.dataprepper.plugins.codec.json.JsonInputCodecConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +51,7 @@ class JsonRecordsGenerator implements RecordsGenerator {
 
     @Override
     public InputCodec getCodec() {
-        return new JsonInputCodec();
+        return new JsonInputCodec(new JsonInputCodecConfig());
     }
 
     @Override


### PR DESCRIPTION
### Description
This PR is to add support for additional configuration entries in the `JsonInputCodec` so that CloudWatch logs from subscription filters could be decoded in Data Prepper. [CloudWatch Subscription Filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html)

For the input message from CloudWatch

```
{
    "owner": "111111111111",
    "logGroup": "CloudTrail/logs",
    "logStream": "111111111111_CloudTrail/logs_us-east-1",
    "subscriptionFilters": [
        "Destination"
    ],
    "messageType": "DATA_MESSAGE",
    "logEvents": [
        {
            "id": "31953106606966983378809025079804211143289615424298221568",
            "timestamp": 1432826855000,
            "message": "{\"eventVersion\":\"1.03\",\"userIdentity\":{\"type\":\"Root\"}"
        },
        {
            "id": "31953106606966983378809025079804211143289615424298221569",
            "timestamp": 1432826855000,
            "message": "{\"eventVersion\":\"1.03\",\"userIdentity\":{\"type\":\"Root\"}"
        },
        {
            "id": "31953106606966983378809025079804211143289615424298221570",
            "timestamp": 1432826855000,
            "message": "{\"eventVersion\":\"1.03\",\"userIdentity\":{\"type\":\"Root\"}"
        }
    ]
}
``` 
and with the following configuration:
```
      codec:
        json:
          key_name: "logEvents"
          include_keys: ['owner', 'logGroup', 'logStream' ]
          include_keys_metadata: ['owner', 'logGroup', 'logStream' ]
```
the output event should be split into 3 separate events with additional data and metadata as specified in the config
```
{
  "id": "31953106606966983378809025079804211143289615424298221568",
  "timestamp": 1432826855000,
  "message": "{\"eventVersion\":\"1.03\",\"userIdentity\":{\"type\":\"Root\"}",
  "owner": "111111111111",
  "logGroup": "CloudTrail/logs",
  "logStream": "111111111111_CloudTrail/logs_us-east-1",
}

{
  "id": "31953106606966983378809025079804211143289615424298221569",
  "timestamp": 1432826855000,
  "message": "{\"eventVersion\":\"1.03\",\"userIdentity\":{\"type\":\"Root\"}",
  "owner": "111111111111",
  "logGroup": "CloudTrail/logs",
  "logStream": "111111111111_CloudTrail/logs_us-east-1",
}

{
  "id": "31953106606966983378809025079804211143289615424298221570",
  "timestamp": 1432826855000,
  "message": "{\"eventVersion\":\"1.03\",\"userIdentity\":{\"type\":\"Root\"}",
  "owner": "111111111111",
  "logGroup": "CloudTrail/logs",
  "logStream": "111111111111_CloudTrail/logs_us-east-1",
}
```

### Issues Resolved
Resolves #5045
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
