### PR TITLE
Allow ~ in keys for escaped json pointer characters

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -158,6 +158,7 @@ class JacksonEventKey implements EventKey {
                     || c == '.'
                     || c == '-'
                     || c == '_'
+                    || c == '~'
                     || c == '@'
                     || c == '/'
                     || c == '['

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -68,7 +68,8 @@ class JacksonEventKeyTest {
             "key-with-hyphen",
             "key_with_underscore",
             "key@with@at",
-            "key[with]brackets"
+            "key[with]brackets",
+            "key~1withtilda"
     })
     void getKey_returns_expected_result(final String key) {
         assertThat(new JacksonEventKey(key).getKey(), equalTo(key));


### PR DESCRIPTION
### Description
Json pointer uses ~ character as the escape sequence in some places. For example, a literal / in the key name will be escaped with ~1, but Data Prepper JacksonEventKey is blocking this by not allowing ~ character
 
### Issues Resolved
Resolves #5101 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
