### PR TITLE
Fix TINYINT(1) data type mapping in rds source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManager.java
@@ -12,6 +12,13 @@ import java.util.Properties;
 
 public class ConnectionManager {
     static final String JDBC_URL_FORMAT = "jdbc:mysql://%s:%d";
+    static final String USERNAME_KEY = "user";
+    static final String PASSWORD_KEY = "password";
+    static final String USE_SSL_KEY = "useSSL";
+    static final String REQUIRE_SSL_KEY = "requireSSL";
+    static final String TINY_INT_ONE_IS_BIT_KEY = "tinyInt1isBit";
+    static final String TRUE_VALUE = "true";
+    static final String FALSE_VALUE = "false";
     private final String hostName;
     private final int port;
     private final String username;
@@ -28,14 +35,15 @@ public class ConnectionManager {
 
     public Connection getConnection() throws SQLException {
         final Properties props = new Properties();
-        props.setProperty("user", username);
-        props.setProperty("password", password);
+        props.setProperty(USERNAME_KEY, username);
+        props.setProperty(PASSWORD_KEY, password);
         if (requireSSL) {
-            props.setProperty("useSSL", "true");
-            props.setProperty("requireSSL", "true");
+            props.setProperty(USE_SSL_KEY, TRUE_VALUE);
+            props.setProperty(REQUIRE_SSL_KEY, TRUE_VALUE);
         } else {
-            props.setProperty("useSSL", "false");
+            props.setProperty(USE_SSL_KEY, FALSE_VALUE);
         }
+        props.setProperty(TINY_INT_ONE_IS_BIT_KEY, FALSE_VALUE);
         final String jdbcUrl = String.format(JDBC_URL_FORMAT, hostName, port);
         return doGetConnection(jdbcUrl, props);
     }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/ConnectionManagerTest.java
@@ -20,6 +20,13 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.FALSE_VALUE;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.PASSWORD_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.REQUIRE_SSL_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.TINY_INT_ONE_IS_BIT_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.TRUE_VALUE;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.USERNAME_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.schema.ConnectionManager.USE_SSL_KEY;
 
 
 class ConnectionManagerTest {
@@ -51,10 +58,11 @@ class ConnectionManagerTest {
 
         assertThat(jdbcUrlArgumentCaptor.getValue(), is(String.format(ConnectionManager.JDBC_URL_FORMAT, hostName, port)));
         final Properties properties = propertiesArgumentCaptor.getValue();
-        assertThat(properties.getProperty("user"), is(username));
-        assertThat(properties.getProperty("password"), is(password));
-        assertThat(properties.getProperty("useSSL"), is("true"));
-        assertThat(properties.getProperty("requireSSL"), is("true"));
+        assertThat(properties.getProperty(USERNAME_KEY), is(username));
+        assertThat(properties.getProperty(PASSWORD_KEY), is(password));
+        assertThat(properties.getProperty(USE_SSL_KEY), is(TRUE_VALUE));
+        assertThat(properties.getProperty(REQUIRE_SSL_KEY), is(TRUE_VALUE));
+        assertThat(properties.getProperty(TINY_INT_ONE_IS_BIT_KEY), is(FALSE_VALUE));
     }
 
     @Test
@@ -69,9 +77,10 @@ class ConnectionManagerTest {
 
         assertThat(jdbcUrlArgumentCaptor.getValue(), is(String.format(ConnectionManager.JDBC_URL_FORMAT, hostName, port)));
         final Properties properties = propertiesArgumentCaptor.getValue();
-        assertThat(properties.getProperty("user"), is(username));
-        assertThat(properties.getProperty("password"), is(password));
-        assertThat(properties.getProperty("useSSL"), is("false"));
+        assertThat(properties.getProperty(USERNAME_KEY), is(username));
+        assertThat(properties.getProperty(PASSWORD_KEY), is(password));
+        assertThat(properties.getProperty(USE_SSL_KEY), is(FALSE_VALUE));
+        assertThat(properties.getProperty(TINY_INT_ONE_IS_BIT_KEY), is(FALSE_VALUE));
     }
 
     private ConnectionManager createObjectUnderTest() {


### PR DESCRIPTION
### Description
TINYINT(1) columns show up as BIT type when we query the column types, which results in error:
```
2024-11-25T14:06:41,668 [rds-source-binlog-processor-1] ERROR org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener - Failed to process change event of type EXT_WRITE_ROWS
java.lang.IllegalArgumentException: Unsupported value type. The value is of type: class java.lang.Integer
    at org.opensearch.dataprepper.plugins.source.rds.datatype.impl.NumericTypeHandler.handleBit(NumericTypeHandler.java:63) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.datatype.impl.NumericTypeHandler.handleNumericType(NumericTypeHandler.java:38) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.datatype.impl.NumericTypeHandler.handle(NumericTypeHandler.java:25) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.datatype.impl.NumericTypeHandler.handle(NumericTypeHandler.java:12) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.datatype.DataTypeHelper.getDataByColumnType(DataTypeHelper.java:29) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.handleRowChangeEvent(BinlogEventListener.java:373) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.handleInsertEvent(BinlogEventListener.java:269) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.lambda$handleEventAndErrors$1(BinlogEventListener.java:448) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:141) ~[micrometer-core-1.13.0.jar:1.13.0]
    at org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.handleEventAndErrors(BinlogEventListener.java:448) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.lambda$processEvent$0(BinlogEventListener.java:442) ~[rds-source-2.11.0-SNAPSHOT.jar:?]
```

This PR sets JDBC connector property `tinyInt1isBit` to false so that the column type returned for TINYINT(1) would be TINYINT instead of BIT.

Reference: https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-result-sets.html#cj-conn-prop_tinyInt1isBit
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
