### PR TITLE
Add getColumnDataTypes method to SchemaManager to get datatype for table columns

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -27,8 +27,7 @@ public class SchemaManager {
     static final String BINLOG_POSITION = "Position";
     static final int NUM_OF_RETRIES = 3;
     static final int BACKOFF_IN_MILLIS = 500;
-    public static final String COLUMN_NAME1 = "COLUMN_NAME";
-    public static final String TYPE_NAME = "TYPE_NAME";
+    static final String TYPE_NAME = "TYPE_NAME";
     private final ConnectionManager connectionManager;
 
     public SchemaManager(ConnectionManager connectionManager) {
@@ -66,7 +65,7 @@ public class SchemaManager {
                 try (ResultSet columns = metaData.getColumns(database, null, tableName, null)) {
                     while (columns.next()) {
                         columnsToDataType.put(
-                            columns.getString(COLUMN_NAME1),
+                            columns.getString(COLUMN_NAME),
                             columns.getString(TYPE_NAME)
                         );
                     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -27,6 +27,8 @@ public class SchemaManager {
     static final String BINLOG_POSITION = "Position";
     static final int NUM_OF_RETRIES = 3;
     static final int BACKOFF_IN_MILLIS = 500;
+    public static final String COLUMN_NAME1 = "COLUMN_NAME";
+    public static final String TYPE_NAME = "TYPE_NAME";
     private final ConnectionManager connectionManager;
 
     public SchemaManager(ConnectionManager connectionManager) {
@@ -64,8 +66,8 @@ public class SchemaManager {
                 try (ResultSet columns = metaData.getColumns(database, null, tableName, null)) {
                     while (columns.next()) {
                         columnsToDataType.put(
-                            columns.getString("COLUMN_NAME"),
-                            columns.getString("TYPE_NAME")
+                            columns.getString(COLUMN_NAME1),
+                            columns.getString(TYPE_NAME)
                         );
                     }
                 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
@@ -36,6 +36,7 @@ import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_POSITION;
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_STATUS_QUERY;
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.COLUMN_NAME;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.TYPE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class SchemaManagerTest {
@@ -154,12 +155,11 @@ class SchemaManagerTest {
         // Setup ResultSet to return our expected columns
         when(resultSet.next())
                 .thenReturn(true, true, true, false); // Three columns, then done
-        when(resultSet.getString("COLUMN_NAME"))
+        when(resultSet.getString(COLUMN_NAME))
                 .thenReturn("id", "name", "created_at");
-        when(resultSet.getString("TYPE_NAME"))
+        when(resultSet.getString(TYPE_NAME))
                 .thenReturn("INTEGER", "VARCHAR", "TIMESTAMP");
 
-        // Act
         Map<String, String> result = schemaManager.getColumnDataTypes(database, tableName);
 
         assertThat(result, notNullValue());

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
@@ -14,17 +14,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_FILE;
@@ -40,6 +45,9 @@ class SchemaManagerTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Connection connection;
+
+    @Mock
+    private DatabaseMetaData databaseMetaData;
 
     @Mock
     private ResultSet resultSet;
@@ -103,6 +111,60 @@ class SchemaManagerTest {
         final Optional<BinlogCoordinate> binlogCoordinate = schemaManager.getCurrentBinaryLogPosition();
 
         assertThat(binlogCoordinate.isPresent(), is(false));
+    }
+
+    @Test
+    public void getColumnDataTypes_whenFailedToRetrieveColumns_shouldThrowException() throws SQLException {
+        final String database = UUID.randomUUID().toString();
+        final String tableName = UUID.randomUUID().toString();
+
+        when(connectionManager.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getColumns(database, null, tableName, null)).thenThrow(new SQLException("Test exception"));
+
+        assertThrows(RuntimeException.class, () -> schemaManager.getColumnDataTypes(database, tableName));
+    }
+
+    @Test
+    public void getColumnDataTypes_whenFailedToGetConnection_shouldThrowException() throws SQLException {
+        final String database = UUID.randomUUID().toString();
+        final String tableName = UUID.randomUUID().toString();
+
+        when(connectionManager.getConnection()).thenThrow(new SQLException("Connection failed"));
+
+        assertThrows(RuntimeException.class, () -> schemaManager.getColumnDataTypes(database, tableName));
+    }
+
+    @Test
+    void getColumnDataTypes_whenColumnsExist_shouldReturnValidMapping() throws SQLException {
+        final String database = UUID.randomUUID().toString();
+        final String tableName = UUID.randomUUID().toString();
+        final Map<String, String> expectedColumnTypes = Map.of(
+                "id", "INTEGER",
+                "name", "VARCHAR",
+                "created_at", "TIMESTAMP"
+        );
+
+        // Setup the mocks
+        when(connectionManager.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getColumns(database, null, tableName, null))
+                .thenReturn(resultSet);
+
+        // Setup ResultSet to return our expected columns
+        when(resultSet.next())
+                .thenReturn(true, true, true, false); // Three columns, then done
+        when(resultSet.getString("COLUMN_NAME"))
+                .thenReturn("id", "name", "created_at");
+        when(resultSet.getString("TYPE_NAME"))
+                .thenReturn("INTEGER", "VARCHAR", "TIMESTAMP");
+
+        // Act
+        Map<String, String> result = schemaManager.getColumnDataTypes(database, tableName);
+
+        assertThat(result, notNullValue());
+        assertThat(result.size(), is(expectedColumnTypes.size()));
+        assertThat(result, equalTo(expectedColumnTypes));
     }
 
     private SchemaManager createObjectUnderTest() {


### PR DESCRIPTION
### Description
Add getColumnDataTypes method to SchemaManager to get datatype for table columns.
 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
