### PR TITLE
Postgres schema name fix

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/MetadataKeyAttributes.java
@@ -18,6 +18,8 @@ public class MetadataKeyAttributes {
 
     static final String EVENT_DATABASE_NAME_METADATA_ATTRIBUTE = "database_name";
 
+    static final String EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE = "schema_name";
+
     static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
 
     static final String INGESTION_EVENT_TYPE_ATTRIBUTE = "ingestion_type";

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
@@ -45,6 +46,7 @@ public abstract class RecordConverter {
 
     public Event convert(final Event event,
                          final String databaseName,
+                         final String schemaName,
                          final String tableName,
                          final OpenSearchBulkActions bulkAction,
                          final List<String> primaryKeys,
@@ -62,6 +64,7 @@ public abstract class RecordConverter {
         }
 
         eventMetadata.setAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE, databaseName);
+        eventMetadata.setAttribute(EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE, schemaName);
         eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableName);
         eventMetadata.setAttribute(BULK_ACTION_METADATA_ATTRIBUTE, bulkAction.toString());
         setIngestionTypeMetadata(event);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
@@ -27,8 +27,8 @@ public class DataFileProgressState {
     private String sourceDatabase;
 
     /**
-     * For PostgreSQL engine type, schema is the schema name.
-     * For MySQL engine type, this field will store database name, same as sourceDataBase field.
+     * For PostgreSQL engine type, sourceSchema is the schema name.
+     * For MySQL engine type, this field will store database name, same as sourceDatabase field.
      */
     @JsonProperty("sourceSchema")
     private String sourceSchema;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/DataFileProgressState.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 
 import java.util.List;
 import java.util.Map;
@@ -25,9 +27,12 @@ public class DataFileProgressState {
     private String sourceDatabase;
 
     /**
-     * For MySQL, sourceTable is in the format of tableName
-     * For Postgres, sourceTable is in the format of schemaName.tableName
+     * For PostgreSQL engine type, schema is the schema name.
+     * For MySQL engine type, this field will store database name, same as sourceDataBase field.
      */
+    @JsonProperty("sourceSchema")
+    private String sourceSchema;
+
     @JsonProperty("sourceTable")
     private String sourceTable;
 
@@ -70,6 +75,25 @@ public class DataFileProgressState {
 
     public void setSourceDatabase(String sourceDatabase) {
         this.sourceDatabase = sourceDatabase;
+    }
+
+    public String getSourceSchema() {
+        return sourceSchema;
+    }
+
+    public void setSourceSchema(String sourceSchema) {
+        this.sourceSchema = sourceSchema;
+    }
+
+    @JsonIgnore
+    public String getFullSourceTableName() {
+        if (EngineType.fromString(engineType) == EngineType.MYSQL) {
+            return sourceDatabase + "." + sourceTable;
+        } else if (EngineType.fromString(engineType) == EngineType.POSTGRES) {
+            return sourceDatabase + "." + sourceSchema + "." + sourceTable;
+        } else {
+            throw new RuntimeException("Unsupported engine type: " + engineType);
+        }
     }
 
     public String getSourceTable() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
-import static org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata.DOT_DELIMITER;
 
 public class DataFileLoader implements Runnable {
 
@@ -126,7 +125,7 @@ public class DataFileLoader implements Runnable {
 
                     DataFileProgressState progressState = dataFilePartition.getProgressState().get();
 
-                    final String fullTableName = progressState.getSourceDatabase() + DOT_DELIMITER + progressState.getSourceTable();
+                    final String fullTableName = progressState.getFullSourceTableName();
                     final List<String> primaryKeys = progressState.getPrimaryKeyMap().getOrDefault(fullTableName, List.of());
                     transformEvent(event, fullTableName, EngineType.fromString(progressState.getEngineType()));
 
@@ -135,6 +134,7 @@ public class DataFileLoader implements Runnable {
                     final Event transformedEvent = recordConverter.convert(
                             event,
                             progressState.getSourceDatabase(),
+                            progressState.getSourceSchema(),
                             progressState.getSourceTable(),
                             OpenSearchBulkActions.INDEX,
                             primaryKeys,

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -320,13 +320,11 @@ public class ExportScheduler implements Runnable {
         for (final String objectKey : dataFileObjectKeys) {
             final DataFileProgressState progressState = new DataFileProgressState();
             final ExportObjectKey exportObjectKey = ExportObjectKey.fromString(objectKey);
-            final String database = exportObjectKey.getDatabaseName();
-            final String table = engineType == EngineType.MYSQL ?
-                    exportObjectKey.getTableName() :
-                    exportObjectKey.getSchemaName() + DOT_DELIMITER + exportObjectKey.getTableName();
 
-            progressState.setSourceDatabase(database);
-            progressState.setSourceTable(table);
+            progressState.setEngineType(engineType.toString());
+            progressState.setSourceDatabase(exportObjectKey.getDatabaseName());
+            progressState.setSourceSchema(exportObjectKey.getSchemaName());
+            progressState.setSourceTable(exportObjectKey.getTableName());
             progressState.setSnapshotTime(snapshotTime);
             progressState.setPrimaryKeyMap(primaryKeyMap);
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/TableMetadata.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/TableMetadata.java
@@ -13,6 +13,7 @@ public class TableMetadata {
     public static final String DOT_DELIMITER = ".";
 
     private final String databaseName;
+    private final String schemaName;
     private final String tableName;
     private final List<String> columnNames;
     private final List<String> columnTypes;
@@ -22,6 +23,7 @@ public class TableMetadata {
 
     private TableMetadata(final Builder builder) {
         this.databaseName = builder.databaseName;
+        this.schemaName = builder.schemaName != null ? builder.schemaName : builder.databaseName;
         this.tableName = builder.tableName;
         this.columnNames = builder.columnNames;
         this.columnTypes = builder.columnTypes;
@@ -32,6 +34,10 @@ public class TableMetadata {
 
     public String getDatabaseName() {
         return databaseName;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
     }
 
     public String getTableName() {
@@ -68,6 +74,7 @@ public class TableMetadata {
 
     public static class Builder {
         private String databaseName;
+        private String schemaName;
         private String tableName;
         private List<String> columnNames = Collections.emptyList();
         private List<String> columnTypes = Collections.emptyList();
@@ -80,6 +87,11 @@ public class TableMetadata {
 
         public Builder withDatabaseName(String databaseName) {
             this.databaseName = databaseName;
+            return this;
+        }
+
+        public Builder withSchemaName(String schemaName) {
+            this.schemaName = schemaName;
             return this;
         }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/MySQLResyncWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/MySQLResyncWorker.java
@@ -101,6 +101,7 @@ public class MySQLResyncWorker implements Runnable {
             final Event pipelineEvent = recordConverter.convert(
                     dataPrepperEvent,
                     database,
+                    database,
                     table,
                     OpenSearchBulkActions.INDEX,
                     primaryKeys,

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/PostgresSchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/PostgresSchemaManager.java
@@ -102,19 +102,19 @@ public class PostgresSchemaManager implements SchemaManager {
                         primaryKeys.add(rs.getString(COLUMN_NAME));
                     }
                     if (primaryKeys.isEmpty()) {
-                        throw new NoSuchElementException("No primary keys found for table " + table);
+                        throw new NoSuchElementException("No primary keys found for table " + fullTableName);
                     }
                     return primaryKeys;
                 }
             } catch (NoSuchElementException e) {
                 throw e;
             } catch (Exception e) {
-                LOG.error("Failed to get primary keys for table {}, retrying", table, e);
+                LOG.error("Failed to get primary keys for table {}, retrying", fullTableName, e);
             }
             applyBackoff();
             retry++;
         }
-        throw new RuntimeException("Failed to get primary keys for table " + table);
+        throw new RuntimeException("Failed to get primary keys for table " + fullTableName);
     }
 
     private void applyBackoff() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -390,6 +390,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             final Event pipelineEvent = recordConverter.convert(
                     dataPrepperEvent,
                     tableMetadata.getDatabaseName(),
+                    tableMetadata.getDatabaseName(),
                     tableMetadata.getTableName(),
                     bulkAction,
                     primaryKeys,

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 public class LogicalReplicationEventProcessor {
+
     enum TupleDataType {
         NEW('N'),
         KEY('K'),
@@ -76,6 +77,7 @@ public class LogicalReplicationEventProcessor {
     static final int DEFAULT_BUFFER_BATCH_SIZE = 1_000;
     static final int NUM_OF_RETRIES = 3;
     static final int BACKOFF_IN_MILLIS = 500;
+    static final String DOT_DELIMITER_REGEX = "\\.";
     static final String CHANGE_EVENTS_PROCESSED_COUNT = "changeEventsProcessed";
     static final String CHANGE_EVENTS_PROCESSING_ERROR_COUNT = "changeEventsProcessingErrors";
     static final String BYTES_RECEIVED = "bytesReceived";
@@ -442,7 +444,7 @@ public class LogicalReplicationEventProcessor {
     }
 
     private String getDatabaseName(List<String> tableNames) {
-        return tableNames.get(0).split("\\.")[0];
+        return tableNames.get(0).split(DOT_DELIMITER_REGEX)[0];
     }
 
     private void handleMessageWithRetries(ByteBuffer message, Consumer<ByteBuffer> function, MessageType messageType) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
@@ -229,6 +229,7 @@ public class LogicalReplicationEventProcessor {
                 .withSchemaName(schemaName)
                 .withTableName(tableName)
                 .withColumnNames(columnNames)
+                .withColumnTypes(columnTypes)
                 .withPrimaryKeys(primaryKeys)
                 .build();
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/ExportRecordConverterTest.java
@@ -29,6 +29,7 @@ import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKe
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_S3_PARTITION_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
@@ -54,6 +55,7 @@ class ExportRecordConverterTest {
     @Test
     void test_convert() {
         final String databaseName = UUID.randomUUID().toString();
+        final String schemaName = UUID.randomUUID().toString();
         final String tableName = UUID.randomUUID().toString();
         final String primaryKeyName = UUID.randomUUID().toString();
         final List<String> primaryKeys = List.of(primaryKeyName);
@@ -67,11 +69,12 @@ class ExportRecordConverterTest {
                 .build();
 
         Event actualEvent = exportRecordConverter.convert(
-                testEvent, databaseName, tableName, OpenSearchBulkActions.INDEX, primaryKeys,
+                testEvent, databaseName, schemaName, tableName, OpenSearchBulkActions.INDEX, primaryKeys,
                 eventCreateTimeEpochMillis, eventVersionNumber, null);
 
         // Assert
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE), equalTo(databaseName));
+        assertThat(actualEvent.getMetadata().getAttribute(EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE), equalTo(schemaName));
         assertThat(actualEvent.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), equalTo(tableName));
         assertThat(actualEvent.getMetadata().getAttribute(BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
         assertThat(actualEvent.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(primaryKeyValue));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
@@ -27,6 +27,7 @@ import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKe
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_DATABASE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_S3_PARTITION_KEY;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
@@ -54,6 +55,7 @@ class StreamRecordConverterTest {
     void test_convert_returns_expected_event() {
         final Map<String, Object> rowData = Map.of("key1", "value1", "key2", "value2");
         final String databaseName = UUID.randomUUID().toString();
+        final String schemaName = UUID.randomUUID().toString();
         final String tableName = UUID.randomUUID().toString();
         final EventType eventType = EventType.EXT_WRITE_ROWS;
         final OpenSearchBulkActions bulkAction = OpenSearchBulkActions.INDEX;
@@ -67,11 +69,12 @@ class StreamRecordConverterTest {
                 .build();
 
         Event event = streamRecordConverter.convert(
-                testEvent, databaseName, tableName, bulkAction, primaryKeys,
+                testEvent, databaseName, schemaName, tableName, bulkAction, primaryKeys,
                 eventCreateTimeEpochMillis, eventVersionNumber, eventType);
 
         assertThat(event.toMap(), is(rowData));
         assertThat(event.getMetadata().getAttribute(EVENT_DATABASE_NAME_METADATA_ATTRIBUTE), is(databaseName));
+        assertThat(event.getMetadata().getAttribute(EVENT_SCHEMA_NAME_METADATA_ATTRIBUTE), equalTo(schemaName));
         assertThat(event.getMetadata().getAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE), is(tableName));
         assertThat(event.getMetadata().getAttribute(CHANGE_EVENT_TYPE_METADATA_ATTRIBUTE), is(eventType.toString()));
         assertThat(event.getMetadata().getAttribute(BULK_ACTION_METADATA_ATTRIBUTE), is(bulkAction.toString()));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/BinaryTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/BinaryTypeHandlerTest.java
@@ -22,11 +22,11 @@ public class BinaryTypeHandlerTest {
         final MySQLDataType columnType = MySQLDataType.BINARY;
         final String columnName = "binaryColumn";
         final String testData = UUID.randomUUID().toString();
-        final TableMetadata metadata = TableMetadata.builder().
-                withTableName(UUID.randomUUID().toString()).
-                withDatabaseName(UUID.randomUUID().toString()).
-                withColumnNames(List.of(columnName)).
-                withPrimaryKeys(List.of(columnName))
+        final TableMetadata metadata = TableMetadata.builder()
+                .withTableName(UUID.randomUUID().toString())
+                .withDatabaseName(UUID.randomUUID().toString())
+                .withColumnNames(List.of(columnName))
+                .withPrimaryKeys(List.of(columnName))
                 .build();
         final Object result = handler.handle(columnType, columnName, testData.getBytes(), metadata);
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -134,7 +134,7 @@ class DataFileLoaderTest {
         when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
         when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
         when(event.toJsonString()).thenReturn(randomString);
-        when(recordConverter.convert(any(), any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(event);
+        when(recordConverter.convert(any(), any(), any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(event);
 
         AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
         ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
@@ -184,7 +184,7 @@ class DataFileLoaderTest {
         when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
         when(event.toJsonString()).thenReturn(randomString);
 
-        when(recordConverter.convert(any(), any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(event);
+        when(recordConverter.convert(any(), any(), any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(event);
 
         ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
         AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportSchedulerTest.java
@@ -11,11 +11,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.DataFilePartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.ExportPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.ExportProgressState;
@@ -111,12 +114,14 @@ class ExportSchedulerTest {
                 exportJobFailureCounter, exportS3ObjectsTotalCounter);
     }
 
-    @Test
-    void test_given_export_partition_and_export_task_id_then_complete_export() throws InterruptedException {
+    @ParameterizedTest
+    @EnumSource(EngineType.class)
+    void test_given_export_partition_and_export_task_id_then_complete_export(EngineType engineType) throws InterruptedException {
         when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.of(exportPartition));
         when(exportPartition.getPartitionKey()).thenReturn(UUID.randomUUID().toString());
         final String exportTaskId = UUID.randomUUID().toString();
         when(exportProgressState.getExportTaskId()).thenReturn(exportTaskId);
+        when(exportProgressState.getEngineType()).thenReturn(engineType.toString());
         when(exportPartition.getProgressState()).thenReturn(Optional.of(exportProgressState));
         when(exportTaskManager.checkExportStatus(exportTaskId)).thenReturn(ExportStatus.COMPLETE.name());
 
@@ -149,14 +154,16 @@ class ExportSchedulerTest {
         verify(exportJobFailureCounter, never()).increment();
     }
 
-    @Test
-    void test_given_export_partition_without_export_task_id_then_start_and_complete_export() throws InterruptedException {
+    @ParameterizedTest
+    @EnumSource(EngineType.class)
+    void test_given_export_partition_without_export_task_id_then_start_and_complete_export(EngineType engineType) throws InterruptedException {
         when(sourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).thenReturn(Optional.of(exportPartition));
         when(exportPartition.getPartitionKey()).thenReturn(UUID.randomUUID().toString());
         final String exportTaskId = UUID.randomUUID().toString();
         when(exportProgressState.getExportTaskId())
                 .thenReturn(null)
                 .thenReturn(exportTaskId);
+        when(exportProgressState.getEngineType()).thenReturn(engineType.toString());
         when(exportPartition.getProgressState()).thenReturn(Optional.of(exportProgressState));
         final String dbIdentifier = UUID.randomUUID().toString();
         when(exportPartition.getDbIdentifier()).thenReturn(dbIdentifier);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/MySQLResyncWorkerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/MySQLResyncWorkerTest.java
@@ -105,7 +105,7 @@ class MySQLResyncWorkerTest {
         when(progressState.getPrimaryKeys()).thenReturn(List.of(primaryKeyName));
         when(queryManager.selectRows(queryStatement)).thenReturn(rows);
         when(dbTableMetadata.getTableColumnDataTypeMap()).thenReturn(tableColumnTypeMap);
-        when(recordConverter.convert(any(Event.class), eq(database), eq(table), eq(OpenSearchBulkActions.INDEX),
+        when(recordConverter.convert(any(Event.class), eq(database), eq(database), eq(table), eq(OpenSearchBulkActions.INDEX),
                 eq(List.of(primaryKeyName)), eq(eventTimestampMillis), eq(eventTimestampMillis), eq(null)))
                 .thenReturn(dataPrepperEvent);
 


### PR DESCRIPTION
### Description
Postgres tables are specified as `database.schema.table`, while MySQL tables are specified as `database.table`. This PR fixes an issue that the metadata in Postgres export and stream are not consistent. 

In summary, we use `databaseName`, `schemaName` and `tableName` across the rds source plugin. `schemaName` is specific for Postgres, but for MySQL, we also fill this field with the same value as `databaseName`.

Also refactors `TableMetadata` to use builder pattern. A lot of its usages in test code were updated.
 
### Issues Resolved
Contributes to #5309 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
