### PR TITLE
Add new metrics for tracking bytes received and processed by KDS

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
@@ -50,7 +50,7 @@ public class KinesisRecordConverter {
                 event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
                 event.getMetadata().setExternalOriginationTime(externalOriginationTime);
                 records.add(KinesisInputOutputRecord.builder()
-                        .withKinesisClientRecord(kinesisClientRecord)
+                        .withIncomingRecordSizeBytes(kinesisClientRecord.data().position())
                         .withDataPrepperRecord(record).build());
             });
         }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverter.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kinesis.source.processor.KinesisInputOutputRecord;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.io.ByteArrayInputStream;
@@ -32,13 +33,12 @@ public class KinesisRecordConverter {
         this.codec = codec;
     }
 
-    public List<Record<Event>> convert(final DecompressionEngine decompressionEngine,
-                                       List<KinesisClientRecord> kinesisClientRecords,
-                                       final String streamName) throws IOException {
-        List<Record<Event>> records = new ArrayList<>();
+    public List<KinesisInputOutputRecord> convert(final DecompressionEngine decompressionEngine,
+                                             List<KinesisClientRecord> kinesisClientRecords,
+                                             final String streamName) throws IOException {
+        List<KinesisInputOutputRecord> records = new ArrayList<>();
         for (KinesisClientRecord kinesisClientRecord : kinesisClientRecords) {
             processRecord(decompressionEngine, kinesisClientRecord, record -> {
-                records.add(record);
                 Event event = record.getData();
                 EventMetadata eventMetadata = event.getMetadata();
                 eventMetadata.setAttribute(MetadataKeyAttributes.KINESIS_STREAM_NAME_METADATA_ATTRIBUTE,
@@ -49,6 +49,9 @@ public class KinesisRecordConverter {
                 final Instant externalOriginationTime = kinesisClientRecord.approximateArrivalTimestamp();
                 event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
                 event.getMetadata().setExternalOriginationTime(externalOriginationTime);
+                records.add(KinesisInputOutputRecord.builder()
+                        .withKinesisClientRecord(kinesisClientRecord)
+                        .withDataPrepperRecord(record).build());
             });
         }
         return records;

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisInputOutputRecord.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisInputOutputRecord.java
@@ -15,12 +15,11 @@ import lombok.Builder;
 import lombok.Getter;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
-import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 @Builder(setterPrefix = "with")
 @Getter
 @AllArgsConstructor
 public class KinesisInputOutputRecord {
     private Record<Event> dataPrepperRecord;
-    private KinesisClientRecord kinesisClientRecord;
+    private long incomingRecordSizeBytes;
 }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisInputOutputRecord.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisInputOutputRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kinesis.source.processor;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+@Builder(setterPrefix = "with")
+@Getter
+@AllArgsConstructor
+public class KinesisInputOutputRecord {
+    private Record<Event> dataPrepperRecord;
+    private KinesisClientRecord kinesisClientRecord;
+}

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
@@ -39,9 +39,7 @@ import software.amazon.kinesis.processor.ShardRecordProcessor;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
-import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
@@ -178,7 +176,7 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
             int eventCount = 0;
             for (KinesisInputOutputRecord kinesisInputOutputRecord: kinesisOutputRecords) {
                 Record<Event> dataPrepperRecord = kinesisInputOutputRecord.getDataPrepperRecord();
-                int incomingRecordSizeBytes = kinesisInputOutputRecord.getKinesisClientRecord().data().position();
+                long incomingRecordSizeBytes = kinesisInputOutputRecord.getIncomingRecordSizeBytes();
                 bytesReceivedSummary.record(incomingRecordSizeBytes);
                 Event event = dataPrepperRecord.getData();
                 acknowledgementSetOpt.ifPresent(acknowledgementSet -> acknowledgementSet.add(event));

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
@@ -12,6 +12,7 @@ package org.opensearch.dataprepper.plugins.kinesis.source.processor;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -39,6 +40,7 @@ import software.amazon.kinesis.retrieval.KinesisClientRecord;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
@@ -70,10 +72,14 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
     private final Counter recordsProcessed;
     private final Counter recordProcessingErrors;
     private final Counter checkpointFailures;
+    private final DistributionSummary bytesReceivedSummary;
+    private final DistributionSummary bytesProcessedSummary;
     public static final String ACKNOWLEDGEMENT_SET_SUCCESS_METRIC_NAME = "acknowledgementSetSuccesses";
     public static final String ACKNOWLEDGEMENT_SET_FAILURES_METRIC_NAME = "acknowledgementSetFailures";
-    public static final String KINESIS_RECORD_PROCESSED = "recordProcessed";
-    public static final String KINESIS_RECORD_PROCESSING_ERRORS = "recordProcessingErrors";
+    public static final String KINESIS_RECORD_PROCESSED_METRIC_NAME = "recordProcessed";
+    public static final String KINESIS_RECORD_PROCESSING_ERRORS_METRIC_NAME = "recordProcessingErrors";
+    public static final String KINESIS_RECORD_BYTES_RECEIVED_METRIC_NAME = "bytesReceived";
+    public static final String KINESIS_RECORD_BYTES_PROCESSED_METRIC_NAME = "bytesProcessed";
     public static final String KINESIS_CHECKPOINT_FAILURES = "checkpointFailures";
     public static final String KINESIS_STREAM_TAG_KEY = "stream";
     private AtomicBoolean isStopRequested;
@@ -93,9 +99,11 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.acknowledgementSetSuccesses = pluginMetrics.counterWithTags(ACKNOWLEDGEMENT_SET_SUCCESS_METRIC_NAME, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
         this.acknowledgementSetFailures = pluginMetrics.counterWithTags(ACKNOWLEDGEMENT_SET_FAILURES_METRIC_NAME, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
-        this.recordsProcessed = pluginMetrics.counterWithTags(KINESIS_RECORD_PROCESSED, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
-        this.recordProcessingErrors = pluginMetrics.counterWithTags(KINESIS_RECORD_PROCESSING_ERRORS, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
+        this.recordsProcessed = pluginMetrics.counterWithTags(KINESIS_RECORD_PROCESSED_METRIC_NAME, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
+        this.recordProcessingErrors = pluginMetrics.counterWithTags(KINESIS_RECORD_PROCESSING_ERRORS_METRIC_NAME, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
         this.checkpointFailures = pluginMetrics.counterWithTags(KINESIS_CHECKPOINT_FAILURES, KINESIS_STREAM_TAG_KEY, streamIdentifier.streamName());
+        this.bytesReceivedSummary = pluginMetrics.summary(KINESIS_RECORD_BYTES_RECEIVED_METRIC_NAME);
+        this.bytesProcessedSummary = pluginMetrics.summary(KINESIS_RECORD_BYTES_PROCESSED_METRIC_NAME);
         this.checkpointInterval = kinesisStreamConfig.getCheckPointInterval();
         this.bufferAccumulator = bufferAccumulator;
         this.kinesisCheckpointerTracker = kinesisCheckpointerTracker;
@@ -161,6 +169,12 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
 
             // Track the records for checkpoint purpose
             kinesisCheckpointerTracker.addRecordForCheckpoint(extendedSequenceNumber, processRecordsInput.checkpointer());
+
+            // Get the size of bytes received from Kinesis stream
+            final List<Integer> recordBytes = new ArrayList<>();
+            processRecordsInput.records().forEach(kinesisClientRecord-> recordBytes.add(kinesisClientRecord.data().remaining()));
+            bytesReceivedSummary.record(recordBytes.stream().mapToLong(Integer::longValue).sum());
+
             List<Record<Event>> records = kinesisRecordConverter.convert(
                     kinesisStreamConfig.getCompression().getDecompressionEngine(),
                     processRecordsInput.records(), streamIdentifier.streamName());
@@ -177,6 +191,7 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
             // Flush buffer at the end
             bufferAccumulator.flush();
             recordsProcessed.increment(eventCount);
+            bytesProcessedSummary.record(recordBytes.stream().mapToLong(Integer::longValue).sum());
 
             // If acks are not enabled, mark the sequence number for checkpoint
             if (!acknowledgementsEnabled) {

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisInputOutputRecordTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisInputOutputRecordTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kinesis.source;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kinesis.source.converter.MetadataKeyAttributes;
+import org.opensearch.dataprepper.plugins.kinesis.source.processor.KinesisInputOutputRecord;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class KinesisInputOutputRecordTest {
+
+    @Test
+    void builder_defaultCreatesObjectCorrectly() {
+
+        KinesisInputOutputRecord kinesisInputOutputRecord = KinesisInputOutputRecord.builder().build();
+
+        assertNull(kinesisInputOutputRecord.getKinesisClientRecord());
+        assertNull(kinesisInputOutputRecord.getDataPrepperRecord());
+    }
+
+    @Test
+    void builder_createsObjectCorrectly() {
+        Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        event.getMetadata().setAttribute(MetadataKeyAttributes.KINESIS_STREAM_NAME_METADATA_ATTRIBUTE, UUID.randomUUID().toString());
+        Record<Event> record = new Record<>(event);
+        KinesisClientRecord kinesisClientRecord = KinesisClientRecord.builder()
+                .data(ByteBuffer.wrap(event.toJsonString().getBytes()))
+                .sequenceNumber(Integer.toString(1000)).subSequenceNumber(1).build();
+
+        KinesisInputOutputRecord kinesisInputOutputRecord = KinesisInputOutputRecord.builder()
+                .withKinesisClientRecord(kinesisClientRecord)
+                .withDataPrepperRecord(record)
+                .build();
+
+        assertNotNull(kinesisInputOutputRecord.getKinesisClientRecord());
+        assertNotNull(kinesisInputOutputRecord.getDataPrepperRecord());
+        assertEquals(kinesisInputOutputRecord.getDataPrepperRecord(), record);
+        assertEquals(kinesisInputOutputRecord.getKinesisClientRecord(), kinesisClientRecord);
+    }
+}

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisInputOutputRecordTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisInputOutputRecordTest.java
@@ -32,7 +32,7 @@ public class KinesisInputOutputRecordTest {
 
         KinesisInputOutputRecord kinesisInputOutputRecord = KinesisInputOutputRecord.builder().build();
 
-        assertNull(kinesisInputOutputRecord.getKinesisClientRecord());
+        assertEquals(0L, kinesisInputOutputRecord.getIncomingRecordSizeBytes());
         assertNull(kinesisInputOutputRecord.getDataPrepperRecord());
     }
 
@@ -46,13 +46,12 @@ public class KinesisInputOutputRecordTest {
                 .sequenceNumber(Integer.toString(1000)).subSequenceNumber(1).build();
 
         KinesisInputOutputRecord kinesisInputOutputRecord = KinesisInputOutputRecord.builder()
-                .withKinesisClientRecord(kinesisClientRecord)
+                .withIncomingRecordSizeBytes(100L)
                 .withDataPrepperRecord(record)
                 .build();
 
-        assertNotNull(kinesisInputOutputRecord.getKinesisClientRecord());
         assertNotNull(kinesisInputOutputRecord.getDataPrepperRecord());
         assertEquals(kinesisInputOutputRecord.getDataPrepperRecord(), record);
-        assertEquals(kinesisInputOutputRecord.getKinesisClientRecord(), kinesisClientRecord);
+        assertEquals(100L, kinesisInputOutputRecord.getIncomingRecordSizeBytes());
     }
 }

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverterTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverterTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.model.codec.InputCodec;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.codec.json.NdjsonInputCodec;
 import org.opensearch.dataprepper.plugins.codec.json.NdjsonInputConfig;

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverterTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/converter/KinesisRecordConverterTest.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.codec.json.NdjsonInputCodec;
 import org.opensearch.dataprepper.plugins.codec.json.NdjsonInputConfig;
+import org.opensearch.dataprepper.plugins.kinesis.source.processor.KinesisInputOutputRecord;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.io.ByteArrayInputStream;
@@ -99,13 +100,13 @@ public class KinesisRecordConverterTest {
         InputStream inputStream = new ByteArrayInputStream(writer.toString().getBytes());
         when(decompressionEngine.createInputStream(any(InputStream.class))).thenReturn(inputStream);
 
-        List<Record<Event>> events = kinesisRecordConverter.convert(decompressionEngine, List.of(kinesisClientRecord), streamId);
+        List<KinesisInputOutputRecord> kinesisOutputRecords = kinesisRecordConverter.convert(decompressionEngine, List.of(kinesisClientRecord), streamId);
 
-        assertEquals(events.size(), numRecords);
-        events.forEach(eventRecord -> {
-            assertEquals(eventRecord.getData().getMetadata().getAttribute(MetadataKeyAttributes.KINESIS_PARTITION_KEY_METADATA_ATTRIBUTE), partitionKey);
-            assertEquals(eventRecord.getData().getMetadata().getAttribute(MetadataKeyAttributes.KINESIS_SEQUENCE_NUMBER_METADATA_ATTRIBUTE), sequenceNumber);
-            assertEquals(eventRecord.getData().getMetadata().getAttribute(MetadataKeyAttributes.KINESIS_SUB_SEQUENCE_NUMBER_METADATA_ATTRIBUTE), subsequenceNumber);
+        assertEquals(kinesisOutputRecords.size(), numRecords);
+        kinesisOutputRecords.forEach(KinesisInputOutputRecord -> {
+            assertEquals(KinesisInputOutputRecord.getDataPrepperRecord().getData().getMetadata().getAttribute(MetadataKeyAttributes.KINESIS_PARTITION_KEY_METADATA_ATTRIBUTE), partitionKey);
+            assertEquals(KinesisInputOutputRecord.getDataPrepperRecord().getData().getMetadata().getAttribute(MetadataKeyAttributes.KINESIS_SEQUENCE_NUMBER_METADATA_ATTRIBUTE), sequenceNumber);
+            assertEquals(KinesisInputOutputRecord.getDataPrepperRecord().getData().getMetadata().getAttribute(MetadataKeyAttributes.KINESIS_SUB_SEQUENCE_NUMBER_METADATA_ATTRIBUTE), subsequenceNumber);
         });
     }
 

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessorTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessorTest.java
@@ -224,15 +224,16 @@ public class KinesisRecordProcessorTest {
                 .sequenceNumber(Integer.toString(1000)).subSequenceNumber(1).build();
         List<KinesisClientRecord> kinesisClientRecords = new ArrayList<>();
         kinesisClientRecords.add(kinesisClientRecord);
+        final long recordsSize = kinesisClientRecords.stream()
+                .map(kclRecord -> kclRecord.data().position())
+                .mapToLong(Integer::longValue).sum();
+
         records.add(KinesisInputOutputRecord.builder()
                 .withDataPrepperRecord(record)
-                .withKinesisClientRecord(kinesisClientRecord).build()
+                .withIncomingRecordSizeBytes(recordsSize).build()
         );
         when(processRecordsInput.records()).thenReturn(kinesisClientRecords);
 
-        final Long recordsSize = kinesisClientRecords.stream()
-                .map(kclRecord -> kclRecord.data().position())
-                .mapToLong(Integer::longValue).sum();
 
         InputStream inputStream = mock(InputStream.class);
         when(decompressionEngine.createInputStream(inputStream)).thenReturn(inputStream);
@@ -267,8 +268,8 @@ public class KinesisRecordProcessorTest {
 
         verify(acknowledgementSetManager, times(0)).create(any(), any(Duration.class));
         verify(recordProcessed, times(1)).increment(anyDouble());
-        verify(bytesReceivedSummary, times(1)).record(eq(recordsSize.doubleValue()));
-        verify(bytesProcessedSummary, times(1)).record(eq(recordsSize.doubleValue()));
+        verify(bytesReceivedSummary, times(1)).record(eq((double) recordsSize));
+        verify(bytesProcessedSummary, times(1)).record(eq((double) recordsSize));
     }
 
     @Test
@@ -287,14 +288,13 @@ public class KinesisRecordProcessorTest {
                 .sequenceNumber(Integer.toString(1000)).subSequenceNumber(1).build();
         List<KinesisClientRecord> kinesisClientRecords = new ArrayList<>();
         kinesisClientRecords.add(kinesisClientRecord);
-        records.add(KinesisInputOutputRecord.builder()
-                .withDataPrepperRecord(record)
-                .withKinesisClientRecord(kinesisClientRecord).build()
-        );
-
-        final Long recordsSize = kinesisClientRecords.stream()
+        final long recordsSize = kinesisClientRecords.stream()
                 .map(kclRecord -> kclRecord.data().position())
                 .mapToLong(Integer::longValue).sum();
+        records.add(KinesisInputOutputRecord.builder()
+                .withDataPrepperRecord(record)
+                .withIncomingRecordSizeBytes(recordsSize).build()
+        );
 
         when(processRecordsInput.records()).thenReturn(kinesisClientRecords);
         when(kinesisRecordConverter.convert(eq(decompressionEngine), eq(kinesisClientRecords), eq(streamId))).thenReturn(records);
@@ -322,8 +322,8 @@ public class KinesisRecordProcessorTest {
 
         verify(acknowledgementSetManager, times(0)).create(any(), any(Duration.class));
         verify(recordProcessed, times(1)).increment(anyDouble());
-        verify(bytesReceivedSummary, times(1)).record(eq(recordsSize.doubleValue()));
-        verify(bytesProcessedSummary, times(1)).record(eq(recordsSize.doubleValue()));
+        verify(bytesReceivedSummary, times(1)).record(eq((double) recordsSize));
+        verify(bytesProcessedSummary, times(1)).record(eq((double) recordsSize));
     }
 
     @Test
@@ -353,13 +353,13 @@ public class KinesisRecordProcessorTest {
         List<KinesisClientRecord> kinesisClientRecords = new ArrayList<>();
         when(processRecordsInput.records()).thenReturn(kinesisClientRecords);
         kinesisClientRecords.add(kinesisClientRecord);
-        records.add(KinesisInputOutputRecord.builder()
-                .withDataPrepperRecord(record)
-                .withKinesisClientRecord(kinesisClientRecord).build()
-        );
-        final Long recordsSize = kinesisClientRecords.stream()
+        final long recordsSize = kinesisClientRecords.stream()
                 .map(kclRecord -> kclRecord.data().position())
                 .mapToLong(Integer::longValue).sum();
+        records.add(KinesisInputOutputRecord.builder()
+                .withDataPrepperRecord(record)
+                .withIncomingRecordSizeBytes(recordsSize).build()
+        );
         when(kinesisRecordConverter.convert(eq(decompressionEngine), eq(kinesisClientRecords), eq(streamId))).thenReturn(records);
 
         kinesisRecordProcessor = new KinesisRecordProcessor(bufferAccumulator, kinesisSourceConfig,
@@ -390,8 +390,8 @@ public class KinesisRecordProcessorTest {
         verify(acknowledgementSetSuccesses, atLeastOnce()).increment();
         verify(recordProcessed, times(1)).increment(anyDouble());
         verifyNoInteractions(recordProcessingErrors);
-        verify(bytesReceivedSummary, times(1)).record(eq(recordsSize.doubleValue()));
-        verify(bytesProcessedSummary, times(1)).record(eq(recordsSize.doubleValue()));
+        verify(bytesReceivedSummary, times(1)).record(eq((double) recordsSize));
+        verify(bytesProcessedSummary, times(1)).record(eq((double) recordsSize));
     }
 
     @Test
@@ -420,13 +420,13 @@ public class KinesisRecordProcessorTest {
         List<KinesisClientRecord> kinesisClientRecords = new ArrayList<>();
         when(processRecordsInput.records()).thenReturn(kinesisClientRecords);
         kinesisClientRecords.add(kinesisClientRecord);
-        records.add(KinesisInputOutputRecord.builder()
-                .withDataPrepperRecord(record)
-                .withKinesisClientRecord(kinesisClientRecord).build()
-        );
-        final Long recordsSize = kinesisClientRecords.stream()
+        final long recordsSize = kinesisClientRecords.stream()
                 .map(kclRecord -> kclRecord.data().position())
                 .mapToLong(Integer::longValue).sum();
+        records.add(KinesisInputOutputRecord.builder()
+                .withDataPrepperRecord(record)
+                .withIncomingRecordSizeBytes(recordsSize).build()
+        );
         when(kinesisRecordConverter.convert(eq(decompressionEngine), eq(kinesisClientRecords), eq(streamId))).thenReturn(records);
 
         kinesisRecordProcessor = new KinesisRecordProcessor(bufferAccumulator, kinesisSourceConfig,
@@ -456,8 +456,8 @@ public class KinesisRecordProcessorTest {
 
         verify(acknowledgementSetManager, times(0)).create(any(), any(Duration.class));
         verify(recordProcessed, times(1)).increment(anyDouble());
-        verify(bytesReceivedSummary, times(1)).record(eq(recordsSize.doubleValue()));
-        verify(bytesProcessedSummary, times(1)).record(eq(recordsSize.doubleValue()));
+        verify(bytesReceivedSummary, times(1)).record(eq((double) recordsSize));
+        verify(bytesProcessedSummary, times(1)).record(eq((double) recordsSize));
     }
 
     @Test
@@ -475,17 +475,16 @@ public class KinesisRecordProcessorTest {
                 .data(ByteBuffer.wrap(event.toJsonString().getBytes()))
                 .sequenceNumber(Integer.toString(1000)).subSequenceNumber(1).build();
         kinesisClientRecords.add(kinesisClientRecord);
+        final long recordsSize = kinesisClientRecords.stream()
+                .map(kclRecord -> kclRecord.data().position())
+                .mapToLong(Integer::longValue).sum();
         records.add(KinesisInputOutputRecord.builder()
                 .withDataPrepperRecord(record)
-                .withKinesisClientRecord(kinesisClientRecord).build()
+                .withIncomingRecordSizeBytes(recordsSize).build()
         );
         when(kinesisRecordConverter.convert(eq(decompressionEngine), eq(kinesisClientRecords), eq(streamId))).thenReturn(records);
         final Throwable exception = mock(RuntimeException.class);
         doThrow(exception).when(bufferAccumulator).add(any(Record.class));
-
-        final Long recordsSize = kinesisClientRecords.stream()
-                .map(kclRecord -> kclRecord.data().position())
-                .mapToLong(Integer::longValue).sum();
 
         kinesisRecordProcessor = new KinesisRecordProcessor(bufferAccumulator, kinesisSourceConfig,
                 acknowledgementSetManager, pluginMetrics, kinesisRecordConverter, kinesisCheckpointerTracker, streamIdentifier);
@@ -494,8 +493,8 @@ public class KinesisRecordProcessorTest {
         assertDoesNotThrow(() -> kinesisRecordProcessor.processRecords(processRecordsInput));
         verify(recordProcessingErrors, times(1)).increment();
         verify(recordProcessed, times(0)).increment(anyDouble());
-        verify(bytesReceivedSummary, times(1)).record(eq(recordsSize.doubleValue()));
-        verify(bytesProcessedSummary, times(0)).record(eq(recordsSize.doubleValue()));
+        verify(bytesReceivedSummary, times(1)).record(eq((double) recordsSize));
+        verify(bytesProcessedSummary, times(0)).record(eq((double) recordsSize));
     }
 
     @Test
@@ -513,13 +512,13 @@ public class KinesisRecordProcessorTest {
         List<KinesisClientRecord> kinesisClientRecords = new ArrayList<>();
         when(processRecordsInput.records()).thenReturn(kinesisClientRecords);
         kinesisClientRecords.add(kinesisClientRecord);
-        records.add(KinesisInputOutputRecord.builder()
-                .withDataPrepperRecord(record)
-                .withKinesisClientRecord(kinesisClientRecord).build()
-        );
-        final Long recordsSize = kinesisClientRecords.stream()
+        final long recordsSize = kinesisClientRecords.stream()
                 .map(kclRecord -> kclRecord.data().position())
                 .mapToLong(Integer::longValue).sum();
+        records.add(KinesisInputOutputRecord.builder()
+                .withDataPrepperRecord(record)
+                .withIncomingRecordSizeBytes(recordsSize).build()
+        );
 
         when(kinesisRecordConverter.convert(eq(decompressionEngine), eq(kinesisClientRecords), eq(streamId))).thenReturn(records);
         final Throwable exception = mock(RuntimeException.class);
@@ -532,8 +531,8 @@ public class KinesisRecordProcessorTest {
         assertDoesNotThrow(() -> kinesisRecordProcessor.processRecords(processRecordsInput));
         verify(recordProcessingErrors, times(1)).increment();
         verify(recordProcessed, times(0)).increment(anyDouble());
-        verify(bytesReceivedSummary, times(1)).record(eq(recordsSize.doubleValue()));
-        verify(bytesProcessedSummary, times(1)).record(eq(recordsSize.doubleValue()));
+        verify(bytesReceivedSummary, times(1)).record(eq((double) recordsSize));
+        verify(bytesProcessedSummary, times(1)).record(eq((double) recordsSize));
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR is to add two new metrics for KDS source plugin named `bytesReceived` and `bytesProcessed` to track the size of throughput being ingested from Kinesis Data Streams.
 
### Issues Resolved
Resolves #1082
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
