### PR TITLE
Change response_cardinality config for lambda processor to response_events_match

### DIFF
--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorConfig.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorConfig.java
@@ -43,8 +43,8 @@ public class LambdaProcessorConfig {
     private InvocationType invocationType = InvocationType.REQUEST_RESPONSE;
 
     @JsonPropertyDescription("Defines the way Data Prepper treats the response from Lambda")
-    @JsonProperty("response_cardinality")
-    private ResponseCardinality responseCardinality = ResponseCardinality.STRICT;
+    @JsonProperty("response_events_match")
+    private Boolean responseEventsMatch = Boolean.FALSE;
 
     @JsonPropertyDescription("sdk timeout defines the time sdk maintains the connection to the client before timing out")
     @JsonProperty("connection_timeout")
@@ -99,7 +99,7 @@ public class LambdaProcessorConfig {
         return invocationType;
     }
 
-    public ResponseCardinality getResponseCardinality() {
-        return responseCardinality;
+    public Boolean getResponseEventsMatch() {
+        return responseEventsMatch;
     }
 }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorConfig.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorConfig.java
@@ -44,7 +44,7 @@ public class LambdaProcessorConfig {
 
     @JsonPropertyDescription("Defines the way Data Prepper treats the response from Lambda")
     @JsonProperty("response_events_match")
-    private Boolean responseEventsMatch = Boolean.FALSE;
+    private boolean responseEventsMatch = false;
 
     @JsonPropertyDescription("sdk timeout defines the time sdk maintains the connection to the client before timing out")
     @JsonProperty("connection_timeout")

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/ResponseCardinality.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/ResponseCardinality.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public enum ResponseCardinality {
     STRICT("strict"),
     AGGREGATE("aggregate");

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
@@ -116,7 +116,7 @@ public class LambdaProcessorTest {
         when(lambdaProcessorConfig.getFunctionName()).thenReturn("test-function");
         when(lambdaProcessorConfig.getWhenCondition()).thenReturn(null);
         when(lambdaProcessorConfig.getInvocationType()).thenReturn(InvocationType.REQUEST_RESPONSE);
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.FALSE);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
         when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
         when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("testRole");
@@ -205,7 +205,7 @@ public class LambdaProcessorTest {
     @Test
     public void testDoExecute_WithRecords_SuccessfulProcessing() throws Exception {
         // Arrange
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.TRUE);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
         Event event = mock(Event.class);
         Record<Event> record = new Record<>(event);
         Collection<Record<Event>> records = Collections.singletonList(record);
@@ -290,7 +290,7 @@ public class LambdaProcessorTest {
     @Test
     public void testConvertLambdaResponseToEvent_WithEqualEventCounts_SuccessfulProcessing() throws Exception {
         // Arrange
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.TRUE);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
         setupTestObject();
         populatePrivateFields();
         List<Record<Event>> resultRecords = new ArrayList<>();
@@ -353,7 +353,7 @@ public class LambdaProcessorTest {
     @Test
     public void testConvertLambdaResponseToEvent_WithUnequalEventCounts_SuccessfulProcessing() throws Exception {
         // Arrange
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.FALSE);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
         setupTestObject();
         populatePrivateFields();
         List<Record<Event>> resultRecords = new ArrayList<>();
@@ -434,7 +434,7 @@ public class LambdaProcessorTest {
         when(invokeResponse.payload()).thenReturn(sdkBytes);
         when(invokeResponse.statusCode()).thenReturn(200); // Success status code
         when(lambdaCommonHandler.checkStatusCode(any())).thenReturn(true);
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.TRUE);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
 
         // Mock the responseCodec.parse to add three events
         doAnswer(invocation -> {

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
@@ -116,7 +116,7 @@ public class LambdaProcessorTest {
         when(lambdaProcessorConfig.getFunctionName()).thenReturn("test-function");
         when(lambdaProcessorConfig.getWhenCondition()).thenReturn(null);
         when(lambdaProcessorConfig.getInvocationType()).thenReturn(InvocationType.REQUEST_RESPONSE);
-        when(lambdaProcessorConfig.getResponseCardinality()).thenReturn(ResponseCardinality.STRICT);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.FALSE);
         when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
         when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("testRole");
@@ -205,6 +205,7 @@ public class LambdaProcessorTest {
     @Test
     public void testDoExecute_WithRecords_SuccessfulProcessing() throws Exception {
         // Arrange
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.TRUE);
         Event event = mock(Event.class);
         Record<Event> record = new Record<>(event);
         Collection<Record<Event>> records = Collections.singletonList(record);
@@ -289,6 +290,7 @@ public class LambdaProcessorTest {
     @Test
     public void testConvertLambdaResponseToEvent_WithEqualEventCounts_SuccessfulProcessing() throws Exception {
         // Arrange
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.TRUE);
         setupTestObject();
         populatePrivateFields();
         List<Record<Event>> resultRecords = new ArrayList<>();
@@ -351,7 +353,7 @@ public class LambdaProcessorTest {
     @Test
     public void testConvertLambdaResponseToEvent_WithUnequalEventCounts_SuccessfulProcessing() throws Exception {
         // Arrange
-        when(lambdaProcessorConfig.getResponseCardinality()).thenReturn(ResponseCardinality.AGGREGATE);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.FALSE);
         setupTestObject();
         populatePrivateFields();
         List<Record<Event>> resultRecords = new ArrayList<>();
@@ -362,7 +364,6 @@ public class LambdaProcessorTest {
         when(invokeResponse.payload()).thenReturn(sdkBytes);
         when(invokeResponse.statusCode()).thenReturn(200); // Success status code
         when(lambdaCommonHandler.checkStatusCode(any())).thenReturn(true);
-        when(lambdaProcessorConfig.getResponseCardinality()).thenReturn(ResponseCardinality.AGGREGATE);
         // Mock the responseCodec.parse to add three events
         doAnswer(invocation -> {
             InputStream inputStream = (InputStream) invocation.getArgument(0);
@@ -433,7 +434,7 @@ public class LambdaProcessorTest {
         when(invokeResponse.payload()).thenReturn(sdkBytes);
         when(invokeResponse.statusCode()).thenReturn(200); // Success status code
         when(lambdaCommonHandler.checkStatusCode(any())).thenReturn(true);
-        when(lambdaProcessorConfig.getResponseCardinality()).thenReturn(ResponseCardinality.STRICT);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(Boolean.TRUE);
 
         // Mock the responseCodec.parse to add three events
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description
Change response_cardinality config for lambda processor to response_events_match.

response_events_match = False will be the default and will use AggregateResponseEventHandling Strategy.
When true, it will use Strict Strategy.
 
### Issues Resolved
Contributes towards  #5031 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
