### PR TITLE
Plugin metrics injection

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,18 +15,19 @@ import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSe
 import org.opensearch.dataprepper.core.event.EventFactoryApplicationContextMarker;
 import org.opensearch.dataprepper.core.validation.LoggingPluginErrorsHandler;
 import org.opensearch.dataprepper.core.validation.PluginErrorCollector;
-import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
-import org.opensearch.dataprepper.plugins.configtest.TestComponentWithConfigInject;
-import org.opensearch.dataprepper.plugins.configtest.TestDISourceWithConfig;
-import org.opensearch.dataprepper.validation.PluginErrorsHandler;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
 import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.plugins.TestObjectPlugin;
+import org.opensearch.dataprepper.plugins.configtest.TestComponentWithConfigInject;
+import org.opensearch.dataprepper.plugins.configtest.TestDISourceWithConfig;
 import org.opensearch.dataprepper.plugins.test.TestComponent;
 import org.opensearch.dataprepper.plugins.test.TestDISource;
 import org.opensearch.dataprepper.plugins.test.TestPlugin;
+import org.opensearch.dataprepper.validation.PluginErrorsHandler;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.util.Collections;
@@ -129,7 +131,7 @@ class DefaultPluginFactoryIT {
     }
 
     @Test
-    void loadPlugin_should_return_a_new_plugin_instance_with_DI_context_and_config_injected() {
+    void loadPlugin_should_return_a_new_plugin_instance_with_DI_context_with_config_and_plugin_metrics_injected() {
 
         final String requiredStringValue = UUID.randomUUID().toString();
         final String optionalStringValue = UUID.randomUUID().toString();
@@ -152,6 +154,9 @@ class DefaultPluginFactoryIT {
         assertThat(pluginConfig.getRequiredString(), equalTo(requiredStringValue));
         assertThat(pluginConfig.getOptionalString(), equalTo(optionalStringValue));
         assertThat(plugin.getTestComponent().getIdentifier(), equalTo("test-component-with-plugin-config-injected"));
+        PluginMetrics pluginMetrics = plugin.getTestComponent().getPluginMetrics();
+        assertInstanceOf(PluginMetrics.class, pluginMetrics);
+        assertInstanceOf(Counter.class, pluginMetrics.counter("testCounter"));
     }
 
     @Test

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -64,14 +64,14 @@ public class DefaultPluginFactory implements PluginFactory {
         this.pluginBeanFactoryProvider = Objects.requireNonNull(pluginBeanFactoryProvider);
         this.pluginConfigurationObservableFactory = pluginConfigurationObservableFactory;
 
-        if(pluginProviders.isEmpty()) {
+        if (pluginProviders.isEmpty()) {
             throw new RuntimeException("Data Prepper requires at least one PluginProvider. " +
                     "Your Data Prepper configuration may be missing the org.opensearch.dataprepper.plugin.PluginProvider file.");
         }
     }
 
     @Override
-    public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final Object ... args) {
+    public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final Object... args) {
         final String pluginName = pluginSetting.getName();
         final Class<? extends T> pluginClass = getPluginClass(baseClass, pluginName);
 
@@ -100,7 +100,7 @@ public class DefaultPluginFactory implements PluginFactory {
 
         final Integer numberOfInstances = numberOfInstancesFunction.apply(pluginClass);
 
-        if(numberOfInstances == null || numberOfInstances < 0)
+        if (numberOfInstances == null || numberOfInstances < 0)
             throw new IllegalArgumentException("The numberOfInstances must be provided as a non-negative integer.");
 
         final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, null);
@@ -121,7 +121,7 @@ public class DefaultPluginFactory implements PluginFactory {
                 .createDefaultPluginConfigObservable(pluginConfigurationConverter, pluginConfigurationType, pluginSetting);
 
         Class[] markersToScan = pluginAnnotation.packagesToScan();
-        BeanFactory beanFactory = pluginBeanFactoryProvider.createPluginSpecificContext(markersToScan, configuration);
+        BeanFactory beanFactory = pluginBeanFactoryProvider.createPluginSpecificContext(markersToScan, configuration, pluginSetting);
 
         return new ComponentPluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProvider.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -20,8 +21,8 @@ import java.util.Objects;
 /**
  * @since 1.3
  * <p>
- *     Used to create new instances of ApplicationContext that can be used to provide a per plugin instance isolated ApplicationContext
- *     scope. CoreApplicationContext is unavailable to sharedPluginApplicationContext and its children.
+ * Used to create new instances of ApplicationContext that can be used to provide a per plugin instance isolated ApplicationContext
+ * scope. CoreApplicationContext is unavailable to sharedPluginApplicationContext and its children.
  * </p>
  * <p>pluginIsolatedApplicationContext inherits from {@link PluginBeanFactoryProvider#sharedPluginApplicationContext}</p>
  * <p>{@link PluginBeanFactoryProvider#sharedPluginApplicationContext} inherits from <i>publicContext</i></p>
@@ -53,19 +54,22 @@ class PluginBeanFactoryProvider {
     }
 
     /**
+     * @return BeanFactory A BeanFactory that inherits from {@link PluginBeanFactoryProvider#sharedPluginApplicationContext}
      * @since 1.3
      * Creates a new isolated application context that inherits from
      * {@link PluginBeanFactoryProvider#sharedPluginApplicationContext} then returns new context's BeanFactory.
      * {@link PluginBeanFactoryProvider#sharedPluginApplicationContext} should not be directly accessible to plugins.
      * instead, a new isolated {@link ApplicationContext} should be created.
-     * @return BeanFactory A BeanFactory that inherits from {@link PluginBeanFactoryProvider#sharedPluginApplicationContext}
      */
-    public BeanFactory createPluginSpecificContext(Class[] markersToScan, Object configuration) {
+    public BeanFactory createPluginSpecificContext(Class[] markersToScan, Object configuration, final PluginSetting pluginSetting) {
         AnnotationConfigApplicationContext isolatedPluginApplicationContext = new AnnotationConfigApplicationContext();
         DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) isolatedPluginApplicationContext.getBeanFactory();
-        if(markersToScan !=null && markersToScan.length>0) {
-            if(configuration !=null && !(configuration instanceof PluginSetting)) {
+        if (markersToScan != null && markersToScan.length > 0) {
+            if (configuration != null && !(configuration instanceof PluginSetting)) {
                 beanFactory.registerSingleton(configuration.getClass().getName(), configuration);
+            }
+            if (pluginSetting != null) {
+                beanFactory.registerSingleton(PluginMetrics.class.getName(), PluginMetrics.fromPluginSetting(pluginSetting));
             }
             // If packages to scan is provided in this plugin annotation, which indicates
             // that this plugin is interested in using Dependency Injection isolated for its module

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -216,7 +216,7 @@ class DefaultPluginFactoryTest {
                     equalTo(expectedInstance));
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{TestDISource.class}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{TestDISource.class}, convertedConfiguration, pluginSetting);
         }
 
         @Test
@@ -233,7 +233,7 @@ class DefaultPluginFactoryTest {
                     equalTo(expectedInstance));
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
         }
 
         @Test
@@ -283,7 +283,7 @@ class DefaultPluginFactoryTest {
             assertThat(plugins, notNullValue());
             assertThat(plugins.size(), equalTo(0));
 
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, null);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, null, pluginSetting);
             verifyNoInteractions(pluginCreator);
         }
 
@@ -299,7 +299,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 1);
 
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
@@ -309,7 +309,7 @@ class DefaultPluginFactoryTest {
             final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
             assertThat(pipelineDescriptionObj.length, equalTo(1));
             assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
-            final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
+            final PipelineDescription actualPipelineDescription = (PipelineDescription) pipelineDescriptionObj[0];
             assertThat(actualPipelineDescription.getPipelineName(), is(pipelineName));
             assertThat(plugins, notNullValue());
             assertThat(plugins.size(), equalTo(1));
@@ -328,7 +328,7 @@ class DefaultPluginFactoryTest {
 
             final Object plugin = createObjectUnderTest().loadPlugin(baseClass, pluginSetting, object);
 
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
             verify(pluginConfigurationObservableFactory).createDefaultPluginConfigObservable(eq(pluginConfigurationConverter),
                     eq(PluginSetting.class), eq(pluginSetting));
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
@@ -338,7 +338,7 @@ class DefaultPluginFactoryTest {
             final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
             assertThat(pipelineDescriptionObj.length, equalTo(1));
             assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
-            final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
+            final PipelineDescription actualPipelineDescription = (PipelineDescription) pipelineDescriptionObj[0];
             assertThat(actualPipelineDescription.getPipelineName(), is(pipelineName));
             assertThat(plugin, notNullValue());
             assertThat(plugin, equalTo(expectedInstance));
@@ -380,7 +380,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 3);
 
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
             verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final List<ComponentPluginArgumentsContext> actualPluginArgumentsContextList = pluginArgumentsContextArgCapture.getAllValues();
@@ -390,7 +390,7 @@ class DefaultPluginFactoryTest {
                 final Object[] pipelineDescriptionObj = pluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
                 assertThat(pipelineDescriptionObj.length, equalTo(1));
                 assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
-                final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
+                final PipelineDescription actualPipelineDescription = (PipelineDescription) pipelineDescriptionObj[0];
                 assertThat(actualPipelineDescription.getPipelineName(), is(pipelineName));
             });
             assertThat(plugins, notNullValue());
@@ -416,7 +416,7 @@ class DefaultPluginFactoryTest {
             final List<?> plugins = createObjectUnderTest().loadPlugins(
                     baseClass, pluginSetting, c -> 1);
 
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
             verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
@@ -425,7 +425,7 @@ class DefaultPluginFactoryTest {
             assertThat(pipelineDescriptionObj.length, equalTo(2));
             assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
             assertThat(pipelineDescriptionObj[1], sameInstance(suppliedAdditionalArgument));
-            final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
+            final PipelineDescription actualPipelineDescription = (PipelineDescription) pipelineDescriptionObj[0];
             assertThat(actualPipelineDescription.getPipelineName(), is(pipelineName));
             assertThat(plugins, notNullValue());
             assertThat(plugins.size(), equalTo(1));
@@ -458,7 +458,7 @@ class DefaultPluginFactoryTest {
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
             MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).deprecatedName(), equalTo(TEST_SINK_DEPRECATED_NAME));
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
         }
     }
 
@@ -487,7 +487,7 @@ class DefaultPluginFactoryTest {
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));
             MatcherAssert.assertThat(expectedInstance.getClass().getAnnotation(DataPrepperPlugin.class).alternateNames(), equalTo(new String[]{TEST_SINK_ALTERNATE_NAME}));
-            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration);
+            verify(beanFactoryProvider).createPluginSpecificContext(new Class[]{}, convertedConfiguration, pluginSetting);
         }
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginBeanFactoryProviderTest.java
@@ -78,7 +78,7 @@ class PluginBeanFactoryProviderTest {
         final PluginBeanFactoryProvider beanFactoryProvider = createObjectUnderTest();
 
         verify(context).getParent();
-        assertThat(beanFactoryProvider.createPluginSpecificContext(new Class[]{}, null), is(instanceOf(BeanFactory.class)));
+        assertThat(beanFactoryProvider.createPluginSpecificContext(new Class[]{}, null, null), is(instanceOf(BeanFactory.class)));
     }
 
     @Test
