### PR TITLE
Add metrics to stream acknowledgement manager

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
@@ -18,6 +18,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
 
 public class StreamAcknowledgementManager {
     private static final Logger LOG = LoggerFactory.getLogger(StreamAcknowledgementManager.class);
@@ -109,12 +111,10 @@ public class StreamAcknowledgementManager {
                     }
                 } else {
                     if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
-                        LOG.debug("No records processed. Extend the lease of the partition worker.");
+                        LOG.info(NOISY, "No records processed. Extend the lease of the partition worker.");
                         partitionCheckpoint.extendLease();
                         this.noDataExtendLeaseCount.increment();
                         lastCheckpointTime = System.currentTimeMillis();
-                    } else {
-
                     }
                 }
             } catch (Exception e) {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamScheduler.java
@@ -109,7 +109,7 @@ public class StreamScheduler implements Runnable {
     private StreamWorker getStreamWorker (final StreamPartition streamPartition) {
         final DataStreamPartitionCheckpoint partitionCheckpoint = new DataStreamPartitionCheckpoint(sourceCoordinator, streamPartition);
         final StreamAcknowledgementManager streamAcknowledgementManager = new StreamAcknowledgementManager(acknowledgementSetManager, partitionCheckpoint,
-                sourceConfig.getPartitionAcknowledgmentTimeout(), DEFAULT_MONITOR_WAIT_TIME_MS, DEFAULT_CHECKPOINT_INTERVAL_MILLS);
+                sourceConfig.getPartitionAcknowledgmentTimeout(), DEFAULT_MONITOR_WAIT_TIME_MS, DEFAULT_CHECKPOINT_INTERVAL_MILLS, pluginMetrics);
         final PartitionKeyRecordConverter recordConverter = getPartitionKeyRecordConverter(streamPartition);
         final CollectionConfig partitionCollectionConfig = sourceConfig.getCollections().stream()
                 .filter(collectionConfig -> collectionConfig.getCollection().equals(streamPartition.getCollection()))

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManagerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManagerTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -110,7 +111,7 @@ public class StreamAcknowledgementManagerTest {
         assertThat(streamAckManager.getCheckpoints().peek(), is(nullValue()));
         verify(positiveAcknowledgementSets).increment();
         verifyNoInteractions(negativeAcknowledgementSets);
-        verify(recordsCheckpointed).increment(anyDouble());
+        verify(recordsCheckpointed, atLeastOnce()).increment(anyDouble());
     }
 
     @Test
@@ -148,9 +149,9 @@ public class StreamAcknowledgementManagerTest {
                 verify(partitionCheckpoint).checkpoint(resumeToken2, recordCount2));
         assertThat(streamAckManager.getCheckpoints().peek(), is(nullValue()));
 
-        verify(positiveAcknowledgementSets, times(2)).increment();
+        verify(positiveAcknowledgementSets, atLeastOnce()).increment();
         verifyNoInteractions(negativeAcknowledgementSets);
-        verify(recordsCheckpointed, times(2)).increment(anyDouble());
+        verify(recordsCheckpointed, atLeastOnce()).increment(anyDouble());
     }
 
     @Test

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -36,7 +36,6 @@ import io.netty.util.AsciiString;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
-import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary;


### PR DESCRIPTION
### Description
There appears to be an issue with the DocumentDB source plugin in DataPrepper where, if the host is restarted, the pipeline is unable to continue consuming stream data. Upon further investigation, this occurs because the stream lease in the source coordination store is removed, preventing the pipeline from ingesting the affected stream partition.

To address this, we need metrics to monitor the cadence of checkpoints, acknowledgments, and lease extensions, providing better visibility into stream acknowledgment behavior.

This PR introduces additional metrics to the Stream Acknowledgment Manager, enabling improved visibility into checkpointing cadence, tracking both positive and negative acknowledgments, and monitoring when the lease for the current DataPrepper instance is extended.
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
