### PR TITLE
Fix for the flaky OTel log test - by synchronizing the evictions

### DIFF
--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.caffeine
     testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation project(':data-prepper-test-common')
 }
 
 jacocoTestCoverageVerification {


### PR DESCRIPTION
### Description
Caffeine cache evictions happen in async mode that leaves no control to a test method to guarantee the max size limit is enforced. If we have to enforce max size then we need to ask Caffeine to do evictions synchronously. But setting the max cache size to zero disables the cache and gives more consistent behavior. Read more here https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.0.3/com/github/benmanes/caffeine/cache/Caffeine.html#maximumSize-long-

To fix this flaky test, I suggest to set the max size to zero. Basically, disable the cache instead of setting the max size to 1.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
