### PR TITLE
Fix PeerForwardingProcessorDecorator to process records locally when exclude identification keys is set

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -102,7 +102,6 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
         for (Record<Event> record: records) {
             if (((RequiresPeerForwarding)innerProcessor).isApplicableEventForPeerForwarding(record.getData())) {
                 if (isPeerForwardingDisabled()) {
-                    System.out.println("=====PROCESSING LOCALLY====");
                     recordsToProcessLocally.add(record);
                 } else {
                     recordsToProcess.add(record);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -101,7 +101,12 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
         final Collection<Record<Event>> recordsSkipped = new ArrayList<>();
         for (Record<Event> record: records) {
             if (((RequiresPeerForwarding)innerProcessor).isApplicableEventForPeerForwarding(record.getData())) {
-                recordsToProcess.add(record);
+                if (isPeerForwardingDisabled()) {
+                    System.out.println("=====PROCESSING LOCALLY====");
+                    recordsToProcessLocally.add(record);
+                } else {
+                    recordsToProcess.add(record);
+                }
             } else if (((RequiresPeerForwarding)innerProcessor).isForLocalProcessingOnly(record.getData())){
                 recordsToProcessLocally.add(record);
             } else {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -173,9 +173,11 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_with_localProcessingOnlyWithExcludeIdentificationKeys() {
-            List<Processor> processorList = new ArrayList<>();
-            processorList.add((Processor) requiresPeerForwarding);
-            processorList.add((Processor) requiresPeerForwardingCopy);
+            List<Processor> objectsUnderTest = new ArrayList<>();
+            Processor innerProcessor1 = (Processor)requiresPeerForwarding;
+            Processor innerProcessor2 = (Processor)requiresPeerForwardingCopy;
+            objectsUnderTest.add(innerProcessor1);
+            objectsUnderTest.add(innerProcessor2);
 
             LocalPeerForwarder localPeerForwarder = mock(LocalPeerForwarder.class);
             when(peerForwarderProvider.register(pipelineName, (Processor) requiresPeerForwarding, pluginId, identificationKeys, PIPELINE_WORKER_THREADS)).thenReturn(localPeerForwarder);
@@ -185,16 +187,14 @@ class PeerForwardingProcessingDecoratorTest {
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(true);
             when(requiresPeerForwardingCopy.isApplicableEventForPeerForwarding(event)).thenReturn(true);
 
-            Processor processor1 = (Processor)requiresPeerForwarding;
-            Processor processor2 = (Processor)requiresPeerForwardingCopy;
-            when(processor1.execute(testData)).thenReturn(testData);
-            when(processor2.execute(testData)).thenReturn(testData);
+            when(innerProcessor1.execute(testData)).thenReturn(testData);
+            when(innerProcessor2.execute(testData)).thenReturn(testData);
 
             when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(identificationKeys);
             when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(identificationKeys);
             when(requiresPeerForwardingCopy.getIdentificationKeys()).thenReturn(identificationKeys);
 
-            final List<Processor> processors = createObjectUnderTestDecoratedProcessorsWithExcludeIdentificationKeys(processorList, Set.of(identificationKeys));
+            final List<Processor> processors = createObjectUnderTestDecoratedProcessorsWithExcludeIdentificationKeys(objectsUnderTest, Set.of(identificationKeys));
             assertThat(processors.size(), equalTo(2));
             for (final Processor processor: processors) {
                 assertTrue(((PeerForwardingProcessorDecorator)processor).isPeerForwardingDisabled());


### PR DESCRIPTION
### Description
Fix PeerForwardingProcessorDecorator to process records locally when exclude identification keys is set.
The changes in PR 5127 missed a step in execute() which is supposed to process records locally if peer forwarding is disabled for a processor
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
