### PR TITLE
bug(opensearch-sink) Setting 'insecure' should override 'cert'

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -105,7 +105,7 @@ pipeline:
 
 - `hosts`: A list of IP addresses of OpenSearch nodes.
 
-- `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that the OpenSearch cluster is using.
+- `cert`(optional): CA certificate that is pem encoded. Accepts both `.pem` or `.crt`. This enables the client to trust the CA that has signed the certificate that the OpenSearch cluster is using. This setting has no effect if `insecure` is set to `true`.
 Default is null.
 
 - `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon OpenSearch Service. See [security](security.md) for details. Default to `false`.
@@ -118,7 +118,7 @@ Default is null.
 
 - `aws_sts_header_overrides`: An optional map of header overrides to make when assuming the IAM role for the sink plugin.
 
-- `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
+- `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Setting this will override any `cert` configured. Default to `false`.
 
 - `aws` (Optional) : AWS configurations. See [AWS Configuration](#aws_configuration) for details. SigV4 is enabled by default when this option is used. If this option is present, `aws_` options are not expected to be present. If any of `aws_` options are present along with this, error is thrown.
 
@@ -674,10 +674,10 @@ and then every hour after the first time the index is processed.
 
 ### <a name="connection_configuration">Connection Configuration</a>
 
-* `insecure` (Optional): A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to false.
+* `insecure` (Optional): A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Setting this will override any `cert` configured. Default to false.
 
 
-* `cert` (Optional) : CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that the OpenSearch cluster is using. Default is null.
+* `cert` (Optional) : CA certificate that is pem encoded. Accepts both `.pem` or `.crt`. This enables the client to trust the CA that has signed the certificate that the OpenSearch cluster is using. This setting has no effect if `insecure` is set to `true`. Default is null.
 
 
 * `socket_timeout` (Optional) : A String that indicates the timeout duration for waiting for data. Supports ISO_8601 notation Strings ("PT20.345S", "PT15M", etc.) as well as simple notation Strings for seconds ("60s") and milliseconds ("1500ms"). If this timeout value not set, the underlying Apache HttpClient would rely on operating system settings for managing socket timeouts.

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -275,11 +275,11 @@ public class ConnectionConfiguration {
 
     final String certPath = pluginSetting.getStringOrDefault(CERT_PATH, null);
     final boolean insecure = pluginSetting.getBooleanOrDefault(INSECURE, false);
-    if (certPath != null) {
-      builder = builder.withCert(certPath);
-    } else {
-      //We will set insecure flag only if certPath is null
-      builder = builder.withInsecure(insecure);
+    // Insecure == true will override configured certPath
+    if (insecure) {
+      builder.withInsecure(insecure);
+    } else if (certPath != null) {
+      builder.withCert(certPath);
     }
     final String proxy = pluginSetting.getStringOrDefault(PROXY, null);
     builder = builder.withProxy(proxy);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
@@ -283,7 +283,20 @@ class ConnectionConfigurationTests {
         client.close();
     }
 
-    @Test
+  @Test
+  void testCreateClientWithInsecureAndCertPath() throws IOException {
+    // Insecure should take precedence over cert path when both are set
+    final PluginSetting pluginSetting = generatePluginSetting(
+        TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, true);
+    final ConnectionConfiguration connectionConfiguration =
+        ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
+    assertNull(connectionConfiguration.getCertPath());
+    final RestHighLevelClient client = connectionConfiguration.createClient(awsCredentialsSupplier);
+    assertNotNull(client);
+    client.close();
+  }
+
+  @Test
     void testCreateOpenSearchClientWithCertPath() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);


### PR DESCRIPTION
### Description
This PR flips the precedence between `cert` and `insecure` config options so that `insecure: true` overrides the presence of `cert`.

### Issues Resolved
Resolves #5267
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
