### PR TITLE
Change Kafka Buffer defaults for fetch.max.wait.ms, fetch.min.bytes, partition.assignment.strategy, close consumer on shutdown

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
@@ -26,8 +26,8 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     private static final Long DEFAULT_RETENTION_PERIOD = 604800000L;
     static final boolean DEFAULT_AUTO_COMMIT = false;
     static final ByteCount DEFAULT_FETCH_MAX_BYTES = ByteCount.parse("50mb");
-    static final Duration DEFAULT_FETCH_MAX_WAIT = Duration.ofMillis(500);
-    static final ByteCount DEFAULT_FETCH_MIN_BYTES = ByteCount.parse("1b");
+    static final Duration DEFAULT_FETCH_MAX_WAIT = Duration.ofMillis(1000);
+    static final ByteCount DEFAULT_FETCH_MIN_BYTES = ByteCount.parse("2kb");
     static final ByteCount DEFAULT_MAX_PARTITION_FETCH_BYTES = ByteCount.parse("1mb");
     static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(45);
     static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -12,6 +12,7 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaJsonDeserializer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -167,6 +168,7 @@ public class KafkaCustomConsumerFactory {
         properties.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, (int)topicConfig.getFetchMaxBytes());
         properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, topicConfig.getFetchMaxWait());
         properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, (int)topicConfig.getFetchMinBytes());
+        properties.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
     }
 
     private void setSchemaRegistryProperties(final KafkaConsumerConfig kafkaConsumerConfig, final Properties properties, final TopicConfig topicConfig) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicConsumerMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicConsumerMetrics.java
@@ -10,6 +10,8 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -17,6 +19,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class KafkaTopicConsumerMetrics {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicConsumerMetrics.class);
     static final String NUMBER_OF_POSITIVE_ACKNOWLEDGEMENTS = "numberOfPositiveAcknowledgements";
     static final String NUMBER_OF_NEGATIVE_ACKNOWLEDGEMENTS = "numberOfNegativeAcknowledgements";
     static final String NUMBER_OF_RECORDS_FAILED_TO_PARSE = "numberOfRecordsFailedToParse";
@@ -82,7 +85,10 @@ public class KafkaTopicConsumerMetrics {
                     double max = 0.0;
                     for (Map.Entry<KafkaConsumer, Map<String, Double>> entry : metricValues.entrySet()) {
                         Map<String, Double> consumerMetrics = entry.getValue();
-                        synchronized(consumerMetrics) {
+                        synchronized (consumerMetrics) {
+                            if (consumerMetrics.get(metricName) == null) {
+                                LOG.debug("No consumer metric for recordsLagMax found");
+                            }
                             max = Math.max(max, consumerMetrics.get(metricName));
                         }
                     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -334,6 +334,7 @@ class KafkaBufferTest {
         kafkaBuffer.shutdown();
         verify(executorService).shutdown();
         verify(executorService).awaitTermination(eq(EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT), eq(TimeUnit.SECONDS));
+        verify(consumer).closeConsumer();
     }
 
     @Test


### PR DESCRIPTION
### Description
When data prepper scales horizontally and removes data prepper instances, this can cause instability due to using the RangeAssignor, since the behavior for RangeAssignor is 

```
When a rebalance occurs, all consumers drop all their partitions and get reassigned (a full rebalance).
```

CoopeartiveStickyAssignor will gradually release partitions instead of dropping them all at once and reassigning when a consumer leave the group

Additionally, the `fetch.max.wait.ms` at 500 ms and `fetch.min.bytes` as 1 will lead to many more calls to consume and return smaller number of records. Changing this to 1000 ms and 2 kb will lead to less calls to consume and more records being returned in each poll call, which will also lower the utilization on the kafka cluster.

Lastly, the Kafka buffer consumers were not calling `consumer.close()` on shutdown, which will mean that the Kafka server will wait for heartbeat to fail (around 45 seconds) before it realizes it has lost a consumer, rather than immediately. 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
