### PR TITLE
Example values for rename_keys, split_string, substitute_string, truncate

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.event.EventKey;
 import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;
@@ -42,9 +44,12 @@ public class RenameKeyProcessorConfig {
         private boolean overwriteIfToKeyExists = false;
 
         @JsonProperty("rename_when")
-        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be " +
-                "run on the event. By default, all events will be processed unless otherwise stated.")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> " +
+                "that will be evaluated to determine whether the processor will be run on the event. " +
+                "By default, all events will be processed if no condition is provided.")
+        @ExampleValues(
+                @Example(value = "startsWith(/path, \"https://\")", description = "Rename the string only if it starts with an HTTPS scheme.")
+        )
         private String renameWhen;
 
         public EventKey getFromKey() {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -18,6 +18,8 @@ import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.model.annotations.ConditionalRequired;
 import org.opensearch.dataprepper.model.annotations.ConditionalRequired.IfThenElse;
 import org.opensearch.dataprepper.model.annotations.ConditionalRequired.SchemaProperty;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.event.EventKey;
 
 import java.util.List;
@@ -51,6 +53,9 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         @AlsoRequired(values = {
                 @AlsoRequired.Required(name=DELIMITER_REGEX_KEY, allowedValues = {"null", "\"\""})
         })
+        @ExampleValues(
+                @Example(value = "/", description = "Split a file path.")
+        )
         private String delimiter;
 
         @JsonProperty("delimiter_regex")
@@ -59,11 +64,17 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         @AlsoRequired(values = {
                 @AlsoRequired.Required(name="delimiter", allowedValues = {"null", "\"\""})
         })
+        @ExampleValues(
+                @Example(value = "(file:///|/+)", description = "Split a file URI, treating multiple slashes as a single slash.")
+        )
         private String delimiterRegex;
 
         @JsonProperty("split_when")
         @JsonPropertyDescription("Specifies under what condition the <code>split_string</code> processor should perform splitting. " +
                 "Default is no condition.")
+        @ExampleValues(
+                @Example(value = "startsWith(/path, \"file://\")", description = "Split a string only if it starts with the file URI scheme.")
+        )
         private String splitWhen;
 
         public EventKey getSource() {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
@@ -31,7 +31,7 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
                 "for more information.")
         @ExampleValues({
                 @Example(value = "/+", description = "Matches at least one forward slash and can be used to normalize a path."),
-                @Example(value = "'[?&#=]'", description = "Matches some special characters common in URIs.")
+                @Example(value = "[?&#=]", description = "Matches some special characters common in URIs.")
         })
         private String from;
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.event.EventKey;
 
 import java.util.List;
@@ -27,15 +29,22 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
                 "be escaped using <code>\\\\</code> when using double quotes and <code>\\</code> when using single quotes. " +
                 "See <a href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html\">Java Patterns</a> " +
                 "for more information.")
+        @ExampleValues({
+                @Example(value = "/+", description = "Matches at least one forward slash and can be used to normalize a path."),
+                @Example(value = "'[?&#=]'", description = "Matches some special characters common in URIs.")
+        })
         private String from;
 
         @JsonPropertyDescription("The string to be substituted for each match of <code>from</code>.")
         private String to;
 
         @JsonProperty("substitute_when")
-        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
-                "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will be " +
-                "run on the event. By default, all events will be processed unless otherwise stated.")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> " +
+                "that will be evaluated to determine whether the processor will be run on the event. " +
+                "By default, all events will be processed if no condition is provided.")
+        @ExampleValues(
+                @Example(value = "startsWith(/request_uri, \"https://\")", description = "Substitute on the string only if it starts with an HTTPS scheme.")
+        )
         private String substituteWhen;
 
         public EventKey getSource() {

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -13,6 +13,8 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue; 
 import jakarta.validation.Valid;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.List;
 
@@ -41,8 +43,11 @@ public class TruncateProcessorConfig {
         private Boolean recurse = false;
 
         @JsonProperty("truncate_when")
-        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/test != false</code>. " +
-                "If specified, the <code>truncate</code> processor will only run on events when the expression evaluates to true. ")
+        @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>. " +
+                "If specified, the <code>truncate</code> processor will only run on events when the expression evaluates to true.")
+        @ExampleValues(
+                @Example(value = "length(/node_name) > 10", description = "Truncate if the value of node_name is greater than 10 characters.")
+        )
         private String truncateWhen;
 
         public Entry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen, final Boolean recurse) {


### PR DESCRIPTION
### Description

Adds example values to `rename_keys`, `split_string`, `substitute_string`, and `truncate` processors.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
