### PR TITLE
Changelog 2.10.1

### DIFF
--- a/release/release-notes/data-prepper.change-log-2.10.1.md
+++ b/release/release-notes/data-prepper.change-log-2.10.1.md
@@ -1,0 +1,13 @@
+
+* __Fix AWS Sdk dependency conflict (#5082) (#5085)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Thu, 17 Oct 2024 17:02:22 -0700
+    
+    EAD -&gt; refs/heads/2.10, refs/remotes/upstream/2.10
+    Signed-off-by: Souvik Bose &lt;souvbose@amazon.com&gt;
+    Co-authored-by: Souvik Bose
+    &lt;souvbose@amazon.com&gt;
+    (cherry picked from commit 2575db341812c50ce00a187734b3033999a0e126)
+     Co-authored-by: Souvik Bose &lt;souvik04in@gmail.com&gt;
+
+

--- a/release/release-notes/data-prepper.change-log-2.10.1.md
+++ b/release/release-notes/data-prepper.change-log-2.10.1.md
@@ -1,4 +1,20 @@
 
+* __Generated THIRD-PARTY file for 42737ed (#5093)__
+
+  [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Mon, 21 Oct 2024 10:37:08 -0700
+
+  EAD -&gt; refs/heads/2.10, refs/remotes/upstream/2.10
+  Signed-off-by: GitHub &lt;noreply@github.com&gt;
+  Co-authored-by: dlvenable
+  &lt;dlvenable@users.noreply.github.com&gt;
+
+* __Updates the version to 2.10.1. (#5091)__
+
+  [David Venable](mailto:dlv@amazon.com) - Mon, 21 Oct 2024 10:25:23 -0700
+
+
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt;
+
 * __Fix AWS Sdk dependency conflict (#5082) (#5085)__
 
     [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Thu, 17 Oct 2024 17:02:22 -0700


### PR DESCRIPTION
### Description
This PR Is to add change log for 2.10.1 patch release.

```
git fetch upstream
git switch 2.10
git fetch upstream --tags
git pull
git-release-notes 2.10.0..HEAD markdown > release/release-notes/data-prepper.change-log-2.10.1.md
git switch main
```
 
### Check List
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
