### PR TITLE
Support for dynamic renaming of keys

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -125,7 +125,10 @@ class JacksonEventKey implements EventKey {
     }
 
     private String checkAndTrimKey(final String key) {
-        checkKey(key);
+        if(!supportedActions.equals(Collections.singleton(EventKeyFactory.EventAction.DELETE)))
+        {
+            checkKey(key);
+        }
         return trimTrailingSlashInKey(key);
     }
 
@@ -161,7 +164,8 @@ class JacksonEventKey implements EventKey {
                     || c == '@'
                     || c == '/'
                     || c == '['
-                    || c == ']')) {
+                    || c == ']'
+            )) {
 
                 return false;
             }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -525,7 +525,6 @@ public class JacksonEventTest {
     private <T extends Throwable> void assertThrowsForKeyCheck(final Class<T> expectedThrowable, final String key) {
         assertThrows(expectedThrowable, () -> event.put(key, UUID.randomUUID()));
         assertThrows(expectedThrowable, () -> event.get(key, String.class));
-        assertThrows(expectedThrowable, () -> event.delete(key));
     }
 
     @Test

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
@@ -19,13 +19,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
+import java.util.LinkedList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -49,7 +51,7 @@ public class RenameKeyProcessorTests {
     @Test
     void invalid_rename_when_throws_InvalidPluginConfigurationException() {
         final String renameWhen = UUID.randomUUID().toString();
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", "newMessage", true, renameWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null,"newMessage", true, renameWhen)));
 
 
         when(expressionEvaluator.isValidExpressionStatement(renameWhen)).thenReturn(false);
@@ -58,8 +60,19 @@ public class RenameKeyProcessorTests {
     }
 
     @Test
+    void invalid_config_when_both_from_key_empty_throws_InvalidPluginConfigurationException() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null,null, "newMessage", true, null)));
+        assertThrows(InvalidPluginConfigurationException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void invalid_config_when_both_from_key_set_throws_InvalidPluginConfigurationException() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message","m.*", "newMessage", true, null)));
+        assertThrows(InvalidPluginConfigurationException.class, this::createObjectUnderTest);
+    }
+    @Test
     public void testSingleOverwriteRenameProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", "newMessage", true, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null,"newMessage", true, null)));
 
         final RenameKeyProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -73,7 +86,7 @@ public class RenameKeyProcessorTests {
 
     @Test
     public void testSingleNoOverwriteRenameProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", "newMessage", false, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null,"newMessage", false, null)));
 
         final RenameKeyProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -86,8 +99,54 @@ public class RenameKeyProcessorTests {
     }
 
     @Test
+    public void testFromKeyPatternNoOverwriteRenameProcessorTests() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "(detailed_timestamp|detail_timestamp).*","detailed_timestamp", false, null)));
+
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("detailed_timestamp_1004", "test2");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("detailed_timestamp"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("detailed_timestamp_1004"), is(false));
+        assertThat(editedRecords.get(0).getData().get("detailed_timestamp", Object.class), equalTo("test2"));
+    }
+    @Test
+    public void testFromKeyPatternGroupingPatternRenameProcessorTests() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "(detailed_timestamp|detail_timestamp).*","detailed_timestamp", false, null)));
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("detailed_timestamp_1004", "test2");
+        record.getData().put("test_key","test_value");
+        final Record<Event> second_record = getEvent("thisisanewmessage");
+        second_record.getData().put("detail_timestamp-123", "test3");
+        Collection<Record<Event>> records = new ArrayList<>();
+        records.add(record);
+        records.add(second_record);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(records);
+        assertThat(editedRecords.get(0).getData().containsKey("detailed_timestamp"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("test_key"), is(true));
+        assertThat(editedRecords.get(1).getData().containsKey("detailed_timestamp"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("detailed_timestamp_1004"), is(false));
+        assertThat(editedRecords.get(1).getData().containsKey("detail_timestamp-123"), is(false));
+        assertThat(editedRecords.get(0).getData().get("detailed_timestamp", Object.class), equalTo("test2"));
+        assertThat(editedRecords.get(1).getData().get("detailed_timestamp", Object.class), equalTo("test3"));
+    }
+    @Test
+    public void testFromKeyPatternOverwriteRenameProcessorTests() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "me.*","newMessage", true, null)));
+
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("newMessage", "test2");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(false));
+        assertThat(editedRecords.get(0).getData().get("newMessage", Object.class), equalTo("thisisamessage"));
+    }
+
+    @Test
     public void testFromKeyDneRenameProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message2", "newMessage", false, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message2",null, "newMessage", false, null)));
 
         final RenameKeyProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -100,8 +159,8 @@ public class RenameKeyProcessorTests {
 
     @Test
     public void testMultiMixedOverwriteRenameProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", "newMessage", true, null),
-                createEntry("message2", "existingMessage", false, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message",null, "newMessage", true, null),
+                createEntry("message2",null, "existingMessage", false, null)));
 
         final RenameKeyProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -118,8 +177,23 @@ public class RenameKeyProcessorTests {
 
     @Test
     public void testChainRenamingRenameProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", "newMessage", true, null),
-                createEntry("newMessage", "message3", true, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message",null, "newMessage", true, null),
+                createEntry("newMessage", null,"message3", true, null)));
+
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message3"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(false));
+        assertThat(editedRecords.get(0).getData().get("message3", Object.class), equalTo("thisisamessage"));
+    }
+
+    @Test
+    public void testChainRenamingFromKeyPatternRenameProcessorTests() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null,"me.*", "newMessage", true, null),
+                createEntry(null, "new.*","message3", true, null)));
 
         final RenameKeyProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -135,7 +209,7 @@ public class RenameKeyProcessorTests {
     public void testNoRename_when_RenameWhen_returns_false() {
         final String renameWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", "newMessage", false, renameWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message",null, "newMessage", false, renameWhen)));
         when(expressionEvaluator.isValidExpressionStatement(renameWhen)).thenReturn(true);
 
         final RenameKeyProcessor processor = createObjectUnderTest();
@@ -150,14 +224,16 @@ public class RenameKeyProcessorTests {
         assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("thisisamessage"));
     }
 
+
+
     private RenameKeyProcessor createObjectUnderTest() {
         return new RenameKeyProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }
 
-    private RenameKeyProcessorConfig.Entry createEntry(final String fromKey, final String toKey, final boolean overwriteIfToKeyExists, final String renameWhen) {
-        final EventKey fromEventKey = eventKeyFactory.createEventKey(fromKey);
+    private RenameKeyProcessorConfig.Entry createEntry(final String fromKey, final String fromKeyPattern, final String toKey, final boolean overwriteIfToKeyExists, final String renameWhen) {
+        final EventKey fromEventKey = (fromKey == null) ? null : eventKeyFactory.createEventKey(fromKey);
         final EventKey toEventKey = eventKeyFactory.createEventKey(toKey);
-        return new RenameKeyProcessorConfig.Entry(fromEventKey, toEventKey, overwriteIfToKeyExists, renameWhen);
+        return new RenameKeyProcessorConfig.Entry(fromEventKey,fromKeyPattern, toEventKey, overwriteIfToKeyExists, renameWhen);
     }
 
     private List<RenameKeyProcessorConfig.Entry> createListOfEntries(final RenameKeyProcessorConfig.Entry... entries) {


### PR DESCRIPTION
### Description
It includes support for dynamic renaming of keys in rename processor where the user can now give a regex pattern to match the keys that needs to be replaced.
 
### Issues Resolved
Resolves #4849 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
