### PR TITLE
Adding Java Time module to jackson Object mapper

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourcePartition.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourcePartition.java
@@ -5,9 +5,11 @@
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +35,8 @@ import java.util.Optional;
 public abstract class EnhancedSourcePartition<T> implements EnhancedPartition<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(EnhancedSourcePartition.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper(new JsonFactory())
+            .registerModule(new JavaTimeModule());
 
     private SourcePartitionStoreItem sourcePartitionStoreItem;
 
@@ -49,9 +52,8 @@ public abstract class EnhancedSourcePartition<T> implements EnhancedPartition<T>
      * Helper method to convert progress state.
      * This is because the state is currently stored as a String in the coordination store.
      *
-     * @param progressStateClass class of progress state
+     * @param progressStateClass               class of progress state
      * @param serializedPartitionProgressState serialized value of the partition progress state
-     *
      * @return returns the converted value of the progress state
      */
     public T convertStringToPartitionProgressState(Class<T> progressStateClass, final String serializedPartitionProgressState) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestInstantTypeProgressState.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestInstantTypeProgressState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.source.coordinator.enhanced;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public class TestInstantTypeProgressState {
+
+    @JsonProperty("testValue")
+    private Instant testValue;
+
+    public TestInstantTypeProgressState(@JsonProperty("testValue") final Instant testValue) {
+        this.testValue = testValue;
+    }
+
+    public Instant getTestValue() {
+        return testValue;
+    }
+
+}


### PR DESCRIPTION
### Description
Adding Java Time module to jackson Object mapper to enable Java Time specific object types to be serializable and deserializable. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
