### PR TITLE
Add external origination time for events created from S3 Object

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3InputFile.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3InputFile.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import java.time.Duration;
+import java.time.Instant;
 
 public class S3InputFile implements InputFile {
 
@@ -44,6 +45,15 @@ public class S3InputFile implements InputFile {
     @Override
     public long getLength() {
         return getMetadata().contentLength();
+    }
+
+    /**
+     * Return the last modified time of the file
+     *
+     * @return last modified time
+     */
+    public Instant getLastModified() {
+        return getMetadata().lastModified();
     }
 
     /**

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorkerTest.java
@@ -22,6 +22,8 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.io.InputFile;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
@@ -196,8 +198,12 @@ class S3ObjectWorkerTest {
         numEventsAdded = 0;
         doAnswer(a -> {
             Record record = mock(Record.class);
-            Event event = mock(Event.class);
+            final Event event = mock(Event.class);
+            final EventMetadata metadata = mock(EventMetadata.class);
+            final EventHandle eventHandle = mock(EventHandle.class);
             when(record.getData()).thenReturn(event);
+            when(event.getMetadata()).thenReturn(metadata);
+            when(event.getEventHandle()).thenReturn(eventHandle);
             Consumer c = (Consumer)a.getArgument(2);
             c.accept(record);
             return null;
@@ -274,7 +280,11 @@ class S3ObjectWorkerTest {
 
         final Record<Event> record = mock(Record.class);
         final Event event = mock(Event.class);
+        final EventMetadata metadata = mock(EventMetadata.class);
+        final EventHandle eventHandle = mock(EventHandle.class);
         when(record.getData()).thenReturn(event);
+        when(event.getMetadata()).thenReturn(metadata);
+        when(event.getEventHandle()).thenReturn(eventHandle);
 
         consumerUnderTest.accept(record);
 
@@ -307,7 +317,11 @@ class S3ObjectWorkerTest {
 
         final Record<Event> record = mock(Record.class);
         final Event event = mock(Event.class);
+        final EventMetadata metadata = mock(EventMetadata.class);
+        final EventHandle eventHandle = mock(EventHandle.class);
         when(record.getData()).thenReturn(event);
+        when(event.getMetadata()).thenReturn(metadata);
+        when(event.getEventHandle()).thenReturn(eventHandle);
         consumerUnderTest.accept(record);
 
         final InOrder inOrder = inOrder(eventConsumer, bufferAccumulator, sourceCoordinator);


### PR DESCRIPTION
### Description
Adds external origination time for events created from S3 Object. This applies to events created by both S3 SQS and S3Scan sources
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
