### PR TITLE
FIX: unsupported message format in kafka

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/MessageFormat.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/MessageFormat.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -33,6 +34,7 @@ public enum MessageFormat {
 
     @JsonCreator
     public static MessageFormat getByMessageFormatByName(final String name) {
-        return MESSAGE_FORMAT_MAP.get(name.toLowerCase());
+        return Optional.ofNullable(MESSAGE_FORMAT_MAP.get(name.toLowerCase())).orElseThrow(
+                () -> new IllegalArgumentException("Unsupported message format in kafka plugin: " + name));
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/MessageFormatTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/MessageFormatTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.kafka.util;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -12,12 +13,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class MessageFormatTest {
 	@ParameterizedTest
 	@EnumSource(MessageFormat.class)
-	void getByNameTest(final MessageFormat name) {
+	void getByNameSupportedTest(final MessageFormat name) {
 		assertThat(MessageFormat.getByMessageFormatByName(name.name()), is(name));
+	}
+
+	@Test
+	void getByNameUnsupportedTest() {
+		assertThrows(IllegalArgumentException.class, () -> MessageFormat.getByMessageFormatByName("unknown"));
 	}
 }


### PR DESCRIPTION
### Description
This PR fixes the NPE due to currently unsupported confluent registry schema type
 
### Issues Resolved
Resolves #4648 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
