### PR TITLE
Detect cascading actions in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'com.zendesk:mysql-binlog-connector-java:0.29.2'
     implementation 'com.mysql:mysql-connector-j:8.4.0'
 
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(path: ':data-prepper-test-event')

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactory.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Expo
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ResyncPartition;
 
 import java.util.function.Function;
 
@@ -34,6 +35,8 @@ public class PartitionFactory implements Function<SourcePartitionStoreItem, Enha
                 return new DataFilePartition(partitionStoreItem);
             case StreamPartition.PARTITION_TYPE:
                 return new StreamPartition(partitionStoreItem);
+            case ResyncPartition.PARTITION_TYPE:
+                return new ResyncPartition(partitionStoreItem);
             default:
                 // Unable to acquire other partitions.
                 return new GlobalState(partitionStoreItem);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/ResyncPartition.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/partition/ResyncPartition.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.partition;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ResyncProgressState;
+
+import java.util.Optional;
+
+public class ResyncPartition extends EnhancedSourcePartition<ResyncProgressState> {
+
+    public static final String PARTITION_TYPE = "RESYNC";
+
+    private final String database;
+    private final String table;
+    private final long timestamp;
+    private final ResyncProgressState state;
+
+    public ResyncPartition(String database, String table, long timestamp, ResyncProgressState state) {
+        this.database = database;
+        this.table = table;
+        this.timestamp = timestamp;
+        this.state = state;
+    }
+
+    public ResyncPartition(SourcePartitionStoreItem sourcePartitionStoreItem) {
+        setSourcePartitionStoreItem(sourcePartitionStoreItem);
+        String[] keySplits = sourcePartitionStoreItem.getSourcePartitionKey().split("\\|");
+        database = keySplits[0];
+        table = keySplits[1];
+        timestamp = Long.parseLong(keySplits[2]);
+        state = convertStringToPartitionProgressState(ResyncProgressState.class, sourcePartitionStoreItem.getPartitionProgressState());
+    }
+
+    @Override
+    public String getPartitionType() {
+        return PARTITION_TYPE;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return database + "|" + table + "|" + timestamp;
+    }
+
+    @Override
+    public Optional<ResyncProgressState> getProgressState() {
+        if (state != null) {
+            return Optional.of(state);
+        }
+        return Optional.empty();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/ResyncProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/ResyncProgressState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class ResyncProgressState {
+    @JsonProperty("foreignKeyName")
+    private String foreignKeyName;
+
+    @JsonProperty("updatedValue")
+    private Object updatedValue;
+
+    @JsonProperty("primaryKeys")
+    private List<String> primaryKeys;
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/StreamProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/StreamProgressState.java
@@ -7,6 +7,9 @@ package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.opensearch.dataprepper.plugins.source.rds.model.ForeignKeyRelation;
+
+import java.util.List;
 
 public class StreamProgressState {
 
@@ -15,6 +18,9 @@ public class StreamProgressState {
 
     @JsonProperty("waitForExport")
     private boolean waitForExport = false;
+
+    @JsonProperty("foreignKeyRelations")
+    private List<ForeignKeyRelation> foreignKeyRelations;
 
     public BinlogCoordinate getCurrentPosition() {
         return currentPosition;
@@ -30,5 +36,13 @@ public class StreamProgressState {
 
     public void setWaitForExport(boolean waitForExport) {
         this.waitForExport = waitForExport;
+    }
+
+    public List<ForeignKeyRelation> getForeignKeyRelations() {
+        return foreignKeyRelations;
+    }
+
+    public void setForeignKeyRelations(List<ForeignKeyRelation> foreignKeyRelations) {
+        this.foreignKeyRelations = foreignKeyRelations;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
+import static org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata.DOT_DELIMITER;
 
 public class DataFileLoader implements Runnable {
 
@@ -116,7 +117,7 @@ public class DataFileLoader implements Runnable {
 
                     DataFileProgressState progressState = dataFilePartition.getProgressState().get();
 
-                    final String fullTableName = progressState.getSourceDatabase() + "." + progressState.getSourceTable();
+                    final String fullTableName = progressState.getSourceDatabase() + DOT_DELIMITER + progressState.getSourceTable();
                     final List<String> primaryKeys = progressState.getPrimaryKeyMap().getOrDefault(fullTableName, List.of());
 
                     final long snapshotTime = progressState.getSnapshotTime();

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -160,6 +160,7 @@ public class LeaderScheduler implements Runnable {
         final StreamProgressState progressState = new StreamProgressState();
         progressState.setWaitForExport(sourceConfig.isExportEnabled());
         getCurrentBinlogPosition().ifPresent(progressState::setCurrentPosition);
+        progressState.setForeignKeyRelations(schemaManager.getForeignKeyRelations(sourceConfig.getTableNames()));
         StreamPartition streamPartition = new StreamPartition(sourceConfig.getDbIdentifier(), progressState);
         sourceCoordinator.createPartition(streamPartition);
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ForeignKeyAction.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ForeignKeyAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import java.sql.DatabaseMetaData;
+import java.util.Set;
+
+public enum ForeignKeyAction {
+    CASCADE,
+    NO_ACTION,
+    RESTRICT,
+    SET_DEFAULT,
+    SET_NULL,
+    UNKNOWN;
+
+    /**
+     * Returns the corresponding ForeignKeyAction for the given metadata action value.
+     *
+     * @param action the metadata action value
+     * @return the corresponding ForeignKeyAction
+     */
+    public static ForeignKeyAction getActionFromMetadata(short action) {
+        switch (action) {
+            case DatabaseMetaData.importedKeyCascade:
+                return CASCADE;
+            case DatabaseMetaData.importedKeySetNull:
+                return SET_NULL;
+            case DatabaseMetaData.importedKeySetDefault:
+                return SET_DEFAULT;
+            case DatabaseMetaData.importedKeyRestrict:
+                return RESTRICT;
+            case DatabaseMetaData.importedKeyNoAction:
+                return NO_ACTION;
+            default:
+                return UNKNOWN;
+        }
+    }
+
+    /**
+     * Checks if the foreign key action is one of the cascading actions (CASCADE, SET_DEFAULT, SET_NULL)
+     * that will result in changes to the foreign key value when referenced key in parent table changes.
+     *
+     * @param foreignKeyAction the foreign key action
+     * @return true if the foreign key action is a cascade action, false otherwise
+     */
+    public static boolean isCascadingAction(ForeignKeyAction foreignKeyAction) {
+        if (foreignKeyAction == null) {
+            return false;
+        }
+        return Set.of(CASCADE, SET_DEFAULT, SET_NULL).contains(foreignKeyAction);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ForeignKeyAction.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ForeignKeyAction.java
@@ -16,6 +16,7 @@ public enum ForeignKeyAction {
     SET_NULL,
     UNKNOWN;
 
+    private static final Set<ForeignKeyAction> CASCADING_ACTIONS = Set.of(CASCADE, SET_DEFAULT, SET_NULL);
     /**
      * Returns the corresponding ForeignKeyAction for the given metadata action value.
      *
@@ -50,6 +51,6 @@ public enum ForeignKeyAction {
         if (foreignKeyAction == null) {
             return false;
         }
-        return Set.of(CASCADE, SET_DEFAULT, SET_NULL).contains(foreignKeyAction);
+        return CASCADING_ACTIONS.contains(foreignKeyAction);
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ForeignKeyRelation.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ForeignKeyRelation.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ForeignKeyRelation {
+    // TODO: add java docs
+    @JsonProperty("database_name")
+    private final String databaseName;
+
+    @JsonProperty("parent_table_name")
+    private final String parentTableName;
+
+    @JsonProperty("referenced_key_name")
+    private final String referencedKeyName;
+
+    @JsonProperty("child_table_name")
+    private final String childTableName;
+
+    @JsonProperty("foreign_key_name")
+    private final String foreignKeyName;
+
+    @JsonProperty("foreign_key_default_value")
+    @Builder.Default
+    private Object foreignKeyDefaultValue = null;
+
+    @JsonProperty("update_action")
+    private final ForeignKeyAction updateAction;
+
+    @JsonProperty("delete_action")
+    private final ForeignKeyAction deleteAction;
+
+    @JsonCreator
+    public ForeignKeyRelation(@JsonProperty("database_name") String databaseName,
+                              @JsonProperty("parent_table_name") String parentTableName,
+                              @JsonProperty("referenced_key_name") String referencedKeyName,
+                              @JsonProperty("child_table_name") String childTableName,
+                              @JsonProperty("foreign_key_name") String foreignKeyName,
+                              @JsonProperty("foreign_key_default_value") Object foreignKeyDefaultValue,
+                              @JsonProperty("update_action") ForeignKeyAction updateAction,
+                              @JsonProperty("delete_action") ForeignKeyAction deleteAction) {
+        this.databaseName = databaseName;
+        this.parentTableName = parentTableName;
+        this.referencedKeyName = referencedKeyName;
+        this.childTableName = childTableName;
+        this.foreignKeyName = foreignKeyName;
+        this.foreignKeyDefaultValue = foreignKeyDefaultValue;
+        this.updateAction = updateAction;
+        this.deleteAction = deleteAction;
+    }
+
+    /**
+     * Checks either update action or delete action is one of the cascading actions (CASCADE, SET_DEFAULT, SET_NULL).
+     *
+     * @param foreignKeyRelation The foreign key relation.
+     * @return True if the foreign key relation contains a cascade action, false otherwise.
+     */
+    public static boolean containsCascadingAction(ForeignKeyRelation foreignKeyRelation) {
+        return ForeignKeyAction.isCascadingAction(foreignKeyRelation.getUpdateAction()) ||
+                ForeignKeyAction.isCascadingAction(foreignKeyRelation.getDeleteAction());
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ParentTable.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ParentTable.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A data model for a parent table in a foreign key relationship
+ */
+@Getter
+@Builder
+public class ParentTable {
+    private final String databaseName;
+    private final String tableName;
+    /**
+     * Column name to a list of ForeignKeyRelation in which the column is referenced
+     */
+    private final Map<String, List<ForeignKeyRelation>> referencedColumnMap;
+
+    @Getter(AccessLevel.NONE)
+    @Builder.Default
+    private Map<String, List<ForeignKeyRelation>> columnsWithCascadingUpdate = null;
+
+    @Getter(AccessLevel.NONE)
+    @Builder.Default
+    private Map<String, List<ForeignKeyRelation>> columnsWithCascadingDelete = null;
+
+    /**
+     * Returns a map of column name to a list of ForeignKeyRelation in which the column is referenced and the update action is cascading.
+     * @return a map of column name to a list of ForeignKeyRelation
+     */
+    public Map<String, List<ForeignKeyRelation>> getColumnsWithCascadingUpdate() {
+        if (columnsWithCascadingUpdate != null) {
+            return columnsWithCascadingUpdate;
+        }
+
+        final Map<String, List<ForeignKeyRelation>> columnsWithCascadingUpdate = new HashMap<>();
+        for (String column : referencedColumnMap.keySet()) {
+            for (ForeignKeyRelation foreignKeyRelation : referencedColumnMap.get(column)) {
+                if (ForeignKeyAction.isCascadingAction(foreignKeyRelation.getUpdateAction())) {
+                    if (!columnsWithCascadingUpdate.containsKey(column)) {
+                        columnsWithCascadingUpdate.put(column, new ArrayList<>());
+                    }
+                    columnsWithCascadingUpdate.get(column).add(foreignKeyRelation);
+                }
+            }
+        }
+        return columnsWithCascadingUpdate;
+    }
+
+    /**
+     * Returns a map of column name to a list of ForeignKeyRelation in which the column is referenced and the delete action is cascading.
+     * @return a map of column name to a list of ForeignKeyRelation
+     */
+    public Map<String, List<ForeignKeyRelation>> getColumnsWithCascadingDelete() {
+        if (columnsWithCascadingDelete != null) {
+            return columnsWithCascadingDelete;
+        }
+
+        final Map<String, List<ForeignKeyRelation>> columnsWithCascadingDelete = new HashMap<>();
+        for (String column : referencedColumnMap.keySet()) {
+            for (ForeignKeyRelation foreignKeyRelation : referencedColumnMap.get(column)) {
+                if (ForeignKeyAction.isCascadingAction(foreignKeyRelation.getDeleteAction())) {
+                    if (!columnsWithCascadingDelete.containsKey(column)) {
+                        columnsWithCascadingDelete.put(column, new ArrayList<>());
+                    }
+                    columnsWithCascadingDelete.get(column).add(foreignKeyRelation);
+                }
+            }
+        }
+        return columnsWithCascadingDelete;
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ParentTable.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/ParentTable.java
@@ -44,7 +44,7 @@ public class ParentTable {
             return columnsWithCascadingUpdate;
         }
 
-        final Map<String, List<ForeignKeyRelation>> columnsWithCascadingUpdate = new HashMap<>();
+        columnsWithCascadingUpdate = new HashMap<>();
         for (String column : referencedColumnMap.keySet()) {
             for (ForeignKeyRelation foreignKeyRelation : referencedColumnMap.get(column)) {
                 if (ForeignKeyAction.isCascadingAction(foreignKeyRelation.getUpdateAction())) {
@@ -67,7 +67,7 @@ public class ParentTable {
             return columnsWithCascadingDelete;
         }
 
-        final Map<String, List<ForeignKeyRelation>> columnsWithCascadingDelete = new HashMap<>();
+        columnsWithCascadingDelete = new HashMap<>();
         for (String column : referencedColumnMap.keySet()) {
             for (ForeignKeyRelation foreignKeyRelation : referencedColumnMap.get(column)) {
                 if (ForeignKeyAction.isCascadingAction(foreignKeyRelation.getDeleteAction())) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/TableMetadata.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/TableMetadata.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.plugins.source.rds.model;
 import java.util.List;
 
 public class TableMetadata {
+    public static final String DOT_DELIMITER = ".";
+
     private String databaseName;
     private String tableName;
     private List<String> columnNames;
@@ -29,7 +31,7 @@ public class TableMetadata {
     }
 
     public String getFullTableName() {
-        return databaseName + "." + tableName;
+        return databaseName + DOT_DELIMITER + tableName;
     }
 
     public List<String> getColumnNames() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.resync;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ResyncPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ResyncProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.ForeignKeyAction;
+import org.opensearch.dataprepper.plugins.source.rds.model.ForeignKeyRelation;
+import org.opensearch.dataprepper.plugins.source.rds.model.ParentTable;
+import org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class CascadingActionDetector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CascadingActionDetector.class);
+
+    private final EnhancedSourceCoordinator sourceCoordinator;
+
+    public CascadingActionDetector(final EnhancedSourceCoordinator sourceCoordinator) {
+        this.sourceCoordinator = sourceCoordinator;
+    }
+
+    /**
+     * Gets TableName to ParentTable mapping from given stream partition.
+     * Only parent tables that have cascading update/delete actions defined (CASCADE, SET_NULL, SET_DEFAULT) are included in this map.
+     * @param streamPartition stream partition
+     * @return A map from TableName to ParentTable
+     */
+    public Map<String, ParentTable> getParentTableMap(StreamPartition streamPartition) {
+        final Map<String, ParentTable> parentTableMap = new HashMap<>();
+        if (streamPartition.getProgressState().isEmpty()) {
+            return parentTableMap;
+        }
+
+        List<ForeignKeyRelation> foreignKeyRelations = streamPartition.getProgressState().get().getForeignKeyRelations();;
+
+        for (ForeignKeyRelation foreignKeyRelation : foreignKeyRelations) {
+            if (!ForeignKeyRelation.containsCascadingAction(foreignKeyRelation)) {
+                // skip foreign key relations without cascading actions
+                continue;
+            }
+
+            final String fullParentTableName = getFullTableName(foreignKeyRelation.getDatabaseName(), foreignKeyRelation.getParentTableName());
+            ParentTable parentTable;
+            if (!parentTableMap.containsKey(fullParentTableName)) {
+                Map<String, List<ForeignKeyRelation>> referencedColumnMap = new HashMap<>();
+                referencedColumnMap.put(foreignKeyRelation.getReferencedKeyName(), new ArrayList<>(List.of(foreignKeyRelation)));
+                parentTable = ParentTable.builder()
+                        .databaseName(foreignKeyRelation.getDatabaseName())
+                        .tableName(foreignKeyRelation.getParentTableName())
+                        .referencedColumnMap(referencedColumnMap)
+                        .build();
+                parentTableMap.put(fullParentTableName, parentTable);
+            } else {
+                parentTable = parentTableMap.get(fullParentTableName);
+                if (!parentTable.getReferencedColumnMap().containsKey(foreignKeyRelation.getReferencedKeyName())) {
+                    parentTable.getReferencedColumnMap().put(foreignKeyRelation.getReferencedKeyName(), new ArrayList<>());
+                }
+                parentTable.getReferencedColumnMap().get(foreignKeyRelation.getReferencedKeyName()).add(foreignKeyRelation);
+            }
+        }
+        LOG.debug("ParentTables are {}", parentTableMap.keySet());
+        return parentTableMap;
+    }
+
+    /**
+     * Detects if a binlog event contains cascading updates and if detected, creates resync partitions
+     */
+    public void detectCascadingUpdates(Event event, Map<String, ParentTable> parentTableMap, TableMetadata tableMetadata) {
+        final UpdateRowsEventData data = event.getData();
+        if (parentTableMap.containsKey(tableMetadata.getFullTableName())) {
+            final ParentTable parentTable = parentTableMap.get(tableMetadata.getFullTableName());
+
+            for (Map.Entry<Serializable[], Serializable[]> row : data.getRows()) {
+                // Find out for this row, which columns are changing
+                LOG.debug("Checking for updated columns");
+                final Map<String, Object> updatedColumnsAndValues = IntStream.range(0, row.getKey().length)
+                        .filter(i -> !row.getKey()[i].equals(row.getValue()[i]))
+                        .mapToObj(i -> tableMetadata.getColumnNames().get(i))
+                        .collect(Collectors.toMap(
+                                column -> column,
+                                column -> row.getValue()[tableMetadata.getColumnNames().indexOf(column)]
+                        ));
+                LOG.debug("These columns were updated: {}", updatedColumnsAndValues);
+
+                LOG.debug("Decide whether to create resync partitions");
+                // Create resync partition if changing columns are associated with cascading update
+                for (String column : updatedColumnsAndValues.keySet()) {
+                    if (parentTable.getColumnsWithCascadingUpdate().containsKey(column)) {
+                        for (ForeignKeyRelation foreignKeyRelation : parentTable.getColumnsWithCascadingUpdate().get(column)) {
+                            if (foreignKeyRelation.getUpdateAction() == ForeignKeyAction.CASCADE) {
+                                createResyncPartition(
+                                        foreignKeyRelation.getDatabaseName(),
+                                        foreignKeyRelation.getChildTableName(),
+                                        foreignKeyRelation.getForeignKeyName(),
+                                        updatedColumnsAndValues.get(column),
+                                        tableMetadata.getPrimaryKeys(),
+                                        event.getHeader().getTimestamp());
+                            } else if (foreignKeyRelation.getUpdateAction() == ForeignKeyAction.SET_NULL) {
+                                createResyncPartition(
+                                        foreignKeyRelation.getDatabaseName(),
+                                        foreignKeyRelation.getChildTableName(),
+                                        foreignKeyRelation.getForeignKeyName(),
+                                        null,
+                                        tableMetadata.getPrimaryKeys(),
+                                        event.getHeader().getTimestamp());
+                            } else if (foreignKeyRelation.getUpdateAction() == ForeignKeyAction.SET_DEFAULT) {
+                                createResyncPartition(
+                                        foreignKeyRelation.getDatabaseName(),
+                                        foreignKeyRelation.getChildTableName(),
+                                        foreignKeyRelation.getForeignKeyName(),
+                                        foreignKeyRelation.getForeignKeyDefaultValue(),
+                                        tableMetadata.getPrimaryKeys(),
+                                        event.getHeader().getTimestamp());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Detects if a binlog event contains cascading deletes and if detected, creates resync partitions
+     */
+    public void detectCascadingDeletes(Event event, Map<String, ParentTable> parentTableMap, TableMetadata tableMetadata) {
+        if (parentTableMap.containsKey(tableMetadata.getFullTableName())) {
+            final ParentTable parentTable = parentTableMap.get(tableMetadata.getFullTableName());
+
+            for (String column : parentTable.getColumnsWithCascadingDelete().keySet()) {
+                for (ForeignKeyRelation foreignKeyRelation : parentTable.getColumnsWithCascadingDelete().get(column)) {
+                    if (foreignKeyRelation.getDeleteAction() == ForeignKeyAction.CASCADE) {
+                        LOG.warn("Cascade delete is not supported yet");
+                    } else if (foreignKeyRelation.getDeleteAction() == ForeignKeyAction.SET_NULL) {
+                        // foreign key in the child table will be set to NULL
+                        createResyncPartition(
+                                foreignKeyRelation.getDatabaseName(),
+                                foreignKeyRelation.getChildTableName(),
+                                foreignKeyRelation.getForeignKeyName(),
+                                null,
+                                tableMetadata.getPrimaryKeys(),
+                                event.getHeader().getTimestamp());
+                    } else if (foreignKeyRelation.getDeleteAction() == ForeignKeyAction.SET_DEFAULT) {
+                        createResyncPartition(
+                                foreignKeyRelation.getDatabaseName(),
+                                foreignKeyRelation.getChildTableName(),
+                                foreignKeyRelation.getForeignKeyName(),
+                                foreignKeyRelation.getForeignKeyDefaultValue(),
+                                tableMetadata.getPrimaryKeys(),
+                                event.getHeader().getTimestamp());
+                    }
+                }
+            }
+        }
+    }
+
+    private String getFullTableName(String database, String table) {
+        return database + "." + table;
+    }
+
+    private void createResyncPartition(String database, String childTable, String foreignKeyName, Object updatedValue, List<String> primaryKeys, long eventTimestampMillis) {
+        LOG.debug("Create Resyc partition for table {} and column {} with new value {}", childTable, foreignKeyName, updatedValue);
+        final ResyncProgressState progressState = new ResyncProgressState();
+        progressState.setForeignKeyName(foreignKeyName);
+        progressState.setUpdatedValue(updatedValue);
+        progressState.setPrimaryKeys(primaryKeys);
+
+        final ResyncPartition resyncPartition = new ResyncPartition(database, childTable, eventTimestampMillis, progressState);
+        sourceCoordinator.createPartition(resyncPartition);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata.DOT_DELIMITER;
+
 public class CascadingActionDetector {
 
     private static final Logger LOG = LoggerFactory.getLogger(CascadingActionDetector.class);
@@ -171,7 +173,7 @@ public class CascadingActionDetector {
     }
 
     private String getFullTableName(String database, String table) {
-        return database + "." + table;
+        return database + DOT_DELIMITER + table;
     }
 
     private void createResyncPartition(String database, String childTable, String foreignKeyName, Object updatedValue, List<String> primaryKeys, long eventTimestampMillis) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 public class SchemaManager {
     private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
+
+    static final String[] TABLE_TYPES = new String[]{"TABLE"};
     static final String COLUMN_NAME = "COLUMN_NAME";
     static final String BINLOG_STATUS_QUERY = "SHOW MASTER STATUS";
     static final String BINLOG_FILE = "File";
@@ -36,6 +38,7 @@ public class SchemaManager {
     static final String PKCOLUMN_NAME = "PKCOLUMN_NAME";
     static final String UPDATE_RULE = "UPDATE_RULE";
     static final String DELETE_RULE = "DELETE_RULE";
+    static final String COLUMN_DEF = "COLUMN_DEF";
     private final ConnectionManager connectionManager;
 
     public SchemaManager(ConnectionManager connectionManager) {
@@ -121,11 +124,10 @@ public class SchemaManager {
             try (final Connection connection = connectionManager.getConnection()) {
                 final List<ForeignKeyRelation> foreignKeyRelations = new ArrayList<>();
                 DatabaseMetaData metaData = connection.getMetaData();
-                String[] tableTypes = new String[]{"TABLE"};
                 for (final String tableName : tableNames) {
                     String database = tableName.split("\\.")[0];
                     String table = tableName.split("\\.")[1];
-                    ResultSet tableResult = metaData.getTables(database, null, table, tableTypes);
+                    ResultSet tableResult = metaData.getTables(database, null, table, TABLE_TYPES);
                     while (tableResult.next()) {
                         ResultSet foreignKeys = metaData.getImportedKeys(database, null, table);
 
@@ -143,7 +145,7 @@ public class SchemaManager {
                                 ResultSet columnResult = metaData.getColumns(database, null, table, fkColumnName);
 
                                 if (columnResult.next()) {
-                                    defaultValue = columnResult.getObject("COLUMN_DEF");
+                                    defaultValue = columnResult.getObject(COLUMN_DEF);
                                 }
                             }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactoryTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/coordination/PartitionFactoryTest.java
@@ -10,9 +10,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ResyncPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
 
 import java.util.UUID;
 
@@ -43,6 +46,36 @@ class PartitionFactoryTest {
         when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
 
         assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(ExportPartition.class));
+    }
+
+    @Test
+    void given_stream_partition_item_then_create_stream_partition() {
+        PartitionFactory objectUnderTest = createObjectUnderTest();
+        when(partitionStoreItem.getSourceIdentifier()).thenReturn(UUID.randomUUID() + "|" + StreamPartition.PARTITION_TYPE);
+        when(partitionStoreItem.getSourcePartitionKey()).thenReturn(UUID.randomUUID().toString());
+        when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
+
+        assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(StreamPartition.class));
+    }
+
+    @Test
+    void given_datafile_partition_item_then_create_datafile_partition() {
+        PartitionFactory objectUnderTest = createObjectUnderTest();
+        when(partitionStoreItem.getSourceIdentifier()).thenReturn(UUID.randomUUID() + "|" + DataFilePartition.PARTITION_TYPE);
+        when(partitionStoreItem.getSourcePartitionKey()).thenReturn(UUID.randomUUID() + "|" + UUID.randomUUID() + "|" + UUID.randomUUID());
+        when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
+
+        assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(DataFilePartition.class));
+    }
+
+    @Test
+    void given_resync_partition_item_then_create_resync_partition() {
+        PartitionFactory objectUnderTest = createObjectUnderTest();
+        when(partitionStoreItem.getSourceIdentifier()).thenReturn(UUID.randomUUID() + "|" + ResyncPartition.PARTITION_TYPE);
+        when(partitionStoreItem.getSourcePartitionKey()).thenReturn(UUID.randomUUID() + "|" + UUID.randomUUID() + "|12345");
+        when(partitionStoreItem.getPartitionProgressState()).thenReturn(null);
+
+        assertThat(objectUnderTest.apply(partitionStoreItem), instanceOf(ResyncPartition.class));
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetectorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetectorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.resync;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ResyncPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ResyncProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
+import org.opensearch.dataprepper.plugins.source.rds.model.ForeignKeyAction;
+import org.opensearch.dataprepper.plugins.source.rds.model.ForeignKeyRelation;
+import org.opensearch.dataprepper.plugins.source.rds.model.ParentTable;
+import org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CascadingActionDetectorTest {
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private Event event;
+
+    @Mock
+    private TableMetadata tableMetadata;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private StreamPartition streamPartition;
+
+    private CascadingActionDetector objectUnderTest;
+    private ForeignKeyRelation foreignKeyRelationWithCascading;
+    private ForeignKeyRelation foreignKeyRelationWithoutCascading;
+    private Map<String, ParentTable> parentTableMap;
+
+    @BeforeEach
+    void setUp() {
+        objectUnderTest = createObjectUnderTest();
+        prepareTestTables();
+    }
+
+    @Test
+    void testGetParentTableMap_returns_empty_list_if_stream_progress_state_is_empty() {
+        when(streamPartition.getProgressState()).thenReturn(Optional.empty());
+
+        Map<String, ParentTable> actualParentTableMap = objectUnderTest.getParentTableMap(streamPartition);
+
+        assertThat(actualParentTableMap.size(), is(0));
+    }
+
+    @Test
+    void testGetParentTableMap_returns_only_foreign_relations_with_cascading_actions() {
+        final StreamProgressState progressState = mock(StreamProgressState.class);
+        when(streamPartition.getProgressState()).thenReturn(Optional.of(progressState));
+        when(progressState.getForeignKeyRelations()).thenReturn(List.of(foreignKeyRelationWithCascading, foreignKeyRelationWithoutCascading));
+
+        Map<String, ParentTable> actualParentTableMap = objectUnderTest.getParentTableMap(streamPartition);
+
+        assertThat(actualParentTableMap.size(), is(1));
+        assertThat(actualParentTableMap.containsKey("test-database.parent-table1"), is(true));
+
+        final ParentTable parentTable = actualParentTableMap.get("test-database.parent-table1");
+        assertThat(parentTable.getDatabaseName(), is("test-database"));
+        assertThat(parentTable.getTableName(), is("parent-table1"));
+        assertThat(parentTable.getReferencedColumnMap().size(), is(1));
+        assertThat(parentTable.getReferencedColumnMap().containsKey("referenced-column"), is(true));
+        assertThat(parentTable.getReferencedColumnMap().get("referenced-column").size(), is(1));
+        assertThat(parentTable.getReferencedColumnMap().get("referenced-column").get(0), is(foreignKeyRelationWithCascading));
+    }
+
+    @Test
+    void testDetectCascadingUpdates() {
+        UpdateRowsEventData data = mock(UpdateRowsEventData.class);
+        List<Map.Entry<Serializable[], Serializable[]>> rows = List.of(Map.entry(new Serializable[]{"old-value"}, new Serializable[]{"new-value"}));
+        long timestampInMillis = Instant.now().toEpochMilli();
+        List<String> primaryKeys = List.of("primary-key");
+        when(event.getData()).thenReturn(data);
+        when(event.getHeader().getTimestamp()).thenReturn(timestampInMillis);
+        when(tableMetadata.getFullTableName()).thenReturn("test-database.parent-table1");
+        when(data.getRows()).thenReturn(rows);
+        when(tableMetadata.getColumnNames()).thenReturn(List.of("referenced-column"));
+        when(tableMetadata.getPrimaryKeys()).thenReturn(primaryKeys);
+
+        objectUnderTest.detectCascadingUpdates(event, parentTableMap, tableMetadata);
+
+        ArgumentCaptor<ResyncPartition> resyncPartitionArgumentCaptor = ArgumentCaptor.forClass(ResyncPartition.class);
+        verify(sourceCoordinator).createPartition(resyncPartitionArgumentCaptor.capture());
+        ResyncPartition resyncPartition = resyncPartitionArgumentCaptor.getValue();
+
+        assertThat(resyncPartition.getPartitionKey(), is("test-database|child-table|" + timestampInMillis));
+
+        ResyncProgressState progressState = resyncPartition.getProgressState().get();
+        assertThat(progressState.getForeignKeyName(), is("foreign-key1"));
+        assertThat(progressState.getUpdatedValue(), is("new-value"));
+        assertThat(progressState.getPrimaryKeys(), is(primaryKeys));
+    }
+
+    @Test
+    void detectCascadingDeletes() {
+        long timestampInMillis = Instant.now().toEpochMilli();
+        List<String> primaryKeys = List.of("primary-key");
+        when(event.getHeader().getTimestamp()).thenReturn(timestampInMillis);
+        when(tableMetadata.getFullTableName()).thenReturn("test-database.parent-table1");
+        when(tableMetadata.getPrimaryKeys()).thenReturn(primaryKeys);
+
+        objectUnderTest.detectCascadingDeletes(event, parentTableMap, tableMetadata);
+
+        ArgumentCaptor<ResyncPartition> resyncPartitionArgumentCaptor = ArgumentCaptor.forClass(ResyncPartition.class);
+        verify(sourceCoordinator).createPartition(resyncPartitionArgumentCaptor.capture());
+        ResyncPartition resyncPartition = resyncPartitionArgumentCaptor.getValue();
+
+        assertThat(resyncPartition.getPartitionKey(), is("test-database|child-table|" + timestampInMillis));
+
+        ResyncProgressState progressState = resyncPartition.getProgressState().get();
+        assertThat(progressState.getForeignKeyName(), is("foreign-key1"));
+        assertThat(progressState.getUpdatedValue(), nullValue());
+        assertThat(progressState.getPrimaryKeys(), is(primaryKeys));
+    }
+
+    private CascadingActionDetector createObjectUnderTest() {
+        return new CascadingActionDetector(sourceCoordinator);
+    }
+
+    private void prepareTestTables() {
+        final String databaseName = "test-database";
+        final String parentTableName1 = "parent-table1";
+        final String parentTableName2 = "parent-table2";
+        final String referencedColumnName = "referenced-column";
+        final String childTableName = "child-table";
+        final String foreignKey1 = "foreign-key1";
+        final String foreignKey2 = "foreign-key2";
+
+
+        foreignKeyRelationWithCascading = ForeignKeyRelation.builder()
+                .databaseName(databaseName)
+                .parentTableName(parentTableName1)
+                .referencedKeyName(referencedColumnName)
+                .childTableName(childTableName)
+                .foreignKeyName(foreignKey1)
+                .updateAction(ForeignKeyAction.CASCADE)
+                .deleteAction(ForeignKeyAction.SET_NULL)
+                .build();
+
+        foreignKeyRelationWithoutCascading = ForeignKeyRelation.builder()
+                .databaseName(databaseName)
+                .parentTableName(parentTableName2)
+                .referencedKeyName(referencedColumnName)
+                .childTableName(childTableName)
+                .foreignKeyName(foreignKey2)
+                .updateAction(ForeignKeyAction.RESTRICT)
+                .build();
+
+        ParentTable parentTable1 = ParentTable.builder()
+                .databaseName(databaseName)
+                .tableName(parentTableName1)
+                .referencedColumnMap(Map.of(referencedColumnName, List.of(foreignKeyRelationWithCascading)))
+                .build();
+
+        parentTableMap = Map.of(databaseName + "." + parentTableName1, parentTable1);
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetectorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetectorTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata.DOT_DELIMITER;
 
 @ExtendWith(MockitoExtension.class)
 class CascadingActionDetectorTest {
@@ -179,6 +180,6 @@ class CascadingActionDetectorTest {
                 .referencedColumnMap(Map.of(referencedColumnName, List.of(foreignKeyRelationWithCascading)))
                 .build();
 
-        parentTableMap = Map.of(databaseName + "." + parentTableName1, parentTable1);
+        parentTableMap = Map.of(databaseName + DOT_DELIMITER + parentTableName1, parentTable1);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManagerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata.DOT_DELIMITER;
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_FILE;
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_POSITION;
 import static org.opensearch.dataprepper.plugins.source.rds.schema.SchemaManager.BINLOG_STATUS_QUERY;
@@ -181,7 +182,7 @@ class SchemaManagerTest {
     void test_getForeignKeyRelations_returns_foreign_key_relations() throws SQLException {
         final String databaseName = "test-db";
         final String tableName = "test-table";
-        final List<String> tableNames = List.of(databaseName + "." + tableName);
+        final List<String> tableNames = List.of(databaseName + DOT_DELIMITER + tableName);
         final ResultSet tableResult = mock(ResultSet.class);
         final ResultSet foreignKeys = mock(ResultSet.class);
         final String fkTableName = UUID.randomUUID().toString();

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -26,6 +26,8 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.resync.CascadingActionDetector;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -47,6 +49,9 @@ import static org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventLi
 class BinlogEventListenerTest {
 
     @Mock
+    private StreamPartition streamPartition;
+
+    @Mock
     private Buffer<Record<Event>> buffer;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -63,6 +68,9 @@ class BinlogEventListenerTest {
 
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private CascadingActionDetector cascadingActionDetector;
 
     @Mock
     private ExecutorService eventListnerExecutorService;
@@ -153,7 +161,8 @@ class BinlogEventListenerTest {
     }
 
     private BinlogEventListener createObjectUnderTest() {
-        return new BinlogEventListener(buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient, streamCheckpointer, acknowledgementSetManager);
+        return BinlogEventListener.create(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
+                streamCheckpointer, acknowledgementSetManager, cascadingActionDetector);
     }
 
     private void verifyHandlerCallHelper() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
@@ -23,6 +23,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.source.rds.resync.CascadingActionDetector;
 
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -108,7 +109,9 @@ class StreamWorkerTaskRefresherTest {
              MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
             streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
                     .thenReturn(streamWorker);
-            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
+                            any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer),
+                            eq(acknowledgementSetManager), any(CascadingActionDetector.class)))
                     .thenReturn(binlogEventListener);
             streamWorkerTaskRefresher.initialize(sourceConfig);
         }
@@ -142,7 +145,9 @@ class StreamWorkerTaskRefresherTest {
              MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
             streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
                     .thenReturn(streamWorker);
-            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
+                            any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer),
+                            eq(acknowledgementSetManager), any(CascadingActionDetector.class)))
                     .thenReturn(binlogEventListener);
             streamWorkerTaskRefresher.initialize(sourceConfig);
             streamWorkerTaskRefresher.update(sourceConfig2);
@@ -175,7 +180,9 @@ class StreamWorkerTaskRefresherTest {
              MockedStatic<BinlogEventListener> binlogEventListenerMockedStatic = mockStatic(BinlogEventListener.class)) {
             streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(BinaryLogClient.class), eq(pluginMetrics)))
                     .thenReturn(streamWorker);
-            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(buffer), any(RdsSourceConfig.class), any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+            binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
+                            any(String.class), eq(pluginMetrics), eq(binlogClient), eq(streamCheckpointer),
+                            eq(acknowledgementSetManager), any(CascadingActionDetector.class)))
                     .thenReturn(binlogEventListener);
             streamWorkerTaskRefresher.initialize(sourceConfig);
             streamWorkerTaskRefresher.update(sourceConfig);


### PR DESCRIPTION
### Description
When a foreign key with cascading action defined, the cascading changes in the child tables won't appear in binlog. The rds source plugin will try to detect cascading changes and generate pipeline events for them. This PR covers the first part to detect cascades and save the information in the coordination store (as resync partitions). Next PR (#5171) will cover the processing of those partitions.
 
### Issues Resolved
Contributes to #4561 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
