### PR TITLE
refactored to remove handlers passing

### DIFF
--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessor.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessor.java
@@ -52,206 +52,210 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 @DataPrepperPlugin(name = "aws_lambda", pluginType = Processor.class, pluginConfigurationType = LambdaProcessorConfig.class)
 public class LambdaProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
 
-  public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS = "lambdaProcessorObjectsEventsSucceeded";
-  public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED = "lambdaProcessorObjectsEventsFailed";
-  public static final String NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsSucceeded";
-  public static final String NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsFailed";
-  public static final String LAMBDA_LATENCY_METRIC = "lambdaProcessorLatency";
-  public static final String REQUEST_PAYLOAD_SIZE = "requestPayloadSize";
-  public static final String RESPONSE_PAYLOAD_SIZE = "responsePayloadSize";
+    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS = "lambdaProcessorObjectsEventsSucceeded";
+    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED = "lambdaProcessorObjectsEventsFailed";
+    public static final String NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsSucceeded";
+    public static final String NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsFailed";
+    public static final String LAMBDA_LATENCY_METRIC = "lambdaProcessorLatency";
+    public static final String REQUEST_PAYLOAD_SIZE = "requestPayloadSize";
+    public static final String RESPONSE_PAYLOAD_SIZE = "responsePayloadSize";
 
-  private static final Logger LOG = LoggerFactory.getLogger(LambdaProcessor.class);
-  final PluginSetting codecPluginSetting;
-  final PluginFactory pluginFactory;
-  final LambdaProcessorConfig lambdaProcessorConfig;
-  private final String whenCondition;
-  private final ExpressionEvaluator expressionEvaluator;
-  private final Counter numberOfRecordsSuccessCounter;
-  private final Counter numberOfRecordsFailedCounter;
-  private final Counter numberOfRequestsSuccessCounter;
-  private final Counter numberOfRequestsFailedCounter;
-  private final Timer lambdaLatencyMetric;
-  private final List<String> tagsOnMatchFailure;
-  private final LambdaAsyncClient lambdaAsyncClient;
-  private final DistributionSummary requestPayloadMetric;
-  private final DistributionSummary responsePayloadMetric;
-  private final ResponseEventHandlingStrategy responseStrategy;
-  private final JsonOutputCodecConfig jsonOutputCodecConfig;
+    private static final Logger LOG = LoggerFactory.getLogger(LambdaProcessor.class);
+    final PluginSetting codecPluginSetting;
+    final PluginFactory pluginFactory;
+    final LambdaProcessorConfig lambdaProcessorConfig;
+    private final String whenCondition;
+    private final ExpressionEvaluator expressionEvaluator;
+    private final Counter numberOfRecordsSuccessCounter;
+    private final Counter numberOfRecordsFailedCounter;
+    private final Counter numberOfRequestsSuccessCounter;
+    private final Counter numberOfRequestsFailedCounter;
+    private final Timer lambdaLatencyMetric;
+    private final List<String> tagsOnMatchFailure;
+    private final LambdaAsyncClient lambdaAsyncClient;
+    private final DistributionSummary requestPayloadMetric;
+    private final DistributionSummary responsePayloadMetric;
+    private final ResponseEventHandlingStrategy responseStrategy;
+    private final JsonOutputCodecConfig jsonOutputCodecConfig;
 
