### PR TITLE
Upgrade opensearch-java client to 2.20.0 version.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -41,7 +41,7 @@ dependencyResolutionManagement {
             library('protobuf-util', 'com.google.protobuf', 'protobuf-java-util').versionRef('protobuf')
             version('opentelemetry', '0.16.0-alpha')
             library('opentelemetry-proto', 'io.opentelemetry.proto', 'opentelemetry-proto').versionRef('opentelemetry')
-            version('opensearchJava', '2.8.1')
+            version('opensearchJava', '2.20.0')
             library('opensearch-java', 'org.opensearch.client', 'opensearch-java').versionRef('opensearchJava')
             version('opensearch', '1.3.14')
             library('opensearch-client', 'org.opensearch.client', 'opensearch-rest-client').versionRef('opensearch')


### PR DESCRIPTION
### Description
Updates the opensearch-java client from `2.8.1` to `2.20.0` version. This is needed to support `flat_object`object field type in index template of data prepper. Data-Prepper uses opensearch-java client `2.8.1` version which doesn't have support for `flat_object`, to fix this we need to upgrade opensearch-java client to atleast `2.8.2` or greater version. https://github.com/opensearch-project/opensearch-java/commit/c7abca3697154b08da5e634b3635348f2236e598#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL7
 
### Issues Resolved
Resolves #5425 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
