### PR TITLE
Fix parquet decimal bytes values

### DIFF
--- a/data-prepper-plugins/parquet-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/GenericRecordJsonEncoder.java
+++ b/data-prepper-plugins/parquet-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/GenericRecordJsonEncoder.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.avro.LogicalType;
@@ -120,8 +121,9 @@ public class GenericRecordJsonEncoder {
             buffer.append("\"");
         } else if (isBytes(datum)) {
             final String bytesAsString = StandardCharsets.UTF_8.decode((ByteBuffer) datum).toString();
-            if (isBigDecimal(bytesAsString)) {
-                buffer.append(new BigDecimal(bytesAsString).doubleValue());
+            final Optional<BigDecimal> bytesAsBigDecimal = getBigDecimal(bytesAsString);
+            if (bytesAsBigDecimal.isPresent()) {
+                buffer.append(bytesAsBigDecimal.get().doubleValue());
             } else {
                 buffer.append("{\"bytes\": \"");
                 ByteBuffer bytes = ((ByteBuffer) datum).duplicate();
@@ -192,12 +194,11 @@ public class GenericRecordJsonEncoder {
         builder.append(StringEscapeUtils.escapeJava(string));
     }
 
-    private boolean isBigDecimal(String decimalString) {
+    private Optional<BigDecimal> getBigDecimal(String decimalString) {
         try {
-            final BigDecimal bigDecimal = new BigDecimal(decimalString);
-            return true;
+            return Optional.of(new BigDecimal(decimalString));
         } catch (final Exception e) {
-            return false;
+            return Optional.empty();
         }
     }
 }

--- a/data-prepper-plugins/parquet-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/GenericRecordJsonEncoderTest.java
+++ b/data-prepper-plugins/parquet-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/GenericRecordJsonEncoderTest.java
@@ -5,8 +5,11 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -198,6 +201,26 @@ class GenericRecordJsonEncoderTest {
         record.put("rawData", ByteBuffer.wrap(new byte[]{34, 92, 13, 10, 9}));
 
         String expectedJson = "{\"nested\": null, \"id\": null, \"value\": null, \"floatValue\": null, \"alternateIds\": null, \"metadata\": null, \"lastUpdated\": null, \"rawData\": {\"bytes\": \"\\\"\\\\\\r\\n\\t\"}, \"suit\": null}";
+
+        String json = encoder.serialize(record);
+
+        assertEquals(expectedJson, json);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = { 3.2, 5.0, 7.8})
+    void serialize_WithBytes_that_can_be_converted_to_big_decimal_Returns_expected_Json(
+            final Double decimalValue
+    ) {
+        // Test for serializing bytes with special characters
+        GenericRecord record = new GenericData.Record(SCHEMA);
+
+        final ByteBuffer buffer = StandardCharsets.UTF_8.encode(decimalValue.toString());
+        record.put("rawData", buffer);
+
+        String expectedJson = "{\"nested\": null, \"id\": null, \"value\": null, \"floatValue\": null, \"alternateIds\": null, \"metadata\": null, \"lastUpdated\": null, \"rawData\": " +
+                decimalValue + "," +
+                " \"suit\": null}";
 
         String json = encoder.serialize(record);
 


### PR DESCRIPTION
### Description
Currently, the parquet reader is handling bytes values by always adding a key-value pair of { "bytes": "escaped-json-string" } to the Event. 

When there is a decimal value, it still writes this bytes key-value pair, even though it can be converted to decimal and can be added as a raw value in the Event.

This change just checks the decoded String of the bytes to see if they can be converted to big decimal, and if so they will be added as a raw decimal value to the Event. Otherwise the same behavior as before is kept.

Tested this on a sample parquet file that was previously getting "bytes" key-value for decimal values
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