-  @DataPrepperPluginConstructor
-  public LambdaProcessor(final PluginFactory pluginFactory, final PluginMetrics pluginMetrics,
-      final LambdaProcessorConfig lambdaProcessorConfig,
-      final AwsCredentialsSupplier awsCredentialsSupplier,
-      final ExpressionEvaluator expressionEvaluator) {
-    super(pluginMetrics);
-    this.expressionEvaluator = expressionEvaluator;
-    this.pluginFactory = pluginFactory;
-    this.lambdaProcessorConfig = lambdaProcessorConfig;
-    this.numberOfRecordsSuccessCounter = pluginMetrics.counter(
-        NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS);
-    this.numberOfRecordsFailedCounter = pluginMetrics.counter(
-        NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED);
-    this.numberOfRequestsSuccessCounter = pluginMetrics.counter(
-        NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA);
-    this.numberOfRequestsFailedCounter = pluginMetrics.counter(
-        NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA);
-    this.lambdaLatencyMetric = pluginMetrics.timer(LAMBDA_LATENCY_METRIC);
-    this.requestPayloadMetric = pluginMetrics.summary(REQUEST_PAYLOAD_SIZE);
-    this.responsePayloadMetric = pluginMetrics.summary(RESPONSE_PAYLOAD_SIZE);
-    this.whenCondition = lambdaProcessorConfig.getWhenCondition();
-    this.tagsOnMatchFailure = lambdaProcessorConfig.getTagsOnFailure();
+    @DataPrepperPluginConstructor
+    public LambdaProcessor(final PluginFactory pluginFactory, final PluginMetrics pluginMetrics,
+        final LambdaProcessorConfig lambdaProcessorConfig,
+        final AwsCredentialsSupplier awsCredentialsSupplier,
+        final ExpressionEvaluator expressionEvaluator) {
+        super(pluginMetrics);
+        this.expressionEvaluator = expressionEvaluator;
+        this.pluginFactory = pluginFactory;
+        this.lambdaProcessorConfig = lambdaProcessorConfig;
+        this.numberOfRecordsSuccessCounter = pluginMetrics.counter(
+            NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS);
+        this.numberOfRecordsFailedCounter = pluginMetrics.counter(
+            NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED);
+        this.numberOfRequestsSuccessCounter = pluginMetrics.counter(
+            NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA);
+        this.numberOfRequestsFailedCounter = pluginMetrics.counter(
+            NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA);
+        this.lambdaLatencyMetric = pluginMetrics.timer(LAMBDA_LATENCY_METRIC);
+        this.requestPayloadMetric = pluginMetrics.summary(REQUEST_PAYLOAD_SIZE);
+        this.responsePayloadMetric = pluginMetrics.summary(RESPONSE_PAYLOAD_SIZE);
+        this.whenCondition = lambdaProcessorConfig.getWhenCondition();
+        this.tagsOnMatchFailure = lambdaProcessorConfig.getTagsOnFailure();
 
-    PluginModel responseCodecConfig = lambdaProcessorConfig.getResponseCodecConfig();
+        PluginModel responseCodecConfig = lambdaProcessorConfig.getResponseCodecConfig();
 
-    if (responseCodecConfig == null) {
-      // Default to JsonInputCodec with default settings
-      codecPluginSetting = new PluginSetting("json", Collections.emptyMap());
-    } else {
-      codecPluginSetting = new PluginSetting(responseCodecConfig.getPluginName(),
-          responseCodecConfig.getPluginSettings());
-    }
-
-    jsonOutputCodecConfig = new JsonOutputCodecConfig();
-    jsonOutputCodecConfig.setKeyName(lambdaProcessorConfig.getBatchOptions().getKeyName());
-
-    ClientOptions clientOptions = lambdaProcessorConfig.getClientOptions();
-    if (clientOptions == null) {
-      clientOptions = new ClientOptions();
-    }
-    lambdaAsyncClient = LambdaClientFactory.createAsyncLambdaClient(
-        lambdaProcessorConfig.getAwsAuthenticationOptions(),
-        awsCredentialsSupplier,
-        clientOptions
-    );
-
-    // Select the correct strategy based on the configuration
-    if (lambdaProcessorConfig.getResponseEventsMatch()) {
-      this.responseStrategy = new StrictResponseEventHandlingStrategy();
-    } else {
-      this.responseStrategy = new AggregateResponseEventHandlingStrategy();
-    }
-
-  }
-
-  @Override
-  public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
-    if (records.isEmpty()) {
-      return records;
-    }
-
-    List<Record<Event>> resultRecords = new ArrayList<>();
-    List<Record<Event>> recordsToLambda = new ArrayList<>();
-    for (Record<Event> record : records) {
-      final Event event = record.getData();
-      // If the condition is false, add the event to resultRecords as-is
-      if (whenCondition != null && !expressionEvaluator.evaluateConditional(whenCondition, event)) {
-        resultRecords.add(record);
-        continue;
-      }
-      recordsToLambda.add(record);
-    }
-
-    Map<Buffer, CompletableFuture<InvokeResponse>> bufferToFutureMap = LambdaCommonHandler.sendRecords(
-        recordsToLambda, lambdaProcessorConfig, lambdaAsyncClient,
-        new OutputCodecContext());
-
-    for (Map.Entry<Buffer, CompletableFuture<InvokeResponse>> entry : bufferToFutureMap.entrySet()) {
-      CompletableFuture<InvokeResponse> future = entry.getValue();
-      Buffer inputBuffer = entry.getKey();
-      try {
-        InvokeResponse response = future.join();
-        Duration latency = inputBuffer.stopLatencyWatch();
-        lambdaLatencyMetric.record(latency.toMillis(), TimeUnit.MILLISECONDS);
-        if (isSuccess(response)) {
-          numberOfRecordsSuccessCounter.increment(inputBuffer.getEventCount());
-          numberOfRequestsSuccessCounter.increment();
-          resultRecords.addAll(convertLambdaResponseToEvent(inputBuffer, response));
+        if (responseCodecConfig == null) {
+            // Default to JsonInputCodec with default settings
+            codecPluginSetting = new PluginSetting("json", Collections.emptyMap());
         } else {
-          LOG.error("Lambda invoke failed with error {} ", response.statusCode());
-          resultRecords.addAll(addFailureTags(inputBuffer.getRecords()));
+            codecPluginSetting = new PluginSetting(responseCodecConfig.getPluginName(),
+                responseCodecConfig.getPluginSettings());
         }
-      } catch (Exception e) {
-        LOG.error("Exception from Lambda invocation ", e);
-        numberOfRecordsFailedCounter.increment(inputBuffer.getEventCount());
-        numberOfRequestsFailedCounter.increment();
-        resultRecords.addAll(addFailureTags(inputBuffer.getRecords()));
-      }
+
+        jsonOutputCodecConfig = new JsonOutputCodecConfig();
+        jsonOutputCodecConfig.setKeyName(lambdaProcessorConfig.getBatchOptions().getKeyName());
+
+        ClientOptions clientOptions = lambdaProcessorConfig.getClientOptions();
+        if (clientOptions == null) {
+            clientOptions = new ClientOptions();
+        }
+        lambdaAsyncClient = LambdaClientFactory.createAsyncLambdaClient(
+            lambdaProcessorConfig.getAwsAuthenticationOptions(),
+            awsCredentialsSupplier,
+            clientOptions
+        );
+
+        // Select the correct strategy based on the configuration
+        if (lambdaProcessorConfig.getResponseEventsMatch()) {
+            this.responseStrategy = new StrictResponseEventHandlingStrategy();
+        } else {
+            this.responseStrategy = new AggregateResponseEventHandlingStrategy();
+        }
+
     }
-    return resultRecords;
-  }
 
-  /*
-   * Assumption: Lambda always returns json array.
-   * 1. If response has an array, we assume that we split the individual events.
-   * 2. If it is not an array, then create one event per response.
-   */
-  List<Record<Event>> convertLambdaResponseToEvent(Buffer flushedBuffer,
-      final InvokeResponse lambdaResponse) {
-    InputCodec responseCodec = pluginFactory.loadPlugin(InputCodec.class, codecPluginSetting);
-    List<Record<Event>> originalRecords = flushedBuffer.getRecords();
-    try {
-      List<Event> parsedEvents = new ArrayList<>();
+    @Override
+    public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
+        if (records.isEmpty()) {
+            return records;
+        }
 
-      List<Record<Event>> resultRecords = new ArrayList<>();
-      SdkBytes payload = lambdaResponse.payload();
-      // Handle null or empty payload
-      if (payload == null || payload.asByteArray() == null || payload.asByteArray().length == 0) {
-        LOG.warn(NOISY, "Lambda response payload is null or empty, dropping the original events");
-      } else {
-        InputStream inputStream = new ByteArrayInputStream(payload.asByteArray());
-        //Convert to response codec
+        List<Record<Event>> resultRecords = new ArrayList<>();
+        List<Record<Event>> recordsToLambda = new ArrayList<>();
+        for (Record<Event> record : records) {
+            final Event event = record.getData();
+            // If the condition is false, add the event to resultRecords as-is
+            if (whenCondition != null && !expressionEvaluator.evaluateConditional(whenCondition,
+                event)) {
+                resultRecords.add(record);
+                continue;
+            }
+            recordsToLambda.add(record);
+        }
+
+        Map<Buffer, CompletableFuture<InvokeResponse>> bufferToFutureMap = LambdaCommonHandler.sendRecords(
+            recordsToLambda, lambdaProcessorConfig, lambdaAsyncClient,
+            new OutputCodecContext());
+
+        for (Map.Entry<Buffer, CompletableFuture<InvokeResponse>> entry : bufferToFutureMap.entrySet()) {
+            CompletableFuture<InvokeResponse> future = entry.getValue();
+            Buffer inputBuffer = entry.getKey();
+            try {
+                InvokeResponse response = future.join();
+                Duration latency = inputBuffer.stopLatencyWatch();
+                lambdaLatencyMetric.record(latency.toMillis(), TimeUnit.MILLISECONDS);
+                if (isSuccess(response)) {
+                    numberOfRecordsSuccessCounter.increment(inputBuffer.getEventCount());
+                    numberOfRequestsSuccessCounter.increment();
+                    resultRecords.addAll(convertLambdaResponseToEvent(inputBuffer, response));
+                } else {
+                    LOG.error("Lambda invoke failed with error {} ", response.statusCode());
+                    resultRecords.addAll(addFailureTags(inputBuffer.getRecords()));
+                }
+            } catch (Exception e) {
+                LOG.error("Exception from Lambda invocation ", e);
+                numberOfRecordsFailedCounter.increment(inputBuffer.getEventCount());
+                numberOfRequestsFailedCounter.increment();
+                resultRecords.addAll(addFailureTags(inputBuffer.getRecords()));
+            }
+        }
+        return resultRecords;
+    }
+
+    /*
+     * Assumption: Lambda always returns json array.
+     * 1. If response has an array, we assume that we split the individual events.
+     * 2. If it is not an array, then create one event per response.
+     */
+    List<Record<Event>> convertLambdaResponseToEvent(Buffer flushedBuffer,
+        final InvokeResponse lambdaResponse) {
+        InputCodec responseCodec = pluginFactory.loadPlugin(InputCodec.class, codecPluginSetting);
+        List<Record<Event>> originalRecords = flushedBuffer.getRecords();
         try {
-          responseCodec.parse(inputStream, record -> {
-            Event event = record.getData();
-            parsedEvents.add(event);
-          });
-        } catch (IOException ex) {
-          throw new RuntimeException(ex);
+            List<Event> parsedEvents = new ArrayList<>();
+
+            List<Record<Event>> resultRecords = new ArrayList<>();
+            SdkBytes payload = lambdaResponse.payload();
+            // Handle null or empty payload
+            if (payload == null || payload.asByteArray() == null
+                || payload.asByteArray().length == 0) {
+                LOG.warn(NOISY,
+                    "Lambda response payload is null or empty, dropping the original events");
+            } else {
+                InputStream inputStream = new ByteArrayInputStream(payload.asByteArray());
+                //Convert to response codec
+                try {
+                    responseCodec.parse(inputStream, record -> {
+                        Event event = record.getData();
+                        parsedEvents.add(event);
+                    });
+                } catch (IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+
+                LOG.debug("Parsed Event Size:{}, FlushedBuffer eventCount:{}, " +
+                        "FlushedBuffer size:{}", parsedEvents.size(), flushedBuffer.getEventCount(),
+                    flushedBuffer.getSize());
+                responseStrategy.handleEvents(parsedEvents, originalRecords, resultRecords,
+                    flushedBuffer);
+            }
+            return resultRecords;
+        } catch (Exception e) {
+            LOG.error(NOISY, "Error converting Lambda response to Event");
+            addFailureTags(flushedBuffer.getRecords());
+            return originalRecords;
         }
-
-        LOG.debug("Parsed Event Size:{}, FlushedBuffer eventCount:{}, " +
-                "FlushedBuffer size:{}", parsedEvents.size(), flushedBuffer.getEventCount(),
-            flushedBuffer.getSize());
-        responseStrategy.handleEvents(parsedEvents, originalRecords, resultRecords, flushedBuffer);
-      }
-      return resultRecords;
-    } catch (Exception e) {
-      LOG.error(NOISY, "Error converting Lambda response to Event");
-      addFailureTags(flushedBuffer.getRecords());
-      return originalRecords;
     }
-  }
 
-  /*
-   * If one event in the Buffer fails, we consider that the entire
-   * Batch fails and tag each event in that Batch.
-   */
-  private List<Record<Event>> addFailureTags(List<Record<Event>> records) {
-    // Add failure tags to each event in the batch
-    for (Record<Event> record : records) {
-      Event event = record.getData();
-      EventMetadata metadata = event.getMetadata();
-      if (metadata != null) {
-        metadata.addTags(tagsOnMatchFailure);
-      } else {
-        LOG.warn("Event metadata is null, cannot add failure tags.");
-      }
+    /*
+     * If one event in the Buffer fails, we consider that the entire
+     * Batch fails and tag each event in that Batch.
+     */
+    private List<Record<Event>> addFailureTags(List<Record<Event>> records) {
+        // Add failure tags to each event in the batch
+        for (Record<Event> record : records) {
+            Event event = record.getData();
+            EventMetadata metadata = event.getMetadata();
+            if (metadata != null) {
+                metadata.addTags(tagsOnMatchFailure);
+            } else {
+                LOG.warn("Event metadata is null, cannot add failure tags.");
+            }
+        }
+        return records;
     }
-    return records;
-  }
 
 
-  @Override
-  public void prepareForShutdown() {
-  }
+    @Override
+    public void prepareForShutdown() {
+    }
 
-  @Override
-  public boolean isReadyForShutdown() {
-    return true;
-  }
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
 
-  @Override
-  public void shutdown() {
-  }
+    @Override
+    public void shutdown() {
+    }
 
 }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessor.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessor.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.lambda.processor;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+import static org.opensearch.dataprepper.plugins.lambda.common.LambdaCommonHandler.isSuccess;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -18,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
@@ -49,205 +52,206 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 @DataPrepperPlugin(name = "aws_lambda", pluginType = Processor.class, pluginConfigurationType = LambdaProcessorConfig.class)
 public class LambdaProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
 
-    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS = "lambdaProcessorObjectsEventsSucceeded";
-    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED = "lambdaProcessorObjectsEventsFailed";
-    public static final String NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsSucceeded";
-    public static final String NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsFailed";
-    public static final String LAMBDA_LATENCY_METRIC = "lambdaProcessorLatency";
-    public static final String REQUEST_PAYLOAD_SIZE = "requestPayloadSize";
-    public static final String RESPONSE_PAYLOAD_SIZE = "responsePayloadSize";
+  public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS = "lambdaProcessorObjectsEventsSucceeded";
+  public static final String NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED = "lambdaProcessorObjectsEventsFailed";
+  public static final String NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsSucceeded";
+  public static final String NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA = "lambdaProcessorNumberOfRequestsFailed";
+  public static final String LAMBDA_LATENCY_METRIC = "lambdaProcessorLatency";
+  public static final String REQUEST_PAYLOAD_SIZE = "requestPayloadSize";
+  public static final String RESPONSE_PAYLOAD_SIZE = "responsePayloadSize";
 
-    private static final Logger LOG = LoggerFactory.getLogger(LambdaProcessor.class);
-    final PluginSetting codecPluginSetting;
-    final PluginFactory pluginFactory;
-    final LambdaProcessorConfig lambdaProcessorConfig;
-    private final String whenCondition;
-    private final ExpressionEvaluator expressionEvaluator;
-    private final Counter numberOfRecordsSuccessCounter;
-    private final Counter numberOfRecordsFailedCounter;
-    private final Counter numberOfRequestsSuccessCounter;
-    private final Counter numberOfRequestsFailedCounter;
-    private final Timer lambdaLatencyMetric;
-    private final List<String> tagsOnMatchFailure;
-    private final LambdaAsyncClient lambdaAsyncClient;
-    private final DistributionSummary requestPayloadMetric;
-    private final DistributionSummary responsePayloadMetric;
-    private final ResponseEventHandlingStrategy responseStrategy;
-    private final JsonOutputCodecConfig jsonOutputCodecConfig;
-    LambdaCommonHandler lambdaCommonHandler;
+  private static final Logger LOG = LoggerFactory.getLogger(LambdaProcessor.class);
+  final PluginSetting codecPluginSetting;
+  final PluginFactory pluginFactory;
+  final LambdaProcessorConfig lambdaProcessorConfig;
+  private final String whenCondition;
+  private final ExpressionEvaluator expressionEvaluator;
+  private final Counter numberOfRecordsSuccessCounter;
+  private final Counter numberOfRecordsFailedCounter;
+  private final Counter numberOfRequestsSuccessCounter;
+  private final Counter numberOfRequestsFailedCounter;
+  private final Timer lambdaLatencyMetric;
+  private final List<String> tagsOnMatchFailure;
+  private final LambdaAsyncClient lambdaAsyncClient;
+  private final DistributionSummary requestPayloadMetric;
+  private final DistributionSummary responsePayloadMetric;
+  private final ResponseEventHandlingStrategy responseStrategy;
+  private final JsonOutputCodecConfig jsonOutputCodecConfig;
 
-    @DataPrepperPluginConstructor
-    public LambdaProcessor(final PluginFactory pluginFactory, final PluginMetrics pluginMetrics,
-                           final LambdaProcessorConfig lambdaProcessorConfig,
-                           final AwsCredentialsSupplier awsCredentialsSupplier,
-                           final ExpressionEvaluator expressionEvaluator) {
-        super(pluginMetrics);
-        this.expressionEvaluator = expressionEvaluator;
-        this.pluginFactory = pluginFactory;
-        this.lambdaProcessorConfig = lambdaProcessorConfig;
-        this.numberOfRecordsSuccessCounter = pluginMetrics.counter(
-                NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS);
-        this.numberOfRecordsFailedCounter = pluginMetrics.counter(
-                NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED);
-        this.numberOfRequestsSuccessCounter = pluginMetrics.counter(
-                NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA);
-        this.numberOfRequestsFailedCounter = pluginMetrics.counter(
-                NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA);
-        this.lambdaLatencyMetric = pluginMetrics.timer(LAMBDA_LATENCY_METRIC);
-        this.requestPayloadMetric = pluginMetrics.summary(REQUEST_PAYLOAD_SIZE);
-        this.responsePayloadMetric = pluginMetrics.summary(RESPONSE_PAYLOAD_SIZE);
-        this.whenCondition = lambdaProcessorConfig.getWhenCondition();
-        this.tagsOnMatchFailure = lambdaProcessorConfig.getTagsOnFailure();
+  @DataPrepperPluginConstructor
+  public LambdaProcessor(final PluginFactory pluginFactory, final PluginMetrics pluginMetrics,
+      final LambdaProcessorConfig lambdaProcessorConfig,
+      final AwsCredentialsSupplier awsCredentialsSupplier,
+      final ExpressionEvaluator expressionEvaluator) {
+    super(pluginMetrics);
+    this.expressionEvaluator = expressionEvaluator;
+    this.pluginFactory = pluginFactory;
+    this.lambdaProcessorConfig = lambdaProcessorConfig;
+    this.numberOfRecordsSuccessCounter = pluginMetrics.counter(
+        NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS);
+    this.numberOfRecordsFailedCounter = pluginMetrics.counter(
+        NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED);
+    this.numberOfRequestsSuccessCounter = pluginMetrics.counter(
+        NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA);
+    this.numberOfRequestsFailedCounter = pluginMetrics.counter(
+        NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA);
+    this.lambdaLatencyMetric = pluginMetrics.timer(LAMBDA_LATENCY_METRIC);
+    this.requestPayloadMetric = pluginMetrics.summary(REQUEST_PAYLOAD_SIZE);
+    this.responsePayloadMetric = pluginMetrics.summary(RESPONSE_PAYLOAD_SIZE);
+    this.whenCondition = lambdaProcessorConfig.getWhenCondition();
+    this.tagsOnMatchFailure = lambdaProcessorConfig.getTagsOnFailure();
 
-        PluginModel responseCodecConfig = lambdaProcessorConfig.getResponseCodecConfig();
+    PluginModel responseCodecConfig = lambdaProcessorConfig.getResponseCodecConfig();
 
-        if (responseCodecConfig == null) {
-            // Default to JsonInputCodec with default settings
-            codecPluginSetting = new PluginSetting("json", Collections.emptyMap());
+    if (responseCodecConfig == null) {
+      // Default to JsonInputCodec with default settings
+      codecPluginSetting = new PluginSetting("json", Collections.emptyMap());
+    } else {
+      codecPluginSetting = new PluginSetting(responseCodecConfig.getPluginName(),
+          responseCodecConfig.getPluginSettings());
+    }
+
+    jsonOutputCodecConfig = new JsonOutputCodecConfig();
+    jsonOutputCodecConfig.setKeyName(lambdaProcessorConfig.getBatchOptions().getKeyName());
+
+    ClientOptions clientOptions = lambdaProcessorConfig.getClientOptions();
+    if (clientOptions == null) {
+      clientOptions = new ClientOptions();
+    }
+    lambdaAsyncClient = LambdaClientFactory.createAsyncLambdaClient(
+        lambdaProcessorConfig.getAwsAuthenticationOptions(),
+        awsCredentialsSupplier,
+        clientOptions
+    );
+
+    // Select the correct strategy based on the configuration
+    if (lambdaProcessorConfig.getResponseEventsMatch()) {
+      this.responseStrategy = new StrictResponseEventHandlingStrategy();
+    } else {
+      this.responseStrategy = new AggregateResponseEventHandlingStrategy();
+    }
+
+  }
+
+  @Override
+  public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
+    if (records.isEmpty()) {
+      return records;
+    }
+
+    List<Record<Event>> resultRecords = new ArrayList<>();
+    List<Record<Event>> recordsToLambda = new ArrayList<>();
+    for (Record<Event> record : records) {
+      final Event event = record.getData();
+      // If the condition is false, add the event to resultRecords as-is
+      if (whenCondition != null && !expressionEvaluator.evaluateConditional(whenCondition, event)) {
+        resultRecords.add(record);
+        continue;
+      }
+      recordsToLambda.add(record);
+    }
+
+    Map<Buffer, CompletableFuture<InvokeResponse>> bufferToFutureMap = LambdaCommonHandler.sendRecords(
+        recordsToLambda, lambdaProcessorConfig, lambdaAsyncClient,
+        new OutputCodecContext());
+
+    for (Map.Entry<Buffer, CompletableFuture<InvokeResponse>> entry : bufferToFutureMap.entrySet()) {
+      CompletableFuture<InvokeResponse> future = entry.getValue();
+      Buffer inputBuffer = entry.getKey();
+      try {
+        InvokeResponse response = future.join();
+        Duration latency = inputBuffer.stopLatencyWatch();
+        lambdaLatencyMetric.record(latency.toMillis(), TimeUnit.MILLISECONDS);
+        if (isSuccess(response)) {
+          numberOfRecordsSuccessCounter.increment(inputBuffer.getEventCount());
+          numberOfRequestsSuccessCounter.increment();
+          resultRecords.addAll(convertLambdaResponseToEvent(inputBuffer, response));
         } else {
-            codecPluginSetting = new PluginSetting(responseCodecConfig.getPluginName(),
-                    responseCodecConfig.getPluginSettings());
+          LOG.error("Lambda invoke failed with error {} ", response.statusCode());
+          resultRecords.addAll(addFailureTags(inputBuffer.getRecords()));
         }
-
-        jsonOutputCodecConfig = new JsonOutputCodecConfig();
-        jsonOutputCodecConfig.setKeyName(lambdaProcessorConfig.getBatchOptions().getKeyName());
-
-        ClientOptions clientOptions = lambdaProcessorConfig.getClientOptions();
-        if(clientOptions == null){
-            clientOptions = new ClientOptions();
-        }
-        lambdaAsyncClient = LambdaClientFactory.createAsyncLambdaClient(
-                lambdaProcessorConfig.getAwsAuthenticationOptions(),
-                awsCredentialsSupplier,
-                clientOptions
-        );
-
-        // Select the correct strategy based on the configuration
-        if (lambdaProcessorConfig.getResponseEventsMatch()) {
-            this.responseStrategy = new StrictResponseEventHandlingStrategy();
-        } else {
-            this.responseStrategy = new AggregateResponseEventHandlingStrategy();
-        }
-
+      } catch (Exception e) {
+        LOG.error("Exception from Lambda invocation ", e);
+        numberOfRecordsFailedCounter.increment(inputBuffer.getEventCount());
+        numberOfRequestsFailedCounter.increment();
+        resultRecords.addAll(addFailureTags(inputBuffer.getRecords()));
+      }
     }
+    return resultRecords;
+  }
 
-    @Override
-    public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
-        if (records.isEmpty()) {
-            return records;
-        }
+  /*
+   * Assumption: Lambda always returns json array.
+   * 1. If response has an array, we assume that we split the individual events.
+   * 2. If it is not an array, then create one event per response.
+   */
+  List<Record<Event>> convertLambdaResponseToEvent(Buffer flushedBuffer,
+      final InvokeResponse lambdaResponse) {
+    InputCodec responseCodec = pluginFactory.loadPlugin(InputCodec.class, codecPluginSetting);
+    List<Record<Event>> originalRecords = flushedBuffer.getRecords();
+    try {
+      List<Event> parsedEvents = new ArrayList<>();
 
-        List<Record<Event>> resultRecords = Collections.synchronizedList(new ArrayList());
-        List<Record<Event>> recordsToLambda = new ArrayList<>();
-        for (Record<Event> record : records) {
-            final Event event = record.getData();
-            // If the condition is false, add the event to resultRecords as-is
-            if (whenCondition != null && !expressionEvaluator.evaluateConditional(whenCondition, event)) {
-                resultRecords.add(record);
-                continue;
-            }
-            recordsToLambda.add(record);
-        }
+      List<Record<Event>> resultRecords = new ArrayList<>();
+      SdkBytes payload = lambdaResponse.payload();
+      // Handle null or empty payload
+      if (payload == null || payload.asByteArray() == null || payload.asByteArray().length == 0) {
+        LOG.warn(NOISY, "Lambda response payload is null or empty, dropping the original events");
+      } else {
+        InputStream inputStream = new ByteArrayInputStream(payload.asByteArray());
+        //Convert to response codec
         try {
-            resultRecords.addAll(
-                    lambdaCommonHandler.sendRecords(recordsToLambda, lambdaProcessorConfig, lambdaAsyncClient,
-                            new OutputCodecContext(),
-                            (inputBuffer, response) -> {
-                                Duration latency = inputBuffer.stopLatencyWatch();
-                                lambdaLatencyMetric.record(latency.toMillis(), TimeUnit.MILLISECONDS);
-                                numberOfRecordsSuccessCounter.increment(inputBuffer.getEventCount());
-                                numberOfRequestsSuccessCounter.increment();
-                                return convertLambdaResponseToEvent(inputBuffer, response);
-                            },
-                            (inputBuffer) -> {
-                                Duration latency = inputBuffer.stopLatencyWatch();
-                                lambdaLatencyMetric.record(latency.toMillis(), TimeUnit.MILLISECONDS);
-                                numberOfRecordsFailedCounter.increment(inputBuffer.getEventCount());
-                                numberOfRequestsFailedCounter.increment();
-                                return addFailureTags(inputBuffer.getRecords());
-                            })
-
-            );
-        } catch (Exception e) {
-            LOG.info("Exception in doExecute");
-            numberOfRecordsFailedCounter.increment(recordsToLambda.size());
-            resultRecords.addAll(addFailureTags(recordsToLambda));
-        }
-        return resultRecords;
-    }
-
-    /*
-     * Assumption: Lambda always returns json array.
-     * 1. If response has an array, we assume that we split the individual events.
-     * 2. If it is not an array, then create one event per response.
-     */
-    List<Record<Event>> convertLambdaResponseToEvent(Buffer flushedBuffer,
-                                                     final InvokeResponse lambdaResponse) {
-        InputCodec responseCodec = pluginFactory.loadPlugin(InputCodec.class, codecPluginSetting);
-        List<Record<Event>> originalRecords = flushedBuffer.getRecords();
-        try {
-            List<Event> parsedEvents = new ArrayList<>();
-
-            List<Record<Event>> resultRecords = new ArrayList<>();
-            SdkBytes payload = lambdaResponse.payload();
-            // Handle null or empty payload
-            if (payload == null || payload.asByteArray() == null || payload.asByteArray().length == 0) {
-                LOG.warn(NOISY, "Lambda response payload is null or empty, dropping the original events");
-            } else {
-                InputStream inputStream = new ByteArrayInputStream(payload.asByteArray());
-                //Convert to response codec
-                try {
-                    responseCodec.parse(inputStream, record -> {
-                        Event event = record.getData();
-                        parsedEvents.add(event);
-                    });
-                } catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-
-                LOG.debug("Parsed Event Size:{}, FlushedBuffer eventCount:{}, " +
-                                "FlushedBuffer size:{}", parsedEvents.size(), flushedBuffer.getEventCount(),
-                        flushedBuffer.getSize());
-                responseStrategy.handleEvents(parsedEvents, originalRecords, resultRecords, flushedBuffer);
-            }
-            return resultRecords;
-        } catch (Exception e) {
-            LOG.error(NOISY, "Error converting Lambda response to Event");
-            addFailureTags(flushedBuffer.getRecords());
-            return originalRecords;
-        }
-    }
-
-    /*
-     * If one event in the Buffer fails, we consider that the entire
-     * Batch fails and tag each event in that Batch.
-     */
-    private List<Record<Event>> addFailureTags(List<Record<Event>> records) {
-        // Add failure tags to each event in the batch
-        for (Record<Event> record : records) {
+          responseCodec.parse(inputStream, record -> {
             Event event = record.getData();
-            EventMetadata metadata = event.getMetadata();
-            if (metadata != null) {
-                metadata.addTags(tagsOnMatchFailure);
-            } else {
-                LOG.warn("Event metadata is null, cannot add failure tags.");
-            }
+            parsedEvents.add(event);
+          });
+        } catch (IOException ex) {
+          throw new RuntimeException(ex);
         }
-        return records;
+
+        LOG.debug("Parsed Event Size:{}, FlushedBuffer eventCount:{}, " +
+                "FlushedBuffer size:{}", parsedEvents.size(), flushedBuffer.getEventCount(),
+            flushedBuffer.getSize());
+        responseStrategy.handleEvents(parsedEvents, originalRecords, resultRecords, flushedBuffer);
+      }
+      return resultRecords;
+    } catch (Exception e) {
+      LOG.error(NOISY, "Error converting Lambda response to Event");
+      addFailureTags(flushedBuffer.getRecords());
+      return originalRecords;
     }
+  }
+
+  /*
+   * If one event in the Buffer fails, we consider that the entire
+   * Batch fails and tag each event in that Batch.
+   */
+  private List<Record<Event>> addFailureTags(List<Record<Event>> records) {
+    // Add failure tags to each event in the batch
+    for (Record<Event> record : records) {
+      Event event = record.getData();
+      EventMetadata metadata = event.getMetadata();
+      if (metadata != null) {
+        metadata.addTags(tagsOnMatchFailure);
+      } else {
+        LOG.warn("Event metadata is null, cannot add failure tags.");
+      }
+    }
+    return records;
+  }
 
 
-    @Override
-    public void prepareForShutdown() {
-    }
+  @Override
+  public void prepareForShutdown() {
+  }
 
-    @Override
-    public boolean isReadyForShutdown() {
-        return true;
-    }
+  @Override
+  public boolean isReadyForShutdown() {
+    return true;
+  }
 
-    @Override
-    public void shutdown() {
-    }
+  @Override
+  public void shutdown() {
+  }
 
 }

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/common/accumulator/InMemoryBufferTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/common/accumulator/InMemoryBufferTest.java
@@ -46,6 +46,10 @@ class InMemoryBufferTest {
   @Mock
   private LambdaAsyncClient lambdaAsyncClient;
 
+  public static Record<Event> getSampleRecord() {
+    Event event = JacksonEvent.fromMessage(String.valueOf(UUID.randomUUID()));
+    return new Record<>(event);
+  }
 
   @Test
   void test_with_write_event_into_buffer() {
@@ -85,11 +89,6 @@ class InMemoryBufferTest {
       InvokeResponse response = responseFuture.join();
       assertThat(response.statusCode(), equalTo(200));
     });
-  }
-
-  private Record<Event> getSampleRecord() {
-    Event event = JacksonEvent.fromMessage(String.valueOf(UUID.randomUUID()));
-    return new Record<>(event);
   }
 
   @Test
@@ -146,11 +145,4 @@ class InMemoryBufferTest {
 
   }
 
-  private byte[] generateByteArray() {
-    byte[] bytes = new byte[1000];
-    for (int i = 0; i < 1000; i++) {
-      bytes[i] = (byte) i;
-    }
-    return bytes;
-  }
 }

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
@@ -76,422 +76,428 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class LambdaProcessorTest {
 
-  // Mock dependencies
-  @Mock
-  private AwsAuthenticationOptions awsAuthenticationOptions;
-
-  @Mock
-  private Buffer bufferMock;
-
-  @Mock
-  private PluginFactory pluginFactory;
-
-  @Mock
-  private PluginMetrics pluginMetrics;
-
-  @Mock
-  private LambdaProcessorConfig lambdaProcessorConfig;
-
-  @Mock
-  private AwsCredentialsSupplier awsCredentialsSupplier;
-
-  @Mock
-  private ExpressionEvaluator expressionEvaluator;
-
-  @Mock
-  private LambdaCommonHandler lambdaCommonHandler;
-
-  @Mock
-  private InputCodec responseCodec;
-
-
-  @Mock
-  private Counter numberOfRecordsSuccessCounter;
-
-  @Mock
-  private Counter numberOfRequestsSuccessCounter;
-
-  @Mock
-  private Counter numberOfRecordsFailedCounter;
-  @Mock
-  private Counter numberOfRequestsFailedCounter;
-
-  @Mock
-  private InvokeResponse invokeResponse;
-
-  @Mock
-  private Timer lambdaLatencyMetric;
-
-  // The class under test
-  private LambdaProcessor lambdaProcessor;
-
-  @BeforeEach
-  public void setUp() throws Exception {
-    MockitoAnnotations.openMocks(this);
-
-    // Mock PluginMetrics counters and timers
-    when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS))).thenReturn(
-        numberOfRecordsSuccessCounter);
-    when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED))).thenReturn(
-        numberOfRecordsFailedCounter);
-    when(pluginMetrics.counter(eq(NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA))).thenReturn(
-        numberOfRecordsSuccessCounter);
-    when(pluginMetrics.counter(eq(NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA))).thenReturn(
-        numberOfRecordsFailedCounter);
-    when(pluginMetrics.timer(anyString())).thenReturn(lambdaLatencyMetric);
-    when(pluginMetrics.gauge(anyString(), any(AtomicLong.class))).thenAnswer(
-        invocation -> invocation.getArgument(1));
-
-    ClientOptions clientOptions = new ClientOptions();
-    when(lambdaProcessorConfig.getClientOptions()).thenReturn(clientOptions);
-    when(lambdaProcessorConfig.getFunctionName()).thenReturn("test-function");
-    when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
-    when(lambdaProcessorConfig.getInvocationType()).thenReturn(InvocationType.REQUEST_RESPONSE);
-    BatchOptions batchOptions = mock(BatchOptions.class);
-    ThresholdOptions thresholdOptions = mock(ThresholdOptions.class);
-    when(lambdaProcessorConfig.getBatchOptions()).thenReturn(batchOptions);
-    when(lambdaProcessorConfig.getWhenCondition()).thenReturn(null);
-    when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
-
-    // Mock AWS Authentication Options
-    when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
-    when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("testRole");
-
-    // Mock BatchOptions and ThresholdOptions
-    when(batchOptions.getThresholdOptions()).thenReturn(thresholdOptions);
-    when(thresholdOptions.getEventCount()).thenReturn(10);
-    when(thresholdOptions.getMaximumSize()).thenReturn(ByteCount.parse("6mb"));
-    when(thresholdOptions.getEventCollectTimeOut()).thenReturn(Duration.ofSeconds(30));
-    when(batchOptions.getKeyName()).thenReturn("key");
-
-    // Mock PluginFactory to return the mocked responseCodec
-    when(pluginFactory.loadPlugin(eq(InputCodec.class), any(PluginSetting.class))).thenReturn(
-        responseCodec);
-
-    // Instantiate the LambdaProcessor manually
-    lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
-        awsCredentialsSupplier, expressionEvaluator);
-
-    // Mock InvokeResponse
-    when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String("[{\"key\":\"value\"}]"));
-    when(invokeResponse.statusCode()).thenReturn(200); // Success status code
-
-    // Mock LambdaAsyncClient inside LambdaProcessor
-    LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
-    setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
-
-    // Mock the invoke method to return a completed future
-    CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
-        invokeResponse);
-    when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
-
-    // Mock Response Codec parse method
-    doNothing().when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
-
-  }
-
-  private void populatePrivateFields() throws Exception {
-    List<String> tagsOnMatchFailure = Collections.singletonList("failure_tag");
-    // Use reflection to set the private fields
-    setPrivateField(lambdaProcessor, "numberOfRecordsSuccessCounter",
-        numberOfRecordsSuccessCounter);
-    setPrivateField(lambdaProcessor, "numberOfRequestsSuccessCounter",
-        numberOfRequestsSuccessCounter);
-    setPrivateField(lambdaProcessor, "numberOfRecordsFailedCounter", numberOfRecordsFailedCounter);
-    setPrivateField(lambdaProcessor, "numberOfRequestsFailedCounter",
-        numberOfRequestsFailedCounter);
-    setPrivateField(lambdaProcessor, "tagsOnMatchFailure", tagsOnMatchFailure);
-    setPrivateField(lambdaProcessor, "lambdaCommonHandler", lambdaCommonHandler);
-  }
-
-  // Helper method to set private fields via reflection
-  private void setPrivateField(Object targetObject, String fieldName, Object value)
-      throws Exception {
-    Field field = targetObject.getClass().getDeclaredField(fieldName);
-    field.setAccessible(true);
-    field.set(targetObject, value);
-  }
-
-  @Test
-  public void testProcessorDefaults() {
-    // Create a new LambdaProcessorConfig with default values
-    LambdaProcessorConfig defaultConfig = new LambdaProcessorConfig();
-
-    // Test default values
-    assertNull(defaultConfig.getFunctionName());
-    assertNull(defaultConfig.getAwsAuthenticationOptions());
-    assertNull(defaultConfig.getResponseCodecConfig());
-    assertEquals(InvocationType.REQUEST_RESPONSE, defaultConfig.getInvocationType());
-    assertFalse(defaultConfig.getResponseEventsMatch());
-    assertNull(defaultConfig.getWhenCondition());
-    assertTrue(defaultConfig.getTagsOnFailure().isEmpty());
-
-    // Test ClientOptions defaults
-    ClientOptions clientOptions = defaultConfig.getClientOptions();
-    assertNotNull(clientOptions);
-    assertEquals(ClientOptions.DEFAULT_CONNECTION_RETRIES, clientOptions.getMaxConnectionRetries());
-    assertEquals(ClientOptions.DEFAULT_API_TIMEOUT, clientOptions.getApiCallTimeout());
-    assertEquals(ClientOptions.DEFAULT_CONNECTION_TIMEOUT, clientOptions.getConnectionTimeout());
-    assertEquals(ClientOptions.DEFAULT_MAXIMUM_CONCURRENCY, clientOptions.getMaxConcurrency());
-    assertEquals(ClientOptions.DEFAULT_BASE_DELAY, clientOptions.getBaseDelay());
-    assertEquals(ClientOptions.DEFAULT_MAX_BACKOFF, clientOptions.getMaxBackoff());
-
-    // Test BatchOptions defaults
-    BatchOptions batchOptions = defaultConfig.getBatchOptions();
-    assertNotNull(batchOptions);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"lambda-processor-success-config.yaml"})
-  public void testDoExecute_WithExceptionDuringProcessing(String configFileName) {
-    // Arrange
-    List<Record<Event>> records = Collections.singletonList(getSampleRecord());
-    LambdaProcessorConfig lambdaProcessorConfig = createLambdaConfigurationFromYaml(configFileName);
-    LambdaProcessor lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics,
-        lambdaProcessorConfig,
-        awsCredentialsSupplier, expressionEvaluator);
-
-    // make batch options null to generate exception
-    when(lambdaProcessorConfig.getBatchOptions()).thenReturn(null);
-    // Act
-    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
-
-    // Assert
-    assertEquals(1, result.size());
-    verify(numberOfRecordsFailedCounter, times(1)).increment(1.0);
-  }
-
-  @Test
-  public void testDoExecute_WithEmptyResponse() throws Exception {
-    // Arrange
-    Event event = mock(Event.class);
-    Record<Event> record = new Record<>(event);
-    List<Record<Event>> records = Collections.singletonList(record);
-
-    // Mock Buffer to return empty payload
-    when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String(""));
-
-    // Act
-    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
-
-    // Assert
-    assertEquals(0, result.size(), "Result should be empty due to empty Lambda response.");
-    verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
-  }
-
-  @Test
-  public void testDoExecute_WithNullResponse() throws Exception {
-    // Arrange
-    Event event = mock(Event.class);
-    Record<Event> record = new Record<>(event);
-    List<Record<Event>> records = Collections.singletonList(record);
-
-    // Mock Buffer to return null payload
-    when(invokeResponse.payload()).thenReturn(null);
-
-    // Act
-    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
-
-    // Assert
-    assertEquals(0, result.size(), "Result should be empty due to null Lambda response.");
-    verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
-  }
-
-  @Test
-  public void testDoExecute_WithEmptyRecords() {
-    // Arrange
-    Collection<Record<Event>> records = Collections.emptyList();
-
-    // Act
-    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
-
-    // Assert
-    assertEquals(0, result.size(), "Result should be empty when input records are empty.");
-    verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
-    verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
-  }
-
-  @Test
-  public void testDoExecute_WhenConditionFalse() {
-    // Arrange
-    Event event = mock(Event.class);
-    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-    when(event.getEventHandle()).thenReturn(eventHandle);
-    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
-    Record<Event> record = new Record<>(event);
-    Collection<Record<Event>> records = Collections.singletonList(record);
-
-    // Mock condition evaluator to return false
-    when(expressionEvaluator.evaluateConditional(anyString(), eq(event))).thenReturn(false);
-    when(lambdaProcessorConfig.getWhenCondition()).thenReturn("some_condition");
-
-    // Instantiate the LambdaProcessor manually
-    lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
-        awsCredentialsSupplier, expressionEvaluator);
-
-    // Act
-    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
-
-    // Assert
-    assertEquals(1, result.size(), "Result should contain one record as the condition is false.");
-    verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
-    verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
-  }
-
-  @Test
-  public void testDoExecute_SuccessfulProcessing() throws Exception {
-    // Arrange
-    Event event = mock(Event.class);
-    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-    when(event.getEventHandle()).thenReturn(eventHandle);
-    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
-    Record<Event> record = new Record<>(event);
-    Collection<Record<Event>> records = Collections.singletonList(record);
-
-    // Mock LambdaAsyncClient inside LambdaProcessor
-    LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
-    setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
-
-    // Mock the invoke method to return a completed future
-    CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
-        invokeResponse);
-    when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
-
-    // Mock Buffer behavior
-    when(bufferMock.getEventCount()).thenReturn(0).thenReturn(1).thenReturn(0);
-    when(bufferMock.getRecords()).thenReturn(Collections.singletonList(record));
-
-    doAnswer(invocation -> {
-      invocation.getArgument(0);
-      @SuppressWarnings("unchecked")
-      Consumer<Record<Event>> consumer = invocation.getArgument(1);
-
-      // Simulate parsing by providing a mocked event
-      Event parsedEvent = mock(Event.class);
-      Record<Event> parsedRecord = new Record<>(parsedEvent);
-      consumer.accept(parsedRecord);
-
-      return null;
-    }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
-
-    // Act
-    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
-
-    // Assert
-    assertEquals(1, result.size(), "Result should contain one record.");
-    verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
-  }
-
-  @Test
-  public void testConvertLambdaResponseToEvent_WithEqualEventCounts_SuccessfulProcessing()
-      throws Exception {
-    // Arrange
-    when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
-
-    // Mock LambdaResponse with a valid payload containing two events
-    String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}]";
-    SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
-    when(invokeResponse.payload()).thenReturn(sdkBytes);
-    when(invokeResponse.statusCode()).thenReturn(200); // Success status code
-
-    // Mock the responseCodec.parse to add two events
-    doAnswer(invocation -> {
-      invocation.getArgument(0);
-      @SuppressWarnings("unchecked")
-      Consumer<Record<Event>> consumer = invocation.getArgument(1);
-      Event parsedEvent1 = mock(Event.class);
-      Event parsedEvent2 = mock(Event.class);
-      consumer.accept(new Record<>(parsedEvent1));
-      consumer.accept(new Record<>(parsedEvent2));
-      return null;
-    }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
-
-    // Mock buffer with two original events
-    Event originalEvent1 = mock(Event.class);
-    Event originalEvent2 = mock(Event.class);
-    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
-
-    when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
-    when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
-    Record<Event> originalRecord1 = new Record<>(originalEvent1);
-    Record<Event> originalRecord2 = new Record<>(originalEvent2);
-    List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
-    when(bufferMock.getRecords()).thenReturn(originalRecords);
-    when(bufferMock.getEventCount()).thenReturn(2);
-
-    // Act
-    List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock,
-        invokeResponse);
-
-    // Assert
-    assertEquals(2, resultRecords.size(), "ResultRecords should contain two records.");
-    // Verify that failure tags are not added since it's a successful response
-    verify(originalEvent1, never()).getMetadata();
-    verify(originalEvent2, never()).getMetadata();
-  }
-
-  @Test
-  public void testConvertLambdaResponseToEvent_WithUnequalEventCounts_SuccessfulProcessing()
-      throws Exception {
-    // Arrange
-    // Set responseEventsMatch to false
-    when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
-
-    // Mock LambdaResponse with a valid payload containing three events
-    String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}, {\"key\":\"value3\"}]";
-    SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
-    when(invokeResponse.payload()).thenReturn(sdkBytes);
-    when(invokeResponse.statusCode()).thenReturn(200); // Success status code
-
-    // Mock the responseCodec.parse to add three parsed events
-    doAnswer(invocation -> {
-      invocation.getArgument(0);
-      @SuppressWarnings("unchecked")
-      Consumer<Record<Event>> consumer = invocation.getArgument(1);
-
-      // Create and add three mocked parsed events
-      Event parsedEvent1 = mock(Event.class);
-      Event parsedEvent2 = mock(Event.class);
-      Event parsedEvent3 = mock(Event.class);
-      consumer.accept(new Record<>(parsedEvent1));
-      consumer.accept(new Record<>(parsedEvent2));
-      consumer.accept(new Record<>(parsedEvent3));
-
-      return null;
-    }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
-
-    // Mock buffer with two original events
-    Event originalEvent1 = mock(Event.class);
-    EventMetadata originalMetadata1 = mock(EventMetadata.class);
-    when(originalEvent1.getMetadata()).thenReturn(originalMetadata1);
-
-    Event originalEvent2 = mock(Event.class);
-    EventMetadata originalMetadata2 = mock(EventMetadata.class);
-    when(originalEvent2.getMetadata()).thenReturn(originalMetadata2);
-
-    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
-
-    when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
-    when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
-
-    Record<Event> originalRecord1 = new Record<>(originalEvent1);
-    Record<Event> originalRecord2 = new Record<>(originalEvent2);
-    List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
-    when(bufferMock.getRecords()).thenReturn(originalRecords);
-    when(bufferMock.getEventCount()).thenReturn(2);
-
-    // Act
-    List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock,
-        invokeResponse);
-    // Assert
-    // Verify that three records are added to the result
-    assertEquals(3, resultRecords.size(), "ResultRecords should contain three records.");
-  }
+    // Mock dependencies
+    @Mock
+    private AwsAuthenticationOptions awsAuthenticationOptions;
+
+    @Mock
+    private Buffer bufferMock;
+
+    @Mock
+    private PluginFactory pluginFactory;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private LambdaProcessorConfig lambdaProcessorConfig;
+
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
+    @Mock
+    private LambdaCommonHandler lambdaCommonHandler;
+
+    @Mock
+    private InputCodec responseCodec;
+
+
+    @Mock
+    private Counter numberOfRecordsSuccessCounter;
+
+    @Mock
+    private Counter numberOfRequestsSuccessCounter;
+
+    @Mock
+    private Counter numberOfRecordsFailedCounter;
+    @Mock
+    private Counter numberOfRequestsFailedCounter;
+
+    @Mock
+    private InvokeResponse invokeResponse;
+
+    @Mock
+    private Timer lambdaLatencyMetric;
+
+    // The class under test
+    private LambdaProcessor lambdaProcessor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        // Mock PluginMetrics counters and timers
+        when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS))).thenReturn(
+            numberOfRecordsSuccessCounter);
+        when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED))).thenReturn(
+            numberOfRecordsFailedCounter);
+        when(pluginMetrics.counter(eq(NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA))).thenReturn(
+            numberOfRecordsSuccessCounter);
+        when(pluginMetrics.counter(eq(NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA))).thenReturn(
+            numberOfRecordsFailedCounter);
+        when(pluginMetrics.timer(anyString())).thenReturn(lambdaLatencyMetric);
+        when(pluginMetrics.gauge(anyString(), any(AtomicLong.class))).thenAnswer(
+            invocation -> invocation.getArgument(1));
+
+        ClientOptions clientOptions = new ClientOptions();
+        when(lambdaProcessorConfig.getClientOptions()).thenReturn(clientOptions);
+        when(lambdaProcessorConfig.getFunctionName()).thenReturn("test-function");
+        when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(
+            awsAuthenticationOptions);
+        when(lambdaProcessorConfig.getInvocationType()).thenReturn(InvocationType.REQUEST_RESPONSE);
+        BatchOptions batchOptions = mock(BatchOptions.class);
+        ThresholdOptions thresholdOptions = mock(ThresholdOptions.class);
+        when(lambdaProcessorConfig.getBatchOptions()).thenReturn(batchOptions);
+        when(lambdaProcessorConfig.getWhenCondition()).thenReturn(null);
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
+
+        // Mock AWS Authentication Options
+        when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("testRole");
+
+        // Mock BatchOptions and ThresholdOptions
+        when(batchOptions.getThresholdOptions()).thenReturn(thresholdOptions);
+        when(thresholdOptions.getEventCount()).thenReturn(10);
+        when(thresholdOptions.getMaximumSize()).thenReturn(ByteCount.parse("6mb"));
+        when(thresholdOptions.getEventCollectTimeOut()).thenReturn(Duration.ofSeconds(30));
+        when(batchOptions.getKeyName()).thenReturn("key");
+
+        // Mock PluginFactory to return the mocked responseCodec
+        when(pluginFactory.loadPlugin(eq(InputCodec.class), any(PluginSetting.class))).thenReturn(
+            responseCodec);
+
+        // Instantiate the LambdaProcessor manually
+        lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
+            awsCredentialsSupplier, expressionEvaluator);
+
+        // Mock InvokeResponse
+        when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String("[{\"key\":\"value\"}]"));
+        when(invokeResponse.statusCode()).thenReturn(200); // Success status code
+
+        // Mock LambdaAsyncClient inside LambdaProcessor
+        LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
+        setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
+
+        // Mock the invoke method to return a completed future
+        CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
+            invokeResponse);
+        when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
+
+        // Mock Response Codec parse method
+        doNothing().when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+
+    }
+
+    private void populatePrivateFields() throws Exception {
+        List<String> tagsOnMatchFailure = Collections.singletonList("failure_tag");
+        // Use reflection to set the private fields
+        setPrivateField(lambdaProcessor, "numberOfRecordsSuccessCounter",
+            numberOfRecordsSuccessCounter);
+        setPrivateField(lambdaProcessor, "numberOfRequestsSuccessCounter",
+            numberOfRequestsSuccessCounter);
+        setPrivateField(lambdaProcessor, "numberOfRecordsFailedCounter",
+            numberOfRecordsFailedCounter);
+        setPrivateField(lambdaProcessor, "numberOfRequestsFailedCounter",
+            numberOfRequestsFailedCounter);
+        setPrivateField(lambdaProcessor, "tagsOnMatchFailure", tagsOnMatchFailure);
+        setPrivateField(lambdaProcessor, "lambdaCommonHandler", lambdaCommonHandler);
+    }
+
+    // Helper method to set private fields via reflection
+    private void setPrivateField(Object targetObject, String fieldName, Object value)
+        throws Exception {
+        Field field = targetObject.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(targetObject, value);
+    }
+
+    @Test
+    public void testProcessorDefaults() {
+        // Create a new LambdaProcessorConfig with default values
+        LambdaProcessorConfig defaultConfig = new LambdaProcessorConfig();
+
+        // Test default values
+        assertNull(defaultConfig.getFunctionName());
+        assertNull(defaultConfig.getAwsAuthenticationOptions());
+        assertNull(defaultConfig.getResponseCodecConfig());
+        assertEquals(InvocationType.REQUEST_RESPONSE, defaultConfig.getInvocationType());
+        assertFalse(defaultConfig.getResponseEventsMatch());
+        assertNull(defaultConfig.getWhenCondition());
+        assertTrue(defaultConfig.getTagsOnFailure().isEmpty());
+
+        // Test ClientOptions defaults
+        ClientOptions clientOptions = defaultConfig.getClientOptions();
+        assertNotNull(clientOptions);
+        assertEquals(ClientOptions.DEFAULT_CONNECTION_RETRIES,
+            clientOptions.getMaxConnectionRetries());
+        assertEquals(ClientOptions.DEFAULT_API_TIMEOUT, clientOptions.getApiCallTimeout());
+        assertEquals(ClientOptions.DEFAULT_CONNECTION_TIMEOUT,
+            clientOptions.getConnectionTimeout());
+        assertEquals(ClientOptions.DEFAULT_MAXIMUM_CONCURRENCY, clientOptions.getMaxConcurrency());
+        assertEquals(ClientOptions.DEFAULT_BASE_DELAY, clientOptions.getBaseDelay());
+        assertEquals(ClientOptions.DEFAULT_MAX_BACKOFF, clientOptions.getMaxBackoff());
+
+        // Test BatchOptions defaults
+        BatchOptions batchOptions = defaultConfig.getBatchOptions();
+        assertNotNull(batchOptions);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"lambda-processor-success-config.yaml"})
+    public void testDoExecute_WithExceptionDuringProcessing(String configFileName) {
+        // Arrange
+        List<Record<Event>> records = Collections.singletonList(getSampleRecord());
+        LambdaProcessorConfig lambdaProcessorConfig = createLambdaConfigurationFromYaml(
+            configFileName);
+        LambdaProcessor lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics,
+            lambdaProcessorConfig,
+            awsCredentialsSupplier, expressionEvaluator);
+
+        // make batch options null to generate exception
+        when(lambdaProcessorConfig.getBatchOptions()).thenReturn(null);
+        // Act
+        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+
+        // Assert
+        assertEquals(1, result.size());
+        verify(numberOfRecordsFailedCounter, times(1)).increment(1.0);
+    }
+
+    @Test
+    public void testDoExecute_WithEmptyResponse() throws Exception {
+        // Arrange
+        Event event = mock(Event.class);
+        Record<Event> record = new Record<>(event);
+        List<Record<Event>> records = Collections.singletonList(record);
+
+        // Mock Buffer to return empty payload
+        when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String(""));
+
+        // Act
+        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+
+        // Assert
+        assertEquals(0, result.size(), "Result should be empty due to empty Lambda response.");
+        verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
+    }
+
+    @Test
+    public void testDoExecute_WithNullResponse() throws Exception {
+        // Arrange
+        Event event = mock(Event.class);
+        Record<Event> record = new Record<>(event);
+        List<Record<Event>> records = Collections.singletonList(record);
+
+        // Mock Buffer to return null payload
+        when(invokeResponse.payload()).thenReturn(null);
+
+        // Act
+        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+
+        // Assert
+        assertEquals(0, result.size(), "Result should be empty due to null Lambda response.");
+        verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
+    }
+
+    @Test
+    public void testDoExecute_WithEmptyRecords() {
+        // Arrange
+        Collection<Record<Event>> records = Collections.emptyList();
+
+        // Act
+        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+
+        // Assert
+        assertEquals(0, result.size(), "Result should be empty when input records are empty.");
+        verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
+        verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
+    }
+
+    @Test
+    public void testDoExecute_WhenConditionFalse() {
+        // Arrange
+        Event event = mock(Event.class);
+        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+        Record<Event> record = new Record<>(event);
+        Collection<Record<Event>> records = Collections.singletonList(record);
+
+        // Mock condition evaluator to return false
+        when(expressionEvaluator.evaluateConditional(anyString(), eq(event))).thenReturn(false);
+        when(lambdaProcessorConfig.getWhenCondition()).thenReturn("some_condition");
+
+        // Instantiate the LambdaProcessor manually
+        lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
+            awsCredentialsSupplier, expressionEvaluator);
+
+        // Act
+        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+
+        // Assert
+        assertEquals(1, result.size(),
+            "Result should contain one record as the condition is false.");
+        verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
+        verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
+    }
+
+    @Test
+    public void testDoExecute_SuccessfulProcessing() throws Exception {
+        // Arrange
+        Event event = mock(Event.class);
+        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+        Record<Event> record = new Record<>(event);
+        Collection<Record<Event>> records = Collections.singletonList(record);
+
+        // Mock LambdaAsyncClient inside LambdaProcessor
+        LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
+        setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
+
+        // Mock the invoke method to return a completed future
+        CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
+            invokeResponse);
+        when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
+
+        // Mock Buffer behavior
+        when(bufferMock.getEventCount()).thenReturn(0).thenReturn(1).thenReturn(0);
+        when(bufferMock.getRecords()).thenReturn(Collections.singletonList(record));
+
+        doAnswer(invocation -> {
+            invocation.getArgument(0);
+            @SuppressWarnings("unchecked")
+            Consumer<Record<Event>> consumer = invocation.getArgument(1);
+
+            // Simulate parsing by providing a mocked event
+            Event parsedEvent = mock(Event.class);
+            Record<Event> parsedRecord = new Record<>(parsedEvent);
+            consumer.accept(parsedRecord);
+
+            return null;
+        }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+
+        // Act
+        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+
+        // Assert
+        assertEquals(1, result.size(), "Result should contain one record.");
+        verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
+    }
+
+    @Test
+    public void testConvertLambdaResponseToEvent_WithEqualEventCounts_SuccessfulProcessing()
+        throws Exception {
+        // Arrange
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
+
+        // Mock LambdaResponse with a valid payload containing two events
+        String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}]";
+        SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
+        when(invokeResponse.payload()).thenReturn(sdkBytes);
+        when(invokeResponse.statusCode()).thenReturn(200); // Success status code
+
+        // Mock the responseCodec.parse to add two events
+        doAnswer(invocation -> {
+            invocation.getArgument(0);
+            @SuppressWarnings("unchecked")
+            Consumer<Record<Event>> consumer = invocation.getArgument(1);
+            Event parsedEvent1 = mock(Event.class);
+            Event parsedEvent2 = mock(Event.class);
+            consumer.accept(new Record<>(parsedEvent1));
+            consumer.accept(new Record<>(parsedEvent2));
+            return null;
+        }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+
+        // Mock buffer with two original events
+        Event originalEvent1 = mock(Event.class);
+        Event originalEvent2 = mock(Event.class);
+        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+
+        when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
+        when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
+        Record<Event> originalRecord1 = new Record<>(originalEvent1);
+        Record<Event> originalRecord2 = new Record<>(originalEvent2);
+        List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
+        when(bufferMock.getRecords()).thenReturn(originalRecords);
+        when(bufferMock.getEventCount()).thenReturn(2);
+
+        // Act
+        List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock,
+            invokeResponse);
+
+        // Assert
+        assertEquals(2, resultRecords.size(), "ResultRecords should contain two records.");
+        // Verify that failure tags are not added since it's a successful response
+        verify(originalEvent1, never()).getMetadata();
+        verify(originalEvent2, never()).getMetadata();
+    }
+
+    @Test
+    public void testConvertLambdaResponseToEvent_WithUnequalEventCounts_SuccessfulProcessing()
+        throws Exception {
+        // Arrange
+        // Set responseEventsMatch to false
+        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
+
+        // Mock LambdaResponse with a valid payload containing three events
+        String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}, {\"key\":\"value3\"}]";
+        SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
+        when(invokeResponse.payload()).thenReturn(sdkBytes);
+        when(invokeResponse.statusCode()).thenReturn(200); // Success status code
+
+        // Mock the responseCodec.parse to add three parsed events
+        doAnswer(invocation -> {
+            invocation.getArgument(0);
+            @SuppressWarnings("unchecked")
+            Consumer<Record<Event>> consumer = invocation.getArgument(1);
+
+            // Create and add three mocked parsed events
+            Event parsedEvent1 = mock(Event.class);
+            Event parsedEvent2 = mock(Event.class);
+            Event parsedEvent3 = mock(Event.class);
+            consumer.accept(new Record<>(parsedEvent1));
+            consumer.accept(new Record<>(parsedEvent2));
+            consumer.accept(new Record<>(parsedEvent3));
+
+            return null;
+        }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+
+        // Mock buffer with two original events
+        Event originalEvent1 = mock(Event.class);
+        EventMetadata originalMetadata1 = mock(EventMetadata.class);
+        when(originalEvent1.getMetadata()).thenReturn(originalMetadata1);
+
+        Event originalEvent2 = mock(Event.class);
+        EventMetadata originalMetadata2 = mock(EventMetadata.class);
+        when(originalEvent2.getMetadata()).thenReturn(originalMetadata2);
+
+        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+
+        when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
+        when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
+
+        Record<Event> originalRecord1 = new Record<>(originalEvent1);
+        Record<Event> originalRecord2 = new Record<>(originalEvent2);
+        List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
+        when(bufferMock.getRecords()).thenReturn(originalRecords);
+        when(bufferMock.getEventCount()).thenReturn(2);
+
+        // Act
+        List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock,
+            invokeResponse);
+        // Assert
+        // Verify that three records are added to the result
+        assertEquals(3, resultRecords.size(), "ResultRecords should contain three records.");
+    }
 
 }

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorTest.java
@@ -21,12 +21,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.opensearch.dataprepper.plugins.lambda.common.config.ClientOptions;
+import static org.opensearch.dataprepper.plugins.lambda.processor.LambdaProcessor.NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA;
 import static org.opensearch.dataprepper.plugins.lambda.processor.LambdaProcessor.NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED;
 import static org.opensearch.dataprepper.plugins.lambda.processor.LambdaProcessor.NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS;
 import static org.opensearch.dataprepper.plugins.lambda.processor.LambdaProcessor.NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA;
