### PR TITLE
ENH: backfill @AlsoRequired annotation to processor attributes

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/AlsoRequired.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/AlsoRequired.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation used in schema generation to define the names and corresponding values of other required
- * configurations if the configuration represented by the annotated field/method is present.
+ * configurations if the configuration represented by the annotated field/method takes non-null or true value.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.processor.aggregate;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.model.annotations.UsesDataPrepperPlugin;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -23,6 +24,7 @@ import java.util.List;
         "Then, the processor performs an action on each group, helping reduce unnecessary log volume and " +
         "creating aggregated logs over time.")
 public class AggregateProcessorConfig {
+    static final String AGGREGATED_EVENTS_TAG_KEY = "aggregated_events_tag";
     static final int DEFAULT_GROUP_DURATION_SECONDS = 180;
 
     @JsonPropertyDescription("An unordered list by which to group events. Events with the same values as these keys are put into the same group. " +
@@ -49,10 +51,13 @@ public class AggregateProcessorConfig {
 
     @JsonPropertyDescription("A boolean indicating if the unaggregated events should be forwarded to the next processor or sink in the chain.")
     @JsonProperty("output_unaggregated_events")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = AGGREGATED_EVENTS_TAG_KEY)
+    })
     private Boolean outputUnaggregatedEvents = false;
 
     @JsonPropertyDescription("Tag to be used for aggregated events to distinguish aggregated events from unaggregated events.")
-    @JsonProperty("aggregated_events_tag")
+    @JsonProperty(AGGREGATED_EVENTS_TAG_KEY)
     private String aggregatedEventsTag;
 
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as '/some-key == \"test\"', that will be evaluated to determine whether the processor will be run on the event.")

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.time.ZoneId;
 import java.util.List;
