### PR TITLE
Replace underscores in plugin names with dashes for correct doc link

### DIFF
--- a/data-prepper-plugin-schema/src/main/java/org/opensearch/dataprepper/schemas/PluginConfigsJsonSchemaConverter.java
+++ b/data-prepper-plugin-schema/src/main/java/org/opensearch/dataprepper/schemas/PluginConfigsJsonSchemaConverter.java
@@ -118,13 +118,14 @@ public class PluginConfigsJsonSchemaConverter {
     private void addDocumentationLink(final ObjectNode jsonSchemaNode,
                                       final String pluginName,
                                       final Class<?> pluginType) {
+        String formattedPluginName = pluginName.replace("_", "-");
         jsonSchemaNode.put(DOCUMENTATION_LINK_KEY,
                 String.format(
                         PLUGIN_DOCUMENTATION_URL_FORMAT,
                         siteUrl,
                         siteBaseUrl,
                         PLUGIN_TYPE_TO_URI_PARAMETER_MAP.get(pluginType),
-                        pluginName));
+                        formattedPluginName));
     }
 
     private void addPluginName(final ObjectNode jsonSchemaNode,

--- a/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/PluginConfigsJsonSchemaConverterTest.java
+++ b/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/PluginConfigsJsonSchemaConverterTest.java
@@ -77,7 +77,7 @@ class PluginConfigsJsonSchemaConverterTest {
         final Map<String, Object> schemaMap = OBJECT_MAPPER.readValue(result.get("test_plugin"), MAP_TYPE_REFERENCE);
         assertThat(schemaMap, notNullValue());
         assertThat(schemaMap.get(DOCUMENTATION_LINK_KEY), equalTo(
-                "{{site.url}}{{site.baseurl}}/data-prepper/pipelines/configuration/null/test_plugin/"
+                "{{site.url}}{{site.baseurl}}/data-prepper/pipelines/configuration/null/test-plugin/"
         ));
         assertThat(schemaMap.containsKey(PLUGIN_NAME_KEY), is(true));
     }


### PR DESCRIPTION
### Description
Plugin names are formatted like `plugin_name` but opensearch.org documentation links format plugin names like `plugin-name`. This PR adds the conversion behavior to generate valid documentation links in the schemas.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