-import static org.opensearch.dataprepper.plugins.lambda.processor.LambdaProcessor.NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA;
-
+import static org.opensearch.dataprepper.plugins.lambda.sink.LambdaSinkTest.getSampleRecord;
+import static org.opensearch.dataprepper.plugins.lambda.utils.LambdaTestSetupUtil.createLambdaConfigurationFromYaml;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
@@ -42,8 +42,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -53,8 +53,6 @@ import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.codec.InputCodec;
-import org.opensearch.dataprepper.model.codec.OutputCodec;
-import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.Event;
@@ -66,6 +64,7 @@ import org.opensearch.dataprepper.plugins.lambda.common.LambdaCommonHandler;
 import org.opensearch.dataprepper.plugins.lambda.common.accumlator.Buffer;
 import org.opensearch.dataprepper.plugins.lambda.common.config.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.lambda.common.config.BatchOptions;
+import org.opensearch.dataprepper.plugins.lambda.common.config.ClientOptions;
 import org.opensearch.dataprepper.plugins.lambda.common.config.InvocationType;
 import org.opensearch.dataprepper.plugins.lambda.common.config.ThresholdOptions;
 import software.amazon.awssdk.core.SdkBytes;
@@ -76,431 +75,423 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class LambdaProcessorTest {
-    // Mock dependencies
-    @Mock
-    private AwsAuthenticationOptions awsAuthenticationOptions;
 
-    @Mock
-    private Buffer bufferMock;
+  // Mock dependencies
+  @Mock
+  private AwsAuthenticationOptions awsAuthenticationOptions;
 
-    @Mock
-    private PluginFactory pluginFactory;
+  @Mock
+  private Buffer bufferMock;
 
-    @Mock
-    private PluginMetrics pluginMetrics;
+  @Mock
+  private PluginFactory pluginFactory;
 
-    @Mock
-    private LambdaProcessorConfig lambdaProcessorConfig;
+  @Mock
+  private PluginMetrics pluginMetrics;
 
-    @Mock
-    private AwsCredentialsSupplier awsCredentialsSupplier;
+  @Mock
+  private LambdaProcessorConfig lambdaProcessorConfig;
 
-    @Mock
-    private ExpressionEvaluator expressionEvaluator;
+  @Mock
+  private AwsCredentialsSupplier awsCredentialsSupplier;
 
-    @Mock
-    private LambdaCommonHandler lambdaCommonHandler;
+  @Mock
+  private ExpressionEvaluator expressionEvaluator;
 
-    @Mock
-    private InputCodec responseCodec;
+  @Mock
+  private LambdaCommonHandler lambdaCommonHandler;
 
-    @Mock
-    private OutputCodec requestCodec;
+  @Mock
+  private InputCodec responseCodec;
 
-    @Mock
-    private Counter numberOfRecordsSuccessCounter;
 
-    @Mock
-    private Counter numberOfRequestsSuccessCounter;
+  @Mock
+  private Counter numberOfRecordsSuccessCounter;
 
-    @Mock
-    private Counter numberOfRecordsFailedCounter;
-    @Mock
-    private Counter numberOfRequestsFailedCounter;
+  @Mock
+  private Counter numberOfRequestsSuccessCounter;
 
-    @Mock
-    private InvokeResponse invokeResponse;
+  @Mock
+  private Counter numberOfRecordsFailedCounter;
+  @Mock
+  private Counter numberOfRequestsFailedCounter;
 
-    @Mock
-    private Timer lambdaLatencyMetric;
+  @Mock
+  private InvokeResponse invokeResponse;
 
-    @Captor
-    private ArgumentCaptor<Consumer<Record<Event>>> consumerCaptor;
+  @Mock
+  private Timer lambdaLatencyMetric;
 
-    // The class under test
-    private LambdaProcessor lambdaProcessor;
+  // The class under test
+  private LambdaProcessor lambdaProcessor;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this);
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
 
