### PR TITLE
Http source otel logs source test coverage

### DIFF
--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -17,6 +16,7 @@ import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticati
 import org.opensearch.dataprepper.http.HttpServerConfig;
 import org.opensearch.dataprepper.http.LogThrottlingRejectHandler;
 import org.opensearch.dataprepper.http.LogThrottlingStrategy;
+import org.opensearch.dataprepper.http.certificate.CertificateProviderFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -33,7 +33,6 @@ import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.plugins.certificate.CertificateProvider;
 import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
-import org.opensearch.dataprepper.http.certificate.CertificateProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,29 +77,6 @@ public class HTTPSource implements Source<Record<Log>> {
             LOG.warn("Creating http source without authentication. This is not secure.");
             LOG.warn("In order to set up Http Basic authentication for the http source, go here: https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/http-source#authentication-configurations");
         }
-
-        if(authenticationConfiguration != null) {
-            authenticationPluginSetting =
-                    new PluginSetting(authenticationConfiguration.getPluginName(), authenticationConfiguration.getPluginSettings());
-        } else {
-            authenticationPluginSetting =
-                    new PluginSetting(ArmeriaHttpAuthenticationProvider.UNAUTHENTICATED_PLUGIN_NAME, Collections.emptyMap());
-        }
-        authenticationPluginSetting.setPipelineName(pipelineName);
-        authenticationProvider = pluginFactory.loadPlugin(ArmeriaHttpAuthenticationProvider.class, authenticationPluginSetting);
-        httpRequestExceptionHandler = new HttpRequestExceptionHandler(pluginMetrics);
-    }
-
-    @VisibleForTesting
-    HTTPSource(final HTTPSourceConfig sourceConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory,
-               final PipelineDescription pipelineDescription, final CertificateProviderFactory certificateProviderFactory) {
-        this.sourceConfig = sourceConfig;
-        this.pluginMetrics = pluginMetrics;
-        this.pipelineName = pipelineDescription.getPipelineName();
-        this.byteDecoder = new JsonDecoder();
-        this.certificateProviderFactory = certificateProviderFactory;
-        final PluginModel authenticationConfiguration = sourceConfig.getAuthentication();
-        final PluginSetting authenticationPluginSetting;
 
         if(authenticationConfiguration != null) {
             authenticationPluginSetting =

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -58,6 +58,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -646,7 +647,13 @@ class HTTPSourceTest {
             when(certificateProviderFactory.getCertificateProvider()).thenReturn(certificateProvider);
             when(sourceConfig.isSsl()).thenReturn(true);
 
-            HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription,certificateProviderFactory);
+
+            HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+
+            Field field = HTTPSourceUnderTest.getClass().getDeclaredField("certificateProviderFactory");
+            field.setAccessible(true);
+            field.set(HTTPSourceUnderTest, certificateProviderFactory);
+
             HTTPSourceUnderTest.start(testBuffer);
             HTTPSourceUnderTest.stop();
 
@@ -657,6 +664,8 @@ class HTTPSourceTest {
             final String actualPrivateKey = IOUtils.toString(privateKeyIs.getValue(), StandardCharsets.UTF_8.name());
             assertThat(actualCertificate, is(certAsString));
             assertThat(actualPrivateKey, is(keyAsString));
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -670,8 +679,15 @@ class HTTPSourceTest {
             when(certificateProviderFactory.getCertificateProvider()).thenReturn(certificateProvider);
             when(sourceConfig.isSsl()).thenReturn(true);
 
-            HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription,certificateProviderFactory);
+            HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+
+            Field field = HTTPSourceUnderTest.getClass().getDeclaredField("certificateProviderFactory");
+            field.setAccessible(true);
+            field.set(HTTPSourceUnderTest, certificateProviderFactory);
+
             assertThrows(NullPointerException.class, () -> HTTPSourceUnderTest.start(testBuffer));
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -771,7 +771,7 @@ class OTelLogsSourceTest {
     }
 
     @Test
-    void gRPC_with_auth_request_with_invalid_basic_auth_does_not_write_to_buffer() throws Exception{
+    void gRPC_with_auth_request_with_different_basic_auth_credentials_does_not_write_to_buffer() throws Exception{
         when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
         when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
         final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);
@@ -781,8 +781,8 @@ class OTelLogsSourceTest {
         when(oTelLogsSourceConfig.enableUnframedRequests()).thenReturn(true);
         when(oTelLogsSourceConfig.getAuthentication()).thenReturn(new PluginModel("http_basic",
                 Map.of(
-                        "username", "wrong Username",
-                        "password", "wrong Password"
+                        "username", USERNAME,
+                        "password", PASSWORD
                 )));
         configureObjectUnderTest();
         SOURCE.start(buffer);

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -10,6 +10,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -91,6 +92,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -105,6 +107,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -265,6 +268,41 @@ class OTelLogsSourceTest {
                 .aggregate()
                 .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
+    }
+
+    @Test
+    void testHttpRequestWhenSSLRequiredNoResponse() throws InvalidProtocolBufferException {
+        final Map<String, Object> settingsMap = new HashMap<>();
+        settingsMap.put("request_timeout", 5);
+        settingsMap.put(SSL, true);
+        settingsMap.put("useAcmCertForSSL", false);
+        settingsMap.put("sslKeyCertChainFile", "data/certificate/test_cert.crt");
+        settingsMap.put("sslKeyFile", "data/certificate/test_decrypted_key.key");
+        pluginSetting = new PluginSetting("otel_logs", settingsMap);
+        pluginSetting.setPipelineName("pipeline");
+
+        oTelLogsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelLogsSourceConfig.class);
+        SOURCE = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+
+        SOURCE.start(buffer);
+
+        CompletableFuture<AggregatedHttpResponse> future = WebClient.builder()
+                .factory(ClientFactory.insecure())
+                .build()
+                .execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:2021")
+                                .method(HttpMethod.POST)
+                                .path("/opentelemetry.proto.collector.logs.v1.LogsService/Export")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(LOGS_REQUEST).getBytes()))
+                .aggregate();
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+                () -> future.get(2, TimeUnit.SECONDS)
+        );
+        assertInstanceOf(UnprocessedRequestException.class, exception.getCause());
     }
 
     @Test
@@ -771,7 +809,7 @@ class OTelLogsSourceTest {
     }
 
     @Test
-    void gRPC_with_auth_request_with_different_basic_auth_credentials_does_not_write_to_buffer() throws Exception{
+    void gRPC_with_auth_request_with_different_basic_auth_credentials_does_not_write_to_buffer_with_401_response() throws Exception {
         when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
         when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
         final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -114,7 +114,6 @@ import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 Adding additional test coverage for http source and otel logs source
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
