### PR TITLE
Fix flaky unit tests in Rds source

### DIFF
--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
@@ -187,12 +187,13 @@ class DataFileSchedulerTest {
     }
 
     @Test
-    void test_shutdown() {
+    void test_shutdown() throws InterruptedException {
         DataFileScheduler objectUnderTest = createObjectUnderTest();
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(objectUnderTest);
 
         objectUnderTest.shutdown();
+        Thread.sleep(100);
 
         verifyNoMoreInteractions(sourceCoordinator);
         executorService.shutdownNow();

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -262,12 +262,13 @@ class ExportSchedulerTest {
     }
 
     @Test
-    void test_shutDown() {
+    void test_shutDown() throws InterruptedException {
         lenient().when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.empty());
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(exportScheduler);
         exportScheduler.shutdown();
+        Thread.sleep(100);
         verifyNoMoreInteractions(sourceCoordinator, snapshotManager, exportTaskManager, s3Client,
                 exportJobSuccessCounter, exportJobFailureCounter, exportS3ObjectsTotalCounter);
         executorService.shutdownNow();


### PR DESCRIPTION
### Description
Adds sleep time before verifying to reduce flakiness of the shutdown tests. I wasn't able to reproduce the error or verify the fix but adding sleep time helped previously with [another shutdown test](https://github.com/opensearch-project/data-prepper/blob/2f3a2804a456805107699721734d246be105405a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java#L125).
 
### Issues Resolved
https://github.com/opensearch-project/data-prepper/issues/3481#issuecomment-2581524346
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