-        // Mock PluginMetrics counters and timers
-        when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS))).thenReturn(
-            numberOfRecordsSuccessCounter);
-        when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED))).thenReturn(
-            numberOfRecordsFailedCounter);
-        when(pluginMetrics.counter(eq(NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA))).thenReturn(
-                numberOfRecordsSuccessCounter);
-        when(pluginMetrics.counter(eq(NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA))).thenReturn(
-                numberOfRecordsFailedCounter);
-        when(pluginMetrics.timer(anyString())).thenReturn(lambdaLatencyMetric);
-        when(pluginMetrics.gauge(anyString(), any(AtomicLong.class))).thenAnswer(
-            invocation -> invocation.getArgument(1));
+    // Mock PluginMetrics counters and timers
+    when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_SUCCESS))).thenReturn(
+        numberOfRecordsSuccessCounter);
+    when(pluginMetrics.counter(eq(NUMBER_OF_RECORDS_FLUSHED_TO_LAMBDA_FAILED))).thenReturn(
+        numberOfRecordsFailedCounter);
+    when(pluginMetrics.counter(eq(NUMBER_OF_SUCCESSFUL_REQUESTS_TO_LAMBDA))).thenReturn(
+        numberOfRecordsSuccessCounter);
+    when(pluginMetrics.counter(eq(NUMBER_OF_FAILED_REQUESTS_TO_LAMBDA))).thenReturn(
+        numberOfRecordsFailedCounter);
+    when(pluginMetrics.timer(anyString())).thenReturn(lambdaLatencyMetric);
+    when(pluginMetrics.gauge(anyString(), any(AtomicLong.class))).thenAnswer(
+        invocation -> invocation.getArgument(1));
 
