### PR TITLE
Add log for exceptions when processing DynamoDB shards

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamScheduler.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
 /**
  * A scheduler to manage all the stream related work in one place
  */
@@ -100,6 +102,8 @@ public class StreamScheduler implements Runnable {
                 runConsumer.whenComplete((v, ex) -> {
                     numOfWorkers.decrementAndGet();
                     if (ex != null) {
+                        LOG.error(NOISY, "Received exception while processing shard {}, giving up this shard for reprocessing: {}",
+                                streamPartition.getShardId(), ex);
                         coordinator.giveUpPartition(streamPartition);
                     }
                     if (numOfWorkers.get() == 0) {


### PR DESCRIPTION
### Description
There is currently a scenario where a DynamoDB stream shard can be continuously reprocessed, and after looking into the code it appears that this is due to an exception that results in the shard being given up, but Data Prpeper is not logging this exception anywhere
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
