### PR TITLE
Refreshing AWS Secret values on demand

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigVariable.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigVariable.java
@@ -32,6 +32,11 @@ public interface PluginConfigVariable {
     void setValue(Object updatedValue);
 
     /**
+     * Refresh the secret value on demand
+     */
+    void refresh();
+
+    /**
      * Returns if the variable is updatable.
      *
      * @return true if this variable is updatable, false otherwise

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -158,6 +158,10 @@ class VariableExpanderTest {
             }
 
             @Override
+            public void refresh() {
+            }
+
+            @Override
             public boolean isUpdatable() {
                 return true;
             }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariable.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariable.java
@@ -48,6 +48,12 @@ public class AwsPluginConfigVariable implements PluginConfigVariable {
     }
 
     @Override
+    public void refresh() {
+        secretsSupplier.refresh(secretId);
+    }
+
+
+    @Override
     public boolean isUpdatable() {
         return isUpdatable;
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariableTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariableTest.java
@@ -25,6 +25,8 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,6 +81,13 @@ class AwsPluginConfigVariableTest {
     void testSetValueSuccess(final String input) {
         objectUnderTest.setValue(input);
         assertThat(objectUnderTest.getValue(), equalTo(input));
+    }
+
+
+    @Test
+    void testRefreshSecretsWithKey() {
+        objectUnderTest.refresh();
+        verify(secretsSupplier, times(1)).refresh(secretId);
     }
 
 }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/auth/JiraOauthConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/auth/JiraOauthConfig.java
@@ -142,12 +142,16 @@ public class JiraOauthConfig implements JiraAuthConfig {
             } catch (HttpClientErrorException ex) {
                 this.expireTime = Instant.ofEpochMilli(0);
                 this.expiresInSeconds = 0;
-                // Try refreshing the secrets and see if that helps
-                // Refreshing one of the secret refreshes the entire store so we are good to trigger refresh on just one
-                jiraSourceConfig.getAuthenticationConfig().getOauth2Config().getAccessToken().refresh();
+                HttpStatus statusCode = ex.getStatusCode();
                 log.error("Failed to renew access token. Status code: {}, Error Message: {}",
-                        ex.getRawStatusCode(), ex.getMessage());
-                throw new RuntimeException("Failed to renew access token" + ex.getMessage(), ex);
+                        statusCode, ex.getMessage());
+                if (statusCode == HttpStatus.FORBIDDEN || statusCode == HttpStatus.UNAUTHORIZED) {
+                    log.info("Trying to refresh the secrets");
+                    // Try refreshing the secrets and see if that helps
+                    // Refreshing one of the secret refreshes the entire store so we are good to trigger refresh on just one
+                    jiraSourceConfig.getAuthenticationConfig().getOauth2Config().getAccessToken().refresh();
+                }
+                throw new RuntimeException("Failed to renew access token message:" + ex.getMessage(), ex);
             }
         }
     }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/auth/JiraOauthConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/auth/JiraOauthConfig.java
@@ -142,6 +142,9 @@ public class JiraOauthConfig implements JiraAuthConfig {
             } catch (HttpClientErrorException ex) {
                 this.expireTime = Instant.ofEpochMilli(0);
                 this.expiresInSeconds = 0;
+                // Try refreshing the secrets and see if that helps
+                // Refreshing one of the secret refreshes the entire store so we are good to trigger refresh on just one
+                jiraSourceConfig.getAuthenticationConfig().getOauth2Config().getAccessToken().refresh();
                 log.error("Failed to renew access token. Status code: {}, Error Message: {}",
                         ex.getRawStatusCode(), ex.getMessage());
                 throw new RuntimeException("Failed to renew access token" + ex.getMessage(), ex);

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/utils/MockPluginConfigVariableImpl.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/utils/MockPluginConfigVariableImpl.java
@@ -34,6 +34,10 @@ public class MockPluginConfigVariableImpl implements PluginConfigVariable {
     }
 
     @Override
+    public void refresh() {
+    }
+
+    @Override
     public boolean isUpdatable() {
         return true;
     }


### PR DESCRIPTION
### Description
There is already scheduled refresh feature for AWS secrets but with the new enhancement of updating the secret, we need on demand refresh of the secrets to minimize the delay in getting new secrets into the OCUs that are holding up to the old secrets. The fix here is to provide an option to trigger on demand refresh of the secrets.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
