### PR TITLE
Update expiration time based on ttl on the source coordinator item.

### DIFF
--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -98,7 +98,7 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
     public Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String sourceIdentifier, final String ownerId, final Duration ownershipTimeout) {
         final Optional<SourcePartitionStoreItem> acquiredAssignedItem = dynamoDbClientWrapper.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.ASSIGNED,
-                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED), 1);
+                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED), 1, dynamoStoreSettings.getTtl());
 
         if (acquiredAssignedItem.isPresent()) {
             return acquiredAssignedItem;
@@ -106,7 +106,7 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
 
         final Optional<SourcePartitionStoreItem> acquiredUnassignedItem = dynamoDbClientWrapper.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.UNASSIGNED,
-                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED), 5);
+                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED), 5, dynamoStoreSettings.getTtl());
 
         if (acquiredUnassignedItem.isPresent()) {
             return acquiredUnassignedItem;
@@ -114,7 +114,7 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
 
         return dynamoDbClientWrapper.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED,
-                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED), 1);
+                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED), 1, dynamoStoreSettings.getTtl());
     }
 
     @Override

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -62,6 +62,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -464,8 +465,10 @@ public class DynamoDbClientWrapperTest {
 
         final int pageLimit = new Random().nextInt(20);
 
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, pageLimit);
+                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, pageLimit, ttl);
 
         assertThat(result.isEmpty(), equalTo(true));
 
@@ -513,8 +516,10 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
         reflectivelySetField(objectUnderTest, "table", table);
 
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20));
+                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20), ttl);
 
         assertThat(result.isPresent(), equalTo(true));
         assertThat(result.get(), equalTo(acquiredItem));
@@ -530,6 +535,10 @@ public class DynamoDbClientWrapperTest {
         final Instant newPartitionOwnershipTimeout = partitionOwnershipArgumentCaptor.getValue();
 
         assertThat(newPartitionOwnershipTimeout.isAfter(now.plus(ownershipTimeout)), equalTo(true));
+
+        final ArgumentCaptor<Long> expiryTimeArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(acquiredItem).setExpirationTime(expiryTimeArgumentCaptor.capture());
+        assertThat(expiryTimeArgumentCaptor.getValue(), greaterThan(Instant.now().getEpochSecond()));
 
         verify(acquiredItem).setPartitionPriority(newPartitionOwnershipTimeout.toString());
     }
@@ -574,8 +583,10 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
         reflectivelySetField(objectUnderTest, "table", table);
 
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20));
+                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20), ttl);
 
         assertThat(result.isPresent(), equalTo(true));
         assertThat(result.get(), equalTo(acquiredItem));
@@ -593,6 +604,10 @@ public class DynamoDbClientWrapperTest {
         assertThat(newPartitionOwnershipTimeout.isAfter(now.plus(ownershipTimeout)), equalTo(true));
 
         verify(acquiredItem).setPartitionPriority(newPartitionOwnershipTimeout.toString());
+
+        final ArgumentCaptor<Long> expiryTimeArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(acquiredItem).setExpirationTime(expiryTimeArgumentCaptor.capture());
+        assertThat(expiryTimeArgumentCaptor.getValue(), greaterThan(Instant.now().getEpochSecond()));
     }
 
     @ParameterizedTest
@@ -635,8 +650,10 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
         reflectivelySetField(objectUnderTest, "table", table);
 
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20));
+                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20), ttl);
 
         assertThat(result.isEmpty(), equalTo(true));
 
@@ -653,6 +670,10 @@ public class DynamoDbClientWrapperTest {
         assertThat(newPartitionOwnershipTimeout.isAfter(now.plus(ownershipTimeout)), equalTo(true));
 
         verify(acquiredItem).setPartitionPriority(newPartitionOwnershipTimeout.toString());
+
+        final ArgumentCaptor<Long> expiryTimeArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(acquiredItem).setExpirationTime(expiryTimeArgumentCaptor.capture());
+        assertThat(expiryTimeArgumentCaptor.getValue(), greaterThan(Instant.now().getEpochSecond()));
     }
 
     @Test
@@ -681,7 +702,7 @@ public class DynamoDbClientWrapperTest {
         reflectivelySetField(objectUnderTest, "table", table);
 
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.ASSIGNED, sourceStatusCombinationKey, new Random().nextInt(20));
+                ownerId, ownershipTimeout, SourcePartitionStatus.ASSIGNED, sourceStatusCombinationKey, new Random().nextInt(20), Duration.ofSeconds(new Random().nextInt()));
 
         assertThat(result.isEmpty(), equalTo(true));
 
@@ -716,7 +737,7 @@ public class DynamoDbClientWrapperTest {
         reflectivelySetField(objectUnderTest, "table", table);
 
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED, sourceStatusCombinationKey, new Random().nextInt(20));
+                ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED, sourceStatusCombinationKey, new Random().nextInt(20), Duration.ofSeconds(new Random().nextInt()));
 
         assertThat(result.isEmpty(), equalTo(true));
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -465,7 +465,7 @@ public class DynamoDbClientWrapperTest {
 
         final int pageLimit = new Random().nextInt(20);
 
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, pageLimit, ttl);
@@ -516,7 +516,7 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
         reflectivelySetField(objectUnderTest, "table", table);
 
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20), ttl);
@@ -583,7 +583,7 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
         reflectivelySetField(objectUnderTest, "table", table);
 
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20), ttl);
@@ -650,7 +650,7 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
         reflectivelySetField(objectUnderTest, "table", table);
 
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
         final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
                 ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey, new Random().nextInt(20), ttl);

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -245,21 +245,22 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.ASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED),
-                1))
+                1, ttl))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.CLOSED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED),
-                1))
+                1, ttl))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.UNASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED),
-                5))
+                5, ttl))
                 .willReturn(Optional.empty());
 
         final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
@@ -272,13 +273,14 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
 
         final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.ASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED),
-                1))
+                1, ttl))
                 .willReturn(Optional.of(acquiredItem));
 
         final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
@@ -294,23 +296,24 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
 
         final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.ASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED),
-                1))
+                1, ttl))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.UNASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED),
-                5))
+                5, ttl))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.CLOSED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED),
-                1))
+                1, ttl))
                 .willReturn(Optional.of(acquiredItem));
 
         final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
@@ -326,18 +329,19 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
 
         final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.ASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED),
-                1))
+                1, ttl))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.UNASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED),
-                5))
+                5, ttl))
                 .willReturn(Optional.of(acquiredItem));
 
         final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -245,8 +245,9 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
+        given(dynamoStoreSettings.getTtl()).willReturn(ttl);
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.ASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED),
@@ -273,8 +274,8 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
-
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
+        given(dynamoStoreSettings.getTtl()).willReturn(ttl);
         final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
@@ -296,8 +297,9 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
+        given(dynamoStoreSettings.getTtl()).willReturn(ttl);
         final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
@@ -329,8 +331,9 @@ public class DynamoDbSourceCoordinationStoreTest {
         final String ownerId = UUID.randomUUID().toString();
         final String sourceIdentifier = UUID.randomUUID().toString();
         final Duration ownershipTimeout = Duration.ofMinutes(2);
-        final Duration ttl = Duration.ofSeconds(new Random().nextInt());
+        final Duration ttl = Duration.ofSeconds(new Random().nextInt(5)+10);
 
+        given(dynamoStoreSettings.getTtl()).willReturn(ttl);
         final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
 
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,


### PR DESCRIPTION
### Description
Data Prepper is not updating the expiration time on the source coordination table item when it tries to update the source partition to `ASSIGNED`. This PR is to add an expiration time on the item based on the ttl. 
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
