### PR TITLE
Welcoming Santhosh Gandhe (san81) to the Data Prepper maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @sb2k16 @chenqi0805 @engechas @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh
+*   @sb2k16 @chenqi0805 @engechas @san81 @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Souvik Bose          | [sb2k16](https://github.com/sb2k16)               | Amazon      |
 | Qi Chen              | [chenqi0805](https://github.com/chenqi0805)               | Amazon      |
 | Chase Engelbrecht    | [engechas](https://github.com/engechas)                   | Amazon      |
+| Santhosh Gandhe      | [san81](https://github.com/san81)             | Amazon      |
 | Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)             | Amazon      |
 | Dinu John            | [dinujoh](https://github.com/dinujoh)                     | Amazon      |
 | Krishna Kondaka      | [kkondaka](https://github.com/kkondaka)                   | Amazon      |


### PR DESCRIPTION
### Description

Welcoming Santhosh Gandhe ([san81](https://github.com/san81)) to the Data Prepper maintainers.
 
Santhosh has contributed [15 merged PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is%3Apr+author%3Asan81+is%3Aclosed). A few of these to highlight:
* He created a PR that allows plugins to have their own application context so that they can use dependency injection ([#5012](https://github.com/opensearch-project/data-prepper/pull/5012)) which also required a refactoring to Data Prepper core to use different packages ([#5056](https://github.com/opensearch-project/data-prepper/pull/5056)).
* Several PRs to improve the AWS Lambda processor/sink: ([#5204](https://github.com/opensearch-project/data-prepper/pull/5204), [#5211](https://github.com/opensearch-project/data-prepper/pull/5211), [#5202](https://github.com/opensearch-project/data-prepper/pull/5202))
* Introducing the Jira source plugin: ([#5095](https://github.com/opensearch-project/data-prepper/pull/5095), [#5125](https://github.com/opensearch-project/data-prepper/pull/5125))

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
