### PR TITLE
Escape control characters for DynamoDB source

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -123,7 +123,20 @@ public class StreamRecordConverter extends RecordConverter {
      */
     private Map<String, Object> convertData(Map<String, AttributeValue> data) throws JsonProcessingException {
         String jsonData = EnhancedDocument.fromAttributeValueMap(data).toJson();
-        return MAPPER.readValue(jsonData, MAP_TYPE_REFERENCE);
+
+        StringBuilder sanitizedStringBuilder = new StringBuilder();
+        for (int i = 0; i < jsonData.length(); i++) {
+            char c = jsonData.charAt(i);
+            if (Character.isISOControl(c) && c != '\t' && c != '\n' && c != '\r') {
+                // Replace control characters with escaped versions (e.g. \u0000 for null, \u0001 for start of heading, etc.)
+                sanitizedStringBuilder.append(String.format("\\u%04X", (int) c));
+            } else {
+                // Keep normal characters as they are
+                sanitizedStringBuilder.append(c);
+            }
+        }
+        String sanitizedJsonData = sanitizedStringBuilder.toString();
+        return MAPPER.readValue(sanitizedJsonData, MAP_TYPE_REFERENCE);
     }
 
     /**

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -188,7 +188,8 @@ class StreamRecordConverterTest {
             "and/or",
             "c:\\Home",
             "I take\nup multiple\nlines",
-            "String with some \"backquotes\"."
+            "String with some \"backquotes\".",
+            "String with some control characters: \0\1\2\3\4\5\6\7\10\11\12\13\14\15\16\17\20\21\22\23\24\25\26\27\28\29\30\31\127\b\t\n\f\r"
     })
     void test_writeSingleRecordToBuffer_with_other_data(final String additionalString) throws Exception {
 


### PR DESCRIPTION
### Description
Escapes control characters for the DynamoDB source.
 
### Issues Resolved
Resolves #5027
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
