### PR TITLE
Fix Kafka source to override areAcknowlegementsEnabled

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -114,6 +114,11 @@ public class KafkaSource implements Source<Record<Event>> {
     }
 
     @Override
+    public boolean areAcknowledgementsEnabled() {
+        return sourceConfig.getAcknowledgementsEnabled();
+    }
+
+    @Override
     public void start(Buffer<Record<Event>> buffer) {
         try {
             setMdc();

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -130,6 +131,7 @@ class KafkaSourceTest {
         when(sourceConfig.getTopics()).thenReturn((List) List.of(topic1, topic2));
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(sourceConfig.getEncryptionConfig()).thenReturn(encryptionConfig);
+        when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
         when(encryptionConfig.getType()).thenReturn(EncryptionType.NONE);
     }
 
@@ -163,6 +165,15 @@ class KafkaSourceTest {
         assertTrue(Objects.nonNull(kafkaSource));
         kafkaSource.start(buffer);
         assertTrue(Objects.nonNull(kafkaSource.getConsumer()));
+        assertFalse(kafkaSource.areAcknowledgementsEnabled());
+    }
+
+    @Test
+    void test_kafkaSource_withAcknowledgements() {
+        when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(true);
+        kafkaSource = createObjectUnderTest();
+        assertTrue(Objects.nonNull(kafkaSource));
+        assertTrue(kafkaSource.areAcknowledgementsEnabled());
     }
 
     @Test


### PR DESCRIPTION
### Description
Fix Kafka source to override areAcknowlegementsEnabled. All sources supporting acknowledgements must override this interface to reflect the configured value.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