-        ClientOptions clientOptions = new ClientOptions();
-        when(lambdaProcessorConfig.getClientOptions()).thenReturn(clientOptions);
-        when(lambdaProcessorConfig.getFunctionName()).thenReturn("test-function");
-        when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
-        when(lambdaProcessorConfig.getInvocationType()).thenReturn(InvocationType.REQUEST_RESPONSE);
-        BatchOptions batchOptions = mock(BatchOptions.class);
-        ThresholdOptions thresholdOptions = mock(ThresholdOptions.class);
-        when(lambdaProcessorConfig.getBatchOptions()).thenReturn(batchOptions);
-        when(lambdaProcessorConfig.getWhenCondition()).thenReturn(null);
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
+    ClientOptions clientOptions = new ClientOptions();
+    when(lambdaProcessorConfig.getClientOptions()).thenReturn(clientOptions);
+    when(lambdaProcessorConfig.getFunctionName()).thenReturn("test-function");
+    when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
+    when(lambdaProcessorConfig.getInvocationType()).thenReturn(InvocationType.REQUEST_RESPONSE);
+    BatchOptions batchOptions = mock(BatchOptions.class);
+    ThresholdOptions thresholdOptions = mock(ThresholdOptions.class);
+    when(lambdaProcessorConfig.getBatchOptions()).thenReturn(batchOptions);
+    when(lambdaProcessorConfig.getWhenCondition()).thenReturn(null);
+    when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
 
