### PR TITLE
Add support to increase acknowledgment expiry and use in progress check for Dynamo source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.function.Consumer;
 
 /**
@@ -83,4 +84,10 @@ public interface AcknowledgementSet {
      * @since 2.6
      */
     public void addProgressCheck(final Consumer<ProgressCheck> progressCheckCallback, final Duration progressCheckInterval);
+
+    void increaseExpiry(final Duration expiryIncreaseTime);
+
+    Instant getExpirationTime();
+
+    void shutdown();
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -89,5 +89,5 @@ public interface AcknowledgementSet {
 
     Instant getExpirationTime();
 
-    void shutdown();
+    void cancel();
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSet.java
@@ -73,7 +73,7 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
     }
 
     @Override
-    public void shutdown() {
+    public void cancel() {
         if (progressCheckFuture != null) {
             progressCheckFuture.cancel(true);
         }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/DefaultProgressCheck.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/DefaultProgressCheck.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.core.acknowledgements;
 
 import org.opensearch.dataprepper.model.acknowledgements.ProgressCheck;
-
 public class DefaultProgressCheck implements ProgressCheck {
     double ratio;
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetTests.java
@@ -14,10 +14,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -28,6 +32,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultAcknowledgementSetTests {
@@ -273,5 +279,34 @@ class DefaultAcknowledgementSetTests {
                 .untilAsserted(() -> {
                     assertThat(acknowledgementSetResult, equalTo(true));
                 });
+    }
+
+    @Test
+    void increase_expiry_increase_acknowledgment_set_expiry_time() {
+        final AcknowledgementSet objectUnderTest = createObjectUnderTest();
+        final Instant nowPlusEightSeconds = Instant.now().plusSeconds(8);
+
+        objectUnderTest.increaseExpiry(Duration.ofSeconds(10));
+
+        assertThat(objectUnderTest.getExpirationTime().isAfter(nowPlusEightSeconds), equalTo(true));
+    }
+
+    @Test
+    void shutdown_cancels_progress_check_and_callback_future() throws NoSuchFieldException, IllegalAccessException {
+        final AcknowledgementSet objectUnderTest = createObjectUnderTest();
+
+        final ScheduledFuture<?> progressCheck = mock(ScheduledFuture.class);
+        when(progressCheck.cancel(true)).thenReturn(true);
+
+        final Future<?> callbackFuture = mock(Future.class);
+        when(callbackFuture.cancel(false)).thenReturn(true);
+
+        ReflectivelySetField.setField(DefaultAcknowledgementSet.class, objectUnderTest, "progressCheckFuture", progressCheck);
+        ReflectivelySetField.setField(DefaultAcknowledgementSet.class, objectUnderTest, "callbackFuture", callbackFuture);
+
+        objectUnderTest.shutdown();
+
+        verify(callbackFuture).cancel(false);
+        verify(progressCheck).cancel(true);
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetTests.java
@@ -304,7 +304,7 @@ class DefaultAcknowledgementSetTests {
         ReflectivelySetField.setField(DefaultAcknowledgementSet.class, objectUnderTest, "progressCheckFuture", progressCheck);
         ReflectivelySetField.setField(DefaultAcknowledgementSet.class, objectUnderTest, "callbackFuture", callbackFuture);
 
-        objectUnderTest.shutdown();
+        objectUnderTest.cancel();
 
         verify(callbackFuture).cancel(false);
         verify(progressCheck).cancel(true);

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
@@ -40,7 +40,7 @@ public class DynamoDBSourceConfig {
     private Duration shardAcknowledgmentTimeout = Duration.ofMinutes(10);
 
     @JsonProperty("s3_data_file_acknowledgment_timeout")
-    private Duration dataFileAcknowledgmentTimeout = Duration.ofMinutes(5);
+    private Duration dataFileAcknowledgmentTimeout = Duration.ofMinutes(15);
 
     public DynamoDBSourceConfig() {
     }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileCheckpointer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileCheckpointer.java
@@ -21,8 +21,7 @@ import java.util.Optional;
 public class DataFileCheckpointer {
     private static final Logger LOG = LoggerFactory.getLogger(DataFileCheckpointer.class);
 
-    static final Duration CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE = Duration.ofMinutes(5);
-
+    static final Duration CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE = Duration.ofMinutes(10);
 
     private final EnhancedSourceCoordinator enhancedSourceCoordinator;
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoader.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoader.java
@@ -231,7 +231,7 @@ public class DataFileLoader implements Runnable {
             }
         } catch (Exception e) {
             if (acknowledgementSet != null) {
-                acknowledgementSet.shutdown();
+                acknowledgementSet.cancel();
             }
             checkpointer.checkpoint(lineCount);
             String errorMessage = String.format("Loading of s3://%s/%s completed with Exception: %s", bucketName, key, e.getMessage());

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
@@ -333,7 +333,7 @@ public class ShardConsumer implements Runnable {
             }
         } catch (final Exception exc) {
             if (acknowledgementSet != null) {
-                acknowledgementSet.shutdown();
+                acknowledgementSet.cancel();
             }
             throw exc;
         }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
@@ -35,6 +35,10 @@ public class ShardConsumer implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(ShardConsumer.class);
 
+    private static final Duration ACKNOWLEDGMENT_EXPIRY_INCREASE_TIME = Duration.ofMinutes(10);
+
+    private static final Duration ACKNOWLEDGMENT_PROGRESS_CHECK_INTERVAL = Duration.ofMinutes(3);
+
     /**
      * A flag to interrupt the process
      */
@@ -74,7 +78,7 @@ public class ShardConsumer implements Runnable {
     /**
      * Default number of times in the wait for export to do regular checkpoint.
      */
-    private static final int DEFAULT_WAIT_COUNT_TO_CHECKPOINT = 5;
+    private static final int DEFAULT_WAIT_COUNT_TO_CHECKPOINT = 3;
 
     /**
      * Default regular checkpoint interval
@@ -245,78 +249,93 @@ public class ShardConsumer implements Runnable {
             return;
         }
 
+        if (acknowledgementSet != null) {
+            addProgressCheck(acknowledgementSet);
+        }
+
         long lastCheckpointTime = System.currentTimeMillis();
         String sequenceNumber = "";
         int interval;
         List<software.amazon.awssdk.services.dynamodb.model.Record> records;
 
-        while (!shouldStop) {
-            if (shardIterator == null) {
-                // End of Shard
-                LOG.debug("Reached end of shard");
-                checkpointer.checkpoint(sequenceNumber);
-                break;
-            }
-
-            if (System.currentTimeMillis() - lastCheckpointTime > DEFAULT_CHECKPOINT_INTERVAL_MILLS) {
-                LOG.debug("{} records written to buffer for shard {}", recordsWrittenToBuffer, shardId);
-                checkpointer.checkpoint(sequenceNumber);
-                lastCheckpointTime = System.currentTimeMillis();
-            }
-
-            GetRecordsResponse response = callGetRecords(shardIterator);
-            shardIterator = response.nextShardIterator();
-            if (!response.records().isEmpty()) {
-                // Always use the last sequence number for checkpoint
-                sequenceNumber = response.records().get(response.records().size() - 1).dynamodb().sequenceNumber();
-                Instant lastEventTime = response.records().get(response.records().size() - 1).dynamodb().approximateCreationDateTime();
-
-                if (lastEventTime.isBefore(startTime)) {
-                    LOG.debug("Get {} events before start time, ignore...", response.records().size());
-                    continue;
-                }
-                if (waitForExport) {
+        try {
+            while (!shouldStop) {
+                if (shardIterator == null) {
+                    // End of Shard
+                    LOG.debug("Reached end of shard");
                     checkpointer.checkpoint(sequenceNumber);
-                    waitForExport();
-                    waitForExport = false;
+                    break;
                 }
-                records = response.records().stream()
-                        .filter(record -> record.dynamodb().approximateCreationDateTime().isAfter(startTime))
-                        .collect(Collectors.toList());
-                recordConverter.writeToBuffer(acknowledgementSet, records);
-                shardProgress.increment();
-                recordsWrittenToBuffer += records.size();
-                long delay = System.currentTimeMillis() - lastEventTime.toEpochMilli();
-                interval = delay > GET_RECORD_DELAY_THRESHOLD_MILLS ? MINIMUM_GET_RECORD_INTERVAL_MILLS : GET_RECORD_INTERVAL_MILLS;
 
-            } else {
-                interval = GET_RECORD_INTERVAL_MILLS;
-                shardProgress.increment();
+                if (System.currentTimeMillis() - lastCheckpointTime > DEFAULT_CHECKPOINT_INTERVAL_MILLS) {
+                    LOG.debug("{} records written to buffer for shard {}", recordsWrittenToBuffer, shardId);
+                    if (acknowledgementSet != null) {
+                        checkpointer.updateShardForAcknowledgmentWait(shardAcknowledgmentTimeout);
+                    } else {
+                        checkpointer.checkpoint(sequenceNumber);
+                    }
+                    lastCheckpointTime = System.currentTimeMillis();
+                }
+
+                GetRecordsResponse response = callGetRecords(shardIterator);
+                shardIterator = response.nextShardIterator();
+                if (!response.records().isEmpty()) {
+                    // Always use the last sequence number for checkpoint
+                    sequenceNumber = response.records().get(response.records().size() - 1).dynamodb().sequenceNumber();
+                    Instant lastEventTime = response.records().get(response.records().size() - 1).dynamodb().approximateCreationDateTime();
+
+                    if (lastEventTime.isBefore(startTime)) {
+                        LOG.debug("Get {} events before start time, ignore...", response.records().size());
+                        continue;
+                    }
+                    if (waitForExport) {
+                        checkpointer.checkpoint(sequenceNumber);
+                        waitForExport();
+                        waitForExport = false;
+                    }
+                    records = response.records().stream()
+                            .filter(record -> record.dynamodb().approximateCreationDateTime().isAfter(startTime))
+                            .collect(Collectors.toList());
+                    recordConverter.writeToBuffer(acknowledgementSet, records);
+                    shardProgress.increment();
+                    recordsWrittenToBuffer += records.size();
+                    long delay = System.currentTimeMillis() - lastEventTime.toEpochMilli();
+                    interval = delay > GET_RECORD_DELAY_THRESHOLD_MILLS ? MINIMUM_GET_RECORD_INTERVAL_MILLS : GET_RECORD_INTERVAL_MILLS;
+
+                } else {
+                    interval = GET_RECORD_INTERVAL_MILLS;
+                    shardProgress.increment();
+                }
+
+                try {
+                    // Idle between get records call.
+                    Thread.sleep(interval);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
             }
 
-            try {
-                // Idle between get records call.
-                Thread.sleep(interval);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+            // interrupted
+            if (shouldStop) {
+                // Do last checkpoint and then quit
+                LOG.warn("Processing for shard {} was interrupted by a shutdown signal, giving up shard", shardId);
+                checkpointer.checkpoint(sequenceNumber);
+                throw new RuntimeException("Consuming shard was interrupted from shutdown");
             }
-        }
 
-        // interrupted
-        if (shouldStop) {
-            // Do last checkpoint and then quit
-            LOG.warn("Processing for shard {} was interrupted by a shutdown signal, giving up shard", shardId);
-            checkpointer.checkpoint(sequenceNumber);
-            throw new RuntimeException("Consuming shard was interrupted from shutdown");
-        }
+            if (acknowledgementSet != null) {
+                checkpointer.updateShardForAcknowledgmentWait(shardAcknowledgmentTimeout);
+                acknowledgementSet.complete();
+            }
 
-        if (acknowledgementSet != null) {
-            checkpointer.updateShardForAcknowledgmentWait(shardAcknowledgmentTimeout);
-            acknowledgementSet.complete();
-        }
-
-        if (waitForExport) {
-            waitForExport();
+            if (waitForExport) {
+                waitForExport();
+            }
+        } catch (final Exception exc) {
+            if (acknowledgementSet != null) {
+                acknowledgementSet.shutdown();
+            }
+            throw exc;
         }
     }
 
@@ -404,5 +423,10 @@ public class ShardConsumer implements Runnable {
         shouldStop = true;
     }
 
-
+    private void addProgressCheck(final AcknowledgementSet acknowledgementSet) {
+        acknowledgementSet.addProgressCheck(
+                (ignored) -> {
+                    acknowledgementSet.increaseExpiry(ACKNOWLEDGMENT_EXPIRY_INCREASE_TIME);
+                }, ACKNOWLEDGMENT_PROGRESS_CHECK_INTERVAL);
+    }
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamCheckpointer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamCheckpointer.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public class StreamCheckpointer {
     private static final Logger LOG = LoggerFactory.getLogger(StreamCheckpointer.class);
 
-    static final Duration CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE = Duration.ofMinutes(5);
+    static final Duration CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE = Duration.ofMinutes(10);
 
     private final EnhancedSourceCoordinator coordinator;
 


### PR DESCRIPTION
### Description
Fixes acknowledgment sets expiring from Dynamo streams by increasing expiry timeout in progress check

* Increase default s3_data_file_acknowledgment_timeout from 5 minutes to 15 minutes. This default is too low and causes issues for users when they have high buffer usage.
* Fixes another issue where shard partitions would time out on ownership while waiting for export by increasing the interval between checkpoints and increasing the ownership timeout increase for checkpoints on shards.

Tested by running a Dynamo pipeline and verified that no acknowledgments were expiring.


 
### Issues Resolved
Resolves #5412 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
