### PR TITLE
Add jsonValue check on Enum deserializer, default to checking name() function of enum

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.integration;
 
+import org.junit.FixMethodOrder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.Event;
@@ -28,6 +29,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@FixMethodOrder()
 class PipelinesWithAcksIT {
     private static final Logger LOG = LoggerFactory.getLogger(PipelinesWithAcksIT.class);
     private static final String IN_MEMORY_IDENTIFIER = "PipelinesWithAcksIT";

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
@@ -151,7 +151,9 @@ public class PipelineTransformer {
             Buffer pipelineDefinedBuffer = null;
             final PluginSetting bufferPluginSetting = pipelineConfiguration.getBufferPluginSetting();
             try {
-                pipelineDefinedBuffer = pluginFactory.loadPlugin(Buffer.class, bufferPluginSetting, source.getDecoder());
+                if (source != null) {
+                    pipelineDefinedBuffer = pluginFactory.loadPlugin(Buffer.class, bufferPluginSetting, source.getDecoder());
+                }
             } catch (Exception e) {
                 final PluginError pluginError = PluginError.builder()
                         .componentType(PipelineModel.BUFFER_PLUGIN_TYPE)

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
@@ -222,16 +222,11 @@ class PipelineTransformerTests {
         final Map<String, Pipeline> connectedPipelines = pipelineTransformer.transformConfiguration();
         assertThat(connectedPipelines.size(), equalTo(0));
         verify(dataPrepperConfiguration).getPipelineExtensions();
-        assertThat(pluginErrorCollector.getPluginErrors().size(), equalTo(2));
+        assertThat(pluginErrorCollector.getPluginErrors().size(), equalTo(1));
         final PluginError sourcePluginError = pluginErrorCollector.getPluginErrors().get(0);
         assertThat(sourcePluginError.getPipelineName(), equalTo("test-pipeline-1"));
         assertThat(sourcePluginError.getPluginName(), equalTo("file"));
         assertThat(sourcePluginError.getException(), notNullValue());
-        // Buffer plugin gets error due to instantiated source is null
-        final PluginError bufferPluginError = pluginErrorCollector.getPluginErrors().get(1);
-        assertThat(bufferPluginError.getPipelineName(), equalTo("test-pipeline-1"));
-        assertThat(bufferPluginError.getPluginName(), equalTo("bounded_blocking"));
-        assertThat(bufferPluginError.getException(), notNullValue());
     }
 
     @ParameterizedTest

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializer.java
@@ -52,7 +52,9 @@ public class EnumDeserializer extends JsonDeserializer<Enum<?>> implements Conte
                 try {
                     if (jsonCreator.isPresent() && enumConstant.equals(jsonCreator.get().invoke(null, enumValue))) {
                         return (Enum<?>) enumConstant;
-                    } else if (jsonCreator.isEmpty() && enumConstant.toString().toLowerCase().equals(enumValue)) {
+                    } else if (jsonCreator.isEmpty() &&
+                            (enumConstant.toString().toLowerCase().equals(enumValue)
+                                    || enumConstant.toString().equals(enumValue))) {
                         return (Enum<?>) enumConstant;
                     }
                 } catch (IllegalAccessException | InvocationTargetException e) {

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializer.java
@@ -44,6 +44,7 @@ public class EnumDeserializer extends JsonDeserializer<Enum<?>> implements Conte
         final String enumValue = node.asText();
 
         final Optional<Method> jsonCreator = findJsonCreatorMethod();
+        final Optional<Method> jsonValueMethod = findJsonValueMethodForClass();
 
         try {
             jsonCreator.ifPresent(method -> method.setAccessible(true));
@@ -52,9 +53,11 @@ public class EnumDeserializer extends JsonDeserializer<Enum<?>> implements Conte
                 try {
                     if (jsonCreator.isPresent() && enumConstant.equals(jsonCreator.get().invoke(null, enumValue))) {
                         return (Enum<?>) enumConstant;
-                    } else if (jsonCreator.isEmpty() &&
-                            (enumConstant.toString().toLowerCase().equals(enumValue)
-                                    || enumConstant.toString().equals(enumValue))) {
+                    } else if (jsonCreator.isEmpty() && jsonValueMethod.isPresent()
+                            && jsonValueMethod.get().invoke(enumConstant).equals(enumValue)) {
+                        return (Enum<?>) enumConstant;
+                    } else if (jsonCreator.isEmpty() && jsonValueMethod.isEmpty() &&
+                            ((Enum<?>) enumConstant).name().equals(enumValue)) {
                         return (Enum<?>) enumConstant;
                     }
                 } catch (IllegalAccessException | InvocationTargetException e) {
@@ -65,9 +68,6 @@ public class EnumDeserializer extends JsonDeserializer<Enum<?>> implements Conte
             jsonCreator.ifPresent(method -> method.setAccessible(false));
         }
 
-
-
-        final Optional<Method> jsonValueMethod = findJsonValueMethodForClass();
         final List<Object> listOfEnums = jsonValueMethod.map(method -> Arrays.stream(enumClass.getEnumConstants())
                 .map(valueEnum -> {
                     try {
@@ -77,7 +77,7 @@ public class EnumDeserializer extends JsonDeserializer<Enum<?>> implements Conte
                     }
                 })
                 .collect(Collectors.toList())).orElseGet(() -> Arrays.stream(enumClass.getEnumConstants())
-                .map(valueEnum -> valueEnum.toString().toLowerCase())
+                .map(valueEnum -> ((Enum<?>) valueEnum).name())
                 .collect(Collectors.toList()));
 
         throw new IllegalArgumentException(String.format(INVALID_ENUM_VALUE_ERROR_FORMAT, enumValue, listOfEnums));

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializerTest.java
@@ -67,6 +67,21 @@ public class EnumDeserializerTest {
     }
 
     @ParameterizedTest
+    @EnumSource(TestEnumOnlyUppercase.class)
+    void enum_class_with_just_enum_values_returns_expected_enum_constant(final TestEnumOnlyUppercase testEnumOption) throws IOException {
+        final EnumDeserializer objectUnderTest = createObjectUnderTest(TestEnumOnlyUppercase.class);
+        final JsonParser jsonParser = mock(JsonParser.class);
+        final DeserializationContext deserializationContext = mock(DeserializationContext.class);
+        when(jsonParser.getCodec()).thenReturn(objectMapper);
+
+        when(objectMapper.readTree(jsonParser)).thenReturn(new TextNode(testEnumOption.toString()));
+
+        Enum<?> result = objectUnderTest.deserialize(jsonParser, deserializationContext);
+
+        assertThat(result, equalTo(testEnumOption));
+    }
+
+    @ParameterizedTest
     @EnumSource(TestEnumWithoutJsonCreator.class)
     void enum_class_without_json_creator_annotation_returns_expected_enum_constant(final TestEnumWithoutJsonCreator enumWithoutJsonCreator) throws IOException {
         final EnumDeserializer objectUnderTest = createObjectUnderTest(TestEnumWithoutJsonCreator.class);
@@ -170,5 +185,10 @@ public class EnumDeserializerTest {
         static TestEnumWithoutJsonCreator fromOptionValue(final String option) {
             return NAMES_MAP.get(option);
         }
+    }
+
+    private enum TestEnumOnlyUppercase {
+        VALUE_ONE,
+        VALUE_TWO;
     }
 }

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializerTest.java
@@ -67,6 +67,21 @@ public class EnumDeserializerTest {
     }
 
     @ParameterizedTest
+    @EnumSource(TestEnumWithJsonValue.class)
+    void enum_class_with_no_json_creator_and_a_json_value_annotation_returns_expected_enum_constant(final TestEnumWithJsonValue testEnumOption) throws IOException {
+        final EnumDeserializer objectUnderTest = createObjectUnderTest(TestEnumWithJsonValue.class);
+        final JsonParser jsonParser = mock(JsonParser.class);
+        final DeserializationContext deserializationContext = mock(DeserializationContext.class);
+        when(jsonParser.getCodec()).thenReturn(objectMapper);
+
+        when(objectMapper.readTree(jsonParser)).thenReturn(new TextNode(testEnumOption.toString()));
+
+        Enum<?> result = objectUnderTest.deserialize(jsonParser, deserializationContext);
+
+        assertThat(result, equalTo(testEnumOption));
+    }
+
+    @ParameterizedTest
     @EnumSource(TestEnumOnlyUppercase.class)
     void enum_class_with_just_enum_values_returns_expected_enum_constant(final TestEnumOnlyUppercase testEnumOption) throws IOException {
         final EnumDeserializer objectUnderTest = createObjectUnderTest(TestEnumOnlyUppercase.class);
@@ -83,13 +98,13 @@ public class EnumDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(TestEnumWithoutJsonCreator.class)
-    void enum_class_without_json_creator_annotation_returns_expected_enum_constant(final TestEnumWithoutJsonCreator enumWithoutJsonCreator) throws IOException {
+    void enum_class_without_json_creator_or_json_value_annotation_returns_expected_enum_constant(final TestEnumWithoutJsonCreator enumWithoutJsonCreator) throws IOException {
         final EnumDeserializer objectUnderTest = createObjectUnderTest(TestEnumWithoutJsonCreator.class);
         final JsonParser jsonParser = mock(JsonParser.class);
         final DeserializationContext deserializationContext = mock(DeserializationContext.class);
         when(jsonParser.getCodec()).thenReturn(objectMapper);
 
-        when(objectMapper.readTree(jsonParser)).thenReturn(new TextNode(enumWithoutJsonCreator.toString()));
+        when(objectMapper.readTree(jsonParser)).thenReturn(new TextNode(enumWithoutJsonCreator.name()));
 
         Enum<?> result = objectUnderTest.deserialize(jsonParser, deserializationContext);
 
@@ -131,7 +146,7 @@ public class EnumDeserializerTest {
         assertThat(exception, notNullValue());
         final String expectedErrorMessage = "Invalid value \"" + invalidValue + "\". Valid options include";
         assertThat(exception.getMessage(), Matchers.startsWith(expectedErrorMessage));
-
+        assertThat(exception.getMessage(), containsString("[TEST]"));
     }
 
     @Test
@@ -165,6 +180,27 @@ public class EnumDeserializerTest {
             return this.name;
         }
         @JsonCreator
+        static TestEnum fromOptionValue(final String option) {
+            return NAMES_MAP.get(option);
+        }
+    }
+
+    private enum TestEnumWithJsonValue {
+        TEST_ONE("test_json_value_one"),
+        TEST_TWO("test_json_value_two"),
+        TEST_THREE("test_json_value_three");
+        private static final Map<String, TestEnum> NAMES_MAP = Arrays.stream(TestEnum.values())
+                .collect(Collectors.toMap(TestEnum::toString, Function.identity()));
+        private final String name;
+        TestEnumWithJsonValue(final String name) {
+            this.name = name;
+        }
+
+        @JsonValue
+        public String toString() {
+            return this.name;
+        }
+
         static TestEnum fromOptionValue(final String option) {
             return NAMES_MAP.get(option);
         }

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/EnumDeserializerTest.java
@@ -89,7 +89,7 @@ public class EnumDeserializerTest {
         final DeserializationContext deserializationContext = mock(DeserializationContext.class);
         when(jsonParser.getCodec()).thenReturn(objectMapper);
 
-        when(objectMapper.readTree(jsonParser)).thenReturn(new TextNode(testEnumOption.toString()));
+        when(objectMapper.readTree(jsonParser)).thenReturn(new TextNode(testEnumOption.name()));
 
         Enum<?> result = objectUnderTest.deserialize(jsonParser, deserializationContext);
 
@@ -215,7 +215,7 @@ public class EnumDeserializerTest {
             this.name = name;
         }
         public String toString() {
-            return this.name;
+            return UUID.randomUUID().toString();
         }
 
         static TestEnumWithoutJsonCreator fromOptionValue(final String option) {

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
@@ -35,6 +35,7 @@ public class ObjectMapperConfiguration {
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
         simpleModule.addDeserializer(Enum.class, new EnumDeserializer());
+
         simpleModule.addDeserializer(ByteCount.class, new ByteCountDeserializer());
 
         return new ObjectMapper()


### PR DESCRIPTION
### Description
The new EnumDeserializer defaults to checking for the lower case enum value when there is no `@JsonCreator` on the enum class, and this broke basic enums like

```
enum MyEnum {
  ENUM_ONE,
  ENUM_TWO
}
```

Since we don't have consistency in enums as lower case we have to default to checking both for lowercase and uppercase values.

New behavior for deserializing enums

1. Check for JsonCreator and compare using that
2. Check for JsonValue and compare using that
3. Compare to the enum.name() 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
