### PR TITLE
Add validations on route expressions, clean up assertTrue validation messages

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/PipelineParserConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/PipelineParserConfiguration.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.parser.config;
 
 import org.opensearch.dataprepper.breaker.CircuitBreakerManager;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
 import org.opensearch.dataprepper.model.event.EventFactory;
@@ -32,7 +33,8 @@ import org.springframework.context.annotation.Primary;
 @Configuration
 @ComponentScan(basePackages = {
         "org.opensearch.dataprepper.pipeline.parser",
-        "org.opensearch.dataprepper.plugin"
+        "org.opensearch.dataprepper.plugin",
+        "org.opensearch.dataprepper.expression"
 })
 public class PipelineParserConfiguration {
 
@@ -48,7 +50,8 @@ public class PipelineParserConfiguration {
             final AcknowledgementSetManager acknowledgementSetManager,
             final SourceCoordinatorFactory sourceCoordinatorFactory,
             final PluginErrorCollector pluginErrorCollector,
-            final PluginErrorsHandler pluginErrorsHandler
+            final PluginErrorsHandler pluginErrorsHandler,
+            final ExpressionEvaluator expressionEvaluator
             ) {
         return new PipelineTransformer(pipelinesDataFlowModel,
                 pluginFactory,
@@ -60,7 +63,8 @@ public class PipelineParserConfiguration {
                 acknowledgementSetManager,
                 sourceCoordinatorFactory,
                 pluginErrorCollector,
-                pluginErrorsHandler);
+                pluginErrorsHandler,
+                expressionEvaluator);
     }
 
     @Bean

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
@@ -22,12 +22,14 @@ import org.opensearch.dataprepper.TestDataProvider;
 import org.opensearch.dataprepper.acknowledgements.DefaultAcknowledgementSetManager;
 import org.opensearch.dataprepper.breaker.CircuitBreakerManager;
 import org.opensearch.dataprepper.core.event.EventFactoryApplicationContextMarker;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PipelineModel;
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
@@ -64,12 +66,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.parser.PipelineTransformer.CONDITIONAL_ROUTE_INVALID_EXPRESSION_FORMAT;
 
 @ExtendWith(MockitoExtension.class)
 class PipelineTransformerTests {
@@ -93,6 +98,9 @@ class PipelineTransformerTests {
     private CircuitBreakerManager circuitBreakerManager;
     @Mock
     private PluginErrorsHandler pluginErrorsHandler;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
     @Captor
     private ArgumentCaptor<Collection<PluginError>> pluginErrorsArgumentCaptor;
 
@@ -143,7 +151,7 @@ class PipelineTransformerTests {
                 pipelinesDataFlowModel, pluginFactory, peerForwarderProvider,
                 routerFactory, dataPrepperConfiguration, circuitBreakerManager, eventFactory,
                 acknowledgementSetManager, sourceCoordinatorFactory, pluginErrorCollector,
-                pluginErrorsHandler);
+                pluginErrorsHandler, expressionEvaluator);
     }
 
     @Test
@@ -345,6 +353,7 @@ class PipelineTransformerTests {
     @Test
     void parseConfiguration_with_routes_creates_correct_pipeline() {
         mockDataPrepperConfigurationAccesses();
+        when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(true);
         final PipelineTransformer pipelineTransformer =
                 createObjectUnderTest("src/test/resources/valid_multiple_sinks_with_routes.yml");
         final Map<String, Pipeline> pipelineMap = pipelineTransformer.transformConfiguration();
@@ -355,6 +364,34 @@ class PipelineTransformerTests {
         assertThat(entryPipeline, notNullValue());
         assertThat(entryPipeline.getSinks(), notNullValue());
         assertThat(entryPipeline.getSinks().size(), equalTo(2));
+        verify(dataPrepperConfiguration).getPipelineExtensions();
+    }
+
+    @Test
+    void parseConfiguration_with_invalid_route_expressions_handles_errors_and_returns_empty_pipeline_map() {
+        when(expressionEvaluator.isValidExpressionStatement("/value == raw")).thenReturn(true);
+        when(expressionEvaluator.isValidExpressionStatement("/value == service")).thenReturn(false);
+
+        final ArgumentCaptor<Collection<PluginError>> pluginErrorArgumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        doNothing().when(pluginErrorsHandler).handleErrors(pluginErrorArgumentCaptor.capture());
+        final PipelineTransformer pipelineTransformer =
+                createObjectUnderTest("src/test/resources/valid_multiple_sinks_with_routes.yml");
+        final Map<String, Pipeline> pipelineMap = pipelineTransformer.transformConfiguration();
+        assertThat(pipelineMap.keySet().isEmpty(), equalTo(true));
+
+        final Collection<PluginError> pluginErrorCollection = pluginErrorArgumentCaptor.getValue();
+        assertThat(pluginErrorCollection, notNullValue());
+        assertThat(pluginErrorCollection.size(), equalTo(1));
+
+        final PluginError pluginError = pluginErrorCollection.stream().findAny().orElseThrow();
+        final String expectedErrorMessage = String.format(CONDITIONAL_ROUTE_INVALID_EXPRESSION_FORMAT, "service", "/value == service");
+        assertThat(pluginError.getPluginName(), equalTo(null));
+        assertThat(pluginError.getPipelineName(), equalTo("entry-pipeline"));
+        assertThat(pluginError.getComponentType(), equalTo(PipelineModel.ROUTE_PLUGIN_TYPE));
+        assertThat(pluginError.getException(), notNullValue());
+        assertThat(pluginError.getException() instanceof InvalidPluginConfigurationException, equalTo(true));
+        assertThat(pluginError.getException().getMessage(), equalTo(expectedErrorMessage));
+
         verify(dataPrepperConfiguration).getPipelineExtensions();
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/config/PipelineParserConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/config/PipelineParserConfigurationTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.parser.config;
 
 import org.opensearch.dataprepper.breaker.CircuitBreakerManager;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.parser.PipelineTransformer;
@@ -63,12 +64,15 @@ class PipelineParserConfigurationTest {
     @Mock
     private PluginErrorsHandler pluginErrorsHandler;
 
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
     @Test
     void pipelineParser() {
         final PipelineTransformer pipelineTransformer = pipelineParserConfiguration.pipelineParser(
                 pipelinesDataFlowModel, pluginFactory, peerForwarderProvider, routerFactory,
                 dataPrepperConfiguration, circuitBreakerManager, eventFactory, acknowledgementSetManager,
-                sourceCoordinatorFactory, pluginErrorCollector, pluginErrorsHandler);
+                sourceCoordinatorFactory, pluginErrorCollector, pluginErrorsHandler, expressionEvaluator);
 
         assertThat(pipelineTransformer, is(notNullValue()));
     }

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/validation/PluginError.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/validation/PluginError.java
@@ -12,8 +12,8 @@ public class PluginError {
     static final String CAUSED_BY_DELIMITER = " caused by: ";
     private final String pipelineName;
     private final String componentType;
-    @NonNull
     private final String pluginName;
+
     @NonNull
     private final Exception exception;
 
@@ -27,8 +27,11 @@ public class PluginError {
             message.append(componentType);
             message.append(PIPELINE_DELIMITER);
         }
-        message.append(pluginName);
-        message.append(PATH_TO_CAUSE_DELIMITER);
+
+        if (pluginName != null) {
+            message.append(pluginName);
+            message.append(PATH_TO_CAUSE_DELIMITER);
+        }
         message.append(getFlattenedExceptionMessage(CAUSED_BY_DELIMITER));
         return message.toString();
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationConverter.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+import jakarta.validation.constraints.AssertTrue;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
@@ -69,7 +70,7 @@ class PluginConfigurationConverter {
 
         if (!constraintViolations.isEmpty()) {
             final String violationsString = constraintViolations.stream()
-                    .map(v -> v.getPropertyPath().toString() + " " + v.getMessage())
+                    .map(this::constructConstrainViolationMessage)
                     .collect(Collectors.joining(". "));
 
             final String exceptionMessage = String.format("Plugin %s in pipeline %s is configured incorrectly: %s",
@@ -90,6 +91,14 @@ class PluginConfigurationConverter {
         } catch (final Exception e) {
             throw pluginConfigurationErrorHandler.handleException(pluginSetting, e);
         }
+    }
+
+    private String constructConstrainViolationMessage(final ConstraintViolation<Object> constraintViolation) {
+        if (constraintViolation.getConstraintDescriptor().getAnnotation().annotationType().equals(AssertTrue.class)) {
+            return constraintViolation.getMessage();
+        }
+
+        return constraintViolation.getPropertyPath().toString() + " " + constraintViolation.getMessage();
     }
 
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationErrorHandler.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationErrorHandler.java
@@ -38,7 +38,6 @@ public class PluginConfigurationErrorHandler {
         return new InvalidPluginConfigurationException(
                 String.format(GENERIC_PLUGIN_EXCEPTION_FORMAT, pluginSetting.getName(), e.getMessage()));
     }
-
     private RuntimeException handleJsonMappingException(final JsonMappingException e, final PluginSetting pluginSetting) {
         final String parameterPath = getParameterPath(e.getPath());
 

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.processor.csv;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
 
 import java.util.List;
@@ -15,6 +16,8 @@ import java.util.List;
 /**
  * Configuration class for {@link CsvProcessor}.
  */
+
+@JsonPropertyOrder
 @JsonClassDescription("The <code>csv</code> processor parses comma-separated values (CSVs) strings into structured data.")
 public class CsvProcessorConfig {
     static final String DEFAULT_SOURCE = "message";


### PR DESCRIPTION


### Description
This adds a couple of improvements to the validations in Data Prepper

1. Validate the expression in `routes` follows the Data Prepper expression syntax grammar. This validation previously only happened at runtime
2. Remove the method name from the `AssertTrue` validations in the error message
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
