### PR TITLE
Add model for table column metadata for Global state

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/DbMetadata.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/DbMetadata.java
@@ -41,4 +41,12 @@ public class DbMetadata {
                 PORT_KEY, port
         );
     }
+
+    public static DbMetadata fromMap(Map<String, Object> map) {
+        return new DbMetadata(
+                (String) map.get(DB_IDENTIFIER_KEY),
+                (String) map.get(HOST_NAME_KEY),
+                ((Integer) map.get(PORT_KEY))
+        );
+    }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/DbTableMetadata.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/DbTableMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.util.Map;
+
+public class DbTableMetadata {
+
+    private static final String DB_METADATA_KEY = "dbMetadata";
+    private static final String TABLE_COLUMN_METADATA_KEY = "tableColumnDataTypeMap";
+    private final DbMetadata dbMetadata;
+    private final Map<String, Map<String, String>> tableColumnDataTypeMap;
+
+    public DbTableMetadata(final DbMetadata dbMetadata, final Map<String, Map<String, String>> tableColumnDataTypeMap) {
+        this.dbMetadata = dbMetadata;
+        this.tableColumnDataTypeMap = tableColumnDataTypeMap;
+    }
+    
+    public DbMetadata getDbMetadata() {
+        return dbMetadata;
+    }
+
+    public Map<String, Map<String, String>> getTableColumnDataTypeMap() {
+        return tableColumnDataTypeMap;
+    }
+    
+    public Map<String, Object> toMap() {
+        return Map.of(
+                DB_METADATA_KEY, dbMetadata.toMap(),
+                TABLE_COLUMN_METADATA_KEY, tableColumnDataTypeMap
+        );
+    }
+
+    public static DbTableMetadata fromMap(Map<String, Object> map) {
+        return new DbTableMetadata(
+                DbMetadata.fromMap((Map<String, Object>)map.get(DB_METADATA_KEY)),
+                (Map<String, Map<String, String>>) map.get(TABLE_COLUMN_METADATA_KEY)
+        );
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/DbMetadataTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/DbMetadataTest.java
@@ -1,0 +1,48 @@
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class DbMetadataTest {
+
+    @Test
+    public void test_fromMap_success() {
+        final String dbIdentifier = UUID.randomUUID().toString();
+        final String hostName = UUID.randomUUID().toString();
+        final int port = new Random().nextInt();
+        final Map<String, Object> map = new HashMap<>();
+        map.put("dbIdentifier", dbIdentifier);
+        map.put("hostName", hostName);
+        map.put("port", port);
+
+        final DbMetadata result = DbMetadata.fromMap(map);
+
+        assertThat(result.getDbIdentifier(), is(dbIdentifier));
+        assertThat(result.getHostName(), is(hostName));
+        assertThat(result.getPort(), is(port));
+    }
+
+    @Test
+    public void test_toMap_success() {
+        final String dbIdentifier = UUID.randomUUID().toString();
+        final String hostName = UUID.randomUUID().toString();
+        final int port = new Random().nextInt();
+        final DbMetadata dbMetadata = new DbMetadata(dbIdentifier, hostName, port);
+
+        final Map<String, Object> result = dbMetadata.toMap();
+
+        assertThat(result, is(notNullValue()));
+        assertThat(result.size(), is(3));
+        assertThat(result.get("dbIdentifier"), is(dbIdentifier));
+        assertThat(result.get("hostName"), is(hostName));
+        assertThat(result.get("port"), is(port));
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/DbTableMetadataTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/model/DbTableMetadataTest.java
@@ -1,0 +1,63 @@
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DbTableMetadataTest {
+
+    @Test
+    public void test_fromMap_success() {
+        final String dbIdentifier = UUID.randomUUID().toString();
+        final String hostName = UUID.randomUUID().toString();
+        final int port = new Random().nextInt();
+        final String tableName = UUID.randomUUID().toString();
+
+        final DbMetadata dbMetadata = new DbMetadata(dbIdentifier, hostName, port);
+        final Map<String, Map<String, String>> tableColumnDataTypeMap = new HashMap<>();
+        final Map<String, String> columnDataTypeMap = new HashMap<>();
+        columnDataTypeMap.put("int_column", "INTEGER");
+        tableColumnDataTypeMap.put(tableName, columnDataTypeMap);
+
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("dbMetadata", dbMetadata.toMap());
+        map.put("tableColumnDataTypeMap", tableColumnDataTypeMap);
+
+        final DbTableMetadata result = DbTableMetadata.fromMap(map);
+
+        assertThat(result.getDbMetadata().getDbIdentifier(), is(dbIdentifier));
+        assertThat(result.getDbMetadata().getHostName(), is(hostName));
+        assertThat(result.getDbMetadata().getPort(), is(port));
+        assertThat(result.getTableColumnDataTypeMap(), is(tableColumnDataTypeMap));
+    }
+
+    @Test
+    public void test_toMap_success() {
+        final String dbIdentifier = UUID.randomUUID().toString();
+        final String hostName = UUID.randomUUID().toString();
+        final int port = new Random().nextInt();
+        final String tableName = UUID.randomUUID().toString();
+
+        final DbMetadata dbMetadata = new DbMetadata(dbIdentifier, hostName, port);
+        final Map<String, Map<String, String>> tableColumnDataTypeMap = new HashMap<>();
+        final Map<String, String> columnDataTypeMap = new HashMap<>();
+        columnDataTypeMap.put("int_column", "INTEGER");
+        tableColumnDataTypeMap.put(tableName, columnDataTypeMap);
+        final DbTableMetadata dbTableMetadata = new DbTableMetadata(dbMetadata, tableColumnDataTypeMap);
+
+        final Map<String, Object> result = dbTableMetadata.toMap();
+
+        assertThat(result, is(notNullValue()));
+        assertThat(result.size(), is(2));
+        assertThat(result.get("dbMetadata"), is(dbMetadata.toMap()));
+        assertThat(result.get("tableColumnDataTypeMap"), is(tableColumnDataTypeMap));
+    }
+}


### PR DESCRIPTION
### Description
Add model for table column metadata for Global state. The model will be stored in global state and will be available for export and bin log worker to fetch table column metadata such as data type.
 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
