### PR TITLE
Add debug logs for Kafka consumer

### DIFF
--- a/data-prepper-plugins/buffer-common/src/main/java/org/opensearch/dataprepper/buffer/common/BufferAccumulator.java
+++ b/data-prepper-plugins/buffer-common/src/main/java/org/opensearch/dataprepper/buffer/common/BufferAccumulator.java
@@ -68,6 +68,7 @@ public class BufferAccumulator<T extends Record<?>> {
 
     public void flush() throws Exception {
         try {
+            LOG.debug("Flushing buffer accumulator");
             flushAccumulatedToBuffer();
         } catch (final TimeoutException timeoutException) {
             flushWithBackoff();
@@ -80,11 +81,13 @@ public class BufferAccumulator<T extends Record<?>> {
         boolean flushedSuccessfully;
 
         for (int retryCount = 0; retryCount < MAX_FLUSH_RETRIES_ON_IO_EXCEPTION; retryCount++) {
+            LOG.debug("Retrying buffer flush on retry count {}", retryCount);
             final ScheduledFuture<Boolean> flushBufferFuture = scheduledExecutorService.schedule(() -> {
                 try {
                     flushAccumulatedToBuffer();
                     return true;
                 } catch (final TimeoutException e) {
+                    LOG.debug("Timed out retrying buffer accumulator");
                     return false;
                 }
             }, nextDelay, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
### Description
Adds debug logs for kafka consumers to debug why they are intermittently pausing
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