@@ -22,6 +23,8 @@ import java.time.format.DateTimeFormatter;
         "and converts timestamp information to the International Organization for Standardization (ISO) 8601 format. " +
         "This timestamp information can be used as an event timestamp.")
 public class DateProcessorConfig {
+    static final String MATCH_KEY = "match";
+    static final String FROM_TIME_RECEIVED_KEY = "from_time_received";
     static final Boolean DEFAULT_FROM_TIME_RECEIVED = false;
     static final Boolean DEFAULT_TO_ORIGINATION_METADATA = false;
     static final String DEFAULT_DESTINATION = "@timestamp";
@@ -104,6 +107,9 @@ public class DateProcessorConfig {
     @JsonPropertyDescription("When <code>true</code>, the timestamp from the event metadata, " +
             "which is the time at which the source receives the event, is added to the event data. " +
             "This option cannot be defined at the same time as <code>match</code>. Default is <code>false</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = MATCH_KEY, allowedValues = {"null"})
+    })
     private Boolean fromTimeReceived = DEFAULT_FROM_TIME_RECEIVED;
 
     @JsonProperty("match")
@@ -111,6 +117,9 @@ public class DateProcessorConfig {
             "This option cannot be defined at the same time as <code>from_time_received</code>. " +
             "The date processor will use the first pattern that matches each event's timestamp field. " +
             "You must provide at least one pattern unless you have <code>from_time_received</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = FROM_TIME_RECEIVED_KEY, allowedValues = {"null", "false"})
+    })
     private List<DateMatch> match;
 
     @JsonProperty("destination")

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.List;
 @JsonPropertyOrder
 @JsonClassDescription("The <code>flatten</code> processor transforms nested objects inside of events into flattened structures.")
 public class FlattenProcessorConfig {
+    static final String REMOVE_LIST_INDICES_KEY = "remove_list_indices";
 
     private static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
 
@@ -39,7 +41,7 @@ public class FlattenProcessorConfig {
             "The default is <code>false</code> which leaves the source fields.")
     private boolean removeProcessedFields = false;
 
-    @JsonProperty("remove_list_indices")
+    @JsonProperty(REMOVE_LIST_INDICES_KEY)
     @JsonPropertyDescription("When <code>true</code>, the processor converts the fields from the source map into lists and " +
             "puts the lists into the target field. Default is <code>false</code>.")
     private boolean removeListIndices = false;
@@ -47,6 +49,9 @@ public class FlattenProcessorConfig {
     @JsonProperty("remove_brackets")
     @JsonPropertyDescription("When <code>true</code>, the processor also removes brackets around the indices. Can only be " +
             "set to <code>true</code> when <code>remove_list_indices</code> is <code>true</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = REMOVE_LIST_INDICES_KEY, allowedValues = {"true"})
+    })
     private boolean removeBrackets = false;
 
     @JsonProperty("exclude_keys")

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -27,6 +27,9 @@ public class KeyValueProcessorConfig {
     static final String FIELD_SPLIT_CHARACTERS_KEY = "field_split_characters";
     static final String VALUE_SPLIT_CHARACTERS_KEY = "value_split_characters";
     static final String KEY_VALUE_DELIMITER_REGEX_KEY = "key_value_delimiter_regex";
+    static final String REMOVE_BRACKETS_KEY = "remove_brackets";
+    static final String SKIP_DUPLICATE_VALUES_KEY = "skip_duplicate_values";
+    static final String WHITESPACE_KEY = "whitespace";
     static final String DEFAULT_SOURCE = "message";
     static final String DEFAULT_DESTINATION = "parsed_message";
     public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
@@ -137,7 +140,7 @@ public class KeyValueProcessorConfig {
     @JsonPropertyDescription("Allows transforming the key's name such as making the name all lowercase.")
     private TransformOption transformKey = TransformOption.NONE;
 
-    @JsonProperty(value = "whitespace", defaultValue = "lenient")
+    @JsonProperty(value = WHITESPACE_KEY, defaultValue = "lenient")
     @JsonPropertyDescription("Specifies whether to be lenient or strict with the acceptance of " +
             "unnecessary white space surrounding the configured value-split sequence. " +
             "In this case, strict means that whitespace is trimmed and lenient means it is retained in the key name and in the value. " +
@@ -145,13 +148,13 @@ public class KeyValueProcessorConfig {
     @NotNull
     private WhitespaceOption whitespace = WhitespaceOption.LENIENT;
 
-    @JsonProperty(value = "skip_duplicate_values", defaultValue = "false")
+    @JsonProperty(value = SKIP_DUPLICATE_VALUES_KEY, defaultValue = "false")
     @JsonPropertyDescription("A Boolean option for removing duplicate key-value pairs. When set to <code>true</code>, " +
             "only one unique key-value pair will be preserved. Default is <code>false</code>.")
     @NotNull
     private boolean skipDuplicateValues = false;
 
-    @JsonProperty(value = "remove_brackets", defaultValue = "false")
+    @JsonProperty(value = REMOVE_BRACKETS_KEY, defaultValue = "false")
     @JsonPropertyDescription("Specifies whether to treat certain grouping characters as wrapping text that should be removed from values." +
             "When set to <code>true</code>, the following grouping characters will be removed: square brackets, angle brackets, and parentheses. " +
             "The default configuration is <code>false</code> which retains those grouping characters.")
@@ -179,6 +182,11 @@ public class KeyValueProcessorConfig {
             "<code>remove_brackets</code> cannot also be <code>true</code>;\n" +
             "<code>skip_duplicate_values</code> will always be <code>true</code>;\n" +
             "<code>whitespace</code> will always be <code>\"strict\"</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = REMOVE_BRACKETS_KEY, allowedValues = {"false"}),
+            @AlsoRequired.Required(name = SKIP_DUPLICATE_VALUES_KEY, allowedValues = {"true"}),
+            @AlsoRequired.Required(name = WHITESPACE_KEY, allowedValues = {"strict"})
+    })
     private boolean recursive = false;
     
     @JsonProperty(value = "overwrite_if_destination_exists", defaultValue = "true")

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,11 @@ import java.util.Map;
 @JsonPropertyOrder
 @JsonClassDescription("You can use the <code>key_value</code> processor to create structured data by parsing key-value pairs from strings.")
 public class KeyValueProcessorConfig {
+    static final String VALUE_GROUPING_KEY = "value_grouping";
+    static final String FIELD_DELIMITER_REGEX_KEY = "field_delimiter_regex";
+    static final String FIELD_SPLIT_CHARACTERS_KEY = "field_split_characters";
+    static final String VALUE_SPLIT_CHARACTERS_KEY = "value_split_characters";
+    static final String KEY_VALUE_DELIMITER_REGEX_KEY = "key_value_delimiter_regex";
     static final String DEFAULT_SOURCE = "message";
     static final String DEFAULT_DESTINATION = "parsed_message";
     public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
@@ -41,34 +47,47 @@ public class KeyValueProcessorConfig {
             "The default value is <code>parsed_message</code>.")
     private String destination = DEFAULT_DESTINATION;
 
-    @JsonProperty(value = "field_split_characters", defaultValue = DEFAULT_FIELD_SPLIT_CHARACTERS)
+    @JsonProperty(value = FIELD_SPLIT_CHARACTERS_KEY, defaultValue = DEFAULT_FIELD_SPLIT_CHARACTERS)
     @JsonPropertyDescription("A string of characters specifying the delimiter that separates key-value pairs. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "This field cannot be defined along with <code>field_delimiter_regex</code>. " +
             "The default value is <code>&amp;</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = FIELD_DELIMITER_REGEX_KEY, allowedValues = {"null"}),
+    })
     private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
-    @JsonProperty("field_delimiter_regex")
+    @JsonProperty(FIELD_DELIMITER_REGEX_KEY)
     @JsonPropertyDescription("A regular expression specifying the delimiter that separates key-value pairs. " +
             "For example, to split on multiple <code>&amp;</code> characters use <code>&amp;+</code>. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "This field cannot be defined along with <code>field_split_characters</code>. " +
             "If this option is not defined, the <code>key_value</code> processor will parse the source using <code>field_split_characters</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = VALUE_GROUPING_KEY, allowedValues = {"false"}),
+            @AlsoRequired.Required(name = FIELD_SPLIT_CHARACTERS_KEY, allowedValues = {"null"})
+    })
     private String fieldDelimiterRegex;
 
-    @JsonProperty(value = "value_split_characters", defaultValue = DEFAULT_VALUE_SPLIT_CHARACTERS)
+    @JsonProperty(value = VALUE_SPLIT_CHARACTERS_KEY, defaultValue = DEFAULT_VALUE_SPLIT_CHARACTERS)
     @JsonPropertyDescription("A string of characters specifying the delimiter that separates keys from their values within a key-value pair. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "This field cannot be defined along with <code>key_value_delimiter_regex</code>. " +
             "The default value is <code>=</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = KEY_VALUE_DELIMITER_REGEX_KEY, allowedValues = {"null"})
+    })
     private String valueSplitCharacters = DEFAULT_VALUE_SPLIT_CHARACTERS;
 
-    @JsonProperty("key_value_delimiter_regex")
+    @JsonProperty(KEY_VALUE_DELIMITER_REGEX_KEY)
     @JsonPropertyDescription("A regular expression specifying the delimiter that separates keys from their values within a key-value pair. " +
             "For example, to split on multiple <code>=</code> characters use <code>=+</code>. " +
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "This field cannot be defined along with <code>value_split_characters</code>. " +
             "If this option is not defined, the <code>key_value</code> processor will parse the source using <code>value_split_characters</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = VALUE_SPLIT_CHARACTERS_KEY, allowedValues = {"null"})
+    })
     private String keyValueDelimiterRegex;
 
     @JsonProperty(value = "default_values", defaultValue = "{}")
@@ -138,13 +157,16 @@ public class KeyValueProcessorConfig {
             "The default configuration is <code>false</code> which retains those grouping characters.")
     private boolean removeBrackets;
 
-    @JsonProperty(value = "value_grouping", defaultValue = "false")
+    @JsonProperty(value = VALUE_GROUPING_KEY, defaultValue = "false")
     @JsonPropertyDescription("Specifies whether to group values using predefined grouping delimiters. " +
             "If this flag is enabled, then the content between the delimiters is considered to be one entity and " +
             "they are not parsed as key-value pairs. The following characters are used a group delimiters: " +
             "<code>{...}</code>, <code>[...]</code>, <code>&lt;...&gt;</code>, <code>(...)</code>, <code>\"...\"</code>, <code>'...'</code>, <code>http://... (space)</code>, and <code>https:// (space)</code>. " +
             "Default is <code>false</code>. For example, if <code>value_grouping</code> is <code>true</code>, then " +
             "<code>{\"key1=[a=b,c=d]&amp;key2=value2\"}</code> parses to <code>{\"key1\": \"[a=b,c=d]\", \"key2\": \"value2\"}</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = FIELD_DELIMITER_REGEX_KEY, allowedValues = {"null"})
+    })
     private boolean valueGrouping = false;
 
     @JsonProperty(value = "recursive", defaultValue = "false")
