### PR TITLE
Add an alternate name for the KDS source plugin to "kinesis-data-streams"

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisSource.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisSource.java
@@ -27,7 +27,7 @@ import org.opensearch.dataprepper.plugins.kinesis.extension.KinesisLeaseConfigSu
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@DataPrepperPlugin(name = "kinesis", pluginType = Source.class, pluginConfigurationType = KinesisSourceConfig.class)
+@DataPrepperPlugin(name = "kinesis", alternateNames = "kinesis-data-streams", pluginType = Source.class, pluginConfigurationType = KinesisSourceConfig.class)
 public class KinesisSource implements Source<Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(KinesisSource.class);
     private final KinesisSourceConfig kinesisSourceConfig;


### PR DESCRIPTION
### Description
This PR is to add an alternate name for the KDS source plugin `kinesis-data-streams` in data prepper. 
 
### Issues Resolved
Resolves #1082 
 
### Check List
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