-        // Mock AWS Authentication Options
-        when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
-        when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("testRole");
+    // Mock AWS Authentication Options
+    when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
+    when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("testRole");
 
-        // Mock BatchOptions and ThresholdOptions
-        when(batchOptions.getThresholdOptions()).thenReturn(thresholdOptions);
-        when(thresholdOptions.getEventCount()).thenReturn(10);
-        when(thresholdOptions.getMaximumSize()).thenReturn(ByteCount.parse("6mb"));
-        when(thresholdOptions.getEventCollectTimeOut()).thenReturn(Duration.ofSeconds(30));
-        when(batchOptions.getKeyName()).thenReturn("key");
+    // Mock BatchOptions and ThresholdOptions
+    when(batchOptions.getThresholdOptions()).thenReturn(thresholdOptions);
+    when(thresholdOptions.getEventCount()).thenReturn(10);
+    when(thresholdOptions.getMaximumSize()).thenReturn(ByteCount.parse("6mb"));
+    when(thresholdOptions.getEventCollectTimeOut()).thenReturn(Duration.ofSeconds(30));
+    when(batchOptions.getKeyName()).thenReturn("key");
 
-        // Mock Response Codec Configuration
-        PluginModel responseCodecConfig = lambdaProcessorConfig.getResponseCodecConfig();
-        PluginSetting responseCodecPluginSetting;
+    // Mock PluginFactory to return the mocked responseCodec
+    when(pluginFactory.loadPlugin(eq(InputCodec.class), any(PluginSetting.class))).thenReturn(
+        responseCodec);
 
-        if (responseCodecConfig == null) {
-          // Default to JsonInputCodec with default settings
-          responseCodecPluginSetting = new PluginSetting("json", Collections.emptyMap());
-        } else {
-          responseCodecPluginSetting = new PluginSetting(responseCodecConfig.getPluginName(),
-              responseCodecConfig.getPluginSettings());
-        }
+    // Instantiate the LambdaProcessor manually
+    lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
+        awsCredentialsSupplier, expressionEvaluator);
 
-        // Mock PluginFactory to return the mocked responseCodec
-        when(pluginFactory.loadPlugin(eq(InputCodec.class), any(PluginSetting.class))).thenReturn(
-            responseCodec);
+    // Mock InvokeResponse
+    when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String("[{\"key\":\"value\"}]"));
+    when(invokeResponse.statusCode()).thenReturn(200); // Success status code
 
