### PR TITLE
Configurable source coordination lease time

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
@@ -36,8 +36,6 @@ import java.util.Objects;
 public class DataPrepperConfiguration implements ExtensionsConfiguration, EventConfigurationContainer, ExperimentalConfigurationContainer {
     static final Duration DEFAULT_SHUTDOWN_DURATION = Duration.ofSeconds(30L);
 
-    private static final String DEFAULT_SOURCE_COORDINATION_STORE = "in_memory";
-
     static final int MAX_TAGS_NUMBER = 3;
     private static final List<MetricRegistryType> DEFAULT_METRIC_REGISTRY_TYPE = Collections.singletonList(MetricRegistryType.Prometheus);
     private static final PipelineShutdownOption DEFAULT_PIPELINE_SHUTDOWN = PipelineShutdownOption.ON_ANY_PIPELINE_FAILURE;
@@ -107,7 +105,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
         this.authentication = authentication;
         this.circuitBreakerConfig = circuitBreakerConfig;
         this.sourceCoordinationConfig = Objects.isNull(sourceCoordinationConfig)
-                ? new SourceCoordinationConfig(new PluginModel(DEFAULT_SOURCE_COORDINATION_STORE, Collections.emptyMap()), null)
+                ? SourceCoordinationConfig.getDefaultSourceCoordinationConfig()
                 : sourceCoordinationConfig;
         this.pipelineShutdown = pipelineShutdown != null ? pipelineShutdown : DEFAULT_PIPELINE_SHUTDOWN;
         this.eventConfiguration = eventConfiguration != null ? eventConfiguration : EventConfiguration.defaultConfiguration();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/SourceCoordinationConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/SourceCoordinationConfig.java
@@ -11,6 +11,8 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.source.coordinator.UsesSourceCoordination;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -21,18 +23,34 @@ import java.util.Objects;
 public class SourceCoordinationConfig {
 
     private static final String SOURCE_COORDINATOR_METRIC_PREFIX = "source-coordinator";
+    static final Duration DEFAULT_LEASE_TIMEOUT = Duration.ofMinutes(10);
+    static final String DEFAULT_SOURCE_COORDINATION_STORE = "in_memory";
     private final PluginSetting sourceCoordinationStoreConfig;
     private final String partitionPrefix;
+    private final Duration leaseTimeout;
 
     @JsonCreator
     public SourceCoordinationConfig(@JsonProperty("store") final PluginModel sourceCoordinationStoreConfig,
-                                    @JsonProperty("partition_prefix") final String partitionPrefix) {
+                                    @JsonProperty("partition_prefix") final String partitionPrefix,
+                                    @JsonProperty("lease_timeout") final Duration leaseTimeout) {
         Objects.requireNonNull(sourceCoordinationStoreConfig, "source_coordination store must not be null");
 
         this.sourceCoordinationStoreConfig = new PluginSetting(sourceCoordinationStoreConfig.getPluginName(), sourceCoordinationStoreConfig.getPluginSettings());
         this.sourceCoordinationStoreConfig.setPipelineName(SOURCE_COORDINATOR_METRIC_PREFIX);
 
         this.partitionPrefix = partitionPrefix;
+        if (leaseTimeout != null) {
+            this.leaseTimeout = leaseTimeout;
+        } else {
+            this.leaseTimeout = DEFAULT_LEASE_TIMEOUT;
+        }
+    }
+
+    public static SourceCoordinationConfig getDefaultSourceCoordinationConfig() {
+        return new SourceCoordinationConfig(
+                new PluginModel(DEFAULT_SOURCE_COORDINATION_STORE, Collections.emptyMap()),
+                null,
+                null);
     }
 
     public PluginSetting getSourceCoordinationStoreConfig() {
@@ -41,5 +59,9 @@ public class SourceCoordinationConfig {
 
     public String getPartitionPrefix() {
         return partitionPrefix;
+    }
+
+    public Duration getLeaseTimeout() {
+        return leaseTimeout;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -59,7 +59,6 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     static final String PARTITION_NOT_FOUND_ERROR_COUNT = "partitionNotFoundErrors";
     static final String PARTITION_NOT_OWNED_ERROR_COUNT = "partitionNotOwnedErrors";
     static final String PARTITION_UPDATE_ERROR_COUNT = "PartitionUpdateErrors";
-    static final Duration DEFAULT_LEASE_TIMEOUT = Duration.ofMinutes(10);
 
     private static final String hostName;
     static final String PARTITION_TYPE = "PARTITION";
@@ -74,6 +73,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     private final String sourceIdentifier;
     private final String sourceIdentifierWithPartitionType;
     private final String sourceIdentifierWithGlobalStateType;
+    private final Duration leaseTimeout;
     private boolean initialized = false;
 
     private final PluginMetrics pluginMetrics;
@@ -116,6 +116,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         this.sourceIdentifier = Objects.nonNull(sourceCoordinationConfig.getPartitionPrefix()) ?
                 sourceCoordinationConfig.getPartitionPrefix() + "|" + sourceIdentifier :
                 sourceIdentifier;
+        leaseTimeout = sourceCoordinationConfig.getLeaseTimeout();
         this.sourceIdentifierWithPartitionType = this.sourceIdentifier + "|" + PARTITION_TYPE;
         this.sourceIdentifierWithGlobalStateType = this.sourceIdentifier + "|" + GLOBAL_STATE_TYPE;
         this.ownerId = this.sourceIdentifier + ":" + hostName;
@@ -162,7 +163,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     private Optional<SourcePartition<T>> getNextPartitionInternal(final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier, final boolean forceSupplier) {
         validateIsInitialized();
 
-        Optional<SourcePartitionStoreItem> ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifierWithPartitionType, ownerId, DEFAULT_LEASE_TIMEOUT);
+        Optional<SourcePartitionStoreItem> ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifierWithPartitionType, ownerId, leaseTimeout);
         try {
             if ((ownedPartitions.isEmpty() || forceSupplier) && lock.tryLock()) {
                 lastSupplierRunTime = Instant.now();
@@ -180,7 +181,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
                 lock.unlock();
             }
             if (ownedPartitions.isEmpty()) {
-                ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifierWithPartitionType, ownerId, DEFAULT_LEASE_TIMEOUT);
+                ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifierWithPartitionType, ownerId, leaseTimeout);
             }
         }
 
@@ -295,7 +296,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         final SourcePartitionStoreItem itemToUpdate = getSourcePartitionStoreItem(partitionKey, SAVE_STATE_ACTION);
         validatePartitionOwnership(itemToUpdate);
 
-        itemToUpdate.setPartitionOwnershipTimeout(Instant.now().plus(DEFAULT_LEASE_TIMEOUT));
+        itemToUpdate.setPartitionOwnershipTimeout(Instant.now().plus(leaseTimeout));
         itemToUpdate.setPartitionProgressState(convertPartitionProgressStateClasstoString(partitionProgressState));
 
         try {
@@ -325,7 +326,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     @Override
     public void renewPartitionOwnership(final String partitionKey) {
         try {
-            updatePartitionOwnership(partitionKey, DEFAULT_LEASE_TIMEOUT);
+            updatePartitionOwnership(partitionKey, leaseTimeout);
         } catch (final Exception e) {
             LOG.error("Exception while renewing partition ownership for the partition {}: {}", partitionKey, e.getMessage());
             throw e;
@@ -478,7 +479,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
             try {
                 globalStateItemForPartitionCreation.get().setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
                 globalStateItemForPartitionCreation.get().setPartitionOwner(ownerId);
-                globalStateItemForPartitionCreation.get().setPartitionOwnershipTimeout(Instant.now().plus(DEFAULT_LEASE_TIMEOUT));
+                globalStateItemForPartitionCreation.get().setPartitionOwnershipTimeout(Instant.now().plus(leaseTimeout));
                 sourceCoordinationStore.tryUpdateSourcePartitionItem(globalStateItemForPartitionCreation.get());
             } catch (final PartitionUpdateException e) {
                 LOG.debug("Owner %s was not able to acquire the global state item to create new partitions. This means that another instance of Data Prepper has gained the responsibility of creating partitions at this time");

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/model/SourceCoordinationConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/model/SourceCoordinationConfigTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.core.parser.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.core.parser.model.SourceCoordinationConfig.DEFAULT_SOURCE_COORDINATION_STORE;
+
+class SourceCoordinationConfigTest {
+
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        random = new Random();
+    }
+
+    @Test
+    void getDefaultSourceCoordinationConfig_returns_expected_values() {
+        final SourceCoordinationConfig sourceCoordinationConfig = SourceCoordinationConfig.getDefaultSourceCoordinationConfig();
+
+        assertThat(sourceCoordinationConfig, notNullValue());
+        assertThat(sourceCoordinationConfig.getSourceCoordinationStoreConfig(), notNullValue());
+        assertThat(sourceCoordinationConfig.getSourceCoordinationStoreConfig().getName(), equalTo(DEFAULT_SOURCE_COORDINATION_STORE));
+        assertThat(sourceCoordinationConfig.getPartitionPrefix(), nullValue());
+        assertThat(sourceCoordinationConfig.getLeaseTimeout(), equalTo(SourceCoordinationConfig.DEFAULT_LEASE_TIMEOUT));
+    }
+
+    @Test
+    void constructor_with_all_values() {
+        final String pluginName = UUID.randomUUID().toString();
+        final String partitionPrefix = UUID.randomUUID().toString();
+        final Duration leaseTimeout = Duration.ofSeconds(random.nextInt(100) + 1);
+        final SourceCoordinationConfig sourceCoordinationConfig = new SourceCoordinationConfig(
+                new PluginModel(pluginName, Collections.emptyMap()),
+                partitionPrefix,
+                leaseTimeout
+        );
+
+        assertThat(sourceCoordinationConfig, notNullValue());
+        assertThat(sourceCoordinationConfig.getSourceCoordinationStoreConfig(), notNullValue());
+        assertThat(sourceCoordinationConfig.getSourceCoordinationStoreConfig().getName(), equalTo(pluginName));
+        assertThat(sourceCoordinationConfig.getPartitionPrefix(), equalTo(partitionPrefix));
+        assertThat(sourceCoordinationConfig.getLeaseTimeout(), equalTo(leaseTimeout));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerIT.java
@@ -151,7 +151,7 @@ public class S3ScanObjectWorkerIT {
         bucketOwnerProvider = b -> Optional.empty();
 
         final SourceCoordinationStore inMemoryStore = new InMemorySourceCoordinationStore(new PluginSetting("in_memory", Collections.emptyMap()));
-        final SourceCoordinationConfig sourceCoordinationConfig = new SourceCoordinationConfig(new PluginModel("in_memory", Collections.emptyMap()), null);
+        final SourceCoordinationConfig sourceCoordinationConfig = SourceCoordinationConfig.getDefaultSourceCoordinationConfig();
         sourceCoordinator = new LeaseBasedSourceCoordinator<>(S3SourceProgressState.class,
                 inMemoryStore, sourceCoordinationConfig, "s3-test-pipeline", PluginMetrics.fromNames("source-coordinator", "s3-test-pipeline"));
         sourceCoordinator.initialize();


### PR DESCRIPTION
### Description
Make the lease time for source coordination a configuration in `data-prepper-config.yaml`.

Along with the changes, move all responsibility for default source coordination configuration into the `SourceCoordinationConfig` class.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
