### PR TITLE
ism index patterns based on indexAlias/index #5117

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/AbstractIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/AbstractIndexManager.java
@@ -228,7 +228,7 @@ public abstract class AbstractIndexManager implements IndexManager {
     private void checkAndCreateIndexTemplate() throws IOException {
         final boolean isISMEnabled = checkISMEnabled();
         final Optional<String> policyIdOptional = isISMEnabled ?
-                ismPolicyManagementStrategy.checkAndCreatePolicy() :
+                ismPolicyManagementStrategy.checkAndCreatePolicy(configuredIndexAlias) :
                 Optional.empty();
         if (!openSearchSinkConfiguration.getIndexConfiguration().getIndexTemplate().isEmpty()) {
             checkAndCreateIndexTemplate(isISMEnabled, policyIdOptional.orElse(null));
@@ -258,8 +258,8 @@ public abstract class AbstractIndexManager implements IndexManager {
         templateStrategy.createTemplate(indexTemplate);
     }
 
-    final Optional<String> checkAndCreatePolicy() throws IOException {
-        return ismPolicyManagementStrategy.checkAndCreatePolicy();
+    final Optional<String> checkAndCreatePolicy(final String indexAlias) throws IOException {
+        return ismPolicyManagementStrategy.checkAndCreatePolicy(indexAlias);
     }
 
     public void checkAndCreateIndex() throws IOException {
@@ -322,6 +322,7 @@ public abstract class AbstractIndexManager implements IndexManager {
             indexTemplate.putCustomSetting(IndexConstants.ISM_POLICY_ID_SETTING, ismPolicyId);
         }
         indexTemplate.putCustomSetting(IndexConstants.ISM_ROLLOVER_ALIAS_SETTING, rolloverAlias);
+	indexTemplate.putCustomSetting(IndexConstants.PLUGINS_ROLLOVER_ALIAS_SETTING, rolloverAlias);
     }
 
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
@@ -21,6 +21,7 @@ public class IndexConstants {
   public static final String ISM_ENABLED_SETTING = "opendistro.index_state_management.enabled";
   public static final String ISM_POLICY_ID_SETTING = "opendistro.index_state_management.policy_id";
   public static final String ISM_ROLLOVER_ALIAS_SETTING = "opendistro.index_state_management.rollover_alias";
+  public static final String PLUGINS_ROLLOVER_ALIAS_SETTING = "plugins.index_state_management.rollover_alias";
   // TODO: extract out version number into version enum
   public static final String SERVICE_MAP_DEFAULT_TEMPLATE_FILE = "otel-v1-apm-service-map-index-template.json";
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementStrategy.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 interface IsmPolicyManagementStrategy {
 
-    Optional<String> checkAndCreatePolicy() throws IOException;
+    Optional<String> checkAndCreatePolicy(final String indexAlias) throws IOException;
 
     List<String> getIndexPatterns(final String indexAlias);
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/NoIsmPolicyManagement.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/NoIsmPolicyManagement.java
@@ -34,7 +34,7 @@ class NoIsmPolicyManagement implements IsmPolicyManagementStrategy {
     }
 
     @Override
-    public Optional<String> checkAndCreatePolicy() throws IOException {
+    public Optional<String> checkAndCreatePolicy(final String indexAlias) throws IOException {
         return Optional.empty();
     }
 


### PR DESCRIPTION
### Description
We will be able to update the index_patterns of the ISM policy based on the indexAlias created (more useful when its dynamic and/or with rollover feature) when user supplies ism_policy_file. This will not interfere when user wants to manage the policy with superset of wildcard (which should be a manual step). This commit will only ensure policy's index_patterns are updated when user supplies policy_json_file.

Example:
route:
    - cluster-utils: '/route_name == "cluster"'
  sink:
  - opensearch:
      hosts: [ "https://opensearch-node1:9200","https://opensearch-node2:9200" ]
      # Change to your credentials
      username: "admin"
      password: "PGjGcHKfQW1U"
      insecure: true
      dlq_file: /usr/share/data-prepper/log/data-prepper/dlq.log
      # Add a certificate file if you are accessing an OpenSearch cluster with a self-signed certificate
      #cert: /path/to/cert
      normalize_index: true
      index: cluster-utils_eastus2_${cluster_name}
      index_type: custom
      template_type: v1
      template_file: /usr/share/data-prepper/templates/template-file.json
      ism_policy_file: /usr/share/data-prepper/policies/ism-policy.json
      routes: [cluster-utils]
 
Where using data prepper we will create ism policy (if user supplies wildcard cluster-utils*) each time we receive a different cluster_name and will fail because opensearch will not allow having same patterns in multiple policies. Also keeping a single policy wouldn't make sense if we want to manage via AP. with this change data-prepper will create new policy with index pattern as cluster-utils_eastus2_${cluster_name}* which will in-align to index template index_patterns. Also, previous functionality will also work as index_patterns are specific to the indexAlias. However users will have to re-run the policies on the older indexes created. 

Extremely useful with rollover through ISM policy.
 
### Issues Resolved
Resolves #5117 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