@@ -183,6 +205,9 @@ public class KeyValueProcessorConfig {
             "Can be set to either a single quotation mark (<code>'</code>) or a double quotation mark (<code>\"</code>). " +
             "Default is <code>null</code>.")
     @Size(min = 0, max = 1, message = "string_literal_character may only have character")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = VALUE_GROUPING_KEY, allowedValues = {"true"})
+    })
     private String stringLiteralCharacter = null;
 
     @JsonProperty("tags_on_failure")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -20,43 +21,72 @@ import java.util.stream.Stream;
 @JsonPropertyOrder
 @JsonClassDescription("The <code>add_entries</code> processor adds entries to an event.")
 public class AddEntryProcessorConfig {
+    static final String VALUE_EXPRESSION_KEY = "value_expression";
+    static final String METADATA_KEY_KEY = "metadata_key";
+    static final String APPEND_IF_KEY_EXISTS_KEY = "append_if_key_exists";
+    static final String OVERWRITE_IF_KEY_EXISTS_KEY = "overwrite_if_key_exists";
+
     @JsonPropertyOrder
     public static class Entry {
         @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include <code>my_key</code>, " +
                 "<code>myKey</code>, and <code>object/sub_Key</code>. The key can also be a format expression, for example, <code>${/key1}</code> to " +
                 "use the value of field <code>key1</code> as the key.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name=METADATA_KEY_KEY, allowedValues = {"null"})
+        })
         private String key;
 
