### PR TITLE
Fix the lease coordination table permissions

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
@@ -16,20 +16,20 @@ import java.util.Map;
  */
 public class AwsCredentialsOptions {
     private static final AwsCredentialsOptions DEFAULT_OPTIONS = new AwsCredentialsOptions();
-    private static final AwsCredentialsOptions DEFAULT_OPTIONS_WITH_DEFAULT_CREDS =
-            AwsCredentialsOptions.builder().withUseDefaultCredentials(true).build();
+    private static final AwsCredentialsOptions DEFAULT_OPTIONS_WITH_DEFAULT_CREDS_PROVIDER =
+            AwsCredentialsOptions.builder().withUseDefaultCredentialsProvider(true).build();
     private final String stsRoleArn;
     private final String stsExternalId;
     private final Region region;
     private final Map<String, String> stsHeaderOverrides;
-    private final boolean useDefaultCredentials;
+    private final boolean useDefaultCredentialsProvider;
 
     private AwsCredentialsOptions(final Builder builder) {
         this.stsRoleArn = builder.stsRoleArn;
         this.stsExternalId = builder.stsExternalId;
         this.region = builder.region;
         this.stsHeaderOverrides = builder.stsHeaderOverrides != null ? new HashMap<>(builder.stsHeaderOverrides) : Collections.emptyMap();
-        this.useDefaultCredentials = builder.useDefaultCredentials;
+        this.useDefaultCredentialsProvider = builder.useDefaultCredentialsProvider;
     }
 
     private AwsCredentialsOptions() {
@@ -37,7 +37,7 @@ public class AwsCredentialsOptions {
         this.stsExternalId = null;
         this.region = null;
         this.stsHeaderOverrides = Collections.emptyMap();
-        this.useDefaultCredentials = false;
+        this.useDefaultCredentialsProvider = false;
     }
 
     /**
@@ -54,8 +54,8 @@ public class AwsCredentialsOptions {
         return DEFAULT_OPTIONS;
     }
 
-    public static AwsCredentialsOptions defaultOptionsWithDefaultCreds() {
-        return DEFAULT_OPTIONS_WITH_DEFAULT_CREDS;
+    public static AwsCredentialsOptions defaultOptionsWithDefaultCredentialsProvider() {
+        return DEFAULT_OPTIONS_WITH_DEFAULT_CREDS_PROVIDER;
     }
 
     public String getStsRoleArn() {
@@ -74,8 +74,8 @@ public class AwsCredentialsOptions {
         return stsHeaderOverrides;
     }
 
-    public boolean isUseDefaultCredentials() {
-        return useDefaultCredentials;
+    public boolean isUseDefaultCredentialsProvider() {
+        return useDefaultCredentialsProvider;
     }
 
     /**
@@ -86,7 +86,7 @@ public class AwsCredentialsOptions {
         private String stsExternalId;
         private Region region;
         private Map<String, String> stsHeaderOverrides = Collections.emptyMap();
-        private boolean useDefaultCredentials = false;
+        private boolean useDefaultCredentialsProvider = false;
 
         /**
          * Sets the STS role ARN to use.
@@ -139,11 +139,11 @@ public class AwsCredentialsOptions {
         /**
          * Configures whether to use default credentials.
          *
-         * @param useDefaultCredentials
+         * @param useDefaultCredentialsProvider
          * @return The {@link Builder} for continuing to build
          */
-        public Builder withUseDefaultCredentials(final boolean useDefaultCredentials) {
-            this.useDefaultCredentials = useDefaultCredentials;
+        public Builder withUseDefaultCredentialsProvider(final boolean useDefaultCredentialsProvider) {
+            this.useDefaultCredentialsProvider = useDefaultCredentialsProvider;
             return this;
         }
 

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
@@ -16,16 +16,20 @@ import java.util.Map;
  */
 public class AwsCredentialsOptions {
     private static final AwsCredentialsOptions DEFAULT_OPTIONS = new AwsCredentialsOptions();
+    private static final AwsCredentialsOptions DEFAULT_OPTIONS_WITH_DEFAULT_CREDS =
+            AwsCredentialsOptions.builder().withUseDefaultCredentials(true).build();
     private final String stsRoleArn;
     private final String stsExternalId;
     private final Region region;
     private final Map<String, String> stsHeaderOverrides;
+    private final boolean useDefaultCredentials;
 
     private AwsCredentialsOptions(final Builder builder) {
         this.stsRoleArn = builder.stsRoleArn;
         this.stsExternalId = builder.stsExternalId;
         this.region = builder.region;
         this.stsHeaderOverrides = builder.stsHeaderOverrides != null ? new HashMap<>(builder.stsHeaderOverrides) : Collections.emptyMap();
+        this.useDefaultCredentials = builder.useDefaultCredentials;
     }
 
     private AwsCredentialsOptions() {
@@ -33,6 +37,7 @@ public class AwsCredentialsOptions {
         this.stsExternalId = null;
         this.region = null;
         this.stsHeaderOverrides = Collections.emptyMap();
+        this.useDefaultCredentials = false;
     }
 
     /**
@@ -47,6 +52,10 @@ public class AwsCredentialsOptions {
 
     public static AwsCredentialsOptions defaultOptions() {
         return DEFAULT_OPTIONS;
+    }
+
+    public static AwsCredentialsOptions defaultOptionsWithDefaultCreds() {
+        return DEFAULT_OPTIONS_WITH_DEFAULT_CREDS;
     }
 
     public String getStsRoleArn() {
@@ -65,6 +74,10 @@ public class AwsCredentialsOptions {
         return stsHeaderOverrides;
     }
 
+    public boolean isUseDefaultCredentials() {
+        return useDefaultCredentials;
+    }
+
     /**
      * Builder class for {@link AwsCredentialsOptions}.
      */
@@ -73,6 +86,7 @@ public class AwsCredentialsOptions {
         private String stsExternalId;
         private Region region;
         private Map<String, String> stsHeaderOverrides = Collections.emptyMap();
+        private boolean useDefaultCredentials = false;
 
         /**
          * Sets the STS role ARN to use.
@@ -119,6 +133,17 @@ public class AwsCredentialsOptions {
          */
         public Builder withStsHeaderOverrides(final Map<String, String> stsHeaderOverrides) {
             this.stsHeaderOverrides = stsHeaderOverrides;
+            return this;
+        }
+
+        /**
+         * Configures whether to use default credentials.
+         *
+         * @param useDefaultCredentials
+         * @return The {@link Builder} for continuing to build
+         */
+        public Builder withUseDefaultCredentials(final boolean useDefaultCredentials) {
+            this.useDefaultCredentials = useDefaultCredentials;
             return this;
         }
 

--- a/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
+++ b/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
@@ -155,16 +155,17 @@ class AwsCredentialsOptionsTest {
 
     @Test
     void with_DefaultRole() {
-        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.defaultOptionsWithDefaultCreds();
+        final AwsCredentialsOptions awsCredentialsOptionsWithDefaultCredentialsProvider
+                = AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider();
 
-        assertThat(awsCredentialsOptions, notNullValue());
-        assertThat(awsCredentialsOptions.getStsRoleArn(), nullValue());
-        assertTrue(awsCredentialsOptions.isUseDefaultCredentials());
+        assertThat(awsCredentialsOptionsWithDefaultCredentialsProvider, notNullValue());
+        assertThat(awsCredentialsOptionsWithDefaultCredentialsProvider.getStsRoleArn(), nullValue());
+        assertTrue(awsCredentialsOptionsWithDefaultCredentialsProvider.isUseDefaultCredentialsProvider());
     }
 
     @Test
     void defaultCredentialsOptions_returns_same_instance_on_multiple_calls() {
-        assertThat(AwsCredentialsOptions.defaultOptionsWithDefaultCreds(),
-                sameInstance(AwsCredentialsOptions.defaultOptionsWithDefaultCreds()));
+        assertThat(AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider(),
+                sameInstance(AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider()));
     }
 }

--- a/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
+++ b/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AwsCredentialsOptionsTest {
     @Test
@@ -149,5 +150,21 @@ class AwsCredentialsOptionsTest {
     void defaultOptions_returns_same_instance_on_multiple_calls() {
         assertThat(AwsCredentialsOptions.defaultOptions(),
                 sameInstance(AwsCredentialsOptions.defaultOptions()));
+    }
+
+
+    @Test
+    void with_DefaultRole() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.defaultOptionsWithDefaultCreds();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsRoleArn(), nullValue());
+        assertTrue(awsCredentialsOptions.isUseDefaultCredentials());
+    }
+
+    @Test
+    void defaultCredentialsOptions_returns_same_instance_on_multiple_calls() {
+        assertThat(AwsCredentialsOptions.defaultOptionsWithDefaultCreds(),
+                sameInstance(AwsCredentialsOptions.defaultOptionsWithDefaultCreds()));
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -50,7 +50,7 @@ class CredentialsProviderFactory {
     AwsCredentialsProvider providerFromOptions(final AwsCredentialsOptions credentialsOptions) {
         Objects.requireNonNull(credentialsOptions);
 
-        if (credentialsOptions.isUseDefaultCredentials()) {
+        if (credentialsOptions.isUseDefaultCredentialsProvider()) {
             return DefaultCredentialsProvider.create();
         }
 

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -50,6 +50,10 @@ class CredentialsProviderFactory {
     AwsCredentialsProvider providerFromOptions(final AwsCredentialsOptions credentialsOptions) {
         Objects.requireNonNull(credentialsOptions);
 
+        if (credentialsOptions.isUseDefaultCredentials()) {
+            return DefaultCredentialsProvider.create();
+        }
+
         if(credentialsOptions.getStsRoleArn() != null || defaultStsConfiguration.getAwsStsRoleArn() != null) {
             return createStsCredentials(credentialsOptions);
         }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
@@ -175,7 +175,7 @@ public class AwsPluginIT {
 
         final AwsCredentialsOptions awsCredentialsOptions1 = AwsCredentialsOptions.builder()
                 .withRegion(Region.US_EAST_1)
-                .withUseDefaultCredentials(true)
+                .withUseDefaultCredentialsProvider(true)
                 .build();
 
         final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
@@ -184,7 +184,7 @@ public class AwsPluginIT {
 
         final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
                 .withRegion(Region.US_EAST_1)
-                .withUseDefaultCredentials(true)
+                .withUseDefaultCredentialsProvider(true)
                 .build();
 
         final AwsCredentialsProvider awsCredentialsProvider2 = awsCredentialsSupplier.getProvider(awsCredentialsOptions2);

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
@@ -157,6 +157,42 @@ public class AwsPluginIT {
         assertThat(awsCredentialsProvider2, sameInstance(awsCredentialsProvider1));
     }
 
+    @Test
+    void test_AwsPlugin_without_STS_role_and_without_default_role_uses_default_role() {
+
+        createObjectUnderTest().apply(extensionPoints);
+
+        final ArgumentCaptor<ExtensionProvider<AwsCredentialsSupplier>> extensionProviderArgumentCaptor = ArgumentCaptor.forClass(ExtensionProvider.class);
+        verify(extensionPoints).addExtensionProvider(extensionProviderArgumentCaptor.capture());
+
+        final ExtensionProvider<AwsCredentialsSupplier> extensionProvider = extensionProviderArgumentCaptor.getValue();
+
+        final Optional<AwsCredentialsSupplier> optionalSupplier = extensionProvider.provideInstance(context);
+        assertThat(optionalSupplier, notNullValue());
+        assertThat(optionalSupplier.isPresent(), equalTo(true));
+
+        final AwsCredentialsSupplier awsCredentialsSupplier = optionalSupplier.get();
+
+        final AwsCredentialsOptions awsCredentialsOptions1 = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_EAST_1)
+                .withUseDefaultCredentials(true)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
+
+        assertThat(awsCredentialsProvider1, instanceOf(DefaultCredentialsProvider.class));
+
+        final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_EAST_1)
+                .withUseDefaultCredentials(true)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider2 = awsCredentialsSupplier.getProvider(awsCredentialsOptions2);
+
+        assertThat(awsCredentialsProvider2, instanceOf(DefaultCredentialsProvider.class));
+        assertThat(awsCredentialsProvider2, sameInstance(awsCredentialsProvider1));
+    }
+
     private String createStsRole() {
         return String.format("arn:aws:iam::123456789012:role/%s", UUID.randomUUID());
     }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisClientFactory.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisClientFactory.java
@@ -34,7 +34,7 @@ public class KinesisClientFactory {
                 .withStsHeaderOverrides(awsAuthenticationConfig.getAwsStsHeaderOverrides())
                 .build());
         defaultCredentialsProvider = awsCredentialsSupplier.getProvider(
-                AwsCredentialsOptions.defaultOptionsWithDefaultCreds());
+                AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider());
         this.awsAuthenticationConfig = awsAuthenticationConfig;
     }
 

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisClientFactory.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisClientFactory.java
@@ -33,7 +33,8 @@ public class KinesisClientFactory {
                 .withStsExternalId(awsAuthenticationConfig.getAwsStsExternalId())
                 .withStsHeaderOverrides(awsAuthenticationConfig.getAwsStsHeaderOverrides())
                 .build());
-        defaultCredentialsProvider = awsCredentialsSupplier.getProvider(AwsCredentialsOptions.defaultOptions());
+        defaultCredentialsProvider = awsCredentialsSupplier.getProvider(
+                AwsCredentialsOptions.defaultOptionsWithDefaultCreds());
         this.awsAuthenticationConfig = awsAuthenticationConfig;
     }
 


### PR DESCRIPTION
### Description
This PR is to fix the credentials required for Lease Coordination table access. The fix is to use the default credentials instead of the pipeline role when Data Prepper would access the dynamoDb table.
 
### Issues Resolved
Resolves #1082
 
### Check List
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