-        // Instantiate the LambdaProcessor manually
-        lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
-            awsCredentialsSupplier, expressionEvaluator);
+    // Mock LambdaAsyncClient inside LambdaProcessor
+    LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
+    setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
 
-        // Mock InvokeResponse
-        when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String("[{\"key\":\"value\"}]"));
-        when(invokeResponse.statusCode()).thenReturn(200); // Success status code
+    // Mock the invoke method to return a completed future
+    CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
+        invokeResponse);
+    when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
 
-        // Mock LambdaAsyncClient inside LambdaProcessor
-        LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
-        setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
+    // Mock Response Codec parse method
+    doNothing().when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
 
-        // Mock the invoke method to return a completed future
-        CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
-            invokeResponse);
-        when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
+  }
 
-        // Mock Response Codec parse method
-        doNothing().when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+  private void populatePrivateFields() throws Exception {
+    List<String> tagsOnMatchFailure = Collections.singletonList("failure_tag");
+    // Use reflection to set the private fields
+    setPrivateField(lambdaProcessor, "numberOfRecordsSuccessCounter",
+        numberOfRecordsSuccessCounter);
+    setPrivateField(lambdaProcessor, "numberOfRequestsSuccessCounter",
+        numberOfRequestsSuccessCounter);
+    setPrivateField(lambdaProcessor, "numberOfRecordsFailedCounter", numberOfRecordsFailedCounter);
+    setPrivateField(lambdaProcessor, "numberOfRequestsFailedCounter",
+        numberOfRequestsFailedCounter);
+    setPrivateField(lambdaProcessor, "tagsOnMatchFailure", tagsOnMatchFailure);
+    setPrivateField(lambdaProcessor, "lambdaCommonHandler", lambdaCommonHandler);
+  }
 
-    }
-
-    private void populatePrivateFields() throws Exception {
-        List<String> tagsOnMatchFailure = Collections.singletonList("failure_tag");
-        // Use reflection to set the private fields
-        setPrivateField(lambdaProcessor, "numberOfRecordsSuccessCounter",
-            numberOfRecordsSuccessCounter);
-        setPrivateField(lambdaProcessor, "numberOfRequestsSuccessCounter",
-                numberOfRequestsSuccessCounter);
-        setPrivateField(lambdaProcessor, "numberOfRecordsFailedCounter", numberOfRecordsFailedCounter);
-        setPrivateField(lambdaProcessor, "numberOfRequestsFailedCounter", numberOfRequestsFailedCounter);
-        setPrivateField(lambdaProcessor, "tagsOnMatchFailure", tagsOnMatchFailure);
-        setPrivateField(lambdaProcessor, "lambdaCommonHandler", lambdaCommonHandler);
-    }
-
-    // Helper method to set private fields via reflection
-    private void setPrivateField(Object targetObject, String fieldName, Object value)
+  // Helper method to set private fields via reflection
+  private void setPrivateField(Object targetObject, String fieldName, Object value)
       throws Exception {
-        Field field = targetObject.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(targetObject, value);
-    }
+    Field field = targetObject.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(targetObject, value);
+  }
 
-    @Test
-    public void testProcessorDefaults() {
-        // Create a new LambdaProcessorConfig with default values
-        LambdaProcessorConfig defaultConfig = new LambdaProcessorConfig();
+  @Test
+  public void testProcessorDefaults() {
+    // Create a new LambdaProcessorConfig with default values
+    LambdaProcessorConfig defaultConfig = new LambdaProcessorConfig();
 
-        // Test default values
-        assertNull(defaultConfig.getFunctionName());
-        assertNull(defaultConfig.getAwsAuthenticationOptions());
-        assertNull(defaultConfig.getResponseCodecConfig());
-        assertEquals(InvocationType.REQUEST_RESPONSE, defaultConfig.getInvocationType());
-        assertFalse(defaultConfig.getResponseEventsMatch());
-        assertNull(defaultConfig.getWhenCondition());
-        assertTrue(defaultConfig.getTagsOnFailure().isEmpty());
+    // Test default values
+    assertNull(defaultConfig.getFunctionName());
+    assertNull(defaultConfig.getAwsAuthenticationOptions());
+    assertNull(defaultConfig.getResponseCodecConfig());
+    assertEquals(InvocationType.REQUEST_RESPONSE, defaultConfig.getInvocationType());
+    assertFalse(defaultConfig.getResponseEventsMatch());
+    assertNull(defaultConfig.getWhenCondition());
+    assertTrue(defaultConfig.getTagsOnFailure().isEmpty());
 
-        // Test ClientOptions defaults
-        ClientOptions clientOptions = defaultConfig.getClientOptions();
-        assertNotNull(clientOptions);
-        assertEquals(ClientOptions.DEFAULT_CONNECTION_RETRIES, clientOptions.getMaxConnectionRetries());
-        assertEquals(ClientOptions.DEFAULT_API_TIMEOUT, clientOptions.getApiCallTimeout());
-        assertEquals(ClientOptions.DEFAULT_CONNECTION_TIMEOUT, clientOptions.getConnectionTimeout());
-        assertEquals(ClientOptions.DEFAULT_MAXIMUM_CONCURRENCY, clientOptions.getMaxConcurrency());
-        assertEquals(ClientOptions.DEFAULT_BASE_DELAY, clientOptions.getBaseDelay());
-        assertEquals(ClientOptions.DEFAULT_MAX_BACKOFF, clientOptions.getMaxBackoff());
+    // Test ClientOptions defaults
+    ClientOptions clientOptions = defaultConfig.getClientOptions();
+    assertNotNull(clientOptions);
+    assertEquals(ClientOptions.DEFAULT_CONNECTION_RETRIES, clientOptions.getMaxConnectionRetries());
+    assertEquals(ClientOptions.DEFAULT_API_TIMEOUT, clientOptions.getApiCallTimeout());
+    assertEquals(ClientOptions.DEFAULT_CONNECTION_TIMEOUT, clientOptions.getConnectionTimeout());
+    assertEquals(ClientOptions.DEFAULT_MAXIMUM_CONCURRENCY, clientOptions.getMaxConcurrency());
+    assertEquals(ClientOptions.DEFAULT_BASE_DELAY, clientOptions.getBaseDelay());
+    assertEquals(ClientOptions.DEFAULT_MAX_BACKOFF, clientOptions.getMaxBackoff());
 
-        // Test BatchOptions defaults
-        BatchOptions batchOptions = defaultConfig.getBatchOptions();
-        assertNotNull(batchOptions);
-    }
+    // Test BatchOptions defaults
+    BatchOptions batchOptions = defaultConfig.getBatchOptions();
+    assertNotNull(batchOptions);
+  }
 
-    @Test
-    public void testDoExecute_WithExceptionDuringProcessing() throws Exception {
-        // Arrange
-        Event event = mock(Event.class);
-        Record<Event> record = new Record<>(event);
-        List<Record<Event>> records = Collections.singletonList(record);
+  @ParameterizedTest
+  @ValueSource(strings = {"lambda-processor-success-config.yaml"})
+  public void testDoExecute_WithExceptionDuringProcessing(String configFileName) {
+    // Arrange
+    List<Record<Event>> records = Collections.singletonList(getSampleRecord());
+    LambdaProcessorConfig lambdaProcessorConfig = createLambdaConfigurationFromYaml(configFileName);
+    LambdaProcessor lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics,
+        lambdaProcessorConfig,
+        awsCredentialsSupplier, expressionEvaluator);
 
-        // make batch options null to generate exception
-        when(lambdaProcessorConfig.getBatchOptions()).thenReturn(null);
-        // Act
-        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+    // make batch options null to generate exception
+    when(lambdaProcessorConfig.getBatchOptions()).thenReturn(null);
+    // Act
+    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
 
-        // Assert
-        assertEquals(1, result.size());
-        verify(numberOfRecordsFailedCounter, times(1)).increment(1.0);
-    }
+    // Assert
+    assertEquals(1, result.size());
+    verify(numberOfRecordsFailedCounter, times(1)).increment(1.0);
+  }
 
-    @Test
-    public void testDoExecute_WithEmptyResponse() throws Exception {
-        // Arrange
-        Event event = mock(Event.class);
-        Record<Event> record = new Record<>(event);
-        List<Record<Event>> records = Collections.singletonList(record);
+  @Test
+  public void testDoExecute_WithEmptyResponse() throws Exception {
+    // Arrange
+    Event event = mock(Event.class);
+    Record<Event> record = new Record<>(event);
+    List<Record<Event>> records = Collections.singletonList(record);
 
-        // Mock Buffer to return empty payload
-        when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String(""));
+    // Mock Buffer to return empty payload
+    when(invokeResponse.payload()).thenReturn(SdkBytes.fromUtf8String(""));
 
-        // Act
-        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+    // Act
+    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
 
-        // Assert
-        assertEquals(0, result.size(), "Result should be empty due to empty Lambda response.");
-        verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
-    }
+    // Assert
+    assertEquals(0, result.size(), "Result should be empty due to empty Lambda response.");
+    verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
+  }
 
-    @Test
-    public void testDoExecute_WithNullResponse() throws Exception {
-        // Arrange
-        Event event = mock(Event.class);
-        Record<Event> record = new Record<>(event);
-        List<Record<Event>> records = Collections.singletonList(record);
+  @Test
+  public void testDoExecute_WithNullResponse() throws Exception {
+    // Arrange
+    Event event = mock(Event.class);
+    Record<Event> record = new Record<>(event);
+    List<Record<Event>> records = Collections.singletonList(record);
 
-        // Mock Buffer to return null payload
-        when(invokeResponse.payload()).thenReturn(null);
+    // Mock Buffer to return null payload
+    when(invokeResponse.payload()).thenReturn(null);
 
-        // Act
-        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+    // Act
+    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
 
-        // Assert
-        assertEquals(0, result.size(), "Result should be empty due to null Lambda response.");
-        verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
-    }
+    // Assert
+    assertEquals(0, result.size(), "Result should be empty due to null Lambda response.");
+    verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
+  }
 
-    @Test
-    public void testDoExecute_WithEmptyRecords() {
-        // Arrange
-        Collection<Record<Event>> records = Collections.emptyList();
+  @Test
+  public void testDoExecute_WithEmptyRecords() {
+    // Arrange
+    Collection<Record<Event>> records = Collections.emptyList();
 
-        // Act
-        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+    // Act
+    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
 
-        // Assert
-        assertEquals(0, result.size(), "Result should be empty when input records are empty.");
-        verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
-        verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
-    }
+    // Assert
+    assertEquals(0, result.size(), "Result should be empty when input records are empty.");
+    verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
+    verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
+  }
 
-    @Test
-    public void testDoExecute_WhenConditionFalse() {
-        // Arrange
-        Event event = mock(Event.class);
-        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
-        Record<Event> record = new Record<>(event);
-        Collection<Record<Event>> records = Collections.singletonList(record);
+  @Test
+  public void testDoExecute_WhenConditionFalse() {
+    // Arrange
+    Event event = mock(Event.class);
+    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+    when(event.getEventHandle()).thenReturn(eventHandle);
+    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+    Record<Event> record = new Record<>(event);
+    Collection<Record<Event>> records = Collections.singletonList(record);
 
-        // Mock condition evaluator to return false
-        when(expressionEvaluator.evaluateConditional(anyString(), eq(event))).thenReturn(false);
-        when(lambdaProcessorConfig.getWhenCondition()).thenReturn("some_condition");
+    // Mock condition evaluator to return false
+    when(expressionEvaluator.evaluateConditional(anyString(), eq(event))).thenReturn(false);
+    when(lambdaProcessorConfig.getWhenCondition()).thenReturn("some_condition");
 
-        // Instantiate the LambdaProcessor manually
-        lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
-            awsCredentialsSupplier, expressionEvaluator);
+    // Instantiate the LambdaProcessor manually
+    lambdaProcessor = new LambdaProcessor(pluginFactory, pluginMetrics, lambdaProcessorConfig,
+        awsCredentialsSupplier, expressionEvaluator);
 
-        // Act
-        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+    // Act
+    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
 
-        // Assert
-        assertEquals(1, result.size(), "Result should contain one record as the condition is false.");
-        verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
-        verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
-    }
+    // Assert
+    assertEquals(1, result.size(), "Result should contain one record as the condition is false.");
+    verify(numberOfRecordsSuccessCounter, never()).increment(anyDouble());
+    verify(numberOfRecordsFailedCounter, never()).increment(anyDouble());
+  }
 
