### PR TITLE
Default target types to empty map to avoid NPE

### DIFF
--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -31,7 +32,7 @@ public class DissectProcessorConfig {
             "Each key is a field name, and the value is the data type to use for that field. " +
             "Valid data types are <code>integer</code>, <code>double</code>, <code>string</code>, <code>long</code>, <code>big_decimal</code>, and <code>boolean</code>. " +
             "By default, all fields are treated as <code>string</code>.")
-    private Map<String, String> targetTypes;
+    private Map<String, String> targetTypes = Collections.emptyMap();;
 
     @JsonIgnore
     private Map<String, TargetType> targetTypeMap;


### PR DESCRIPTION
### Description
Default target types map to empty map to avoid null pointer exception
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