@@ -86,8 +86,8 @@ class PluginBeanFactoryProviderTest {
         doReturn(context).when(context).getParent();
 
         final PluginBeanFactoryProvider beanFactoryProvider = createObjectUnderTest();
-        final BeanFactory isolatedBeanFactoryA = beanFactoryProvider.createPluginSpecificContext(new Class[]{}, null);
-        final BeanFactory isolatedBeanFactoryB = beanFactoryProvider.createPluginSpecificContext(new Class[]{}, null);
+        final BeanFactory isolatedBeanFactoryA = beanFactoryProvider.createPluginSpecificContext(new Class[]{}, null, null);
+        final BeanFactory isolatedBeanFactoryB = beanFactoryProvider.createPluginSpecificContext(new Class[]{}, null, null);
 
         verify(context).getParent();
         assertThat(isolatedBeanFactoryA, not(sameInstance(isolatedBeanFactoryB)));
@@ -113,7 +113,7 @@ class PluginBeanFactoryProviderTest {
     void testCreatePluginSpecificContext() {
         when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
-        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{TestComponent.class}, null);
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{TestComponent.class}, null, null);
         assertThat(beanFactory, notNullValue());
         assertThat(beanFactory.getBean(TestComponent.class), notNullValue());
     }
@@ -122,7 +122,7 @@ class PluginBeanFactoryProviderTest {
     void testCreatePluginSpecificContext_with_empty_array() {
         when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
-        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{}, null);
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{}, null, null);
         assertThat(beanFactory, notNullValue());
         assertThat(beanFactory, instanceOf(ListableBeanFactory.class));
         ListableBeanFactory listableBeanFactory = (ListableBeanFactory) beanFactory;
