### PR TITLE
Fix enum deserialization for geoip and dissect processors

### DIFF
--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfigTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfigTest.java
@@ -6,8 +6,10 @@ import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 class DissectProcessorConfigTest {
@@ -37,9 +39,15 @@ class DissectProcessorConfigTest {
 
     @Test
     void test_get_targets_types() throws NoSuchFieldException, IllegalAccessException {
-        Map<String, TargetType> targetTypeMap = Map.of("field1", TargetType.INTEGER);
+        Map<String, String> targetTypeMap = Map.of("field1", "integer");
         setField(DissectProcessorConfig.class, dissectProcessorConfig, "targetTypes", targetTypeMap);
-        assertThat(dissectProcessorConfig.getTargetTypes(), is(targetTypeMap));
+
+        assertTrue(dissectProcessorConfig.isTargetTypeValid());
+        final Map<String, TargetType> actualMap = dissectProcessorConfig.getTargetTypes();
+
+        assertThat(actualMap.size(), equalTo(targetTypeMap.size()));
+        assertThat(actualMap.containsKey("field1"), equalTo(true));
+        assertThat(actualMap.get("field1"), equalTo(TargetType.INTEGER));
     }
 
 }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.geoip.processor;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -69,6 +70,7 @@ public class EntryConfig {
      * Gets the desired {@link GeoIPField} based on the configuration.
      * @return A collection of {@link GeoIPField}
      */
+    @JsonIgnore
     public Collection<GeoIPField> getGeoIPFields() {
 
         if (includeFields != null && !includeFields.isEmpty()) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
@@ -51,7 +51,7 @@ public enum TargetType {
     }
 
     @JsonCreator
-    static TargetType fromOptionValue(final String option) {
+    public static TargetType fromOptionValue(final String option) {
         return OPTIONS_MAP.get(DataType.fromTypeName(option));
     }
 


### PR DESCRIPTION
### Description
The geoip and dissect processors contained a `Collection<Enum>` and a `Map<String, Enum>` that the new enum deserializer was getting called for, and it does not deserialize on the types. 

As a short term fix, add @JsonIgnore annotation the geoip enum getter method, and modify the dissect processor to use Map<String, String> with a custom AssertTrue validation and conversion of the target type from string to enum
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
