### PR TITLE
Pass the pipeline identifier as part of the data prepper config.

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfig.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfig.java
@@ -17,4 +17,7 @@ import lombok.Getter;
 public class KinesisLeaseConfig {
     @JsonProperty("lease_coordination")
     private KinesisLeaseCoordinationTableConfig leaseCoordinationTable;
+
+    @JsonProperty("pipeline_identifier")
+    private String pipelineIdentifier;
 }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisService.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisService.java
@@ -60,7 +60,6 @@ public class KinesisService {
     private final String applicationName;
     private final String tableName;
     private final String kclMetricsNamespaceName;
-    private final String pipelineName;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final KinesisSourceConfig kinesisSourceConfig;
     private final KinesisAsyncClient kinesisClient;
@@ -96,8 +95,11 @@ public class KinesisService {
         this.dynamoDbClient = kinesisClientFactory.buildDynamoDBClient(kinesisLeaseConfig.getLeaseCoordinationTable().getAwsRegion());
         this.kinesisClient = kinesisClientFactory.buildKinesisAsyncClient(kinesisSourceConfig.getAwsAuthenticationConfig().getAwsRegion());
         this.cloudWatchClient = kinesisClientFactory.buildCloudWatchAsyncClient(kinesisLeaseConfig.getLeaseCoordinationTable().getAwsRegion());
-        this.pipelineName = pipelineDescription.getPipelineName();
-        this.applicationName = pipelineName;
+        if (kinesisLeaseConfig.getPipelineIdentifier().isEmpty()) {
+            this.applicationName = pipelineDescription.getPipelineName();
+        } else {
+            this.applicationName = kinesisLeaseConfig.getPipelineIdentifier();
+            }
         this.workerIdentifierGenerator = workerIdentifierGenerator;
         this.executorService = Executors.newFixedThreadPool(1);
         final PluginModel codecConfiguration = kinesisSourceConfig.getCodec();

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisService.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisService.java
@@ -11,6 +11,7 @@
 package org.opensearch.dataprepper.plugins.kinesis.source;
 
 import com.amazonaws.SdkClientException;
+import lombok.Getter;
 import lombok.Setter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -41,6 +42,7 @@ import software.amazon.kinesis.exceptions.ThrottlingException;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
 import software.amazon.kinesis.retrieval.polling.PollingConfig;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,7 +59,9 @@ public class KinesisService {
     private final PluginMetrics pluginMetrics;
     private final PluginFactory pluginFactory;
 
+    @Getter
     private final String applicationName;
+
     private final String tableName;
     private final String kclMetricsNamespaceName;
     private final AcknowledgementSetManager acknowledgementSetManager;
@@ -95,7 +99,8 @@ public class KinesisService {
         this.dynamoDbClient = kinesisClientFactory.buildDynamoDBClient(kinesisLeaseConfig.getLeaseCoordinationTable().getAwsRegion());
         this.kinesisClient = kinesisClientFactory.buildKinesisAsyncClient(kinesisSourceConfig.getAwsAuthenticationConfig().getAwsRegion());
         this.cloudWatchClient = kinesisClientFactory.buildCloudWatchAsyncClient(kinesisLeaseConfig.getLeaseCoordinationTable().getAwsRegion());
-        if (kinesisLeaseConfig.getPipelineIdentifier().isEmpty()) {
+        final String pipelineIdentifier = kinesisLeaseConfig.getPipelineIdentifier();
+        if (Objects.isNull(pipelineIdentifier) || pipelineIdentifier.isEmpty()) {
             this.applicationName = pipelineDescription.getPipelineName();
         } else {
             this.applicationName = kinesisLeaseConfig.getPipelineIdentifier();

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigSupplierTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigSupplierTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class KinesisLeaseConfigSupplierTest {
     private static final String LEASE_COORDINATION_TABLE = "lease-table";
+    private static final String PIPELINE_IDENTIFIER = "sample-kinesis-pipeline-0123";
     @Mock
     KinesisLeaseConfig kinesisLeaseConfig;
 
@@ -36,12 +37,14 @@ public class KinesisLeaseConfigSupplierTest {
 
     @Test
     void testGetters() {
+        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(PIPELINE_IDENTIFIER);
         when(kinesisLeaseConfig.getLeaseCoordinationTable()).thenReturn(kinesisLeaseCoordinationTableConfig);
         when(kinesisLeaseCoordinationTableConfig.getTableName()).thenReturn(LEASE_COORDINATION_TABLE);
         when(kinesisLeaseCoordinationTableConfig.getRegion()).thenReturn("us-east-1");
         KinesisLeaseConfigSupplier kinesisLeaseConfigSupplier = createObjectUnderTest();
         assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getLeaseCoordinationTable().getTableName(), equalTo(LEASE_COORDINATION_TABLE));
         assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getLeaseCoordinationTable().getRegion(), equalTo("us-east-1"));
+        assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getPipelineIdentifier(), equalTo(PIPELINE_IDENTIFIER));
     }
 
     @Test

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigSupplierTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigSupplierTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class KinesisLeaseConfigSupplierTest {
     private static final String LEASE_COORDINATION_TABLE = "lease-table";
-    private static final String PIPELINE_IDENTIFIER = "sample-kinesis-pipeline-0123";
+
     @Mock
     KinesisLeaseConfig kinesisLeaseConfig;
 
@@ -37,14 +38,15 @@ public class KinesisLeaseConfigSupplierTest {
 
     @Test
     void testGetters() {
-        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(PIPELINE_IDENTIFIER);
+        final String pipelineIdentifier = UUID.randomUUID().toString();
+        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(pipelineIdentifier);
         when(kinesisLeaseConfig.getLeaseCoordinationTable()).thenReturn(kinesisLeaseCoordinationTableConfig);
         when(kinesisLeaseCoordinationTableConfig.getTableName()).thenReturn(LEASE_COORDINATION_TABLE);
         when(kinesisLeaseCoordinationTableConfig.getRegion()).thenReturn("us-east-1");
         KinesisLeaseConfigSupplier kinesisLeaseConfigSupplier = createObjectUnderTest();
         assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getLeaseCoordinationTable().getTableName(), equalTo(LEASE_COORDINATION_TABLE));
         assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getLeaseCoordinationTable().getRegion(), equalTo("us-east-1"));
-        assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getPipelineIdentifier(), equalTo(PIPELINE_IDENTIFIER));
+        assertThat(kinesisLeaseConfigSupplier.getKinesisExtensionLeaseConfig().get().getPipelineIdentifier(), equalTo(pipelineIdentifier));
     }
 
     @Test

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/extension/KinesisLeaseConfigTest.java
@@ -56,6 +56,8 @@ public class KinesisLeaseConfigTest {
         final KinesisLeaseConfig kinesisLeaseConfig = makeConfig(
                 "src/test/resources/simple_pipeline_with_extensions.yaml");
 
+        assertNotNull(kinesisLeaseConfig.getPipelineIdentifier());
+        assertEquals(kinesisLeaseConfig.getPipelineIdentifier(), "sample-kinesis-pipeline-0123");
         assertNotNull(kinesisLeaseConfig.getLeaseCoordinationTable());
         assertEquals(kinesisLeaseConfig.getLeaseCoordinationTable().getTableName(), "kinesis-pipeline-kcl");
         assertEquals(kinesisLeaseConfig.getLeaseCoordinationTable().getRegion(), "us-east-1");

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisServiceTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisServiceTest.java
@@ -70,6 +70,7 @@ public class KinesisServiceTest {
     private final String PIPELINE_NAME = "kinesis-pipeline-test";
     private final String streamId = "stream-1";
     private static final String codec_plugin_name = "json";
+    private static final String PIPELINE_IDENTIFIER = "sample-kinesis-pipeline-0123";
 
     private static final Duration CHECKPOINT_INTERVAL = Duration.ofMillis(0);
     private static final int NUMBER_OF_RECORDS_TO_ACCUMULATE = 10;
@@ -149,6 +150,7 @@ public class KinesisServiceTest {
         kinesisLeaseConfigSupplier = mock(KinesisLeaseConfigSupplier.class);
         kinesisLeaseConfig = mock(KinesisLeaseConfig.class);
         workerIdentifierGenerator = mock(WorkerIdentifierGenerator.class);
+        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(PIPELINE_IDENTIFIER);
         kinesisLeaseCoordinationTableConfig = mock(KinesisLeaseCoordinationTableConfig.class);
         when(kinesisLeaseConfig.getLeaseCoordinationTable()).thenReturn(kinesisLeaseCoordinationTableConfig);
         when(kinesisLeaseCoordinationTableConfig.getTableName()).thenReturn("kinesis-lease-table");

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisSourceTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisSourceTest.java
@@ -53,8 +53,7 @@ public class KinesisSourceTest {
     private final String PIPELINE_NAME = "kinesis-pipeline-test";
     private final String streamId = "stream-1";
     private static final String codec_plugin_name = "json";
-    private static final String PIPELINE_IDENTIFIER = "sample-kinesis-pipeline-0123";
-
+    private String pipelineIdentifier;
     @Mock
     private PluginMetrics pluginMetrics;
 
@@ -91,6 +90,7 @@ public class KinesisSourceTest {
 
     @BeforeEach
     void setup() {
+        pipelineIdentifier = UUID.randomUUID().toString();
         pluginMetrics = mock(PluginMetrics.class);
         pluginFactory = mock(PluginFactory.class);
         kinesisSourceConfig = mock(KinesisSourceConfig.class);
@@ -111,7 +111,7 @@ public class KinesisSourceTest {
 
         kinesisLeaseConfigSupplier = mock(KinesisLeaseConfigSupplier.class);
         kinesisLeaseConfig = mock(KinesisLeaseConfig.class);
-        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(PIPELINE_IDENTIFIER);
+        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(pipelineIdentifier);
         kinesisLeaseCoordinationTableConfig = mock(KinesisLeaseCoordinationTableConfig.class);
         when(kinesisLeaseConfig.getLeaseCoordinationTable()).thenReturn(kinesisLeaseCoordinationTableConfig);
         when(kinesisLeaseCoordinationTableConfig.getTableName()).thenReturn("table-name");

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisSourceTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisSourceTest.java
@@ -53,6 +53,7 @@ public class KinesisSourceTest {
     private final String PIPELINE_NAME = "kinesis-pipeline-test";
     private final String streamId = "stream-1";
     private static final String codec_plugin_name = "json";
+    private static final String PIPELINE_IDENTIFIER = "sample-kinesis-pipeline-0123";
 
     @Mock
     private PluginMetrics pluginMetrics;
@@ -110,6 +111,7 @@ public class KinesisSourceTest {
 
         kinesisLeaseConfigSupplier = mock(KinesisLeaseConfigSupplier.class);
         kinesisLeaseConfig = mock(KinesisLeaseConfig.class);
+        when(kinesisLeaseConfig.getPipelineIdentifier()).thenReturn(PIPELINE_IDENTIFIER);
         kinesisLeaseCoordinationTableConfig = mock(KinesisLeaseCoordinationTableConfig.class);
         when(kinesisLeaseConfig.getLeaseCoordinationTable()).thenReturn(kinesisLeaseCoordinationTableConfig);
         when(kinesisLeaseCoordinationTableConfig.getTableName()).thenReturn("table-name");

--- a/data-prepper-plugins/kinesis-source/src/test/resources/simple_pipeline_with_extensions.yaml
+++ b/data-prepper-plugins/kinesis-source/src/test/resources/simple_pipeline_with_extensions.yaml
@@ -1,5 +1,6 @@
 extensions:
   kinesis:
+    pipeline_identifier: "sample-kinesis-pipeline-0123"
     lease_coordination:
       table_name: "kinesis-pipeline-kcl"
       region: "us-east-1"


### PR DESCRIPTION
### Description
This PR is to add a `pipeline_identifier` to the data prepper config to ensure that the multiple pipelines can subscribe to the same KDS stream when using enhanced fan-out strategy. This is optional and by default would use the pipeline name as the identifier for the active subscription.
 
### Issues Resolved
Resolves #1082 
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