@@ -137,9 +137,9 @@ class PluginBeanFactoryProviderTest {
         when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
         PluginSetting pipelineSettings = new PluginSetting(UUID.randomUUID().toString(), Map.of("key", "val"));
-        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{}, pipelineSettings);
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{}, pipelineSettings, pipelineSettings);
         assertThat(beanFactory, notNullValue());
-        assertThrows(NoSuchBeanDefinitionException.class, ()->beanFactory.getBean(PluginSetting.class));
+        assertThrows(NoSuchBeanDefinitionException.class, () -> beanFactory.getBean(PluginSetting.class));
     }
 
     @Test
@@ -147,10 +147,10 @@ class PluginBeanFactoryProviderTest {
         when(context.getParent()).thenReturn(context);
         final PluginBeanFactoryProvider objectUnderTest = createObjectUnderTest();
         TestPluginConfiguration config = new TestPluginConfiguration();
-        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{}, config);
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{}, config, null);
         assertThat(beanFactory, notNullValue());
-        assertThrows(NoSuchBeanDefinitionException.class, ()->beanFactory.getBean(TestComponent.class));
-        assertThrows(NoSuchBeanDefinitionException.class, ()->beanFactory.getBean(TestPluginConfiguration.class));
+        assertThrows(NoSuchBeanDefinitionException.class, () -> beanFactory.getBean(TestComponent.class));
+        assertThrows(NoSuchBeanDefinitionException.class, () -> beanFactory.getBean(TestPluginConfiguration.class));
     }
 
     @Test
