### PR TITLE
Add max_receive_count configuration option in S3-SQS source to delete messages that have been received many times

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/SqsOptions.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.s3.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -53,6 +54,11 @@ public class SqsOptions {
     @DurationMin(seconds = 0)
     private Duration pollDelay = DEFAULT_POLL_DELAY_SECONDS;
 
+    @JsonPropertyDescription("Messages that contain an ApproximateReceiveCount greater than this value will be deleted")
+    @JsonProperty("max_receive_attempts")
+    @Min(1)
+    private Integer maxReceiveAttempts;
+
     public String getSqsUrl() {
         return sqsUrl;
     }
@@ -80,4 +86,6 @@ public class SqsOptions {
     public Duration getPollDelay() {
         return pollDelay;
     }
+
+    public Integer getMaxReceiveAttempts() { return maxReceiveAttempts; }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
@@ -24,6 +24,8 @@ public class ParsedMessage {
     private boolean emptyNotification;
     private String detailType;
 
+    private boolean shouldSkipProcessing;
+
     public ParsedMessage(final Message message, final boolean failedParsing) {
         this.message = Objects.requireNonNull(message);
         this.failedParsing = failedParsing;
@@ -40,6 +42,7 @@ public class ParsedMessage {
         this.eventTime = notificationRecords.get(0).getEventTime();
         this.failedParsing = false;
         this.emptyNotification = notificationRecords.isEmpty();
+        this.shouldSkipProcessing = false;
     }
 
     ParsedMessage(final Message message, final S3EventBridgeNotification eventBridgeNotification) {
@@ -49,6 +52,7 @@ public class ParsedMessage {
         this.objectSize = eventBridgeNotification.getDetail().getObject().getSize();
         this.detailType = eventBridgeNotification.getDetailType();
         this.eventTime = eventBridgeNotification.getTime();
+        this.shouldSkipProcessing = false;
     }
 
     public Message getMessage() {
@@ -85,6 +89,12 @@ public class ParsedMessage {
 
     public String getDetailType() {
         return detailType;
+    }
+
+    public boolean isShouldSkipProcessing () { return shouldSkipProcessing; }
+
+    public void setShouldSkipProcessing(final boolean shouldSkipProcessing) {
+        this.shouldSkipProcessing = shouldSkipProcessing;
     }
 
     @Override

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
@@ -120,6 +120,7 @@ class ParsedMessageTest {
             assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
             assertThat(parsedMessage.isFailedParsing(), equalTo(false));
             assertThat(parsedMessage.isEmptyNotification(), equalTo(false));
+            assertThat(parsedMessage.isShouldSkipProcessing(), equalTo(false));
         }
 
         @Test


### PR DESCRIPTION
### Description
Adds an option `max_receive_count` to the sqs configuration to allow for deletion of messages that have been received more than X times. This is not enabled by default

* When ApproximateReceiveCount is greater than 1, do not record the sqsMessageDelay metric
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. https://github.com/opensearch-project/documentation-website/issues/9149
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
