### PR TITLE
Fix NPE in map to list processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessor.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
@@ -22,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,7 +33,6 @@ import java.util.Set;
 @DataPrepperPlugin(name = "map_to_list", pluginType = Processor.class, pluginConfigurationType = MapToListProcessorConfig.class)
 public class MapToListProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(MapToListProcessor.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final MapToListProcessorConfig config;
     private final ExpressionEvaluator expressionEvaluator;
     private final Set<String> excludeKeySet = new HashSet<>();
@@ -72,9 +71,8 @@ public class MapToListProcessor extends AbstractProcessor<Record<Event>, Record<
 
                         for (final Map.Entry<String, Object> entry : sourceMap.entrySet()) {
                             if (!excludeKeySet.contains(entry.getKey())) {
-                                targetNestedList.add(List.of(entry.getKey(), entry.getValue()));
+                                targetNestedList.add(Arrays.asList(entry.getKey(), entry.getValue()));
                             }
-
                         }
                         removeProcessedFields(sourceMap, recordEvent);
                         recordEvent.put(config.getTarget(), targetNestedList);
@@ -82,10 +80,10 @@ public class MapToListProcessor extends AbstractProcessor<Record<Event>, Record<
                         final List<Map<String, Object>> targetList = new ArrayList<>();
                         for (final Map.Entry<String, Object> entry : sourceMap.entrySet()) {
                             if (!excludeKeySet.contains(entry.getKey())) {
-                                targetList.add(Map.of(
-                                        config.getKeyName(), entry.getKey(),
-                                        config.getValueName(), entry.getValue()
-                                ));
+                                final Map<String, Object> listItem = new HashMap<>();
+                                listItem.put(config.getKeyName(), entry.getKey());
+                                listItem.put(config.getValueName(), entry.getValue());
+                                targetList.add(listItem);
                             }
                         }
                         removeProcessedFields(sourceMap, recordEvent);


### PR DESCRIPTION
### Description
Get rid of the use of List.of and Map.of to allow for null values in input map for map_to_list processor
 
### Issues Resolved
Resolves #5341 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
