### PR TITLE
Add e2e ack, checkpointing and metrics to Postgres stream processing

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     testImplementation libs.avro.core
     testImplementation libs.parquet.hadoop
     testImplementation libs.parquet.avro
+//    testImplementation 'org.slf4j:slf4j-simple:2.0.9'
 }

--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -34,5 +34,4 @@ dependencies {
     testImplementation libs.avro.core
     testImplementation libs.parquet.hadoop
     testImplementation libs.parquet.avro
-//    testImplementation 'org.slf4j:slf4j-simple:2.0.9'
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
@@ -83,9 +83,9 @@ public class CascadingActionDetector {
 
     /**
      * Detects if a binlog event contains cascading updates and if detected, creates resync partitions
-     * @param event event
+     * @param event binlog event
      * @param parentTableMap parent table map
-     * @param tableMetadata table meta data
+     * @param tableMetadata table metadata
      */
     public void detectCascadingUpdates(Event event, Map<String, ParentTable> parentTableMap, TableMetadata tableMetadata) {
         final UpdateRowsEventData data = event.getData();
@@ -143,9 +143,9 @@ public class CascadingActionDetector {
 
     /**
      * Detects if a binlog event contains cascading deletes and if detected, creates resync partitions
-     * @param event event
+     * @param event binlog event
      * @param parentTableMap parent table map
-     * @param tableMetadata table meta data
+     * @param tableMetadata table metadata
      */
     public void detectCascadingDeletes(Event event, Map<String, ParentTable> parentTableMap, TableMetadata tableMetadata) {
         if (parentTableMap.containsKey(tableMetadata.getFullTableName())) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -130,7 +130,8 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         this.dbTableMetadata = dbTableMetadata;
         this.streamCheckpointManager = new StreamCheckpointManager(
                 streamCheckpointer, sourceConfig.isAcknowledgmentsEnabled(),
-                acknowledgementSetManager, this::stopClient, sourceConfig.getStreamAcknowledgmentTimeout(), sourceConfig.getEngine());
+                acknowledgementSetManager, this::stopClient, sourceConfig.getStreamAcknowledgmentTimeout(),
+                sourceConfig.getEngine(), pluginMetrics);
         streamCheckpointManager.start();
 
         this.cascadeActionDetector = cascadeActionDetector;
@@ -200,7 +201,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
 
         // Trigger a checkpoint update for this rotate when there're no row mutation events being processed
         if (streamCheckpointManager.getChangeEventStatuses().isEmpty()) {
-            ChangeEventStatus changeEventStatus = streamCheckpointManager.saveChangeEventsStatus(currentBinlogCoordinate);
+            ChangeEventStatus changeEventStatus = streamCheckpointManager.saveChangeEventsStatus(currentBinlogCoordinate, 0);
             if (isAcknowledgmentsEnabled) {
                 changeEventStatus.setAcknowledgmentStatus(ChangeEventStatus.AcknowledgmentStatus.POSITIVE_ACK);
             }
@@ -347,9 +348,10 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             LOG.debug("Current binlog coordinate after receiving a row change event: " + currentBinlogCoordinate);
         }
 
+        final long recordCount = rows.size();
         AcknowledgementSet acknowledgementSet = null;
         if (isAcknowledgmentsEnabled) {
-            acknowledgementSet = streamCheckpointManager.createAcknowledgmentSet(currentBinlogCoordinate);
+            acknowledgementSet = streamCheckpointManager.createAcknowledgmentSet(currentBinlogCoordinate, recordCount);
         }
 
         final long bytes = event.toString().getBytes().length;
@@ -398,7 +400,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         if (isAcknowledgmentsEnabled) {
             acknowledgementSet.complete();
         } else {
-            streamCheckpointManager.saveChangeEventsStatus(currentBinlogCoordinate);
+            streamCheckpointManager.saveChangeEventsStatus(currentBinlogCoordinate, recordCount);
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -130,7 +130,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         this.dbTableMetadata = dbTableMetadata;
         this.streamCheckpointManager = new StreamCheckpointManager(
                 streamCheckpointer, sourceConfig.isAcknowledgmentsEnabled(),
-                acknowledgementSetManager, this::stopClient, sourceConfig.getStreamAcknowledgmentTimeout());
+                acknowledgementSetManager, this::stopClient, sourceConfig.getStreamAcknowledgmentTimeout(), sourceConfig.getEngine());
         streamCheckpointManager.start();
 
         this.cascadeActionDetector = cascadeActionDetector;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ChangeEventStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ChangeEventStatus.java
@@ -13,6 +13,7 @@ public class ChangeEventStatus {
     private final BinlogCoordinate binlogCoordinate;
     private final LogSequenceNumber logSequenceNumber;
     private final long timestamp;
+    private final long recordCount;
     private volatile AcknowledgmentStatus acknowledgmentStatus;
 
     public enum AcknowledgmentStatus {
@@ -21,17 +22,19 @@ public class ChangeEventStatus {
         NO_ACK
     }
 
-    public ChangeEventStatus(final BinlogCoordinate binlogCoordinate, final long timestamp) {
+    public ChangeEventStatus(final BinlogCoordinate binlogCoordinate, final long timestamp, final long recordCount) {
         this.binlogCoordinate = binlogCoordinate;
         this.logSequenceNumber = null;
         this.timestamp = timestamp;
+        this.recordCount = recordCount;
         acknowledgmentStatus = AcknowledgmentStatus.NO_ACK;
     }
 
-    public ChangeEventStatus(final LogSequenceNumber logSequenceNumber, final long timestamp) {
+    public ChangeEventStatus(final LogSequenceNumber logSequenceNumber, final long timestamp, final long recordCount) {
         this.binlogCoordinate = null;
         this.logSequenceNumber = logSequenceNumber;
         this.timestamp = timestamp;
+        this.recordCount = recordCount;
         acknowledgmentStatus = AcknowledgmentStatus.NO_ACK;
     }
 
@@ -61,5 +64,9 @@ public class ChangeEventStatus {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public long getRecordCount() {
+        return recordCount;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ChangeEventStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ChangeEventStatus.java
@@ -5,11 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
+import lombok.Builder;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.postgresql.replication.LogSequenceNumber;
 
 public class ChangeEventStatus {
 
     private final BinlogCoordinate binlogCoordinate;
+    private final LogSequenceNumber logSequenceNumber;
     private final long timestamp;
     private volatile AcknowledgmentStatus acknowledgmentStatus;
 
@@ -21,6 +24,14 @@ public class ChangeEventStatus {
 
     public ChangeEventStatus(final BinlogCoordinate binlogCoordinate, final long timestamp) {
         this.binlogCoordinate = binlogCoordinate;
+        this.logSequenceNumber = null;
+        this.timestamp = timestamp;
+        acknowledgmentStatus = AcknowledgmentStatus.NO_ACK;
+    }
+
+    public ChangeEventStatus(final LogSequenceNumber logSequenceNumber, final long timestamp) {
+        this.binlogCoordinate = null;
+        this.logSequenceNumber = logSequenceNumber;
         this.timestamp = timestamp;
         acknowledgmentStatus = AcknowledgmentStatus.NO_ACK;
     }
@@ -43,6 +54,10 @@ public class ChangeEventStatus {
 
     public BinlogCoordinate getBinlogCoordinate() {
         return binlogCoordinate;
+    }
+
+    public LogSequenceNumber getLogSequenceNumber() {
+        return logSequenceNumber;
     }
 
     public long getTimestamp() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ChangeEventStatus.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ChangeEventStatus.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
-import lombok.Builder;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
 import org.postgresql.replication.LogSequenceNumber;
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationClient.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationClient.java
@@ -47,6 +47,7 @@ public class LogicalReplicationClient implements ReplicationLogClient {
 
     @Override
     public void connect() {
+        LOG.debug("Start connecting logical replication stream. ");
         PGReplicationStream stream;
         try (Connection conn = connectionManager.getConnection()) {
             PGConnection pgConnection = conn.unwrap(PGConnection.class);
@@ -62,6 +63,7 @@ public class LogicalReplicationClient implements ReplicationLogClient {
                 logicalStreamBuilder.withStartPosition(startLsn);
             }
             stream = logicalStreamBuilder.start();
+            LOG.debug("Logical replication stream started. ");
 
             if (eventProcessor != null) {
                 while (!disconnectRequested) {
@@ -88,7 +90,8 @@ public class LogicalReplicationClient implements ReplicationLogClient {
             }
 
             stream.close();
-            LOG.info("Replication stream closed successfully.");
+            disconnectRequested = false;
+            LOG.debug("Replication stream closed successfully.");
         } catch (Exception e) {
             LOG.error("Exception while creating Postgres replication stream. ", e);
         }
@@ -97,6 +100,7 @@ public class LogicalReplicationClient implements ReplicationLogClient {
     @Override
     public void disconnect() {
         disconnectRequested = true;
+        LOG.debug("Requested to disconnect logical replication stream.");
     }
 
     public void setEventProcessor(LogicalReplicationEventProcessor eventProcessor) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
@@ -10,7 +10,6 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
-import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManager.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
@@ -23,6 +25,11 @@ public class StreamCheckpointManager {
     private static final Logger LOG = LoggerFactory.getLogger(StreamCheckpointManager.class);
     static final int REGULAR_CHECKPOINT_INTERVAL_MILLIS = 60_000;
     static final int CHANGE_EVENT_COUNT_PER_CHECKPOINT_BATCH = 1000;
+    static final String POSITIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME = "positiveAcknowledgementSets";
+    static final String NEGATIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME = "negativeAcknowledgementSets";
+    static final String RECORDS_CHECKPOINTED = "recordsCheckpointed";
+    static final String NO_DATA_EXTEND_LEASE_COUNT = "noDataExtendLeaseCount";
+    static final String GIVE_UP_PARTITION_COUNT = "giveupPartitionCount";
 
     private final ConcurrentLinkedQueue<ChangeEventStatus> changeEventStatuses = new ConcurrentLinkedQueue<>();
     private final StreamCheckpointer streamCheckpointer;
@@ -32,20 +39,34 @@ public class StreamCheckpointManager {
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final Duration acknowledgmentTimeout;
     private final EngineType engineType;
+    private final PluginMetrics pluginMetrics;
+    private final Counter positiveAcknowledgementSets;
+    private final Counter negativeAcknowledgementSets;
+    private final Counter recordsCheckpointed;
+    private final Counter noDataExtendLeaseCount;
+    private final Counter giveupPartitionCount;
 
     public StreamCheckpointManager(final StreamCheckpointer streamCheckpointer,
                                    final boolean isAcknowledgmentEnabled,
                                    final AcknowledgementSetManager acknowledgementSetManager,
                                    final Runnable stopStreamRunnable,
                                    final Duration acknowledgmentTimeout,
-                                   final EngineType engineType) {
+                                   final EngineType engineType,
+                                   final PluginMetrics pluginMetrics) {
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.streamCheckpointer = streamCheckpointer;
         this.isAcknowledgmentEnabled = isAcknowledgmentEnabled;
         this.stopStreamRunnable = stopStreamRunnable;
         this.acknowledgmentTimeout = acknowledgmentTimeout;
         this.engineType = engineType;
+        this.pluginMetrics = pluginMetrics;
         executorService = Executors.newSingleThreadExecutor();
+
+        this.positiveAcknowledgementSets = pluginMetrics.counter(POSITIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME);
+        this.negativeAcknowledgementSets = pluginMetrics.counter(NEGATIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME);
+        this.recordsCheckpointed = pluginMetrics.counter(RECORDS_CHECKPOINTED);
+        this.noDataExtendLeaseCount = pluginMetrics.counter(NO_DATA_EXTEND_LEASE_COUNT);
+        this.giveupPartitionCount = pluginMetrics.counter(GIVE_UP_PARTITION_COUNT);
     }
 
     public void start() {
@@ -59,6 +80,7 @@ public class StreamCheckpointManager {
             try {
                 if (changeEventStatuses.isEmpty()) {
                     LOG.debug("No records processed. Extend the lease on stream partition.");
+                    noDataExtendLeaseCount.increment();
                     streamCheckpointer.extendLease();
                 } else {
                     if (isAcknowledgmentEnabled) {
@@ -70,13 +92,14 @@ public class StreamCheckpointManager {
                         }
 
                         if (lastChangeEventStatus != null) {
-                            streamCheckpointer.checkpoint(engineType, lastChangeEventStatus);
+                            checkpoint(engineType, lastChangeEventStatus);
                         }
 
                         // If negative ack is seen, give up partition and exit loop to stop processing stream
                         if (currentChangeEventStatus != null && currentChangeEventStatus.isNegativeAcknowledgment()) {
                             LOG.info("Received negative acknowledgement for change event at {}. Will restart from most recent checkpoint", currentChangeEventStatus.getBinlogCoordinate());
                             streamCheckpointer.giveUpPartition();
+                            giveupPartitionCount.increment();
                             break;
                         }
                     } else {
@@ -86,10 +109,10 @@ public class StreamCheckpointManager {
                             changeEventCount++;
                             // In case queue are populated faster than the poll, checkpoint when reaching certain count
                             if (changeEventCount % CHANGE_EVENT_COUNT_PER_CHECKPOINT_BATCH == 0) {
-                                streamCheckpointer.checkpoint(engineType, currentChangeEventStatus);
+                                checkpoint(engineType, currentChangeEventStatus);
                             }
                         } while (!changeEventStatuses.isEmpty());
-                        streamCheckpointer.checkpoint(engineType, currentChangeEventStatus);
+                        checkpoint(engineType, currentChangeEventStatus);
                     }
                 }
             } catch (Exception e) {
@@ -112,28 +135,28 @@ public class StreamCheckpointManager {
         executorService.shutdownNow();
     }
 
-    public ChangeEventStatus saveChangeEventsStatus(BinlogCoordinate binlogCoordinate) {
-        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(binlogCoordinate, Instant.now().toEpochMilli());
+    public ChangeEventStatus saveChangeEventsStatus(BinlogCoordinate binlogCoordinate, long recordCount) {
+        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(binlogCoordinate, Instant.now().toEpochMilli(), recordCount);
         changeEventStatuses.add(changeEventStatus);
         return changeEventStatus;
     }
 
-    public ChangeEventStatus saveChangeEventsStatus(LogSequenceNumber logSequenceNumber) {
-        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(logSequenceNumber, Instant.now().toEpochMilli());
+    public ChangeEventStatus saveChangeEventsStatus(LogSequenceNumber logSequenceNumber, long recordCount) {
+        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(logSequenceNumber, Instant.now().toEpochMilli(), recordCount);
         changeEventStatuses.add(changeEventStatus);
         return changeEventStatus;
     }
 
-    public AcknowledgementSet createAcknowledgmentSet(BinlogCoordinate binlogCoordinate) {
+    public AcknowledgementSet createAcknowledgmentSet(BinlogCoordinate binlogCoordinate, long recordCount) {
         LOG.debug("Create acknowledgment set for events receive prior to {}", binlogCoordinate);
-        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(binlogCoordinate, Instant.now().toEpochMilli());
+        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(binlogCoordinate, Instant.now().toEpochMilli(), recordCount);
         changeEventStatuses.add(changeEventStatus);
         return getAcknowledgementSet(changeEventStatus);
     }
 
-    public AcknowledgementSet createAcknowledgmentSet(LogSequenceNumber logSequenceNumber) {
+    public AcknowledgementSet createAcknowledgmentSet(LogSequenceNumber logSequenceNumber, long recordCount) {
         LOG.debug("Create acknowledgment set for events receive prior to {}", logSequenceNumber);
-        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(logSequenceNumber, Instant.now().toEpochMilli());
+        final ChangeEventStatus changeEventStatus = new ChangeEventStatus(logSequenceNumber, Instant.now().toEpochMilli(), recordCount);
         changeEventStatuses.add(changeEventStatus);
         return getAcknowledgementSet(changeEventStatus);
     }
@@ -141,11 +164,21 @@ public class StreamCheckpointManager {
     private AcknowledgementSet getAcknowledgementSet(ChangeEventStatus changeEventStatus) {
         return acknowledgementSetManager.create((result) -> {
             if (result) {
+                positiveAcknowledgementSets.increment();
                 changeEventStatus.setAcknowledgmentStatus(ChangeEventStatus.AcknowledgmentStatus.POSITIVE_ACK);
             } else {
+                negativeAcknowledgementSets.increment();
                 changeEventStatus.setAcknowledgmentStatus(ChangeEventStatus.AcknowledgmentStatus.NEGATIVE_ACK);
             }
         }, acknowledgmentTimeout);
+    }
+
+    private void checkpoint(final EngineType engineType, final ChangeEventStatus changeEventStatus) {
+        LOG.debug("Checkpoint at {} with record count {}. ", engineType == EngineType.MYSQL ?
+                changeEventStatus.getBinlogCoordinate() : changeEventStatus.getLogSequenceNumber(),
+                changeEventStatus.getRecordCount());
+        streamCheckpointer.checkpoint(engineType, changeEventStatus);
+        recordsCheckpointed.increment(changeEventStatus.getRecordCount());
     }
 
     //VisibleForTesting

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManager.java
@@ -27,7 +27,7 @@ public class StreamCheckpointManager {
     static final int CHANGE_EVENT_COUNT_PER_CHECKPOINT_BATCH = 1000;
     static final String POSITIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME = "positiveAcknowledgementSets";
     static final String NEGATIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME = "negativeAcknowledgementSets";
-    static final String RECORDS_CHECKPOINTED = "recordsCheckpointed";
+    static final String CHECKPOINT_COUNT = "checkpointCount";
     static final String NO_DATA_EXTEND_LEASE_COUNT = "noDataExtendLeaseCount";
     static final String GIVE_UP_PARTITION_COUNT = "giveupPartitionCount";
 
@@ -42,7 +42,7 @@ public class StreamCheckpointManager {
     private final PluginMetrics pluginMetrics;
     private final Counter positiveAcknowledgementSets;
     private final Counter negativeAcknowledgementSets;
-    private final Counter recordsCheckpointed;
+    private final Counter checkpointCount;
     private final Counter noDataExtendLeaseCount;
     private final Counter giveupPartitionCount;
 
@@ -64,7 +64,7 @@ public class StreamCheckpointManager {
 
         this.positiveAcknowledgementSets = pluginMetrics.counter(POSITIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME);
         this.negativeAcknowledgementSets = pluginMetrics.counter(NEGATIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME);
-        this.recordsCheckpointed = pluginMetrics.counter(RECORDS_CHECKPOINTED);
+        this.checkpointCount = pluginMetrics.counter(CHECKPOINT_COUNT);
         this.noDataExtendLeaseCount = pluginMetrics.counter(NO_DATA_EXTEND_LEASE_COUNT);
         this.giveupPartitionCount = pluginMetrics.counter(GIVE_UP_PARTITION_COUNT);
     }
@@ -178,7 +178,7 @@ public class StreamCheckpointManager {
                 changeEventStatus.getBinlogCoordinate() : changeEventStatus.getLogSequenceNumber(),
                 changeEventStatus.getRecordCount());
         streamCheckpointer.checkpoint(engineType, changeEventStatus);
-        recordsCheckpointed.increment(changeEventStatus.getRecordCount());
+        checkpointCount.increment();
     }
 
     //VisibleForTesting

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointer.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointer.java
@@ -8,9 +8,11 @@ package org.opensearch.dataprepper.plugins.source.rds.stream;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.postgresql.replication.LogSequenceNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,10 +40,28 @@ public class StreamCheckpointer {
         checkpointCounter = pluginMetrics.counter(CHECKPOINT_COUNT);
     }
 
-    public void checkpoint(final BinlogCoordinate binlogCoordinate) {
+    public void checkpoint(final EngineType engineType, final ChangeEventStatus changeEventStatus) {
+        if (engineType == EngineType.MYSQL) {
+            checkpoint(changeEventStatus.getBinlogCoordinate());
+        } else if (engineType == EngineType.POSTGRES) {
+            checkpoint(changeEventStatus.getLogSequenceNumber());
+        } else {
+            throw new IllegalArgumentException("Unsupported engine type " + engineType);
+        }
+    }
+
+    private void checkpoint(final BinlogCoordinate binlogCoordinate) {
         LOG.debug("Checkpointing stream partition {} with binlog coordinate {}", streamPartition.getPartitionKey(), binlogCoordinate);
         Optional<StreamProgressState> progressState = streamPartition.getProgressState();
         progressState.get().getMySqlStreamState().setCurrentPosition(binlogCoordinate);
+        sourceCoordinator.saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
+        checkpointCounter.increment();
+    }
+
+    private void checkpoint(final LogSequenceNumber logSequenceNumber) {
+        LOG.debug("Checkpointing stream partition {} with log sequence number {}", streamPartition.getPartitionKey(), logSequenceNumber);
+        Optional<StreamProgressState> progressState = streamPartition.getProgressState();
+        progressState.get().getPostgresStreamState().setCurrentLsn(logSequenceNumber.asString());
         sourceCoordinator.saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
         checkpointCounter.increment();
     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -150,4 +150,3 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
         return DbTableMetadata.fromMap(globalState.getProgressState().get());
     }
 }
-

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -130,8 +130,8 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
         } else {
             final LogicalReplicationClient logicalReplicationClient = (LogicalReplicationClient) replicationLogClient;
             logicalReplicationClient.setEventProcessor(new LogicalReplicationEventProcessor(
-                streamPartition, sourceConfig, buffer, s3Prefix
-            ));
+                    streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics, logicalReplicationClient,
+                    streamCheckpointer, acknowledgementSetManager));
         }
         final StreamWorker streamWorker = StreamWorker.create(sourceCoordinator, replicationLogClient, pluginMetrics);
         executorService.submit(() -> streamWorker.processStream(streamPartition));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -140,7 +140,7 @@ class DataFileLoaderTest {
         ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
         BufferAccumulator<Record<Event>> bufferAccumulator = mock(BufferAccumulator.class);
         when(builder.build()).thenReturn(parquetReader);
-        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), null);
+        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), (GenericRecord) null);
         try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class);
              MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
 
@@ -191,7 +191,7 @@ class DataFileLoaderTest {
         BufferAccumulator<Record<Event>> bufferAccumulator = mock(BufferAccumulator.class);
         doThrow(new RuntimeException("testing")).when(bufferAccumulator).flush();
         when(builder.build()).thenReturn(parquetReader);
-        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), null);
+        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), (GenericRecord) null);
         try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class);
              MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
             readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -43,6 +45,18 @@ class LogicalReplicationEventProcessorTest {
 
     @Mock
     private Buffer<Record<Event>> buffer;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private LogicalReplicationClient logicalReplicationClient;
+
+    @Mock
+    private StreamCheckpointer streamCheckpointer;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
 
     private ByteBuffer message;
 
@@ -129,8 +143,15 @@ class LogicalReplicationEventProcessorTest {
         assertThrows(IllegalArgumentException.class, () -> objectUnderTest.process(message));
     }
 
+    @Test
+    void test_stopClient() {
+        objectUnderTest.stopClient();
+        verify(logicalReplicationClient).disconnect();
+    }
+
     private LogicalReplicationEventProcessor createObjectUnderTest() {
-        return new LogicalReplicationEventProcessor(streamPartition, sourceConfig, buffer, s3Prefix);
+        return new LogicalReplicationEventProcessor(streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics,
+                logicalReplicationClient, streamCheckpointer, acknowledgementSetManager);
     }
 
     private void setMessageType(MessageType messageType) {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -11,7 +11,6 @@
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,11 +31,11 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.REPLICATION_LOG_EVENT_PROCESSING_TIME;
 
 @ExtendWith(MockitoExtension.class)
 class LogicalReplicationEventProcessorTest {
@@ -70,14 +69,12 @@ class LogicalReplicationEventProcessorTest {
 
     private Random random;
 
-    private Timer eventProcessingTimer;
-
     @BeforeEach
     void setUp() {
         s3Prefix = UUID.randomUUID().toString();
         random = new Random();
-        eventProcessingTimer = Metrics.timer("test-timer");
-        when(pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME)).thenReturn(eventProcessingTimer);
+        when(pluginMetrics.timer(anyString())).thenReturn(Metrics.timer("test-timer"));
+        when(pluginMetrics.counter(anyString())).thenReturn(Metrics.counter("test-counter"));
 
         objectUnderTest = spy(createObjectUnderTest());
     }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -10,6 +10,8 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.stream.BinlogEventListener.REPLICATION_LOG_EVENT_PROCESSING_TIME;
 
 @ExtendWith(MockitoExtension.class)
 class LogicalReplicationEventProcessorTest {
@@ -66,10 +70,14 @@ class LogicalReplicationEventProcessorTest {
 
     private Random random;
 
+    private Timer eventProcessingTimer;
+
     @BeforeEach
     void setUp() {
         s3Prefix = UUID.randomUUID().toString();
         random = new Random();
+        eventProcessingTimer = Metrics.timer("test-timer");
+        when(pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME)).thenReturn(eventProcessingTimer);
 
         objectUnderTest = spy(createObjectUnderTest());
     }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManagerTest.java
@@ -11,12 +11,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
 import org.postgresql.replication.LogSequenceNumber;
 
 import java.time.Duration;
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -44,12 +46,16 @@ class StreamCheckpointManagerTest {
     @Mock
     private Runnable stopStreamRunnable;
 
+    @Mock
+    private PluginMetrics pluginMetrics;
+
     private boolean isAcknowledgmentEnabled = false;
     private EngineType engineType = EngineType.MYSQL;
+    private Random random;
 
     @BeforeEach
     void setUp() {
-
+        random = new Random();
     }
 
     @Test
@@ -81,33 +87,43 @@ class StreamCheckpointManagerTest {
     @Test
     void test_saveChangeEventsStatus_mysql() {
         final BinlogCoordinate binlogCoordinate = mock(BinlogCoordinate.class);
+        final long recordCount = random.nextLong();
         final StreamCheckpointManager streamCheckpointManager = createObjectUnderTest();
-        streamCheckpointManager.saveChangeEventsStatus(binlogCoordinate);
+
+        streamCheckpointManager.saveChangeEventsStatus(binlogCoordinate, recordCount);
 
         assertThat(streamCheckpointManager.getChangeEventStatuses().size(), is(1));
-        assertThat(streamCheckpointManager.getChangeEventStatuses().peek().getBinlogCoordinate(), is(binlogCoordinate));
+        final ChangeEventStatus changeEventStatus = streamCheckpointManager.getChangeEventStatuses().peek();
+        assertThat(changeEventStatus.getBinlogCoordinate(), is(binlogCoordinate));
+        assertThat(changeEventStatus.getRecordCount(), is(recordCount));
     }
 
     @Test
     void test_saveChangeEventsStatus_postgres() {
         final LogSequenceNumber logSequenceNumber = mock(LogSequenceNumber.class);
         engineType = EngineType.POSTGRES;
+        final long recordCount = random.nextLong();
         final StreamCheckpointManager streamCheckpointManager = createObjectUnderTest();
-        streamCheckpointManager.saveChangeEventsStatus(logSequenceNumber);
+
+        streamCheckpointManager.saveChangeEventsStatus(logSequenceNumber, recordCount);
 
         assertThat(streamCheckpointManager.getChangeEventStatuses().size(), is(1));
-        assertThat(streamCheckpointManager.getChangeEventStatuses().peek().getLogSequenceNumber(), is(logSequenceNumber));
+        final ChangeEventStatus changeEventStatus = streamCheckpointManager.getChangeEventStatuses().peek();
+        assertThat(changeEventStatus.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(changeEventStatus.getRecordCount(), is(recordCount));
     }
 
     @Test
     void test_createAcknowledgmentSet_mysql() {
         final BinlogCoordinate binlogCoordinate = mock(BinlogCoordinate.class);
+        final long recordCount = random.nextLong();
         final StreamCheckpointManager streamCheckpointManager = createObjectUnderTest();
-        streamCheckpointManager.createAcknowledgmentSet(binlogCoordinate);
+        streamCheckpointManager.createAcknowledgmentSet(binlogCoordinate, recordCount);
 
         assertThat(streamCheckpointManager.getChangeEventStatuses().size(), is(1));
         ChangeEventStatus changeEventStatus = streamCheckpointManager.getChangeEventStatuses().peek();
         assertThat(changeEventStatus.getBinlogCoordinate(), is(binlogCoordinate));
+        assertThat(changeEventStatus.getRecordCount(), is(recordCount));
         verify(acknowledgementSetManager).create(any(Consumer.class), eq(ACK_TIMEOUT));
     }
 
@@ -115,17 +131,19 @@ class StreamCheckpointManagerTest {
     void test_createAcknowledgmentSet_postgres() {
         final LogSequenceNumber logSequenceNumber = mock(LogSequenceNumber.class);
         engineType = EngineType.POSTGRES;
+        final long recordCount = random.nextLong();
         final StreamCheckpointManager streamCheckpointManager = createObjectUnderTest();
-        streamCheckpointManager.createAcknowledgmentSet(logSequenceNumber);
+        streamCheckpointManager.createAcknowledgmentSet(logSequenceNumber, recordCount);
 
         assertThat(streamCheckpointManager.getChangeEventStatuses().size(), is(1));
         ChangeEventStatus changeEventStatus = streamCheckpointManager.getChangeEventStatuses().peek();
         assertThat(changeEventStatus.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(changeEventStatus.getRecordCount(), is(recordCount));
         verify(acknowledgementSetManager).create(any(Consumer.class), eq(ACK_TIMEOUT));
     }
 
     private StreamCheckpointManager createObjectUnderTest() {
         return new StreamCheckpointManager(
-                streamCheckpointer, isAcknowledgmentEnabled, acknowledgementSetManager, stopStreamRunnable, ACK_TIMEOUT, engineType);
+                streamCheckpointer, isAcknowledgmentEnabled, acknowledgementSetManager, stopStreamRunnable, ACK_TIMEOUT, engineType, pluginMetrics);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointerTest.java
@@ -13,10 +13,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.MySqlStreamState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.PostgresStreamState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.postgresql.replication.LogSequenceNumber;
 
 import java.util.Optional;
 
@@ -40,10 +43,16 @@ class StreamCheckpointerTest {
     private MySqlStreamState mySqlStreamState;
 
     @Mock
+    private PostgresStreamState postgresStreamState;
+
+    @Mock
     private PluginMetrics pluginMetrics;
 
     @Mock
     private Counter checkpointCounter;
+
+    @Mock
+    private ChangeEventStatus changeEventStatus;
 
     private StreamCheckpointer streamCheckpointer;
 
@@ -55,15 +64,31 @@ class StreamCheckpointerTest {
     }
 
     @Test
-    void test_checkpoint() {
+    void test_checkpoint_mysql() {
         final BinlogCoordinate binlogCoordinate = mock(BinlogCoordinate.class);
         final StreamProgressState streamProgressState = mock(StreamProgressState.class);
         when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
         when(streamProgressState.getMySqlStreamState()).thenReturn(mySqlStreamState);
+        when(changeEventStatus.getBinlogCoordinate()).thenReturn(binlogCoordinate);
 
-        streamCheckpointer.checkpoint(binlogCoordinate);
+        streamCheckpointer.checkpoint(EngineType.MYSQL, changeEventStatus);
 
         verify(mySqlStreamState).setCurrentPosition(binlogCoordinate);
+        verify(sourceCoordinator).saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
+        verify(checkpointCounter).increment();
+    }
+
+    @Test
+    void test_checkpoint_postgres() {
+        final LogSequenceNumber logSequenceNumber = mock(LogSequenceNumber.class);
+        final StreamProgressState streamProgressState = mock(StreamProgressState.class);
+        when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+        when(streamProgressState.getPostgresStreamState()).thenReturn(postgresStreamState);
+        when(changeEventStatus.getLogSequenceNumber()).thenReturn(logSequenceNumber);
+
+        streamCheckpointer.checkpoint(EngineType.POSTGRES, changeEventStatus);
+
+        verify(postgresStreamState).setCurrentLsn(logSequenceNumber.asString());
         verify(sourceCoordinator).saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
         verify(checkpointCounter).increment();
     }


### PR DESCRIPTION
### Description
Add e2e ack, checkpointing and metrics to Postgres stream processing. 

This is very similar to MySQL stream processing - binlogCoordinate in MySQL vs logSequenceNumber in Postgres. This PR refactors `StreamCheckpointer` and `StreamCheckpointManager` to support both binlog coordinates and log sequence numbers.
 
### Issues Resolved
Contributes to #5309 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
