### PR TITLE
Handle microseconds in datetime/timestamp and time MySQL data type

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandler.java
@@ -89,7 +89,7 @@ public class TemporalTypeHandler implements DataTypeHandler {
         try {
             // Handle MySQL zero date special case
             if ("0000-00-00".equals(dateStr)) {
-                return null; // or return a specific default value
+                return null;
             }
 
             // Try parsing as Unix timestamp first

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
@@ -59,7 +59,7 @@ class TemporalTypeHandlerTest {
                 Arguments.of("2023-12-25", getEpochMillisFromDate(2023, 12, 25)),
                 Arguments.of("1970-01-01", getEpochMillisFromDate(1970, 1, 1)),
                 Arguments.of("2024-02-29", getEpochMillisFromDate(2024, 2, 29)), // Leap year
-                Arguments.of("0000-00-00", null), // Leap year
+                Arguments.of("0000-00-00", null),
                 Arguments.of("1684108800000", getEpochMillisFromDate(2023, 5, 15))
         );
     }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
@@ -103,7 +103,8 @@ class TemporalTypeHandlerTest {
         return Stream.of(
             Arguments.of("2023-12-25 14:30:00.123456", getEpochMillis(2023, 12, 25, 14, 30, 0, 123456000)),
             Arguments.of("1970-01-01 00:00:00", getEpochMillis(1970, 1, 1, 0, 0, 0, 0)),
-            Arguments.of("1703509900000", 1703509900000L)
+            Arguments.of("1703509900000", 1703509900000L),
+            Arguments.of("1784161123456789", 1784161123456L)
         );
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
@@ -86,7 +86,9 @@ class TemporalTypeHandlerTest {
                 Arguments.of("52200123",
                         getEpochMillis(1970, 1, 1, 14, 30, 0, 123456000)),
                 Arguments.of("16:30:00.000000",
-                        getEpochMillis(1970, 1, 1, 16, 30, 0, 0))
+                        getEpochMillis(1970, 1, 1, 16, 30, 0, 0)),
+                Arguments.of("07:17:00.456789",
+                        getEpochMillis(1970, 1, 1, 7, 17, 0, 456789000))
         );
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
@@ -49,7 +49,7 @@ class TemporalTypeHandlerTest {
 
     @ParameterizedTest
     @MethodSource("provideDateTestCases")
-    void handle_withDateType_returnsCorrectEpochMillis(String input, long expected) {
+    void handle_withDateType_returnsCorrectEpochMillis(String input, Long expected) {
         Long result = temporalTypeHandler.handle(MySQLDataType.DATE, "date_column", input, null);
         assertEquals(expected, result);
     }
@@ -59,6 +59,7 @@ class TemporalTypeHandlerTest {
                 Arguments.of("2023-12-25", getEpochMillisFromDate(2023, 12, 25)),
                 Arguments.of("1970-01-01", getEpochMillisFromDate(1970, 1, 1)),
                 Arguments.of("2024-02-29", getEpochMillisFromDate(2024, 2, 29)), // Leap year
+                Arguments.of("0000-00-00", null), // Leap year
                 Arguments.of("1684108800000", getEpochMillisFromDate(2023, 5, 15))
         );
     }
@@ -83,7 +84,9 @@ class TemporalTypeHandlerTest {
                 Arguments.of("52200000",
                         getEpochMillis(1970, 1, 1, 14, 30, 0, 0)),
                 Arguments.of("52200123",
-                        getEpochMillis(1970, 1, 1, 14, 30, 0, 123456000))
+                        getEpochMillis(1970, 1, 1, 14, 30, 0, 123456000)),
+                Arguments.of("16:30:00.000000",
+                        getEpochMillis(1970, 1, 1, 16, 30, 0, 0))
         );
     }
 


### PR DESCRIPTION
### Description
Handle microseconds in datetime/timestamp and time MySQL data type. Also handle date special case.
 
### Issues Resolved
Contributes to https://github.com/opensearch-project/data-prepper/issues/4561
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
