### PR TITLE
Add examples into processor configs

### DIFF
--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 
 import java.util.Collections;
@@ -18,6 +20,8 @@ import java.util.stream.Collectors;
         "based on user-defined <code>dissect</code> patterns. The processor is well suited for field extraction from log " +
         "messages with a known structure.")
 public class DissectProcessorConfig {
+    static final String DEFAULT_TARGET_TYPES = 'string';
+
     @NotNull
     @JsonProperty("map")
     @JsonPropertyDescription("Defines the <code>dissect</code> patterns for specific keys. " +
@@ -27,7 +31,7 @@ public class DissectProcessorConfig {
             "An example dissect pattern is <code>%{Date} %{Time} %{Log_Type}: %{Message}</code>, which will dissect into four fields.")
     private Map<String, String> map;
 
-    @JsonProperty("target_types")
+    @JsonProperty(value = "target_types", defaultValue = DEFAULT_TARGET_TYPES)
     @JsonPropertyDescription("Specifies the data types for extract fields. " +
             "Each key is a field name, and the value is the data type to use for that field. " +
             "Valid data types are <code>integer</code>, <code>double</code>, <code>string</code>, <code>long</code>, <code>big_decimal</code>, and <code>boolean</code>. " +
@@ -38,6 +42,9 @@ public class DissectProcessorConfig {
     private Map<String, TargetType> targetTypeMap;
 
     @JsonProperty("dissect_when")
+    @ExampleValues({
+        @Example(value = "/log_type == \"ERROR\"", description = "Dissects when the log type is ERROR.")
+    })
     @JsonPropertyDescription("Specifies a condition for performing the <code>dissect</code> operation using a " +
             "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>. " +
             "If specified, the <code>dissect</code> operation will only run when the expression evaluates to true. " +

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
         "based on user-defined <code>dissect</code> patterns. The processor is well suited for field extraction from log " +
         "messages with a known structure.")
 public class DissectProcessorConfig {
-    static final String DEFAULT_TARGET_TYPES = 'string';
+    static final String DEFAULT_TARGET_TYPES = "string";
 
     @NotNull
     @JsonProperty("map")

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -29,6 +29,9 @@ public class DissectProcessorConfig {
             "For details on how to define fields in the <code>dissect</code> pattern, see " + 
             "<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/#field-notations\">here</a>. " +
             "An example dissect pattern is <code>%{Date} %{Time} %{Log_Type}: %{Message}</code>, which will dissect into four fields.")
+    @ExampleValues({
+        @Example(value = "%{Date} %{Time} %{Log_Type}: %{Message}", description = "Extracts the input data into the date, time, log_type, and message fields.")
+    })
     private Map<String, String> map;
 
     @JsonProperty(value = "target_types", defaultValue = DEFAULT_TARGET_TYPES)

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventProcessorConfig.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.NotEmpty;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.event.HandleFailedEventsOption;
 
 @JsonPropertyOrder
@@ -20,6 +22,9 @@ public class DropEventProcessorConfig {
             "The <code>drop_when</code> processor will drop all events where the condition evaluates to true. Those events will not go to any further processors or sinks.")
     @JsonProperty("drop_when")
     @NotEmpty
+    @ExampleValues({
+        @Example(value = "/log_type == \"DEBUG\"", description = "Drops events if the log type is DEBUG.")
+    })
     private String dropWhen;
 
     @JsonPropertyDescription("Specifies how exceptions are handled when an exception occurs while evaluating an event. Default value is <code>skip</code>, which drops the event so that it is not sent to further processors or sinks.")

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -40,7 +40,7 @@ public class FlattenProcessorConfig {
     @JsonPropertyDescription("The target key to put into the flattened fields. If set to an empty string (<code>\"\"</code>) " +
             "then the processor uses the root of the event as the target.")
     @ExampleValues({
-        @Example(value = "flattened-key2", description = "The flattened fields from the source key specified are put into the specified target key.")
+        @Example(value = "flattened-key2", description = "The flattened fields from the source key specified are put into a field named 'flattened-key2'.")
     })
     private String target;
 

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 
 import java.util.ArrayList;
@@ -28,12 +30,18 @@ public class FlattenProcessorConfig {
     @JsonProperty("source")
     @JsonPropertyDescription("The source key on which to perform the operation. If set to an empty string (<code>\"\"</code>), " +
             "then the processor uses the root of the event as the source.")
+    @ExampleValues({
+        @Example(value = "key2", description = "The flatten operation is performed on the source key equivalent to 'key2'")
+    })
     private String source;
 
     @NotNull
     @JsonProperty("target")
     @JsonPropertyDescription("The target key to put into the flattened fields. If set to an empty string (<code>\"\"</code>) " +
             "then the processor uses the root of the event as the target.")
+    @ExampleValues({
+        @Example(value = "flattened-key2", description = "The flattened fields from the source key specified are put into the specified target key.")
+    })
     private String target;
 
     @JsonProperty("remove_processed_fields")
@@ -66,6 +74,9 @@ public class FlattenProcessorConfig {
     @JsonProperty("flatten_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
             "If specified, the <code>flatten</code> processor will only run on events when the expression evaluates to true. ")
+    @ExampleValues({
+        @Example(value = "/some-key == \"test\"", description = "The flatten operation will run when the value of the key is 'test'.")
+    })
     private String flattenWhen;
 
     public String getSource() {

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.plugins.geoip.GeoIPField;
 
 import java.util.Collection;
@@ -26,20 +28,32 @@ public class EntryConfig {
     @JsonPropertyDescription("The key of the source field containing the IP address to geolocate.")
     @JsonProperty("source")
     @NotEmpty
+    @ExampleValues({
+        @Example(value = "clientip", description = "The processor will extract available geolocation data from the IP address provided in the field named 'clientip'")
+    })
     private String source;
 
     @JsonPropertyDescription("The key of the target field in which to set the geolocation data.")
     @JsonProperty(value = "target", defaultValue = DEFAULT_TARGET)
+    @ExampleValues({
+        @Example(value = "clientlocation", description = "The processor will put the geolocation data into a field named 'clientlocation'")
+    })
     private String target = DEFAULT_TARGET;
 
     @JsonPropertyDescription("The list of geolocation fields to include in the target object. By default, this is all the fields provided by the configured databases. " +
             "For example, if you wish to only obtain the actual location, you can specify <code>location</code>.")
     @JsonProperty("include_fields")
+    @ExampleValues({
+        @Example(value = "[asn, asn_organization, network]", description = "The processor will include these fields while extracting geolocation data.")
+    })
     private List<String> includeFields;
 
     @JsonPropertyDescription("The list of geolocation fields to exclude from the target object. " +
             "For example, you can exclude ASN fields by including <code>asn</code>, <code>asn_organization</code>, <code>network</code>, <code>ip</code>.")
     @JsonProperty("exclude_fields")
+    @ExampleValues({
+        @Example(value = "[asn, asn_organization, network]", description = "The processor will exclude these fields while extracting geolocation data.")
+    })
     private List<String> excludeFields;
 
     public String getSource() {

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
@@ -28,23 +28,17 @@ public class EntryConfig {
     @JsonPropertyDescription("The key of the source field containing the IP address to geolocate.")
     @JsonProperty("source")
     @NotEmpty
-    @ExampleValues({
-        @Example(value = "clientip", description = "The processor will extract available geolocation data from the IP address provided in the field named 'clientip'")
-    })
     private String source;
 
     @JsonPropertyDescription("The key of the target field in which to set the geolocation data.")
     @JsonProperty(value = "target", defaultValue = DEFAULT_TARGET)
-    @ExampleValues({
-        @Example(value = "clientlocation", description = "The processor will put the geolocation data into a field named 'clientlocation'")
-    })
     private String target = DEFAULT_TARGET;
 
     @JsonPropertyDescription("The list of geolocation fields to include in the target object. By default, this is all the fields provided by the configured databases. " +
             "For example, if you wish to only obtain the actual location, you can specify <code>location</code>.")
     @JsonProperty("include_fields")
     @ExampleValues({
-        @Example(value = "[asn, asn_organization, network]", description = "The processor will include these fields while extracting geolocation data.")
+        @Example(value = "[location, latitude, longitude]", description = "The processor will include these fields while extracting geolocation data.")
     })
     private List<String> includeFields;
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
@@ -32,19 +34,31 @@ public class GeoIPProcessorConfig {
 
     @JsonProperty("tags_on_engine_failure")
     @JsonPropertyDescription("The tags to add to the event metadata if the <code>geoip</code> processor is unable to enrich an event due to an engine failure.")
+    @ExampleValues({
+        @Example(value = "_engine_failure", description = "Events are tagged with this string when the processor failures to extract geolocation data.")
+    })
     private List<String> tagsOnEngineFailure;
 
     @JsonProperty("tags_on_ip_not_found")
     @JsonPropertyDescription("The tags to add to the event metadata if the <code>geoip</code> processor is unable to find a location for a valid IP address.")
+    @ExampleValues({
+        @Example(value = "_ip_not_found", description = "Events are tagged with this string when a location is not found for a valid IP address.")
+    })
     private List<String> tagsOnIPNotFound;
 
     @JsonProperty("tags_on_no_valid_ip")
     @JsonPropertyDescription("The tags to add to the event metadata if the source field is not a valid IP address. A source field may not be valid because it is incorrectly formatted or is the loopback/localhost IP address.")
+    @ExampleValues({
+        @Example(value = "_invalid_ip", description = "Events are tagged with this string when the IP address is invalid.")
+    })
     private List<String> tagsOnNoValidIp;
 
     @JsonProperty("geoip_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/srcaddr != \"8.8.8.8\"</code>. " +
             "If specified, the <code>geoip</code> processor will only run on events when the expression evaluates to true. ")
+    @ExampleValues({
+        @Example(value = "/srcaddr != \"8.8.8.8\"", description = "The processor will only match when the source IP is equivalent to 8.8.8.8.")
+    })
     private String whenCondition;
 
     /**

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -34,23 +34,14 @@ public class GeoIPProcessorConfig {
 
     @JsonProperty("tags_on_engine_failure")
     @JsonPropertyDescription("The tags to add to the event metadata if the <code>geoip</code> processor is unable to enrich an event due to an engine failure.")
-    @ExampleValues({
-        @Example(value = "_engine_failure", description = "Events are tagged with this string when the processor failures to extract geolocation data.")
-    })
     private List<String> tagsOnEngineFailure;
 
     @JsonProperty("tags_on_ip_not_found")
     @JsonPropertyDescription("The tags to add to the event metadata if the <code>geoip</code> processor is unable to find a location for a valid IP address.")
-    @ExampleValues({
-        @Example(value = "_ip_not_found", description = "Events are tagged with this string when a location is not found for a valid IP address.")
-    })
     private List<String> tagsOnIPNotFound;
 
     @JsonProperty("tags_on_no_valid_ip")
     @JsonPropertyDescription("The tags to add to the event metadata if the source field is not a valid IP address. A source field may not be valid because it is incorrectly formatted or is the loopback/localhost IP address.")
-    @ExampleValues({
-        @Example(value = "_invalid_ip", description = "Events are tagged with this string when the IP address is invalid.")
-    })
     private List<String> tagsOnNoValidIp;
 
     @JsonProperty("geoip_when")

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.Collections;
 import java.util.List;
@@ -55,9 +57,10 @@ public class GrokProcessorConfig {
             "Each key is a source field. The value is a list of possible grok patterns to match on. " +
             "The <code>grok</code> processor will extract values from the first match for each field. " +
             "Default is an empty response body.")
+    @ExampleValues("%{IPV4:clientip} %{WORD:request} %{POSINT:bytes}")
     private Map<String, List<String>> match = Collections.emptyMap();
 
-    @JsonProperty(TARGET_KEY)
+    @JsonProperty(value = TARGET_KEY, defaultValue = DEFAULT_TARGET_KEY)
     @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code> which will write captures into the root of the event.")
     private String targetKey = DEFAULT_TARGET_KEY;
 
@@ -88,7 +91,7 @@ public class GrokProcessorConfig {
     @JsonPropertyDescription("Specifies which directory paths contain the custom pattern files. Default is an empty list.")
     private List<String> patternsDirectories = Collections.emptyList();
 
-    @JsonProperty(PATTERNS_FILES_GLOB)
+    @JsonProperty(value = PATTERNS_FILES_GLOB, defaultValue = "*")
     @JsonPropertyDescription("Specifies which pattern files to use from the directories specified for " +
             "<code>pattern_directories</code>. Default is <code>*</code>.")
     private String patternsFilesGlob = DEFAULT_PATTERNS_FILES_GLOB;
@@ -102,13 +105,22 @@ public class GrokProcessorConfig {
     @JsonPropertyDescription("A <code>List</code> of <code>String</code>s that specifies the tags to be set in the event when grok fails to " +
             "match or an unknown exception occurs while matching. This tag may be used in conditional expressions in " +
             "other parts of the configuration")
+    @ExampleValues({
+        @Example(value = "_match_failure", description = "Events are tagged with this string when matching fails or an unknown exception occurs.")
+    })
     private List<String> tagsOnMatchFailure = Collections.emptyList();
 
     @JsonProperty(TAGS_ON_TIMEOUT)
     @JsonPropertyDescription("The tags to add to the event metadata if the grok match times out.")
+    @ExampleValues({
+        @Example(value = "_timeout", description = "Events are tagged with this string if grok match times out.")
+    })
     private List<String> tagsOnTimeout = Collections.emptyList();
 
     @JsonProperty(GROK_WHEN)
+    @ExampleValues({
+        @Example(value = "/type == \"ipv4\"", description = "When the IP type is IPV4, the processor will perform matching.")
+    })
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/test != false</code>. " +
             "If specified, the <code>grok</code> processor will only run on events when the expression evaluates to true. ")
     private String grokWhen;

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -57,10 +57,12 @@ public class GrokProcessorConfig {
             "Each key is a source field. The value is a list of possible grok patterns to match on. " +
             "The <code>grok</code> processor will extract values from the first match for each field. " +
             "Default is an empty response body.")
-    @ExampleValues("%{IPV4:clientip} %{WORD:request} %{POSINT:bytes}")
+    @ExampleValues({
+        @Example(value = "%{IPV4:clientip} %{WORD:request} %{POSINT:bytes}", description = "Matches on the specific patterns given.")
+    })
     private Map<String, List<String>> match = Collections.emptyMap();
 
-    @JsonProperty(value = TARGET_KEY, defaultValue = DEFAULT_TARGET_KEY)
+    @JsonProperty(TARGET_KEY)
     @JsonPropertyDescription("Specifies a parent-level key used to store all captures. Default value is <code>null</code> which will write captures into the root of the event.")
     private String targetKey = DEFAULT_TARGET_KEY;
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -14,6 +14,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,12 +44,20 @@ public class KeyValueProcessorConfig {
     @NotEmpty
     @JsonProperty(defaultValue = DEFAULT_SOURCE)
     @JsonPropertyDescription("The source field to parse for key-value pairs. The default value is <code>message</code>.")
+    @ExampleValues({
+        @Example(value = "message1", description = "{\"message1\": {\"key1=value1\"}, \"message2\": {\"key2=value2\"}} parses into " +
+        "{\"message1\": {\"key1=value1\"}, \"message2\": {\"key2=value2\"}, \"parsed_message\": {\"key1\": \"value1\"}}.")
+    })
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty(defaultValue = DEFAULT_DESTINATION)
     @JsonPropertyDescription("The destination field for the structured data. The destination will be a structured map with the key value pairs extracted from the source. " +
             "If <code>destination</code> is set to <code>null</code>, the parsed fields will be written to the root of the event. " +
             "The default value is <code>parsed_message</code>.")
+    @ExampleValues({
+        @Example(value = "parsed_data", description = "{\"message\": {\"key1=value1\"}} parses into " +
+        "{\"message\": {\"key1=value1\"}, \"parsed_data\": {\"key1\": \"value1\"}}.")
+    })
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty(value = FIELD_SPLIT_CHARACTERS_KEY, defaultValue = DEFAULT_FIELD_SPLIT_CHARACTERS)
@@ -57,6 +67,9 @@ public class KeyValueProcessorConfig {
             "The default value is <code>&amp;</code>.")
     @AlsoRequired(values = {
             @AlsoRequired.Required(name = FIELD_DELIMITER_REGEX_KEY, allowedValues = {"null"}),
+    })
+    @ExampleValues({
+        @Example(value = "&&", description = "{\"key1=value1&&key2=value2\"} parses into {\"key1\": \"value1\", \"key2\": \"value2\"}.")
     })
     private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
@@ -70,6 +83,9 @@ public class KeyValueProcessorConfig {
             @AlsoRequired.Required(name = VALUE_GROUPING_KEY, allowedValues = {"false"}),
             @AlsoRequired.Required(name = FIELD_SPLIT_CHARACTERS_KEY, allowedValues = {"null"})
     })
+    @ExampleValues({
+        @Example(value = "&\\{2\\}", description = "{\"key1=value1&&key2=value2\"} parses into {\"key1\": \"value1\", \"key2\": \"value2\"}.")
+    })
     private String fieldDelimiterRegex;
 
     @JsonProperty(value = VALUE_SPLIT_CHARACTERS_KEY, defaultValue = DEFAULT_VALUE_SPLIT_CHARACTERS)
@@ -79,6 +95,9 @@ public class KeyValueProcessorConfig {
             "The default value is <code>=</code>.")
     @AlsoRequired(values = {
             @AlsoRequired.Required(name = KEY_VALUE_DELIMITER_REGEX_KEY, allowedValues = {"null"})
+    })
+    @ExampleValues({
+        @Example(value = "==", description = "{\"key1==value1=\"} parses into {\"key1\": \"value1\"}.")
     })
     private String valueSplitCharacters = DEFAULT_VALUE_SPLIT_CHARACTERS;
 
@@ -91,6 +110,9 @@ public class KeyValueProcessorConfig {
     @AlsoRequired(values = {
             @AlsoRequired.Required(name = VALUE_SPLIT_CHARACTERS_KEY, allowedValues = {"null"})
     })
+    @ExampleValues({
+        @Example(value = "&\\{2\\}", description = "{\"key1==value1=\"} parses into {\"key1\": \"value1\"}.")
+    })
     private String keyValueDelimiterRegex;
 
     @JsonProperty(value = "default_values", defaultValue = "{}")
@@ -99,27 +121,40 @@ public class KeyValueProcessorConfig {
             "If the key was parsed from the source field that value will remain and the default value is not used. " +
             "If the default values includes keys which are not part of <code>include_keys</code> those keys and value will be added to the event.")
     @NotNull
+    @ExampleValues("{\"defaultkey\": \"defaultvalue\"}")
     private Map<String, Object> defaultValues = DEFAULT_DEFAULT_VALUES;
 
     @JsonProperty("non_match_value")
     @JsonPropertyDescription("Configures a value to use when the processor cannot split a key-value pair. " +
             "The value specified in this configuration is the value used in <code>destination</code> map. " +
             "The default behavior is to drop the key-value pair.")
+    @ExampleValues({
+        @Example(value = "none", description = "key1value1&key2=value2 parses into {\"key1value1\": \"none\", \"key2\": \"value2\"}.")
+    })
     private Object nonMatchValue = DEFAULT_NON_MATCH_VALUE;
 
     @JsonProperty(value = "include_keys", defaultValue = "[]")
     @JsonPropertyDescription("An array specifying the keys that should be included in the destination field. " +
             "By default, all keys will be added.")
     @NotNull
+    @ExampleValues({
+        @Example(value = "[\"key2\"]", description = "key1=value1&key2=value2 will parse into {\"key2\": \"value2\"}.")
+    })
     private List<String> includeKeys = DEFAULT_INCLUDE_KEYS;
 
     @JsonProperty(value = "exclude_keys", defaultValue = "[]")
     @JsonPropertyDescription("An array specifying the parsed keys that should be excluded from the destination field. " +
             "By default, no keys will be excluded.")
     @NotNull
+    @ExampleValues({
+        @Example(value = "[\"key2\"]", description = "key1=value1&key2=value2 will parse into {\"key1\": \"value1\"}.")
+    })
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonPropertyDescription("A prefix to append before all keys. By default no prefix is added.")
+    @ExampleValues({
+        @Example(value = "custom", description = "{\"key1=value1\"} parses into {\"customkey1\": \"value1\"}.")
+    })
     private String prefix = null;
 
     @JsonProperty("delete_key_regex")
@@ -127,6 +162,9 @@ public class KeyValueProcessorConfig {
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "Cannot be an empty string. " +
             "By default, no characters are deleted from the key.")
+    @ExampleValues({
+        @Example(value = "\\s", description = "{\"key1 =value1\"} parses into {\"key1\": \"value1\"}.")
+    })
     private String deleteKeyRegex;
 
     @JsonProperty("delete_value_regex")
@@ -134,10 +172,18 @@ public class KeyValueProcessorConfig {
             "Special regular expression characters such as <code>[</code> and <code>]</code> must be escaped with <code>\\\\</code>. " +
             "Cannot be an empty string. " +
             "By default, no characters are deleted from the value.")
+    @ExampleValues({
+        @Example(value = "\\s", description = "{\"key1=value1 \"} parses into {\"key1\": \"value1\"}.")
+    })
     private String deleteValueRegex;
 
     @JsonProperty(value = "transform_key", defaultValue = "none")
     @JsonPropertyDescription("Allows transforming the key's name such as making the name all lowercase.")
+    @ExampleValues({
+        @Example(value = "lowercase", description = "{\"Key1=value1\"} will parse into {\"key1\": \"value1\"}."),
+        @Example(value = "uppercase", description = "{\"key1=value1\"} will parse into {\"KEY1\": \"value1\"}."),
+        @Example(value = "capitalize", description = "{\"key1=value1\"} will parse into {\"Key1\": \"value1\"}.")
+    })
     private TransformOption transformKey = TransformOption.NONE;
 
     @JsonProperty(value = WHITESPACE_KEY, defaultValue = "lenient")
@@ -146,6 +192,10 @@ public class KeyValueProcessorConfig {
             "In this case, strict means that whitespace is trimmed and lenient means it is retained in the key name and in the value. " +
             "Default is <code>lenient</code>.")
     @NotNull
+    @ExampleValues({
+        @Example(value = "lenient", description = "{\"key1 = value1\"} will parse into {\"key1 \": \" value1\"}."),
+        @Example(value = "strict", description = "{\"key1 = value1\"} will parse into {\"key1\": \"value1\"}.")
+    })
     private WhitespaceOption whitespace = WhitespaceOption.LENIENT;
 
     @JsonProperty(value = SKIP_DUPLICATE_VALUES_KEY, defaultValue = "false")
@@ -212,19 +262,28 @@ public class KeyValueProcessorConfig {
             "character will be ignored and excluded from key-value parsing. " +
             "Can be set to either a single quotation mark (<code>'</code>) or a double quotation mark (<code>\"</code>). " +
             "Default is <code>null</code>.")
-    @Size(min = 0, max = 1, message = "string_literal_character may only have character")
+    @Size(min = 0, max = 1, message = "string_literal_character may only have one character")
     @AlsoRequired(values = {
             @AlsoRequired.Required(name = VALUE_GROUPING_KEY, allowedValues = {"true"})
+    })
+    @ExampleValues({
+        @Example(value = "\"", description = "text1 \"key1=value1\" text2 key2=value2 would parse to {\"key2\": \"value2\"}.")
     })
     private String stringLiteralCharacter = null;
 
     @JsonProperty("tags_on_failure")
     @JsonPropertyDescription("The tags to add to the event metadata if the <code>key_value</code> processor fails to parse the source string.")
+    @ExampleValues({
+        @Example(value = "[\"keyvalueprocessor_failure\"]", description = "{\"tags\": [\"keyvalueprocessor_failure\"]} will be added to the event’s metadata in the event of a runtime exception.")
+    })
     private List<String> tagsOnFailure;
 
     @JsonProperty("key_value_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/some_key == \"test\"</code>. " +
             "If specified, the <code>key_value</code> processor will only run on events when the expression evaluates to true. ")
+    @ExampleValues({
+        @Example(value = "/some-key == \"test\"", description = "When the key is 'test', the processor will be applied to the event.")
+    })
     private String keyValueWhen;
 
     @AssertTrue(message = "Invalid Configuration. value_grouping option and field_delimiter_regex are mutually exclusive")

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -44,20 +44,12 @@ public class KeyValueProcessorConfig {
     @NotEmpty
     @JsonProperty(defaultValue = DEFAULT_SOURCE)
     @JsonPropertyDescription("The source field to parse for key-value pairs. The default value is <code>message</code>.")
-    @ExampleValues({
-        @Example(value = "message1", description = "{\"message1\": {\"key1=value1\"}, \"message2\": {\"key2=value2\"}} parses into " +
-        "{\"message1\": {\"key1=value1\"}, \"message2\": {\"key2=value2\"}, \"parsed_message\": {\"key1\": \"value1\"}}.")
-    })
     private String source = DEFAULT_SOURCE;
 
     @JsonProperty(defaultValue = DEFAULT_DESTINATION)
     @JsonPropertyDescription("The destination field for the structured data. The destination will be a structured map with the key value pairs extracted from the source. " +
             "If <code>destination</code> is set to <code>null</code>, the parsed fields will be written to the root of the event. " +
             "The default value is <code>parsed_message</code>.")
-    @ExampleValues({
-        @Example(value = "parsed_data", description = "{\"message\": {\"key1=value1\"}} parses into " +
-        "{\"message\": {\"key1=value1\"}, \"parsed_data\": {\"key1\": \"value1\"}}.")
-    })
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty(value = FIELD_SPLIT_CHARACTERS_KEY, defaultValue = DEFAULT_FIELD_SPLIT_CHARACTERS)
@@ -121,9 +113,6 @@ public class KeyValueProcessorConfig {
             "If the key was parsed from the source field that value will remain and the default value is not used. " +
             "If the default values includes keys which are not part of <code>include_keys</code> those keys and value will be added to the event.")
     @NotNull
-    @ExampleValues({
-        @Example(value = "{\"defaultkey\": \"defaultvalue\"}", description = "key1=value1 will parse into {\"key1\": \"value1\", \"defaultkey\": \"defaultvalue\"}.")
-    })
     private Map<String, Object> defaultValues = DEFAULT_DEFAULT_VALUES;
 
     @JsonProperty("non_match_value")
@@ -139,23 +128,17 @@ public class KeyValueProcessorConfig {
     @JsonPropertyDescription("An array specifying the keys that should be included in the destination field. " +
             "By default, all keys will be added.")
     @NotNull
-    @ExampleValues({
-        @Example(value = "[\"key2\"]", description = "key1=value1&key2=value2 will parse into {\"key2\": \"value2\"}.")
-    })
     private List<String> includeKeys = DEFAULT_INCLUDE_KEYS;
 
     @JsonProperty(value = "exclude_keys", defaultValue = "[]")
     @JsonPropertyDescription("An array specifying the parsed keys that should be excluded from the destination field. " +
             "By default, no keys will be excluded.")
     @NotNull
-    @ExampleValues({
-        @Example(value = "[\"key2\"]", description = "key1=value1&key2=value2 will parse into {\"key1\": \"value1\"}.")
-    })
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonPropertyDescription("A prefix to append before all keys. By default no prefix is added.")
     @ExampleValues({
-        @Example(value = "custom", description = "{\"key1=value1\"} parses into {\"customkey1\": \"value1\"}.")
+        @Example(value = "query:", description = "{\"key1=value1\"} parses into {\"query:key1\": \"value1\"}.")
     })
     private String prefix = null;
 
@@ -181,11 +164,6 @@ public class KeyValueProcessorConfig {
 
     @JsonProperty(value = "transform_key", defaultValue = "none")
     @JsonPropertyDescription("Allows transforming the key's name such as making the name all lowercase.")
-    @ExampleValues({
-        @Example(value = "lowercase", description = "{\"Key1=value1\"} will parse into {\"key1\": \"value1\"}."),
-        @Example(value = "uppercase", description = "{\"key1=value1\"} will parse into {\"KEY1\": \"value1\"}."),
-        @Example(value = "capitalize", description = "{\"key1=value1\"} will parse into {\"Key1\": \"value1\"}.")
-    })
     private TransformOption transformKey = TransformOption.NONE;
 
     @JsonProperty(value = WHITESPACE_KEY, defaultValue = "lenient")
@@ -275,9 +253,6 @@ public class KeyValueProcessorConfig {
 
     @JsonProperty("tags_on_failure")
     @JsonPropertyDescription("The tags to add to the event metadata if the <code>key_value</code> processor fails to parse the source string.")
-    @ExampleValues({
-        @Example(value = "[\"keyvalueprocessor_failure\"]", description = "{\"tags\": [\"keyvalueprocessor_failure\"]} will be added to the event’s metadata in the event of a runtime exception.")
-    })
     private List<String> tagsOnFailure;
 
     @JsonProperty("key_value_when")

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -121,7 +121,9 @@ public class KeyValueProcessorConfig {
             "If the key was parsed from the source field that value will remain and the default value is not used. " +
             "If the default values includes keys which are not part of <code>include_keys</code> those keys and value will be added to the event.")
     @NotNull
-    @ExampleValues("{\"defaultkey\": \"defaultvalue\"}")
+    @ExampleValues({
+        @Example(value = "{\"defaultkey\": \"defaultvalue\"}", description = "key1=value1 will parse into {\"key1\": \"value1\", \"defaultkey\": \"defaultvalue\"}.")
+    })
     private Map<String, Object> defaultValues = DEFAULT_DEFAULT_VALUES;
 
     @JsonProperty("non_match_value")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -69,17 +69,11 @@ public class ListToMapProcessorConfig {
     @NotNull
     @JsonProperty("source")
     @JsonPropertyDescription("The list of objects with <code>key</code> fields to be converted into keys for the generated map.")
-    @ExampleValues({
-        @Example(value = "mylist", description = "The key 'mylist' will have a list of objects as its value to be converted into a map.")
-    })
     private String source;
 
     @JsonProperty("target")
     @JsonPropertyDescription("The target for the generated map. When not specified, the generated map will be " +
             "placed in the root node.")
-    @ExampleValues({
-        @Example(value = "result", description = "The generated map will be placed at the 'result' node.")
-    })
     private String target = null;
 
     @JsonProperty("use_source_key")
@@ -90,9 +84,6 @@ public class ListToMapProcessorConfig {
     @JsonProperty("key")
     @JsonPropertyDescription("The key of the fields to be extracted as keys in the generated mappings. Must be " +
             "specified if <code>use_source_key</code> is <code>false</code>.")
-    @ExampleValues({
-        @Example(value = "name", description = "In each list object, 'name' will be extracted and used as the key in the generated map.")
-    })
     private String key;
 
     @JsonProperty("value_key")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -16,6 +16,8 @@ import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.model.annotations.ConditionalRequired;
 import org.opensearch.dataprepper.model.annotations.ConditionalRequired.IfThenElse;
 import org.opensearch.dataprepper.model.annotations.ConditionalRequired.SchemaProperty;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +28,10 @@ import java.util.stream.Collectors;
         @IfThenElse(
                 ifFulfilled = {@SchemaProperty(field = "use_source_key", value = "false")},
                 thenExpect = {@SchemaProperty(field = "key")}
+        ),
+        @IfThenElse(
+                ifFulfilled = {@SchemaProperty(field = "flatten", value = "true")},
+                thenExpect = {@SchemaProperty(field = "flattened_element")}
         )
 })
 @JsonPropertyOrder
@@ -63,11 +69,17 @@ public class ListToMapProcessorConfig {
     @NotNull
     @JsonProperty("source")
     @JsonPropertyDescription("The list of objects with <code>key</code> fields to be converted into keys for the generated map.")
+    @ExampleValues({
+        @Example(value = "mylist", description = "The key 'mylist' will have a list of objects as its value to be converted into a map.")
+    })
     private String source;
 
     @JsonProperty("target")
     @JsonPropertyDescription("The target for the generated map. When not specified, the generated map will be " +
             "placed in the root node.")
+    @ExampleValues({
+        @Example(value = "result", description = "The generated map will be placed at the 'result' node.")
+    })
     private String target = null;
 
     @JsonProperty("use_source_key")
@@ -78,12 +90,18 @@ public class ListToMapProcessorConfig {
     @JsonProperty("key")
     @JsonPropertyDescription("The key of the fields to be extracted as keys in the generated mappings. Must be " +
             "specified if <code>use_source_key</code> is <code>false</code>.")
+    @ExampleValues({
+        @Example(value = "name", description = "In each list object, 'name' will be extracted and used as the key in the generated map.")
+    })
     private String key;
 
     @JsonProperty("value_key")
     @JsonPropertyDescription("When specified, values given a <code>value_key</code> in objects contained in the source list " +
             "will be extracted and converted into the value specified by this option based on the generated map. " +
             "When not specified, objects contained in the source list retain their original value when mapped.")
+    @ExampleValues({
+        @Example(value = "value", description = "In each list object, 'value' will be extracted and used as the value in the generated map.")
+    })
     private String valueKey = null;
 
     @JsonProperty("extract_value")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,20 +30,32 @@ public class MapToListProcessorConfig {
     @JsonProperty("source")
     @JsonPropertyDescription("The source map used to perform the mapping operation. When set to an empty " +
             "string (<code>\"\"</code>), it will use the root of the event as the <code>source</code>.")
+    @ExampleValues({
+        @Example(value = "mymap", description = "The key 'mymap' will have a map of objects as its value to be converted into a list.")
+    })
     private String source;
 
     @NotEmpty
     @NotNull
     @JsonProperty("target")
     @JsonPropertyDescription("The target for the generated list.")
+    @ExampleValues({
+        @Example(value = "mylist", description = "The generated list will be placed at the 'mylist' node.")
+    })
     private String target;
 
     @JsonProperty(value = "key_name", defaultValue = DEFAULT_KEY_NAME)
     @JsonPropertyDescription("The name of the field in which to store the original key. Default is <code>key</code>.")
+    @ExampleValues({
+        @Example(value = "og_key", description = "The original key in the map is stored in 'og_key' in the list.")
+    })
     private String keyName = DEFAULT_KEY_NAME;
 
     @JsonProperty(value = "value_name", defaultValue = DEFAULT_VALUE_NAME)
     @JsonPropertyDescription("The name of the field in which to store the original value. Default is <code>value</code>.")
+    @ExampleValues({
+        @Example(value = "og_value", description = "The original value in the map is stored in 'og_value' in the list.")
+    })
     private String valueName = DEFAULT_VALUE_NAME;
 
     @JsonProperty("remove_processed_fields")
@@ -54,19 +68,28 @@ public class MapToListProcessorConfig {
             "place them in fields in the target list. Default is <code>false</code>.")
     private boolean convertFieldToList = false;
 
-    @JsonProperty("exclude_keys")
+    @JsonProperty(value = "exclude_keys", defaultValue = DEFAULT_EXCLUDE_KEYS)
     @JsonPropertyDescription("The keys in the source map that will be excluded from processing. Default is an " +
             "empty list (<code>[]</code>).")
+    @ExampleValues({
+        @Example(value = "[\"key1\"]", description = "When the key is 'key1', the processor will not include this key-value pair in the list and will leave it in the map.")
+    })
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonProperty("tags_on_failure")
     @JsonPropertyDescription("A list of tags to add to the event metadata when the event fails to process.")
+    @ExampleValues({
+        @Example(value = "[\"_failure\"]", description = "{\"tags\": [\"_failure\"]} will be added to the event’s metadata in the event of a processing failure.")
+    })
     private List<String> tagsOnFailure;
 
     @JsonProperty("map_to_list_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
             "such as <code>/some-key == \"test\"</code>, that will be evaluated to determine whether the processor will " +
             "be run on the event. By default, all events will be processed unless otherwise stated.")
+    @ExampleValues({
+        @Example(value = "/some-key == \"test\"", description = "When the key is 'test', the processor will be applied to the event.")
+    })
     private String mapToListWhen;
 
     public String getSource() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -30,18 +30,12 @@ public class MapToListProcessorConfig {
     @JsonProperty("source")
     @JsonPropertyDescription("The source map used to perform the mapping operation. When set to an empty " +
             "string (<code>\"\"</code>), it will use the root of the event as the <code>source</code>.")
-    @ExampleValues({
-        @Example(value = "mymap", description = "The key 'mymap' will have a map of objects as its value to be converted into a list.")
-    })
     private String source;
 
     @NotEmpty
     @NotNull
     @JsonProperty("target")
     @JsonPropertyDescription("The target for the generated list.")
-    @ExampleValues({
-        @Example(value = "mylist", description = "The generated list will be placed at the 'mylist' node.")
-    })
     private String target;
 
     @JsonProperty(value = "key_name", defaultValue = DEFAULT_KEY_NAME)

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -68,7 +68,7 @@ public class MapToListProcessorConfig {
             "place them in fields in the target list. Default is <code>false</code>.")
     private boolean convertFieldToList = false;
 
-    @JsonProperty(value = "exclude_keys", defaultValue = DEFAULT_EXCLUDE_KEYS)
+    @JsonProperty("exclude_keys")
     @JsonPropertyDescription("The keys in the source map that will be excluded from processing. Default is an " +
             "empty list (<code>[]</code>).")
     @ExampleValues({

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.annotations.UsesDataPrepperPlugin;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -28,16 +30,25 @@ public class ObfuscationProcessorConfig {
     @JsonPropertyDescription("The source field to obfuscate.")
     @NotEmpty
     @NotNull
+    @ExampleValues({
+        @Example(value = "log", description = "The 'log' field in the input data will be obfuscated.")
+    })
     private String source;
 
     @JsonProperty("target")
     @JsonPropertyDescription("The new field in which to store the obfuscated value. " +
             "This leaves the original source field unchanged. " +
             "When no <code>target</code> is provided, the source field updates with the obfuscated value.")
+    @ExampleValues({
+        @Example(value = "newLog", description = "The 'newLog' field in the output data will have the input data obfuscated according to the other configurations that were set.")
+    })
     private String target;
 
     @JsonProperty("patterns")
     @JsonPropertyDescription("A list of regex patterns that allow you to obfuscate specific parts of a field. Only parts that match the regex pattern will obfuscate. When not provided, the processor obfuscates the whole field.")
+    @ExampleValues({
+        @Example(value = "[\"[A-Za-z0-9+_.-]+@([\\w-]+\\.)+[\\w-]{2,4}\"]", description = "This pattern represents an email address that will be obfuscated in the given field.")
+    })
     private List<String> patterns;
 
     @JsonProperty("action")
@@ -53,6 +64,9 @@ public class ObfuscationProcessorConfig {
 
     @JsonProperty("tags_on_match_failure")
     @JsonPropertyDescription("The tag to add to an event if the <code>obfuscate</code> processor fails to match the pattern.")
+    @ExampleValues({
+        @Example(value = "[\"_failure\"]", description = "{\"tags\": [\"_failure\"]} will be added to the event if the processor fails to match the pattern.")
+    })
     private List<String> tagsOnMatchFailure;
 
     @JsonProperty("obfuscate_when")

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -47,7 +47,7 @@ public class ObfuscationProcessorConfig {
     @JsonProperty("patterns")
     @JsonPropertyDescription("A list of regex patterns that allow you to obfuscate specific parts of a field. Only parts that match the regex pattern will obfuscate. When not provided, the processor obfuscates the whole field.")
     @ExampleValues({
-        @Example(value = "[\"[A-Za-z0-9+_.-]+@([\\w-]+\\.)+[\\w-]{2,4}\"]", description = "This pattern represents an email address that will be obfuscated in the given field.")
+        @Example(value = "[A-Za-z0-9+_.-]+@([\\w-]+\\.)+[\\w-]{2,4}", description = "This pattern represents an email address that will be obfuscated in the given field.")
     })
     private List<String> patterns;
 

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskActionConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskActionConfig.java
@@ -21,13 +21,13 @@ public class MaskActionConfig {
 
     @JsonProperty(value = "mask_character", defaultValue = DEFAULT_MASK_CHARACTER)
     @Pattern(regexp = "[*#!%&@]", message = "Valid characters are *, #, $, %, &, ! and @")
-    @JsonPropertyDescription("The character to use to mask text. By default, this is <code>*</code>")
+    @JsonPropertyDescription("The character to use to mask text. By default, this is <code>*</code>. Valid characters are *, #, $, %, &, ! and @")
     private String maskCharacter = DEFAULT_MASK_CHARACTER;
 
     @JsonProperty(value = "mask_character_length", defaultValue = "" + DEFAULT_MASK_LENGTH)
     @Min(1)
     @Max(10)
-    @JsonPropertyDescription("The length of the character mask to apply. By default, this is three characters.")
+    @JsonPropertyDescription("The length of the character mask to apply. By default, this is three characters. The value must be between 1 and 10.")
     private int maskCharacterLength = DEFAULT_MASK_LENGTH;
 
     public MaskActionConfig() {


### PR DESCRIPTION
### Description
Add examples into the following processors:
1. Dissect
2. Drop events
3. Flatten
4. Geoip
5. Grok
6. Key value
7. List to map
8. Lowercase string
9. Map to list
10. Obfuscate

### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
