### PR TITLE
Modify descriptions of processor schemas

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -55,7 +55,7 @@ public class AggregateProcessorConfig {
     @JsonProperty("aggregated_events_tag")
     private String aggregatedEventsTag;
 
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be run on the event.")
     @JsonProperty("aggregate_when")
     private String whenCondition;
 

--- a/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressProcessorConfig.java
+++ b/data-prepper-plugins/decompress-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/decompress/DecompressProcessorConfig.java
@@ -37,7 +37,7 @@ public class DecompressProcessorConfig {
     @JsonProperty("tags_on_failure")
     private List<String> tagsOnFailure = List.of("_decompression_failure");
 
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>'/is_compressed == true'</code>, that determines when the decompress processor will run on certain events.")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>/is_compressed == true</code>, that determines when the decompress processor will run on certain events.")
     @JsonProperty("decompress_when")
     private String decompressWhen;
 

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -34,7 +34,7 @@ public class DissectProcessorConfig {
     @JsonPropertyDescription("Specifies a condition for performing the <code>dissect</code> operation using a " +
             "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>. " +
             "If specified, the <code>dissect</code> operation will only run when the expression evaluates to true. " +
-            "For example, <code>'/some_value == \"log\"'</code>.")
+            "For example, <code>/some_value == \"log\"</code>.")
     private String dissectWhen;
 
     public String getDissectWhen(){

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
@@ -16,7 +16,7 @@ import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 @JsonClassDescription("The <code>drop_events</code> processor conditionally drops events.")
 public class DropEventProcessorConfig {
 
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/log_type == \"DEBUG\"'</code>. " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/log_type == \"DEBUG\"</code>. " +
             "The <code>drop_when</code> processor will drop all events where the condition evaluates to true. Those events will not go to any further processors or sinks.")
     @JsonProperty("drop_when")
     @NotEmpty

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -43,7 +43,7 @@ public class GeoIPProcessorConfig {
     private List<String> tagsOnNoValidIp;
 
     @JsonProperty("geoip_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/srcaddr != \"8.8.8.8\"'</code>. " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/srcaddr != \"8.8.8.8\"</code>. " +
             "If specified, the <code>geoip</code> processor will only run on events when the expression evaluates to true. ")
     private String whenCondition;
 

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -109,7 +109,7 @@ public class GrokProcessorConfig {
     private List<String> tagsOnTimeout = Collections.emptyList();
 
     @JsonProperty(GROK_WHEN)
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/test != false'</code>. " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/test != false</code>. " +
             "If specified, the <code>grok</code> processor will only run on events when the expression evaluates to true. ")
     private String grokWhen;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -61,7 +61,7 @@ public class AddEntryProcessorConfig {
 
         @JsonProperty("add_when")
         @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
+                "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be run on the event.")
         private String addWhen;
 
         public String getKey() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -76,11 +76,11 @@ public class CopyValueProcessorConfig {
     private List<Entry> entries;
 
     @JsonProperty("from_list")
-    @JsonPropertyDescription("The key of the source list to copy values from.")
+    @JsonPropertyDescription("The key of the list of objects to be copied.")
     private String fromList;
 
     @JsonProperty("to_list")
-    @JsonPropertyDescription("The key of the target list to copy values to.")
+    @JsonPropertyDescription("The key of the new list to be added.")
     private String toList;
 
     @JsonProperty("overwrite_if_to_list_exists")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -40,7 +40,7 @@ public class CopyValueProcessorConfig {
 
         @JsonProperty("copy_when")
         @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event.")
+                "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be run on the event.")
         private String copyWhen;
 
         public String getFromKey() {
@@ -76,11 +76,11 @@ public class CopyValueProcessorConfig {
     private List<Entry> entries;
 
     @JsonProperty("from_list")
-    @JsonPropertyDescription("The source list to copy values from.")
+    @JsonPropertyDescription("The key of the source list to copy values from.")
     private String fromList;
 
     @JsonProperty("to_list")
-    @JsonPropertyDescription("The target list to copy values to.")
+    @JsonPropertyDescription("The key of the target list to copy values to.")
     private String toList;
 
     @JsonProperty("overwrite_if_to_list_exists")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -101,7 +101,7 @@ public class ListToMapProcessorConfig {
 
     @JsonProperty("list_to_map_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be " +
             "run on the event. By default, all events will be processed unless otherwise stated.")
     private String listToMapWhen;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -65,7 +65,7 @@ public class MapToListProcessorConfig {
 
     @JsonProperty("map_to_list_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will " +
+            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will " +
             "be run on the event. By default, all events will be processed unless otherwise stated.")
     private String mapToListWhen;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -43,7 +43,7 @@ public class RenameKeyProcessorConfig {
 
         @JsonProperty("rename_when")
         @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+                "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be " +
                 "run on the event. By default, all events will be processed unless otherwise stated.")
         private String renameWhen;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
@@ -25,7 +25,7 @@ public class SelectEntriesProcessorConfig {
 
     @JsonProperty("select_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-            "such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be " +
+            "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be " +
             "run on the event. Default is <code>null</code>. All events will be processed unless otherwise stated.")
     private String selectWhen;
 

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -56,7 +56,7 @@ public class ObfuscationProcessorConfig {
     private List<String> tagsOnMatchFailure;
 
     @JsonProperty("obfuscate_when")
-    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>'/is_testing_data == true'</code>. " +
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/is_testing_data == true</code>. " +
             "If specified, the <code>obfuscate</code> processor will only run on events when the expression evaluates to true. ")
     private String obfuscateWhen;
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/ion/ParseIonProcessorConfig.java
@@ -54,7 +54,7 @@ public class ParseIonProcessorConfig implements CommonParseConfig {
     private List<String> tagsOnFailure;
 
     @JsonProperty("parse_when")
-    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")
+    @JsonPropertyDescription("A Data Prepper [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be run on the event.")
     private String parseWhen;
 
     @JsonProperty(value = "handle_failed_events", defaultValue = "skip")


### PR DESCRIPTION
### Description
- Remove single quotes from field descriptions
- Change descriptions for `from_list` and `to_list` fields in `copy_value` processor. Context is [here](https://github.com/oeyh/documentation-website/blob/data_prepper_copy_lists/_data-prepper/pipelines/configuration/processors/copy-values.md).
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
