### PR TITLE
Handle MySQL Year data type with value <=1900 and >2155

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandler.java
@@ -142,7 +142,15 @@ public class TemporalTypeHandler implements DataTypeHandler {
     private Long handleYear(final String yearStr) {
         try {
             // MySQL YEAR values are typically four-digit numbers (e.g., 2024).
-            return Long.parseLong(yearStr);
+            final long year = Long.parseLong(yearStr);
+
+            // MySQL converts values in 1- or 2-digit strings in the range '0' to '99' to YYYY format
+            // MySQL YEAR values in YYYY format are with a range of 1901 to 2155. Outside this range the value is 0.
+            if (year <= 1900 || year > 2155) {
+                return 0L;
+            }
+
+            return year;
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid year format: " + yearStr, e);
         }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/impl/TemporalTypeHandlerTest.java
@@ -132,8 +132,13 @@ class TemporalTypeHandlerTest {
     private static Stream<Arguments> provideYearTestCases() {
         return Stream.of(
                 Arguments.of("2023", 2023),
-                Arguments.of("1900", 1900),
-                Arguments.of("1997", 1997)
+                Arguments.of("1900", 0),
+                Arguments.of("1997", 1997),
+                Arguments.of("1889", 0),
+                Arguments.of("1901", 1901),
+                Arguments.of("2155", 2155),
+                Arguments.of("2156", 0),
+                Arguments.of("3015", 0)
         );
     }
 


### PR DESCRIPTION
### Description
Handle MySQL Year data type with value <=1900 and >2155.

MySQL converts values in 1- or 2-digit strings in the range '0' to '99' to YYYY format. MySQL YEAR values in YYYY format are with a range of 1901 to 2155. Outside this range the value is 0.
            
### Issues Resolved
Contributes to https://github.com/opensearch-project/data-prepper/issues/4561
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
