### PR TITLE
Updates Data Prepper 2.10.2 release notes with CVE

### DIFF
--- a/release/release-notes/data-prepper.release-notes-2.10.2.md
+++ b/release/release-notes/data-prepper.release-notes-2.10.2.md
@@ -7,4 +7,4 @@
 
 
 ### Security
-* Fix otel_logs_source server configuration for getHttpAuthenticationService ([#5215](https://github.com/opensearch-project/data-prepper/pull/5215))
+* Fix otel_logs_source server configuration for `getHttpAuthenticationService`. Fixes [CVE-2024-55886](https://github.com/opensearch-project/data-prepper/security/advisories/GHSA-725p-63vv-v948). ([#5215](https://github.com/opensearch-project/data-prepper/pull/5215))


### PR DESCRIPTION
### Description

This updates the 2.10.2 release notes with links to the CVE/GHSA published.

https://github.com/opensearch-project/data-prepper/security/advisories/GHSA-725p-63vv-v948
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