@@ -160,7 +160,7 @@ class PluginBeanFactoryProviderTest {
         TestPluginConfiguration config = new TestPluginConfiguration();
         String requiredStringValue = UUID.randomUUID().toString();
         config.setRequiredString(requiredStringValue);
-        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{TestComponent.class}, config);
+        BeanFactory beanFactory = objectUnderTest.createPluginSpecificContext(new Class[]{TestComponent.class}, config, null);
         assertThat(beanFactory, notNullValue());
         assertThat(beanFactory.getBean(TestComponent.class), notNullValue());
         assertThat(beanFactory.getBean(TestPluginConfiguration.class), notNullValue());

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/configtest/TestComponentWithConfigInject.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/configtest/TestComponentWithConfigInject.java
@@ -1,5 +1,6 @@
 package org.opensearch.dataprepper.plugins.configtest;
 
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugin.TestPluginConfiguration;
 
 import javax.inject.Named;
@@ -7,9 +8,11 @@ import javax.inject.Named;
 @Named
 public class TestComponentWithConfigInject {
     private final TestPluginConfiguration configuration;
+    private final PluginMetrics pluginMetrics;
 
-    public TestComponentWithConfigInject(TestPluginConfiguration configuration) {
+    public TestComponentWithConfigInject(TestPluginConfiguration configuration, PluginMetrics pluginMetrics) {
         this.configuration = configuration;
+        this.pluginMetrics = pluginMetrics;
     }
 
     public String getIdentifier() {
@@ -18,5 +21,9 @@ public class TestComponentWithConfigInject {
 
     public TestPluginConfiguration getConfiguration() {
         return configuration;
+    }
+
+    public PluginMetrics getPluginMetrics() {
+        return pluginMetrics;
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -61,13 +61,12 @@ public class JiraService {
     private final JiraSourceConfig jiraSourceConfig;
     private final JiraRestClient jiraRestClient;
     private final Counter searchResultsFoundCounter;
-    private final PluginMetrics jiraPluginMetrics = PluginMetrics.fromNames("jiraService", "aws");
 
 
-    public JiraService(JiraSourceConfig jiraSourceConfig, JiraRestClient jiraRestClient) {
+    public JiraService(JiraSourceConfig jiraSourceConfig, JiraRestClient jiraRestClient, PluginMetrics pluginMetrics) {
         this.jiraSourceConfig = jiraSourceConfig;
         this.jiraRestClient = jiraRestClient;
-        this.searchResultsFoundCounter = jiraPluginMetrics.counter(SEARCH_RESULTS_FOUND);
+        this.searchResultsFoundCounter = pluginMetrics.counter(SEARCH_RESULTS_FOUND);
     }
 
     /**
@@ -132,7 +131,7 @@ public class JiraService {
     private StringBuilder createIssueFilterCriteria(JiraSourceConfig configuration, Instant ts) {
 
         log.info("Creating issue filter criteria");
-        if (!CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameIncludeFilter(configuration)) || !CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameExcludeFilter(configuration)) ) {
+        if (!CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameIncludeFilter(configuration)) || !CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameExcludeFilter(configuration))) {
             validateProjectFilters(configuration);
         }
         StringBuilder jiraQl = new StringBuilder(UPDATED + GREATER_THAN_EQUALS + ts.toEpochMilli());

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -98,7 +98,7 @@ public class JiraService {
         int total;
         int startAt = 0;
         do {
-            SearchResults searchIssues = jiraRestClient.getAllIssues(jql, startAt, configuration);
+            SearchResults searchIssues = jiraRestClient.getAllIssues(jql, startAt);
             List<IssueBean> issueList = new ArrayList<>(searchIssues.getIssues());
             total = searchIssues.getTotal();
             startAt += searchIssues.getIssues().size();

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
@@ -53,24 +53,22 @@ public class JiraRestClient {
     private static final String SEARCH_CALL_LATENCY_TIMER = "searchCallLatency";
     private static final String PROJECTS_FETCH_LATENCY_TIMER = "projectFetchLatency";
     private static final String ISSUES_REQUESTED = "issuesRequested";
+    private int sleepTimeMultiplier = 1000;
     private final RestTemplate restTemplate;
     private final JiraAuthConfig authConfig;
     private final Timer ticketFetchLatencyTimer;
     private final Timer searchCallLatencyTimer;
     private final Timer projectFetchLatencyTimer;
     private final Counter issuesRequestedCounter;
-    private final PluginMetrics jiraPluginMetrics = PluginMetrics.fromNames("jiraRestClient", "aws");
-    private int sleepTimeMultiplier = 1000;
 
-    public JiraRestClient(RestTemplate restTemplate, JiraAuthConfig authConfig) {
+    public JiraRestClient(RestTemplate restTemplate, JiraAuthConfig authConfig, PluginMetrics pluginMetrics) {
         this.restTemplate = restTemplate;
         this.authConfig = authConfig;
 
-        ticketFetchLatencyTimer = jiraPluginMetrics.timer(TICKET_FETCH_LATENCY_TIMER);
-        searchCallLatencyTimer = jiraPluginMetrics.timer(SEARCH_CALL_LATENCY_TIMER);
-        projectFetchLatencyTimer = jiraPluginMetrics.timer(PROJECTS_FETCH_LATENCY_TIMER);
-
-        issuesRequestedCounter = jiraPluginMetrics.counter(ISSUES_REQUESTED);
+        ticketFetchLatencyTimer = pluginMetrics.timer(TICKET_FETCH_LATENCY_TIMER);
+        searchCallLatencyTimer = pluginMetrics.timer(SEARCH_CALL_LATENCY_TIMER);
+        projectFetchLatencyTimer = pluginMetrics.timer(PROJECTS_FETCH_LATENCY_TIMER);
+        issuesRequestedCounter = pluginMetrics.counter(ISSUES_REQUESTED);
     }
 
     /**

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
@@ -16,7 +16,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.plugins.source.jira.JiraSourceConfig;
 import org.opensearch.dataprepper.plugins.source.jira.exception.BadRequestException;
 import org.opensearch.dataprepper.plugins.source.jira.exception.UnAuthorizedException;
 import org.opensearch.dataprepper.plugins.source.jira.models.SearchResults;
@@ -44,7 +43,7 @@ public class JiraRestClient {
 
     public static final String REST_API_SEARCH = "rest/api/3/search";
     public static final String REST_API_FETCH_ISSUE = "rest/api/3/issue";
-    public static final String REST_API_PROJECTS = "/rest/api/3/project/search";
+    //public static final String REST_API_PROJECTS = "/rest/api/3/project/search";
     public static final String FIFTY = "50";
     public static final String START_AT = "startAt";
     public static final String MAX_RESULT = "maxResults";
@@ -74,14 +73,12 @@ public class JiraRestClient {
     /**
      * Method to get Issues.
      *
-     * @param jql           input parameter.
-     * @param startAt       the start at
-     * @param configuration input parameter.
+     * @param jql     input parameter.
+     * @param startAt the start at
      * @return InputStream input stream
      */
     @Timed(SEARCH_CALL_LATENCY_TIMER)
-    public SearchResults getAllIssues(StringBuilder jql, int startAt,
-                                      JiraSourceConfig configuration) {
+    public SearchResults getAllIssues(StringBuilder jql, int startAt) {
 
         String url = authConfig.getUrl() + REST_API_SEARCH;
 

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraIteratorTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraIteratorTest.java
@@ -73,7 +73,7 @@ public class JiraIteratorTest {
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         when(mockSearchResults.getIssues()).thenReturn(new ArrayList<>());
         when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
         assertFalse(jiraIterator.hasNext());
     }
 
@@ -104,7 +104,7 @@ public class JiraIteratorTest {
         mockIssues.add(issue1);
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
         when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
 
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.setCrawlerQWaitTimeMillis(1);
@@ -133,7 +133,7 @@ public class JiraIteratorTest {
         mockIssues.add(issue3);
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
         when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
 
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.setCrawlerQWaitTimeMillis(1);
@@ -150,7 +150,7 @@ public class JiraIteratorTest {
         List<IssueBean> mockIssues = new ArrayList<>();
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
         when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
 
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.setCrawlerQWaitTimeMillis(1);

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraIteratorTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraIteratorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.source.jira.models.IssueBean;
 import org.opensearch.dataprepper.plugins.source.jira.models.SearchResults;
 import org.opensearch.dataprepper.plugins.source.jira.rest.JiraRestClient;
@@ -45,8 +46,6 @@ import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.UPD
 @ExtendWith(MockitoExtension.class)
 public class JiraIteratorTest {
 
-    private final PluginExecutorServiceProvider executorServiceProvider = new PluginExecutorServiceProvider();
-
     @Mock
     private SearchResults mockSearchResults;
     @Mock
@@ -54,12 +53,13 @@ public class JiraIteratorTest {
     private JiraService jiraService;
     @Mock
     private JiraSourceConfig jiraSourceConfig;
-
     private JiraIterator jiraIterator;
+    private final PluginExecutorServiceProvider executorServiceProvider = new PluginExecutorServiceProvider();
 
     @BeforeEach
     void setUp() {
-        jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient));
+        jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient,
+                PluginMetrics.fromNames("jiraIteratorTest", "jira")));
     }
 
     public JiraIterator createObjectUnderTest() {
@@ -118,7 +118,7 @@ public class JiraIteratorTest {
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.hasNext();
         jiraIterator.hasNext();
-        assertTrue(jiraIterator.showFutureList().size() == 1);
+        assertEquals(1, jiraIterator.showFutureList().size());
     }
 
     @Test
@@ -145,7 +145,7 @@ public class JiraIteratorTest {
     }
 
     @Test
-    void testItemInfoQueueEmpty(){
+    void testItemInfoQueueEmpty() {
         jiraIterator = createObjectUnderTest();
         List<IssueBean> mockIssues = new ArrayList<>();
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.source.jira.configuration.Oauth2Config;
 import org.opensearch.dataprepper.plugins.source.jira.exception.BadRequestException;
@@ -71,11 +72,10 @@ import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.UPD
 public class JiraServiceTest {
 
     private static final Logger log = LoggerFactory.getLogger(JiraServiceTest.class);
-    private final PluginExecutorServiceProvider executorServiceProvider = new PluginExecutorServiceProvider();
-
     @Mock
     private JiraRestClient jiraRestClient;
-
+    private final PluginExecutorServiceProvider executorServiceProvider = new PluginExecutorServiceProvider();
+    private final PluginMetrics pluginMetrics = PluginMetrics.fromNames("JiraServiceTest", "jira");
 
     private static InputStream getResourceAsStream(String resourceName) {
         InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName);
@@ -178,7 +178,7 @@ public class JiraServiceTest {
         List<String> issueStatus = new ArrayList<>();
         List<String> projectKey = new ArrayList<>();
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
-        JiraService jiraService = new JiraService(jiraSourceConfig, jiraRestClient);
+        JiraService jiraService = new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics);
         assertNotNull(jiraService);
         when(jiraRestClient.getIssue(anyString())).thenReturn("test String");
         assertNotNull(jiraService.getIssue("test Key"));
@@ -193,7 +193,7 @@ public class JiraServiceTest {
         issueStatus.add("Done");
         projectKey.add("KAN");
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
-        JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient));
+        JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics));
         List<IssueBean> mockIssues = new ArrayList<>();
         IssueBean issue1 = createIssueBean(false, false);
         mockIssues.add(issue1);
@@ -221,7 +221,7 @@ public class JiraServiceTest {
         List<String> projectKey = new ArrayList<>();
         issueType.add("Task");
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
-        JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient));
+        JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics));
         List<IssueBean> mockIssues = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
             IssueBean issue1 = createIssueBean(false, false);
@@ -253,7 +253,7 @@ public class JiraServiceTest {
         projectKey.add("AAAAAAAAAAAAAA");
 
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
-        JiraService jiraService = new JiraService(jiraSourceConfig, jiraRestClient);
+        JiraService jiraService = new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics);
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
@@ -268,7 +268,7 @@ public class JiraServiceTest {
         List<String> projectKey = new ArrayList<>();
         issueType.add("Task");
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
-        JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient));
+        JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics));
 
         doThrow(RuntimeException.class).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
 

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
@@ -206,7 +206,7 @@ public class JiraServiceTest {
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
         when(mockSearchResults.getTotal()).thenReturn(mockIssues.size());
 
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
@@ -232,7 +232,7 @@ public class JiraServiceTest {
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
         when(mockSearchResults.getTotal()).thenReturn(100);
 
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
@@ -270,7 +270,7 @@ public class JiraServiceTest {
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
         JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics));
 
-        doThrow(RuntimeException.class).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt(), any(JiraSourceConfig.class));
+        doThrow(RuntimeException.class).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
@@ -44,8 +44,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.BASIC;
-import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.OAUTH2;
 
 @ExtendWith(MockitoExtension.class)
 public class JiraRestClientTest {
@@ -113,32 +111,26 @@ public class JiraRestClientTest {
     }
 
     @Test
-    public void testGetAllIssuesOauth2() throws JsonProcessingException {
+    public void testGetAllIssuesOauth2() {
         List<String> issueType = new ArrayList<>();
-        List<String> issueStatus = new ArrayList<>();
-        List<String> projectKey = new ArrayList<>();
         issueType.add("Task");
-        JiraSourceConfig jiraSourceConfig = JiraServiceTest.createJiraConfiguration(OAUTH2, issueType, issueStatus, projectKey);
         JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         SearchResults mockSearchResults = mock(SearchResults.class);
         doReturn("http://mock-service.jira.com/").when(authConfig).getUrl();
         doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
-        SearchResults results = jiraRestClient.getAllIssues(jql, 0, jiraSourceConfig);
+        SearchResults results = jiraRestClient.getAllIssues(jql, 0);
         assertNotNull(results);
     }
 
     @Test
-    public void testGetAllIssuesBasic() throws JsonProcessingException {
+    public void testGetAllIssuesBasic() {
         List<String> issueType = new ArrayList<>();
-        List<String> issueStatus = new ArrayList<>();
-        List<String> projectKey = new ArrayList<>();
         issueType.add("Task");
-        JiraSourceConfig jiraSourceConfig = JiraServiceTest.createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
         JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         SearchResults mockSearchResults = mock(SearchResults.class);
         when(authConfig.getUrl()).thenReturn("https://example.com/");
         doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
-        SearchResults results = jiraRestClient.getAllIssues(jql, 0, jiraSourceConfig);
+        SearchResults results = jiraRestClient.getAllIssues(jql, 0);
         assertNotNull(results);
     }
 

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.source.jira.JiraServiceTest;
 import org.opensearch.dataprepper.plugins.source.jira.JiraSourceConfig;
 import org.opensearch.dataprepper.plugins.source.jira.exception.BadRequestException;
@@ -57,6 +58,7 @@ public class JiraRestClientTest {
 
     @Mock
     private JiraAuthConfig authConfig;
+    private final PluginMetrics pluginMetrics = PluginMetrics.fromNames("JiraRestClientTest", "jira");
 
     private static Stream<Arguments> provideHttpStatusCodesWithExceptionClass() {
         return Stream.of(
@@ -74,7 +76,7 @@ public class JiraRestClientTest {
         doReturn(new ResponseEntity<>(exampleTicketResponse, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
         JiraSourceConfig jiraSourceConfig = JiraServiceTest.createJiraConfigurationFromYaml(configFileName);
         JiraAuthConfig authConfig = new JiraAuthFactory(jiraSourceConfig).getObject();
-        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig);
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         String ticketDetails = jiraRestClient.getIssue("key");
         assertEquals(exampleTicketResponse, ticketDetails);
     }
@@ -82,7 +84,7 @@ public class JiraRestClientTest {
     @ParameterizedTest
     @MethodSource("provideHttpStatusCodesWithExceptionClass")
     void testInvokeRestApiTokenExpired(HttpStatus statusCode, Class expectedExceptionType) {
-        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig);
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         jiraRestClient.setSleepTimeMultiplier(1);
         when(authConfig.getUrl()).thenReturn("https://example.com/rest/api/2/issue/key");
         when(restTemplate.getForEntity(any(URI.class), any(Class.class))).thenThrow(new HttpClientErrorException(statusCode));
@@ -91,7 +93,7 @@ public class JiraRestClientTest {
 
     @Test
     void testInvokeRestApiTokenExpiredInterruptException() throws InterruptedException {
-        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig);
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         when(authConfig.getUrl()).thenReturn("https://example.com/rest/api/2/issue/key");
         when(restTemplate.getForEntity(any(URI.class), any(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS));
         jiraRestClient.setSleepTimeMultiplier(100000);
@@ -117,7 +119,7 @@ public class JiraRestClientTest {
         List<String> projectKey = new ArrayList<>();
         issueType.add("Task");
         JiraSourceConfig jiraSourceConfig = JiraServiceTest.createJiraConfiguration(OAUTH2, issueType, issueStatus, projectKey);
-        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig);
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         SearchResults mockSearchResults = mock(SearchResults.class);
         doReturn("http://mock-service.jira.com/").when(authConfig).getUrl();
         doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
@@ -132,7 +134,7 @@ public class JiraRestClientTest {
         List<String> projectKey = new ArrayList<>();
         issueType.add("Task");
         JiraSourceConfig jiraSourceConfig = JiraServiceTest.createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
-        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig);
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         SearchResults mockSearchResults = mock(SearchResults.class);
         when(authConfig.getUrl()).thenReturn("https://example.com/");
         doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
@@ -143,7 +145,7 @@ public class JiraRestClientTest {
     @Test
     public void testRestApiAddressValidation() throws JsonProcessingException {
         when(authConfig.getUrl()).thenReturn("https://224.0.0.1/");
-        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig);
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         assertThrows(BadRequestException.class, () -> jiraRestClient.getIssue("TEST-1"));
     }
 

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/Crawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/Crawler.java
@@ -30,12 +30,10 @@ import static org.opensearch.dataprepper.plugins.source.source_crawler.coordinat
 public class Crawler {
     private static final Logger log = LoggerFactory.getLogger(Crawler.class);
     private final Timer crawlingTimer;
-    private final PluginMetrics pluginMetrics =
-            PluginMetrics.fromNames("sourceCrawler", "crawler");
 
     private final CrawlerClient client;
 
-    public Crawler(CrawlerClient client) {
+    public Crawler(CrawlerClient client, PluginMetrics pluginMetrics) {
         this.client = client;
         this.crawlingTimer = pluginMetrics.timer("crawlingTime");
     }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/WorkerScheduler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/WorkerScheduler.java
@@ -40,7 +40,6 @@ public class WorkerScheduler implements Runnable {
     private final Counter acknowledgementSetSuccesses;
     private final Counter acknowledgementSetFailures;
     private final String sourcePluginName;
-    private final String SOURCE_PLUGIN_NAME = "sourcePluginName";
 
 
     public WorkerScheduler(final String sourcePluginName,
@@ -58,8 +57,8 @@ public class WorkerScheduler implements Runnable {
 
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginMetrics = pluginMetrics;
-        this.acknowledgementSetSuccesses = pluginMetrics.counterWithTags(ACKNOWLEDGEMENT_SET_SUCCESS_METRIC_NAME, SOURCE_PLUGIN_NAME, sourcePluginName);
-        this.acknowledgementSetFailures = pluginMetrics.counterWithTags(ACKNOWLEDGEMENT_SET_FAILURES_METRIC_NAME, SOURCE_PLUGIN_NAME, sourcePluginName);
+        this.acknowledgementSetSuccesses = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_SUCCESS_METRIC_NAME);
+        this.acknowledgementSetFailures = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_FAILURES_METRIC_NAME);
     }
 
     @Override

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
@@ -50,10 +51,11 @@ public class CrawlerTest {
     private LeaderPartition leaderPartition;
     private Crawler crawler;
     private final Instant lastPollTime = Instant.ofEpochMilli(0);
+    private final PluginMetrics pluginMetrics = PluginMetrics.fromNames("CrawlerTest", "crawler");
 
     @BeforeEach
     public void setup() {
-        crawler = new Crawler(client);
+        crawler = new Crawler(client, pluginMetrics);
         when(leaderPartition.getProgressState()).thenReturn(Optional.of(new LeaderProgressState(lastPollTime)));
     }
 


### PR DESCRIPTION
### Description
Making the PluginMetrics as an injectable bean so that we can simply inject this bean in any other spring bean.
Also, clean up some unused variables in Jira source.
Fixed a flaky test in Otel trace processor
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