-        @JsonProperty("metadata_key")
+        @JsonProperty(METADATA_KEY_KEY)
         @JsonPropertyDescription("The key for the new metadata attribute. The argument must be a literal string key " +
                 "and not a JSON Pointer. Either one of <code>key</code> or <code>metadata_key</code> is required.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name="key", allowedValues = {"null"})
+        })
         private String metadataKey;
 
         @JsonPropertyDescription("The value of the new entry to be added, which can be used with any of the " +
                 "following data types: strings, Booleans, numbers, null, nested objects, and arrays.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name="format", allowedValues = {"null"}),
+                @AlsoRequired.Required(name=VALUE_EXPRESSION_KEY, allowedValues = {"null"})
+        })
         private Object value;
 
         @JsonPropertyDescription("A format string to use as the value of the new entry, for example, " +
                 "<code>${key1}-${key2}</code>, where <code>key1</code> and <code>key2</code> are existing keys in the event. Required if neither" +
                 "<code>value</code> nor <code>value_expression</code> is specified.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name="value", allowedValues = {"null"}),
+                @AlsoRequired.Required(name=VALUE_EXPRESSION_KEY, allowedValues = {"null"})
+        })
         private String format;
 
-        @JsonProperty("value_expression")
+        @JsonProperty(VALUE_EXPRESSION_KEY)
         @JsonPropertyDescription("An expression string to use as the value of the new entry. For example, <code>/key</code> " +
                 "is an existing key in the event with a type of either a number, a string, or a Boolean. " +
                 "Expressions can also contain functions returning number/string/integer. For example, " +
                 "<code>length(/key)</code> will return the length of the key in the event when the key is a string. For more " +
                 "information about keys, see <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Expression syntax</a>.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name="value", allowedValues = {"null"}),
+                @AlsoRequired.Required(name="format", allowedValues = {"null"})
+        })
         private String valueExpression;
 
-        @JsonProperty("overwrite_if_key_exists")
+        @JsonProperty(OVERWRITE_IF_KEY_EXISTS_KEY)
         @JsonPropertyDescription("When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists " +
                 "in the event. The default value is <code>false</code>.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name=APPEND_IF_KEY_EXISTS_KEY, allowedValues = {"false"})
+        })
         private boolean overwriteIfKeyExists = false;
 
-        @JsonProperty("append_if_key_exists")
+        @JsonProperty(APPEND_IF_KEY_EXISTS_KEY)
         @JsonPropertyDescription("When set to <code>true</code>, the existing value will be appended if a <code>key</code> already " +
                 "exists in the event. An array will be created if the existing value is not an array. Default is <code>false</code>.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name=OVERWRITE_IF_KEY_EXISTS_KEY, allowedValues = {"false"})
+        })
         private boolean appendIfKeyExists = false;
 
         @JsonProperty("add_when")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.typeconverter.ConverterArguments;
 
 import java.util.List;
