### PR TITLE
Add Kafka consumer record offset to event metadata

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -459,6 +459,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         eventMetadata.setAttribute("kafka_timestamp_type", consumerRecord.timestampType().toString());
         eventMetadata.setAttribute("kafka_topic", topicName);
         eventMetadata.setAttribute("kafka_partition", String.valueOf(partition));
+        eventMetadata.setAttribute("kafka_offset", consumerRecord.offset());
         eventMetadata.setExternalOriginationTime(Instant.ofEpochMilli(receivedTimeStamp));
         event.getEventHandle().setExternalOriginationTime(Instant.ofEpochMilli(receivedTimeStamp));
 


### PR DESCRIPTION
### Description
This change adds an additional field named `kafka_offset` to the event metadata attributes when using the Kafka plugin. This provides the specific offset within the partition from which the record was consumed.
 
### Issues Resolved
Resolves #[5164]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