-    @Test
-    public void testDoExecute_SuccessfulProcessing() throws Exception {
-        // Arrange
-        Event event = mock(Event.class);
-        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
-        Record<Event> record = new Record<>(event);
-        Collection<Record<Event>> records = Collections.singletonList(record);
+  @Test
+  public void testDoExecute_SuccessfulProcessing() throws Exception {
+    // Arrange
+    Event event = mock(Event.class);
+    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+    when(event.getEventHandle()).thenReturn(eventHandle);
+    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+    Record<Event> record = new Record<>(event);
+    Collection<Record<Event>> records = Collections.singletonList(record);
 
-        // Mock LambdaAsyncClient inside LambdaProcessor
-        LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
-        setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
+    // Mock LambdaAsyncClient inside LambdaProcessor
+    LambdaAsyncClient lambdaAsyncClientMock = mock(LambdaAsyncClient.class);
+    setPrivateField(lambdaProcessor, "lambdaAsyncClient", lambdaAsyncClientMock);
 
-        // Mock the invoke method to return a completed future
-        CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
-            invokeResponse);
-        when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
+    // Mock the invoke method to return a completed future
+    CompletableFuture<InvokeResponse> invokeFuture = CompletableFuture.completedFuture(
+        invokeResponse);
+    when(lambdaAsyncClientMock.invoke(any(InvokeRequest.class))).thenReturn(invokeFuture);
 
-        // Mock Buffer behavior
-        when(bufferMock.getEventCount()).thenReturn(0).thenReturn(1).thenReturn(0);
-        when(bufferMock.getRecords()).thenReturn(Collections.singletonList(record));
+    // Mock Buffer behavior
+    when(bufferMock.getEventCount()).thenReturn(0).thenReturn(1).thenReturn(0);
+    when(bufferMock.getRecords()).thenReturn(Collections.singletonList(record));
 
-        doAnswer(invocation -> {
-          InputStream inputStream = invocation.getArgument(0);
-          @SuppressWarnings("unchecked")
-          Consumer<Record<Event>> consumer = invocation.getArgument(1);
+    doAnswer(invocation -> {
+      invocation.getArgument(0);
+      @SuppressWarnings("unchecked")
+      Consumer<Record<Event>> consumer = invocation.getArgument(1);
 
-          // Simulate parsing by providing a mocked event
-          Event parsedEvent = mock(Event.class);
-          Record<Event> parsedRecord = new Record<>(parsedEvent);
-          consumer.accept(parsedRecord);
+      // Simulate parsing by providing a mocked event
+      Event parsedEvent = mock(Event.class);
+      Record<Event> parsedRecord = new Record<>(parsedEvent);
+      consumer.accept(parsedRecord);
 
-          return null;
-        }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+      return null;
+    }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
 
-        // Act
-        Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
+    // Act
+    Collection<Record<Event>> result = lambdaProcessor.doExecute(records);
 
-        // Assert
-        assertEquals(1, result.size(), "Result should contain one record.");
-        verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
-    }
+    // Assert
+    assertEquals(1, result.size(), "Result should contain one record.");
+    verify(numberOfRecordsSuccessCounter, times(1)).increment(1.0);
+  }
 
-    @Test
-    public void testConvertLambdaResponseToEvent_WithEqualEventCounts_SuccessfulProcessing() throws Exception {
-        // Arrange
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
+  @Test
+  public void testConvertLambdaResponseToEvent_WithEqualEventCounts_SuccessfulProcessing()
+      throws Exception {
+    // Arrange
+    when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(true);
 
-        // Mock LambdaResponse with a valid payload containing two events
-        String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}]";
-        SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
-        when(invokeResponse.payload()).thenReturn(sdkBytes);
-        when(invokeResponse.statusCode()).thenReturn(200); // Success status code
+    // Mock LambdaResponse with a valid payload containing two events
+    String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}]";
+    SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
+    when(invokeResponse.payload()).thenReturn(sdkBytes);
+    when(invokeResponse.statusCode()).thenReturn(200); // Success status code
 
-        // Mock the responseCodec.parse to add two events
-        doAnswer(invocation -> {
-            InputStream inputStream = invocation.getArgument(0);
-            @SuppressWarnings("unchecked")
-            Consumer<Record<Event>> consumer = invocation.getArgument(1);
-            Event parsedEvent1 = mock(Event.class);
-            Event parsedEvent2 = mock(Event.class);
-            consumer.accept(new Record<>(parsedEvent1));
-            consumer.accept(new Record<>(parsedEvent2));
-            return null;
-        }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+    // Mock the responseCodec.parse to add two events
+    doAnswer(invocation -> {
+      invocation.getArgument(0);
+      @SuppressWarnings("unchecked")
+      Consumer<Record<Event>> consumer = invocation.getArgument(1);
+      Event parsedEvent1 = mock(Event.class);
+      Event parsedEvent2 = mock(Event.class);
+      consumer.accept(new Record<>(parsedEvent1));
+      consumer.accept(new Record<>(parsedEvent2));
+      return null;
+    }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
 
-        // Mock buffer with two original events
-        Event originalEvent1 = mock(Event.class);
-        Event originalEvent2 = mock(Event.class);
-        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+    // Mock buffer with two original events
+    Event originalEvent1 = mock(Event.class);
+    Event originalEvent2 = mock(Event.class);
+    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
 
-        when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
-        when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
-        Record<Event> originalRecord1 = new Record<>(originalEvent1);
-        Record<Event> originalRecord2 = new Record<>(originalEvent2);
-        List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
-        when(bufferMock.getRecords()).thenReturn(originalRecords);
-        when(bufferMock.getEventCount()).thenReturn(2);
+    when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
+    when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
+    Record<Event> originalRecord1 = new Record<>(originalEvent1);
+    Record<Event> originalRecord2 = new Record<>(originalEvent2);
+    List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
+    when(bufferMock.getRecords()).thenReturn(originalRecords);
+    when(bufferMock.getEventCount()).thenReturn(2);
 
-        // Act
-        List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock, invokeResponse);
+    // Act
+    List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock,
+        invokeResponse);
 
-        // Assert
-        assertEquals(2, resultRecords.size(), "ResultRecords should contain two records.");
-        // Verify that failure tags are not added since it's a successful response
-        verify(originalEvent1, never()).getMetadata();
-        verify(originalEvent2, never()).getMetadata();
-    }
+    // Assert
+    assertEquals(2, resultRecords.size(), "ResultRecords should contain two records.");
+    // Verify that failure tags are not added since it's a successful response
+    verify(originalEvent1, never()).getMetadata();
+    verify(originalEvent2, never()).getMetadata();
+  }
 
-    @Test
-    public void testConvertLambdaResponseToEvent_WithUnequalEventCounts_SuccessfulProcessing() throws Exception {
-        // Arrange
-        // Set responseEventsMatch to false
-        when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
+  @Test
+  public void testConvertLambdaResponseToEvent_WithUnequalEventCounts_SuccessfulProcessing()
+      throws Exception {
+    // Arrange
+    // Set responseEventsMatch to false
+    when(lambdaProcessorConfig.getResponseEventsMatch()).thenReturn(false);
 
-        // Mock LambdaResponse with a valid payload containing three events
-        String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}, {\"key\":\"value3\"}]";
-        SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
-        when(invokeResponse.payload()).thenReturn(sdkBytes);
-        when(invokeResponse.statusCode()).thenReturn(200); // Success status code
+    // Mock LambdaResponse with a valid payload containing three events
+    String payloadString = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}, {\"key\":\"value3\"}]";
+    SdkBytes sdkBytes = SdkBytes.fromByteArray(payloadString.getBytes());
+    when(invokeResponse.payload()).thenReturn(sdkBytes);
+    when(invokeResponse.statusCode()).thenReturn(200); // Success status code
 
-        // Mock the responseCodec.parse to add three parsed events
-        doAnswer(invocation -> {
-            InputStream inputStream = invocation.getArgument(0);
-            @SuppressWarnings("unchecked")
-            Consumer<Record<Event>> consumer = invocation.getArgument(1);
+    // Mock the responseCodec.parse to add three parsed events
+    doAnswer(invocation -> {
+      invocation.getArgument(0);
+      @SuppressWarnings("unchecked")
+      Consumer<Record<Event>> consumer = invocation.getArgument(1);
 
-            // Create and add three mocked parsed events
-            Event parsedEvent1 = mock(Event.class);
-            Event parsedEvent2 = mock(Event.class);
-            Event parsedEvent3 = mock(Event.class);
-            consumer.accept(new Record<>(parsedEvent1));
-            consumer.accept(new Record<>(parsedEvent2));
-            consumer.accept(new Record<>(parsedEvent3));
+      // Create and add three mocked parsed events
+      Event parsedEvent1 = mock(Event.class);
+      Event parsedEvent2 = mock(Event.class);
+      Event parsedEvent3 = mock(Event.class);
+      consumer.accept(new Record<>(parsedEvent1));
+      consumer.accept(new Record<>(parsedEvent2));
+      consumer.accept(new Record<>(parsedEvent3));
 
-            return null;
-        }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
+      return null;
+    }).when(responseCodec).parse(any(InputStream.class), any(Consumer.class));
 
-        // Mock buffer with two original events
-        Event originalEvent1 = mock(Event.class);
-        EventMetadata originalMetadata1 = mock(EventMetadata.class);
-        when(originalEvent1.getMetadata()).thenReturn(originalMetadata1);
+    // Mock buffer with two original events
+    Event originalEvent1 = mock(Event.class);
+    EventMetadata originalMetadata1 = mock(EventMetadata.class);
+    when(originalEvent1.getMetadata()).thenReturn(originalMetadata1);
 
-        Event originalEvent2 = mock(Event.class);
-        EventMetadata originalMetadata2 = mock(EventMetadata.class);
-        when(originalEvent2.getMetadata()).thenReturn(originalMetadata2);
+    Event originalEvent2 = mock(Event.class);
+    EventMetadata originalMetadata2 = mock(EventMetadata.class);
+    when(originalEvent2.getMetadata()).thenReturn(originalMetadata2);
 
-        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-        when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
+    DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+    AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+    when(eventHandle.getAcknowledgementSet()).thenReturn(acknowledgementSet);
 
-        when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
-        when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
+    when(originalEvent1.getEventHandle()).thenReturn(eventHandle);
+    when(originalEvent2.getEventHandle()).thenReturn(eventHandle);
 
-        Record<Event> originalRecord1 = new Record<>(originalEvent1);
-        Record<Event> originalRecord2 = new Record<>(originalEvent2);
-        List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
-        when(bufferMock.getRecords()).thenReturn(originalRecords);
-        when(bufferMock.getEventCount()).thenReturn(2);
+    Record<Event> originalRecord1 = new Record<>(originalEvent1);
+    Record<Event> originalRecord2 = new Record<>(originalEvent2);
+    List<Record<Event>> originalRecords = Arrays.asList(originalRecord1, originalRecord2);
+    when(bufferMock.getRecords()).thenReturn(originalRecords);
+    when(bufferMock.getEventCount()).thenReturn(2);
 
-        // Act
-        List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock, invokeResponse);
-        // Assert
-        // Verify that three records are added to the result
-        assertEquals(3, resultRecords.size(), "ResultRecords should contain three records.");
-    }
+    // Act
+    List<Record<Event>> resultRecords = lambdaProcessor.convertLambdaResponseToEvent(bufferMock,
+        invokeResponse);
+    // Assert
+    // Verify that three records are added to the result
+    assertEquals(3, resultRecords.size(), "ResultRecords should contain three records.");
+  }
 
 }

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/utils/LambdaTestSetupUtil.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/utils/LambdaTestSetupUtil.java
@@ -1,0 +1,42 @@
+package org.opensearch.dataprepper.plugins.lambda.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.io.InputStream;
+import org.opensearch.dataprepper.plugins.lambda.processor.LambdaProcessorConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LambdaTestSetupUtil {
+
+  private static final Logger log = LoggerFactory.getLogger(LambdaTestSetupUtil.class);
+
+  public static ObjectMapper getObjectMapper() {
+    return new ObjectMapper(
+        new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS)).registerModule(
+        new JavaTimeModule());
+  }
+
+  private static InputStream getResourceAsStream(String resourceName) {
+    InputStream inputStream = Thread.currentThread().getContextClassLoader()
+        .getResourceAsStream(resourceName);
+    if (inputStream == null) {
+      inputStream = LambdaTestSetupUtil.class.getResourceAsStream("/" + resourceName);
+    }
+    return inputStream;
+  }
+
+  public static LambdaProcessorConfig createLambdaConfigurationFromYaml(String fileName) {
+    ObjectMapper objectMapper = getObjectMapper();
+    try (InputStream inputStream = getResourceAsStream(fileName)) {
+      return objectMapper.readValue(inputStream, LambdaProcessorConfig.class);
+    } catch (IOException ex) {
+      log.error("Failed to parse pipeline Yaml", ex);
+      throw new RuntimeException(ex);
+    }
+  }
+
+}

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-success-config.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-success-config.yaml
@@ -1,0 +1,13 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+


### PR DESCRIPTION
### Description
Simplified the flow by removing the approach to pass the call-back methods. This helps with code readability and unit testing.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