@@ -18,12 +19,21 @@ import java.util.Optional;
 @JsonClassDescription("The <code>convert_type</code> processor converts a value associated with the specified key in " +
         "a event to the specified type. It is a casting processor that changes the types of specified fields in events.")
 public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
-    @JsonProperty("key")
+    static final String KEY_KEY = "key";
+    static final String KEYS_KEY = "keys";
+
+    @JsonProperty(KEY_KEY)
     @JsonPropertyDescription("Key whose value needs to be converted to a different type.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = KEYS_KEY, allowedValues = {"null"})
+    })
     private String key;
 
-    @JsonProperty("keys")
+    @JsonProperty(KEYS_KEY)
     @JsonPropertyDescription("List of keys whose values needs to be converted to a different type.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = KEY_KEY, allowedValues = {"null"})
+    })
     private List<String> keys;
 
     @JsonProperty(value = "type", defaultValue = "integer")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -13,12 +13,16 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.List;
 
 @JsonPropertyOrder
 @JsonClassDescription("The <code>copy_values</code> processor copies values within an event to other fields within the event.")
 public class CopyValueProcessorConfig {
+    static final String FROM_LIST_KEY = "from_list";
+    static final String TO_LIST_KEY = "to_list";
+
     @JsonPropertyOrder
     public static class Entry {
         @NotEmpty
@@ -75,12 +79,18 @@ public class CopyValueProcessorConfig {
     @JsonPropertyDescription("A list of entries to be copied in an event.")
     private List<Entry> entries;
 
-    @JsonProperty("from_list")
+    @JsonProperty(FROM_LIST_KEY)
     @JsonPropertyDescription("The source list to copy values from.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = TO_LIST_KEY)
+    })
     private String fromList;
 
-    @JsonProperty("to_list")
+    @JsonProperty(TO_LIST_KEY)
     @JsonPropertyDescription("The target list to copy values to.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = FROM_LIST_KEY)
+    })
     private String toList;
 
     @JsonProperty("overwrite_if_to_list_exists")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,8 +23,6 @@ import java.util.stream.Collectors;
 @JsonClassDescription("The <code>list_to_map</code> processor converts a list of objects from an event, " +
         "where each object contains a <code>key</code> field, into a map of target keys.")
 public class ListToMapProcessorConfig {
-    static final String KEY_KEY = "key";
-
     public enum FlattenedElement {
         FIRST("first"),
         LAST("last");
@@ -67,12 +64,9 @@ public class ListToMapProcessorConfig {
     @JsonProperty("use_source_key")
     @JsonPropertyDescription("When <code>true</code>, keys in the generated map will use original keys from the source. " +
             "Default is <code>false</code>.")
-    @AlsoRequired(values = {
-            @AlsoRequired.Required(name = KEY_KEY)
-    })
     private boolean useSourceKey = false;
 
-    @JsonProperty(KEY_KEY)
+    @JsonProperty("key")
     @JsonPropertyDescription("The key of the fields to be extracted as keys in the generated mappings. Must be " +
             "specified if <code>use_source_key</code> is <code>false</code>.")
     private String key;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,6 +24,8 @@ import java.util.stream.Collectors;
 @JsonClassDescription("The <code>list_to_map</code> processor converts a list of objects from an event, " +
         "where each object contains a <code>key</code> field, into a map of target keys.")
 public class ListToMapProcessorConfig {
+    static final String KEY_KEY = "key";
+
     public enum FlattenedElement {
         FIRST("first"),
         LAST("last");
@@ -64,9 +67,12 @@ public class ListToMapProcessorConfig {
     @JsonProperty("use_source_key")
     @JsonPropertyDescription("When <code>true</code>, keys in the generated map will use original keys from the source. " +
             "Default is <code>false</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = KEY_KEY)
+    })
     private boolean useSourceKey = false;
 
-    @JsonProperty("key")
+    @JsonProperty(KEY_KEY)
     @JsonPropertyDescription("The key of the fields to be extracted as keys in the generated mappings. Must be " +
             "specified if <code>use_source_key</code> is <code>false</code>.")
     private String key;

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.model.event.EventKey;
 
 import java.util.List;
@@ -23,6 +24,8 @@ import java.util.List;
 public class SplitStringProcessorConfig implements StringProcessorConfig<SplitStringProcessorConfig.Entry> {
     @JsonPropertyOrder
     public static class Entry {
+        static final String DELIMITER_REGEX_KEY = "delimiter_regex";
+
         @NotEmpty
         @NotNull
         @JsonPropertyDescription("The key name of the field to split.")
@@ -32,11 +35,17 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         @JsonPropertyDescription("The separator character responsible for the split. " +
                 "Cannot be defined at the same time as <code>delimiter_regex</code>. " +
                 "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name=DELIMITER_REGEX_KEY, allowedValues = {"null", "\"\""})
+        })
         private String delimiter;
 
         @JsonProperty("delimiter_regex")
         @JsonPropertyDescription("The regex string responsible for the split. Cannot be defined at the same time as <code>delimiter</code>. " +
                 "At least <code>delimiter</code> or <code>delimiter_regex</code> must be defined.")
+        @AlsoRequired(values = {
+                @AlsoRequired.Required(name="delimiter", allowedValues = {"null", "\"\""})
+        })
         private String delimiterRegex;
 
         @JsonProperty("split_when")

--- a/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
+++ b/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
@@ -17,11 +17,14 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 @JsonPropertyOrder
 @JsonClassDescription("The <code>split_event</code> processor is used to split events based on a delimiter and " +
         "generates multiple events from a user-specified field.")
 public class SplitEventProcessorConfig {
+    static final String DELIMITER_REGEX_KEY = "delimiter_regex";
+
     @NotEmpty
     @NotNull
     @JsonProperty("field")
@@ -30,10 +33,16 @@ public class SplitEventProcessorConfig {
 
     @Size(min = 1, max = 1)
     @JsonPropertyDescription("The delimiter character used for splitting the field. You must provide either the <code>delimiter</code> or the <code>delimiter_regex</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name=DELIMITER_REGEX_KEY, allowedValues = {"null", "\"\""})
+    })
     private String delimiter;
 
-    @JsonProperty("delimiter_regex")
+    @JsonProperty(DELIMITER_REGEX_KEY)
     @JsonPropertyDescription("The regular expression used as the delimiter for splitting the field. You must provide either the <code>delimiter</code> or the <code>delimiter_regex</code>.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name="delimiter", allowedValues = {"null", "\"\""})
+    })
     private String delimiterRegex;
 
     public String getField() {

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TargetsParameterConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TargetsParameterConfig.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.Range;
+import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 import org.opensearch.dataprepper.typeconverter.TypeConverter;
 
@@ -18,6 +19,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public class TargetsParameterConfig {
+    static final String MAP_KEY = "map";
+    static final String REGEX_KEY = "regex";
     private final TypeConverter converter;
     private final LinkedHashMap<Range<Float>, Object> rangeMappings = new LinkedHashMap<>();
     private final Map<String, Object> individualMappings = new HashMap<>();
@@ -27,18 +30,24 @@ public class TargetsParameterConfig {
     @NotNull
     @NotEmpty
     private String target;
-    @JsonProperty("map")
+    @JsonProperty(MAP_KEY)
     @JsonPropertyDescription("A list of key-value pairs that define the translations. Each key represents a possible " +
             "value in the source field, and the corresponding value represents what it should be translated to. " +
             "At least one of <code>map</code> and <code>regex</code> should be configured.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = REGEX_KEY)
+    })
     private Map<String, Object> map;
     @JsonProperty("translate_when")
     @JsonPropertyDescription("Uses a <a href=\"{{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/\">conditional expression</a> " +
             "to specify a condition for performing the translation. When specified, the expression will only translate when the condition is met.")
     private String translateWhen;
-    @JsonProperty("regex")
+    @JsonProperty(REGEX_KEY)
     @JsonPropertyDescription("A map of keys that defines the translation map. " +
             "At least one of <code>map</code> and <code>regex</code> should be configured.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = MAP_KEY)
+    })
     private RegexParameterConfiguration regexParameterConfig;
     @JsonProperty("default")
     @JsonPropertyDescription("The default value to use when no match is found during translation.")


### PR DESCRIPTION
### Description
This PR backfills @AlsoRequired annotation to processor attributes for schema generation purpose:

aggregate:
- [ ] aggregated_events_tag is required when output_unaggregated_events is non null.

flatten:
- [ ] remove_bracket can only be set to true if remove_list_indices is true

key_value:
- [ ] field_split_characters and field_delimiter_regex are mutually exclusive
- [ ] field_delimiter_regex are mutually exclusive with field_split_characters and value_grouping
- [ ] value_split_characters and key_value_delimiter_regex are mutually exclusive
- [ ] string_literal_character depends on value_grouping enabled

add_entry:
- [ ] string_literal_character depends on value_grouping enabled
- [ ] key and metadata_key are mutually exclusive
- [ ] format, value and value_expression are mutually exclusive
- [ ] overwrite_if_key_exists and append_if_key_exists are mutually exclusive

convert_entry:
- [ ] key and keys are mutually exclusive

copy_value
- [ ] from_list and to_list are mutually dependent

split string:
- [ ] delimiter_regex and delimiter are mutually exclusive

split event:
- [ ] delimiter_regex and delimiter are mutually exclusive

Example schema after this change:

```
{
  "$schema" : "https://json-schema.org/draft/2020-12/schema",
  "type" : "object",
  "properties" : {
    "entries" : {
      "description" : "A list of entries to add to the event.",
      "minItems" : 1,
      "type" : "array",
      "items" : {
        "type" : "object",
        "properties" : {
          "key" : {
            "type" : "string",
            "description" : "The key of the new entry to be added. Some examples of keys include <code>my_key</code>, <code>myKey</code>, and <code>object/sub_Key</code>. The key can also be a format expression, for example, <code>${/key1}</code> to use the value of field <code>key1</code> as the key."
          },
          "metadata_key" : {
            "type" : "string",
            "description" : "The key for the new metadata attribute. The argument must be a literal string key and not a JSON Pointer. Either one of <code>key</code> or <code>metadata_key</code> is required."
          },
          "value" : {
            "description" : "The value of the new entry to be added, which can be used with any of the following data types: strings, Booleans, numbers, null, nested objects, and arrays."
          },
          "format" : {
            "type" : "string",
            "description" : "A format string to use as the value of the new entry, for example, <code>${key1}-${key2}</code>, where <code>key1</code> and <code>key2</code> are existing keys in the event. Required if neither<code>value</code> nor <code>value_expression</code> is specified."
          },
          "value_expression" : {
            "type" : "string",
            "description" : "An expression string to use as the value of the new entry. For example, <code>/key</code> is an existing key in the event with a type of either a number, a string, or a Boolean. Expressions can also contain functions returning number/string/integer. For example, <code>length(/key)</code> will return the length of the key in the event when the key is a string. For more information about keys, see <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Expression syntax</a>."
          },
          "overwrite_if_key_exists" : {
            "type" : "boolean",
            "description" : "When set to <code>true</code>, the existing value is overwritten if <code>key</code> already exists in the event. The default value is <code>false</code>."
          },
          "append_if_key_exists" : {
            "type" : "boolean",
            "description" : "When set to <code>true</code>, the existing value will be appended if a <code>key</code> already exists in the event. An array will be created if the existing value is not an array. Default is <code>false</code>."
          },
          "add_when" : {
            "type" : "string",
            "description" : "A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, such as <code>/some-key == \"test\"'</code>, that will be evaluated to determine whether the processor will be run on the event."
          }
        },
        "dependentRequired" : {
          "key" : [ "metadata_key:[null]" ],
          "metadata_key" : [ "key:[null]" ],
          "value" : [ "format:[null]", "value_expression:[null]" ],
          "format" : [ "value:[null]", "value_expression:[null]" ],
          "value_expression" : [ "value:[null]", "format:[null]" ],
          "overwrite_if_key_exists" : [ "append_if_key_exists:[false]" ],
          "append_if_key_exists" : [ "overwrite_if_key_exists:[false]" ]
        }
      }
    }
  },
  "required" : [ "entries" ],
  "description" : "The <code>add_entries</code> processor adds entries to an event.",
  "name" : "add_entries",
  "documentation" : "https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/add_entries/"
}
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
