### PR TITLE
Pipeline Runner Implementation and Tests

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
@@ -12,6 +12,8 @@ import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.core.peerforwarder.PeerForwardingProcessorDecorator;
 import org.opensearch.dataprepper.core.pipeline.Pipeline;
 import org.opensearch.dataprepper.core.pipeline.PipelineConnector;
+import org.opensearch.dataprepper.core.pipeline.PipelineRunnerImpl;
+import org.opensearch.dataprepper.core.pipeline.SupportsPipelineRunner;
 import org.opensearch.dataprepper.core.pipeline.router.Router;
 import org.opensearch.dataprepper.core.pipeline.router.RouterFactory;
 import org.opensearch.dataprepper.core.sourcecoordination.SourceCoordinatorFactory;
@@ -227,6 +229,11 @@ public class PipelineTransformer {
                     eventFactory, acknowledgementSetManager, sourceCoordinatorFactory, processorThreads, readBatchDelay,
                     dataPrepperConfiguration.getProcessorShutdownTimeout(), dataPrepperConfiguration.getSinkShutdownTimeout(),
                     getPeerForwarderDrainTimeout(dataPrepperConfiguration));
+
+            if (pipelineDefinedBuffer instanceof SupportsPipelineRunner) {
+                ((SupportsPipelineRunner) pipelineDefinedBuffer).setPipelineRunner(new PipelineRunnerImpl(pipeline));
+            }
+
             pipelineMap.put(pipelineName, pipeline);
         } catch (Exception ex) {
             //If pipeline construction errors out, we will skip that pipeline and proceed

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.core.pipeline;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.opensearch.dataprepper.DataPrepperShutdownOptions;
 import org.opensearch.dataprepper.core.acknowledgements.InactiveAcknowledgementSetManager;
@@ -194,6 +195,14 @@ public class Pipeline {
         return processorSets;
     }
 
+    /**
+     * @return a flat list of {@link Processor} of this pipeline or an empty list.
+     */
+    @VisibleForTesting
+    public List<Processor> getProcessors() {
+        return getProcessorSets().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+
     public int getReadBatchTimeoutInMillis() {
         return readBatchTimeoutInMillis;
     }
@@ -364,5 +373,9 @@ public class Pipeline {
                 }, null))
             );
         return sinkFutures;
+    }
+
+    public boolean areAcknowledgementsEnabled() {
+        return source.areAcknowledgementsEnabled() || buffer.areAcknowledgementsEnabled();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.core.pipeline;
 
 /**

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java
@@ -1,5 +1,10 @@
 package org.opensearch.dataprepper.core.pipeline;
 
+/**
+ * Pipeline Runner interface encapsulates the functionalities of reading from buffer,
+ * executing the processors and publishing to sinks to provide both synchronous and
+ * asynchronous mechanism for running a pipeline.
+ */
 public interface PipelineRunner {
     void runAllProcessorsAndPublishToSinks();
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java
@@ -7,4 +7,6 @@ package org.opensearch.dataprepper.core.pipeline;
  */
 public interface PipelineRunner {
     void runAllProcessorsAndPublishToSinks();
+
+    Pipeline getPipeline();
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.core.pipeline;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
@@ -1,0 +1,143 @@
+package org.opensearch.dataprepper.core.pipeline;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
+import org.opensearch.dataprepper.core.pipeline.exceptions.InvalidEventHandleException;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.InternalEventHandle;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+public class PipelineRunnerImpl implements PipelineRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineRunnerImpl.class);
+    private final boolean acknowledgementsEnabled;
+    private boolean isEmptyRecordsLogged = false;
+    private final Buffer readBuffer;
+    private final List<Processor> processors;
+    private final Pipeline pipeline;
+
+    public PipelineRunnerImpl(Pipeline pipeline) {
+        List<Processor> processors = pipeline.getProcessorSets().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        this.readBuffer = pipeline.getBuffer();
+        this.processors = processors;
+        this.pipeline = pipeline;
+        this.acknowledgementsEnabled = pipeline.getSource().areAcknowledgementsEnabled() || readBuffer.areAcknowledgementsEnabled();
+    }
+
+    @Override
+    public void runAllProcessorsAndPublishToSinks() {
+        final Map.Entry<Collection, CheckpointState> recordsReadFromBuffer = readFromBuffer(getBuffer(), getPipeline());
+        Collection records = recordsReadFromBuffer.getKey();
+        final CheckpointState checkpointState = recordsReadFromBuffer.getValue();
+        records = runProcessorsAndProcessAcknowledgements(getProcessors(), records);
+        postToSink(getPipeline(), records);
+        // Checkpoint the current batch read from the buffer after being processed by processors and sinks.
+        getBuffer().checkpoint(checkpointState);
+    }
+
+    @VisibleForTesting
+    Map.Entry<Collection, CheckpointState> readFromBuffer(Buffer buffer, Pipeline pipeline) {
+        final Map.Entry<Collection, CheckpointState> readResult = buffer.read(pipeline.getReadBatchTimeoutInMillis());
+        Collection records = readResult.getKey();
+        //TODO Hacky way to avoid logging continuously - Will be removed as part of metrics implementation
+        if (records.isEmpty()) {
+            if(!isEmptyRecordsLogged) {
+                LOG.debug(" {} Worker: No records received from buffer", pipeline.getName());
+                isEmptyRecordsLogged = true;
+            }
+        } else {
+            LOG.debug(" {} Worker: Processing {} records from buffer", pipeline.getName(), records.size());
+        }
+        return readResult;
+    }
+
+    @VisibleForTesting
+    void processAcknowledgements(List<Event> inputEvents, Collection<Record<Event>> outputRecords) {
+        Set<Event> outputEventsSet = outputRecords.stream().map(Record::getData).collect(Collectors.toSet());
+        // For each event in the input events list that is not present in the output events, send positive acknowledgement, if acknowledgements are enabled for it
+        inputEvents.forEach(event -> {
+            EventHandle eventHandle = event.getEventHandle();
+            if (eventHandle != null && eventHandle instanceof DefaultEventHandle) {
+                InternalEventHandle internalEventHandle = (InternalEventHandle)(DefaultEventHandle)eventHandle;
+                if (!outputEventsSet.contains(event)) {
+                    eventHandle.release(true);
+                }
+            } else if (eventHandle != null) {
+                throw new InvalidEventHandleException("Unexpected EventHandle");
+            }
+        });
+    }
+
+    @VisibleForTesting
+    Collection runProcessorsAndProcessAcknowledgements(List<Processor> processors, Collection records) {
+        //Should Empty list from buffer should be sent to the processors? For now sending as the Stateful processors expects it.
+        for (final Processor processor : processors) {
+
+            List<Event> inputEvents = null;
+            if (acknowledgementsEnabled) {
+                inputEvents = ((List<Record<Event>>) records).stream().map(Record::getData).collect(Collectors.toList());
+            }
+
+            try {
+                records = processor.execute(records);
+                // acknowledge missing events only if the processor is not holding events
+                if (!processor.holdsEvents() && inputEvents != null) {
+                    processAcknowledgements(inputEvents, records);
+                }
+            } catch (final Exception e) {
+                LOG.error("A processor threw an exception. This batch of Events will be dropped, and their EventHandles will be released: ", e);
+                if (inputEvents != null) {
+                    processAcknowledgements(inputEvents, Collections.emptyList());
+                }
+
+                records = Collections.emptyList();
+                break;
+            }
+        }
+        return records;
+    }
+
+    /**
+     * TODO Add isolator pattern - Fail if one of the Sink fails [isolator Pattern]
+     * Uses the pipeline method to publish to sinks, waits for each of the sink result to be true before attempting to
+     * process more records from buffer.
+     */
+
+    @VisibleForTesting
+    boolean postToSink(final Pipeline pipeline, final Collection<Record> records) {
+        LOG.debug("Pipeline Worker: Submitting {} processed records to sinks", records.size());
+        final List<Future<Void>> sinkFutures = pipeline.publishToSinks(records);
+        final FutureHelperResult<Void> futureResults = FutureHelper.awaitFuturesIndefinitely(sinkFutures);
+        return futureResults.getFailedReasons().size() == 0;
+    }
+
+    @VisibleForTesting
+    List<Processor> getProcessors() {
+        return processors;
+    }
+
+    @VisibleForTesting
+    Buffer getBuffer() {
+        return readBuffer;
+    }
+
+    @VisibleForTesting
+    Pipeline getPipeline() {
+        return pipeline;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
@@ -6,51 +6,45 @@
 package org.opensearch.dataprepper.core.pipeline;
 
 import io.micrometer.core.instrument.Counter;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
+import org.opensearch.dataprepper.core.pipeline.exceptions.InvalidEventHandleException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.CheckpointState;
 import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.event.DefaultEventHandle;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
-import org.opensearch.dataprepper.model.event.InternalEventHandle;
 import org.opensearch.dataprepper.model.processor.Processor;
-import org.opensearch.dataprepper.model.record.Record;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ProcessWorker implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ProcessWorker.class);
-
     private static final String INVALID_EVENT_HANDLES = "invalidEventHandles";
     private final Buffer readBuffer;
     private final List<Processor> processors;
     private final Pipeline pipeline;
-    private boolean isEmptyRecordsLogged = false;
     private PluginMetrics pluginMetrics;
     private final Counter invalidEventHandlesCounter;
-    private boolean acknowledgementsEnabled;
+    private final PipelineRunner pipelineRunner;
 
     public ProcessWorker(
             final Buffer readBuffer,
             final List<Processor> processors,
             final Pipeline pipeline) {
+        this(readBuffer, processors, pipeline, new PipelineRunnerImpl(pipeline));
+    }
+
+    public ProcessWorker(
+            final Buffer readBuffer,
+            final List<Processor> processors,
+            final Pipeline pipeline,
+            final PipelineRunner pipelineRunner) {
         this.readBuffer = readBuffer;
         this.processors = processors;
         this.pipeline = pipeline;
         this.pluginMetrics = PluginMetrics.fromNames("ProcessWorker", pipeline.getName());
         this.invalidEventHandlesCounter = pluginMetrics.counter(INVALID_EVENT_HANDLES);
-        this.acknowledgementsEnabled = pipeline.getSource().areAcknowledgementsEnabled() || readBuffer.areAcknowledgementsEnabled();
+        this.pipelineRunner = pipelineRunner;
     }
 
     @Override
@@ -97,64 +91,12 @@ public class ProcessWorker implements Runnable {
         LOG.info("Processor shutdown phase 5 complete.");
     }
 
-    private void processAcknowledgements(List<Event> inputEvents, Collection<Record<Event>> outputRecords) {
-        Set<Event> outputEventsSet = outputRecords.stream().map(Record::getData).collect(Collectors.toSet());
-        // For each event in the input events list that is not present in the output events, send positive acknowledgement, if acknowledgements are enabled for it
-        inputEvents.forEach(event -> {
-            EventHandle eventHandle = event.getEventHandle();
-            if (eventHandle != null && eventHandle instanceof DefaultEventHandle) {
-                InternalEventHandle internalEventHandle = (InternalEventHandle)(DefaultEventHandle)eventHandle;
-                if (!outputEventsSet.contains(event)) {
-                    eventHandle.release(true);
-                }
-            } else if (eventHandle != null) {
-                invalidEventHandlesCounter.increment();
-                throw new RuntimeException("Unexpected EventHandle");
-            }
-        });
-    }
-
     private void doRun() {
-        final Map.Entry<Collection, CheckpointState> readResult = readBuffer.read(pipeline.getReadBatchTimeoutInMillis());
-        Collection records = readResult.getKey();
-        final CheckpointState checkpointState = readResult.getValue();
-        //TODO Hacky way to avoid logging continuously - Will be removed as part of metrics implementation
-        if (records.isEmpty()) {
-            if(!isEmptyRecordsLogged) {
-                LOG.debug(" {} Worker: No records received from buffer", pipeline.getName());
-                isEmptyRecordsLogged = true;
-            }
-        } else {
-            LOG.debug(" {} Worker: Processing {} records from buffer", pipeline.getName(), records.size());
+        try {
+            pipelineRunner.runAllProcessorsAndPublishToSinks();
+        } catch (InvalidEventHandleException exception) {
+            invalidEventHandlesCounter.increment();
         }
-        //Should Empty list from buffer should be sent to the processors? For now sending as the Stateful processors expects it.
-        for (final Processor processor : processors) {
-
-            List<Event> inputEvents = null;
-            if (acknowledgementsEnabled) {
-                inputEvents = ((List<Record<Event>>) records).stream().map(Record::getData).collect(Collectors.toList());
-            }
-
-            try {
-                records = processor.execute(records);
-                // acknowledge missing events only if the processor is not holding events
-                if (!processor.holdsEvents() && inputEvents != null) {
-                    processAcknowledgements(inputEvents, records);
-                }
-            } catch (final Exception e) {
-                LOG.error("A processor threw an exception. This batch of Events will be dropped, and their EventHandles will be released: ", e);
-                if (inputEvents != null) {
-                    processAcknowledgements(inputEvents, Collections.emptyList());
-                }
-
-                records = Collections.emptyList();
-                break;
-            }
-        }
-
-        postToSink(records);
-        // Checkpoint the current batch read from the buffer after being processed by processors and sinks.
-        readBuffer.checkpoint(checkpointState);
     }
 
     private boolean areComponentsReadyForShutdown() {
@@ -169,17 +111,5 @@ public class ProcessWorker implements Runnable {
         final boolean isBufferReadyForShutdown = isBufferEmpty || forceStopReadingBuffers;
         LOG.debug("isBufferReadyForShutdown={}, isBufferEmpty={}, forceStopReadingBuffers={}", isBufferReadyForShutdown, isBufferEmpty, forceStopReadingBuffers);
         return isBufferReadyForShutdown;
-    }
-
-    /**
-     * TODO Add isolator pattern - Fail if one of the Sink fails [isolator Pattern]
-     * Uses the pipeline method to publish to sinks, waits for each of the sink result to be true before attempting to
-     * process more records from buffer.
-     */
-    private boolean postToSink(final Collection<Record> records) {
-        LOG.debug("Pipeline Worker: Submitting {} processed records to sinks", records.size());
-        final List<Future<Void>> sinkFutures = pipeline.publishToSinks(records);
-        final FutureHelperResult<Void> futureResults = FutureHelper.awaitFuturesIndefinitely(sinkFutures);
-        return futureResults.getFailedReasons().size() == 0;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/exceptions/InvalidEventHandleException.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/exceptions/InvalidEventHandleException.java
@@ -1,7 +1,0 @@
-package org.opensearch.dataprepper.core.pipeline.exceptions;
-
-public class InvalidEventHandleException extends RuntimeException {
-    public InvalidEventHandleException(final String message) {
-        super(message);
-    }
-}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/exceptions/InvalidEventHandleException.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/exceptions/InvalidEventHandleException.java
@@ -1,0 +1,7 @@
+package org.opensearch.dataprepper.core.pipeline.exceptions;
+
+public class InvalidEventHandleException extends RuntimeException {
+    public InvalidEventHandleException(final String message) {
+        super(message);
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
@@ -1,0 +1,402 @@
+package org.opensearch.dataprepper.core.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
+import org.opensearch.dataprepper.core.pipeline.exceptions.InvalidEventHandleException;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.event.InternalEventHandle;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@ExtendWith(MockitoExtension.class)
+class PipelineRunnerTest {
+    private static final int BUFFER_READ_TIMEOUT_MILLIS = 1000;
+    private static final String MOCK_PIPELINE_NAME = "Test-Pipeline";
+
+    @Mock
+    Pipeline pipeline;
+    @Mock
+    Buffer buffer;
+    @Mock
+    Source source;
+    @Mock
+    Processor processor;
+    @Mock
+    Sink sink;
+    @Mock
+    Record record;
+    @Mock
+    CheckpointState checkpointState;
+    @Mock
+    Event event;
+    @Mock
+    EventHandle eventHandle;
+    @Mock
+    DefaultEventHandle defaultEventHandle;
+
+    private void setupPipeline(boolean shouldEnableAcknowledgements) {
+        when(pipeline.getSource()).thenReturn(source);
+        when(pipeline.getBuffer()).thenReturn(buffer);
+        when(source.areAcknowledgementsEnabled()).thenReturn(shouldEnableAcknowledgements);
+    }
+
+    private PipelineRunnerImpl createObjectUnderTest() {
+        return new PipelineRunnerImpl(pipeline);
+    }
+
+    @Nested
+    class ProcessAcknowledgementsTests {
+        @BeforeEach
+        public void setup() {
+            setupPipeline(false);
+        }
+
+        @Test
+        public void testProcessAcknowledgementsSuccess() {
+            List<Event> inputEvents = List.of(event);
+            Set<Event> outputEvents = mock(Set.class);
+            Collection<Record<Event>> outputRecords = List.of(record);
+            // pass an instance of DefaultEventHandle inorder to have (eventHandle instanceof DefaultEventHandle) return true
+            when(event.getEventHandle()).thenReturn(defaultEventHandle);
+            when(outputRecords.stream().map(Record::getData).collect(Collectors.toSet())).thenReturn(outputEvents);
+
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.processAcknowledgements(inputEvents, outputRecords);
+            verify(defaultEventHandle).release(true);
+        }
+
+        @Test
+        void testProcessAcknowledgementsReleasesMissingEvents() {
+            // Create an event with a DefaultEventHandle
+            when(event.getEventHandle()).thenReturn(defaultEventHandle);
+            List<Event> inputEvents = List.of(event);
+            // Create outputRecords that do not contain the first event to simulate a dropped event
+            Event differentEvent = mock(Event.class);
+            when(record.getData()).thenReturn(differentEvent);
+            Collection<Record<Event>> outputRecords = List.of(record);
+
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.processAcknowledgements(inputEvents, outputRecords);
+            verify(defaultEventHandle).release(true);
+            assertNotSame(event, differentEvent);
+        }
+
+        @Test
+        void testProcessAcknowledgementsDoesNotReleaseWhenEventsPresent() {
+            // Create an event with a DefaultEventHandle.
+            when(event.getEventHandle()).thenReturn(defaultEventHandle);
+            when(record.getData()).thenReturn(event);
+            List<Event> inputEvents = List.of(event);
+            // Create outputRecords that contains the first event.
+            Collection<Record<Event>> outputRecords = List.of(record);
+
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.processAcknowledgements(inputEvents, outputRecords);
+            verify(defaultEventHandle, never()).release(true);
+        }
+
+        @Test
+        public void testProcessAcknowledgementsThrowsInvalidEventHandleException() {
+            List<Event> inputEvents = List.of(event);
+            Collection<Record<Event>> outputRecords = List.of(record);
+            when(event.getEventHandle()).thenReturn(eventHandle);
+
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            assertThrows(InvalidEventHandleException.class, () -> pipelineRunner.processAcknowledgements(inputEvents, outputRecords));
+        }
+    }
+
+    @Nested
+    class PublishToSinkTests {
+        @BeforeEach
+        public void setup() {
+            setupPipeline(false);
+        }
+
+        @Test
+        public void testPublishToSinkHappyCase() {
+            final Future<Void> sinkFuture = mock(Future.class);
+            List<Future<Void>> sinkFutures = List.of(sinkFuture);
+            when(pipeline.publishToSinks(any())).thenReturn(sinkFutures);
+            final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
+            when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
+
+            try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
+                futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
+                        .thenReturn(futureHelperResult);
+                PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+                boolean postToSinkSuccessful = pipelineRunner.postToSink(pipeline, IntStream.range(0, 5)
+                        .mapToObj(i -> new Record("Data " + (i + 1)))
+                        .collect(Collectors.toList()));
+                assertTrue(postToSinkSuccessful);
+            }
+
+            verify(pipeline).publishToSinks(anyCollection());
+        }
+
+        @Test
+        public void testPublishToSinkFailure() {
+            final Future<Void> sinkFuture = mock(Future.class);
+            List<Future<Void>> sinkFutures = List.of(sinkFuture);
+            List<ExecutionException> executionExceptions = List.of(mock(ExecutionException.class));
+            when(pipeline.publishToSinks(any())).thenReturn(sinkFutures);
+            final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
+            when(futureHelperResult.getFailedReasons()).thenReturn(executionExceptions);
+
+            try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
+                futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
+                        .thenReturn(futureHelperResult);
+                PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+                boolean postToSinkSuccessful = pipelineRunner.postToSink(pipeline, IntStream.range(0, 5)
+                        .mapToObj(i -> new Record("Data " + (i + 1)))
+                        .collect(Collectors.toList()));
+                assertFalse(postToSinkSuccessful);
+            }
+
+            verify(pipeline).publishToSinks(anyCollection());
+        }
+    }
+
+    @Nested
+    class ReadFromBufferTests {
+        @BeforeEach
+        public void setup() {
+            setupPipeline(false);
+        }
+
+        @Test
+        public void testReadFromBufferReturnsNoRecords() {
+            final List<Record<String>> records = new ArrayList<>();
+            final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
+            when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
+            when(source.areAcknowledgementsEnabled()).thenReturn(false);
+            when(buffer.areAcknowledgementsEnabled()).thenReturn(false);
+
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            final Map.Entry<Collection, CheckpointState> firstReadResult = pipelineRunner.readFromBuffer(buffer, pipeline);
+            final Map.Entry<Collection, CheckpointState> secondReadResult = pipelineRunner.readFromBuffer(buffer, pipeline);
+            assertTrue(firstReadResult.getKey().isEmpty());
+            assertTrue(secondReadResult.getKey().isEmpty());
+
+            verify(buffer, atLeastOnce()).read(anyInt());
+            verify(pipeline, atLeastOnce()).getReadBatchTimeoutInMillis();
+        }
+
+        @Test
+        public void testReadFromBufferReturnsCorrectRecords() {
+            final List<Record<String>> records = List.of(record);
+            final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
+            when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(BUFFER_READ_TIMEOUT_MILLIS);
+            when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            final Map.Entry<Collection, CheckpointState> returnedReadResult = pipelineRunner.readFromBuffer(buffer, pipeline);
+            assertFalse(returnedReadResult.getKey().isEmpty());
+
+            verify(buffer, atLeastOnce()).read(anyInt());
+            verify(pipeline, atLeastOnce()).getReadBatchTimeoutInMillis();
+        }
+    }
+
+    @Nested
+    class RunProcessorsAndProcessAcknowledgementsTests {
+        @Test
+        void testProcessWorkerWithProcessorsNotHoldingEvents() {
+            setupPipeline(true);
+            when(defaultEventHandle.release(true)).thenReturn(true);
+            lenient().when(event.getEventHandle()).thenReturn(defaultEventHandle);
+            when(record.getData()).thenReturn(event);
+            final List<Record> records = new ArrayList<>();
+            records.add(record);
+
+            when(processor.holdsEvents()).thenReturn(false);
+            when(processor.execute(records)).thenReturn(List.of());
+            List<Processor> processors = List.of(processor);
+
+            final PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.runProcessorsAndProcessAcknowledgements(processors, records);
+
+            verify(defaultEventHandle, atLeast(1)).release(true);
+        }
+
+        @Test
+        void testProcessWorkerWithProcessorsHoldingEventsWithAcknowledgementsEnabled() {
+            setupPipeline(true);
+            final List<Record> records = List.of(record);
+            when(processor.holdsEvents()).thenReturn(true);
+            when(processor.execute(records)).thenReturn(List.of());
+            lenient().when(event.getEventHandle()).thenReturn(eventHandle);
+            when(record.getData()).thenReturn(event);
+
+            final PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.runProcessorsAndProcessAcknowledgements(List.of(processor), records);
+
+            verify(eventHandle, never()).release(true);
+        }
+
+        @Test
+        void testRunProcessorsAndProcessAcknowledgementsWithProcessorDroppingAllRecordsAndAcknowledgmentsEnabledIsHandledProperly() {
+            setupPipeline(true);
+            final List<Record> records = List.of(record);
+            when(processor.holdsEvents()).thenReturn(true);
+            when(processor.execute(records)).thenReturn(Collections.emptyList());
+            final Processor secondProcessor = mock(Processor.class);
+            when(secondProcessor.execute(Collections.emptyList())).thenReturn(Collections.emptyList());
+            List<Processor> processors = List.of(processor, secondProcessor);
+
+            lenient().when(event.getEventHandle()).thenReturn(eventHandle);
+            when(record.getData()).thenReturn(event);
+
+            final PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            Collection result = pipelineRunner.runProcessorsAndProcessAcknowledgements(processors, records);
+
+            verify(eventHandle, never()).release(true);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        public void testrunProcessorsAndProcessAcknowledgementsWhenNoProcessors() {
+            setupPipeline(false);
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            Collection records = pipelineRunner.runProcessorsAndProcessAcknowledgements(new ArrayList<>(), new ArrayList<Record<Event>>());
+
+            assertTrue(records.isEmpty());
+            verify(processor, never()).execute(any());
+        }
+
+        @Test
+        void testRunProcessorsAndProcessAcknowledgementsThrowsException() {
+            List<Record<Event>> inputRecords = new ArrayList<>();
+            final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+            ((InternalEventHandle)defaultEventHandle).addAcknowledgementSet(acknowledgementSet);
+            inputRecords.add(record);
+            setupPipeline(false);
+            // Have the processor throw an exception
+            when(processor.execute(inputRecords)).thenThrow(new RuntimeException());;
+            final Processor skippedProcessor = mock(Processor.class);
+            List<Processor> processors = List.of(processor, skippedProcessor);
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            Collection<?> result = pipelineRunner.runProcessorsAndProcessAcknowledgements(
+                    processors, inputRecords);
+
+            verify(defaultEventHandle, never()).release(anyBoolean());
+            verify(skippedProcessor, never()).execute(inputRecords);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void testRunProcessorsAndProcessAcknowledgementsThrowingExceptionWithAcknowledgmentsEnabledIsHandledProperly() {
+            // Create an event with a DefaultEventHandle.
+            when(event.getEventHandle()).thenReturn(defaultEventHandle);
+            when(record.getData()).thenReturn(event);
+            List<Record<Event>> inputRecords = new ArrayList<>();
+            inputRecords.add(record);
+            setupPipeline(true);
+            // Have the processor throw an exception
+            when(processor.execute(inputRecords)).thenThrow(new RuntimeException());
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            Collection<?> result = pipelineRunner.runProcessorsAndProcessAcknowledgements(
+                    Collections.singletonList(processor), inputRecords);
+
+            verify(defaultEventHandle).release(true);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    class RunAllProcessorsAndPublishToSinksTests {
+        @Test
+        void testRunAllProcessorsAndPublishToSinkWithAcknowledgmentsEnabled() {
+            when(record.getData()).thenReturn(event);
+            Collection recordsList = new ArrayList<>();
+            recordsList.add(record);
+            setupPipeline(true);
+            // Set up additional pipeline behavior
+            when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(BUFFER_READ_TIMEOUT_MILLIS);
+            when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
+            when(pipeline.getProcessorSets()).thenReturn(Collections.singletonList(Collections.singletonList(processor)));
+            when(pipeline.publishToSinks(anyCollection())).thenReturn(
+                    Collections.singletonList(CompletableFuture.completedFuture(null)));
+
+            Map.Entry<Collection, CheckpointState> entry =
+                    new AbstractMap.SimpleEntry<>(recordsList, checkpointState);
+            when(buffer.read(BUFFER_READ_TIMEOUT_MILLIS)).thenReturn(entry);
+            when(processor.execute(recordsList)).thenReturn(recordsList);
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.runAllProcessorsAndPublishToSinks();
+
+            verify(processor).execute(recordsList);
+            verify(pipeline).publishToSinks(recordsList);
+            verify(buffer).checkpoint(checkpointState);
+        }
+
+        @Test
+        void testRunAllProcessorsAndPublishToSinksHappyPathWithoutAcknowledgments() {
+            Collection recordsList = new ArrayList<>();
+            recordsList.add(record);
+            setupPipeline(false);
+            // Set up additional pipeline behavior
+            when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(BUFFER_READ_TIMEOUT_MILLIS);
+            when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
+            when(pipeline.getProcessorSets()).thenReturn(Collections.singletonList(Collections.singletonList(processor)));
+            when(pipeline.publishToSinks(anyCollection())).thenReturn(
+                    Collections.singletonList(CompletableFuture.completedFuture(null)));
+
+            Map.Entry<Collection, CheckpointState> entry =
+                    new AbstractMap.SimpleEntry<>(recordsList, checkpointState);
+            when(buffer.read(BUFFER_READ_TIMEOUT_MILLIS)).thenReturn(entry);
+            when(processor.execute(recordsList)).thenReturn(recordsList);
+            PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
+            pipelineRunner.runAllProcessorsAndPublishToSinks();
+
+            verify(processor).execute(recordsList);
+            verify(pipeline).publishToSinks(recordsList);
+            verify(buffer).checkpoint(checkpointState);
+        }
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.core.pipeline;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineTests.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.DataPrepperShutdownOptions;
 import org.opensearch.dataprepper.core.parser.DataFlowComponent;
 import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
@@ -384,6 +386,34 @@ class PipelineTests {
 
         assertEquals(1, testPipeline.getSinks().size());
         assertEquals(testSink, testPipeline.getSinks().iterator().next());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAreAcknowledgementsEnabled(Boolean isEnabled) {
+        final Source source = mock(Source.class);
+        final Buffer buffer = mock(Buffer.class);
+        when(source.areAcknowledgementsEnabled()).thenReturn(isEnabled);
+        when(buffer.areAcknowledgementsEnabled()).thenReturn(isEnabled);
+        final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, source, buffer, Collections.emptyList(),
+                Collections.emptyList(), router, eventFactory, acknowledgementSetManager, sourceCoordinatorFactory, TEST_PROCESSOR_THREADS,
+                TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout, peerForwarderDrainTimeout);
+
+        assertEquals(isEnabled, testPipeline.areAcknowledgementsEnabled());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAreAcknowledgementsEnabledWhenEitherSourceOrBufferHasAcknowledgementsEnabled(Boolean isEnabled) {
+        final Source source = mock(Source.class);
+        final Buffer buffer = mock(Buffer.class);
+        when(source.areAcknowledgementsEnabled()).thenReturn(!isEnabled);
+        when(buffer.areAcknowledgementsEnabled()).thenReturn(isEnabled);
+        final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, source, buffer, Collections.emptyList(),
+                Collections.emptyList(), router, eventFactory, acknowledgementSetManager, sourceCoordinatorFactory, TEST_PROCESSOR_THREADS,
+                TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout, peerForwarderDrainTimeout);
+
+        assertTrue(testPipeline.areAcknowledgementsEnabled());
     }
 
     @Nested

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
@@ -1,310 +1,167 @@
 package org.opensearch.dataprepper.core.pipeline;
 
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.atLeast;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
-import org.opensearch.dataprepper.model.CheckpointState;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
-import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.event.DefaultEventHandle;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
-import org.opensearch.dataprepper.model.event.InternalEventHandle;
-import org.opensearch.dataprepper.model.processor.Processor;
-import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.source.Source;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.opensearch.dataprepper.core.pipeline.exceptions.InvalidEventHandleException;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.processor.Processor;
+
+import java.time.Duration;
+import java.util.List;
+
 @ExtendWith(MockitoExtension.class)
 public class ProcessWorkerTest {
-
     @Mock
     private Pipeline pipeline;
+
+    @Mock
+    private Processor processor;
 
     @Mock
     private Buffer buffer;
 
     @Mock
-    private Source source;
-
-    private List<Future<Void>> sinkFutures;
+    private PipelineRunnerImpl pipelineRunner;
 
     private List<Processor> processors;
 
     @BeforeEach
     void setup() {
         when(pipeline.isStopRequested()).thenReturn(false).thenReturn(true);
-        when(source.areAcknowledgementsEnabled()).thenReturn(false);
-        when(pipeline.getSource()).thenReturn(source);
-        when(buffer.isEmpty()).thenReturn(true);
         when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(100));
-        when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(500);
-
-        final Future<Void> sinkFuture = mock(Future.class);
-        sinkFutures = List.of(sinkFuture);
-        when(pipeline.publishToSinks(any())).thenReturn(sinkFutures);
+        when(buffer.isEmpty()).thenReturn(true);
     }
 
     private ProcessWorker createObjectUnderTest() {
+        return createObjectUnderTest(true);
+    }
+
+    private ProcessWorker createObjectUnderTest(boolean withPipelineRunner) {
+        if (withPipelineRunner) {
+            return new ProcessWorker(buffer, processors, pipeline, pipelineRunner);
+        }
         return new ProcessWorker(buffer, processors, pipeline);
     }
 
     @Test
     void testProcessWorkerHappyPath() {
+        when(processor.isReadyForShutdown()).thenReturn(true);
+        doNothing().when(pipelineRunner).runAllProcessorsAndPublishToSinks();
+        processors = List.of(processor);
 
-        final List<Record> records = List.of(mock(Record.class));
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
+       final ProcessWorker processWorker = createObjectUnderTest();
+       processWorker.run();
 
-        final Processor processor = mock(Processor.class);
-        when(processor.execute(records)).thenReturn(records);
+        verify(pipelineRunner, atLeastOnce()).runAllProcessorsAndPublishToSinks();
+    }
+
+    @Test
+    void testProcessWorkerInitializesPipelineRunnerCorrectly() {
         when(processor.isReadyForShutdown()).thenReturn(true);
         processors = List.of(processor);
 
-        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
-        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
-
-
-        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
-            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
-                    .thenReturn(futureHelperResult);
-
-            final ProcessWorker processWorker = createObjectUnderTest();
-
+        try (MockedConstruction<PipelineRunnerImpl> pipelineRunnerMockedConstruction = mockConstruction(PipelineRunnerImpl.class,
+                (mock, context) -> doNothing().when(mock).runAllProcessorsAndPublishToSinks())) {
+            final ProcessWorker processWorker = createObjectUnderTest(false);
             processWorker.run();
+
+            pipelineRunnerMockedConstruction.constructed().forEach(pipelineRunner -> {
+                verify(pipelineRunner, atLeastOnce()).runAllProcessorsAndPublishToSinks();
+            });
         }
     }
 
     @Test
-    void testProcessWorkerHappyPathWithAcknowledgments() {
-
-        when(source.areAcknowledgementsEnabled()).thenReturn(true);
-
-        final List<Record<Event>> records = new ArrayList<>();
-        final Record<Event> mockRecord = mock(Record.class);
-        final Event mockEvent = mock(Event.class);
-        final EventHandle eventHandle = mock(DefaultEventHandle.class);
-        when(mockRecord.getData()).thenReturn(mockEvent);
-        when(mockEvent.getEventHandle()).thenReturn(eventHandle);
-
-        records.add(mockRecord);
-
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
-
-        final Processor processor = mock(Processor.class);
-        when(processor.execute(records)).thenReturn(records);
-        when(processor.isReadyForShutdown()).thenReturn(true);
+    void testProcessWorkerShutdownProcessPreparesProcessorsForShutdown() {
         processors = List.of(processor);
-
-        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
-        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
-
-
-        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
-            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
-                    .thenReturn(futureHelperResult);
-
-            final ProcessWorker processWorker = createObjectUnderTest();
-
-            processWorker.run();
-        }
-    }
-
-    @Test
-    void testProcessWorkerWithProcessorsNotHoldingEvents() {
-        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
-        Event event = mock(Event.class);
-        Record record = mock(Record.class);
-        when(eventHandle.release(true)).thenReturn(true);
-        lenient().when(event.getEventHandle()).thenReturn(eventHandle);
-        when(record.getData()).thenReturn(event);
-        final List<Record> records = List.of(record);
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
-
-        final Processor processor1 = mock(Processor.class);
-        when(processor1.holdsEvents()).thenReturn(false);
-        when(processor1.execute(records)).thenReturn(List.of());
-        when(processor1.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor1);
-        when(source.areAcknowledgementsEnabled()).thenReturn(true);
+        when(pipeline.isStopRequested()).thenReturn(false, true);
+        when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
+        when(buffer.isEmpty()).thenReturn(true);
+        when(processor.isReadyForShutdown()).thenReturn(true);
+        doNothing().when(pipelineRunner).runAllProcessorsAndPublishToSinks();
 
         final ProcessWorker processWorker = createObjectUnderTest();
-
         processWorker.run();
 
-        verify(eventHandle, atLeast(1)).release(true);
+        verify(processor, atLeastOnce()).prepareForShutdown();
     }
 
+    @Test
+    void testProcessWorkerInvalidEventHandleIncrementsCounter() {
+        processors = List.of(processor);
+        when(pipeline.isStopRequested()).thenReturn(false, true);
+        when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
+        when(buffer.isEmpty()).thenReturn(true);
+        when(processor.isReadyForShutdown()).thenReturn(true);
+
+        // Create a pipelineRunner mock that throws an InvalidEventHandleException on first call.
+        doThrow(new InvalidEventHandleException(""))
+                .doNothing()
+                .when(pipelineRunner).runAllProcessorsAndPublishToSinks();
+
+        try (MockedStatic<PluginMetrics> pluginMetricsStatic = mockStatic(PluginMetrics.class)) {
+            final PluginMetrics pluginMetrics = mock(PluginMetrics.class);
+            final Counter counter = mock(Counter.class);
+            when(pluginMetrics.counter(any())).thenReturn(counter);
+            pluginMetricsStatic.when(() -> PluginMetrics.fromNames("ProcessWorker", pipeline.getName()))
+                    .thenReturn(pluginMetrics);
+
+            final ProcessWorker processWorker = createObjectUnderTest();
+            processWorker.run();
+
+            verify(counter, atLeastOnce()).increment();
+        }
+    }
 
     @Test
-    void testProcessWorkerWithProcessorsHoldingEvents() {
-        EventHandle eventHandle = mock(EventHandle.class);
-        Event event = mock(Event.class);
-        Record record = mock(Record.class);
-        lenient().when(event.getEventHandle()).thenReturn(eventHandle);
-        when(record.getData()).thenReturn(event);
-        final List<Record> records = List.of(record);
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
-
-        final Processor processor1 = mock(Processor.class);
-        when(processor1.holdsEvents()).thenReturn(true);
-        when(processor1.execute(records)).thenReturn(List.of());
-        when(processor1.isReadyForShutdown()).thenReturn(true);
-
-        processors = List.of(processor1);
-        when(source.areAcknowledgementsEnabled()).thenReturn(true);
+    void testProcessWorkerShutdownProcessWaitsUntilBufferEmpty() {
+        processors = List.of(processor);
+        // First call returns false, then true
+        when(pipeline.isStopRequested()).thenReturn(false, true);
+        when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
+        when(buffer.isEmpty()).thenReturn(false, true);
+        when(processor.isReadyForShutdown()).thenReturn(true);
+        doNothing().when(pipelineRunner).runAllProcessorsAndPublishToSinks();
 
         final ProcessWorker processWorker = createObjectUnderTest();
-
         processWorker.run();
 
-        verify(eventHandle, never()).release(true);
+        // Verify multiple invocations due to the wait loop in shutdown phase 2.
+        verify(pipelineRunner, atLeast(2)).runAllProcessorsAndPublishToSinks();
     }
 
     @Test
-    void testProcessWorkerWithProcessorThrowingExceptionIsCaughtProperly() {
-
-        final List<Record> records = List.of(mock(Record.class));
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
-
-        final Processor processor = mock(Processor.class);
-        when(processor.execute(records)).thenThrow(RuntimeException.class);
+    void testProcessWorkerShutdownProcessForceStopReadingBuffers() {
+        processors = List.of(processor);
+        when(pipeline.isStopRequested()).thenReturn(false, true);
+        when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
+        when(buffer.isEmpty()).thenReturn(false);
+        when(pipeline.isForceStopReadingBuffers()).thenReturn(true);
         when(processor.isReadyForShutdown()).thenReturn(true);
+        doNothing().when(pipelineRunner).runAllProcessorsAndPublishToSinks();
 
-        final Processor skippedProcessor = mock(Processor.class);
-        when(skippedProcessor.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor, skippedProcessor);
+        final ProcessWorker processWorker = createObjectUnderTest();
+        processWorker.run();
 
-        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
-        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
-
-
-        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
-            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
-                    .thenReturn(futureHelperResult);
-
-            final ProcessWorker processWorker = createObjectUnderTest();
-
-            processWorker.run();
-        }
-
-        verify(skippedProcessor, never()).execute(any());
-    }
-
-    @Test
-    void testProcessWorkerWithProcessorThrowingExceptionAndAcknowledgmentsEnabledIsHandledProperly() {
-
-        when(source.areAcknowledgementsEnabled()).thenReturn(true);
-
-        final List<Record<Event>> records = new ArrayList<>();
-        final Record<Event> mockRecord = mock(Record.class);
-        final Event mockEvent = mock(Event.class);
-        final EventHandle eventHandle = mock(DefaultEventHandle.class);
-        final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-        ((InternalEventHandle)eventHandle).addAcknowledgementSet(acknowledgementSet);
-        when(mockRecord.getData()).thenReturn(mockEvent);
-        when(mockEvent.getEventHandle()).thenReturn(eventHandle);
-
-        records.add(mockRecord);
-
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
-
-        final Processor processor = mock(Processor.class);
-        when(processor.execute(records)).thenThrow(RuntimeException.class);
-        when(processor.isReadyForShutdown()).thenReturn(true);
-
-        final Processor skippedProcessor = mock(Processor.class);
-        when(skippedProcessor.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor, skippedProcessor);
-
-        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
-        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
-
-
-        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
-            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
-                    .thenReturn(futureHelperResult);
-
-            final ProcessWorker processWorker = createObjectUnderTest();
-
-            processWorker.run();
-        }
-
-        verify(skippedProcessor, never()).execute(any());
-    }
-
-    @Test
-    void testProcessWorkerWithProcessorDroppingAllRecordsAndAcknowledgmentsEnabledIsHandledProperly() {
-
-        when(source.areAcknowledgementsEnabled()).thenReturn(true);
-
-        final List<Record<Event>> records = new ArrayList<>();
-        final Record<Event> mockRecord = mock(Record.class);
-        final Event mockEvent = mock(Event.class);
-        final EventHandle eventHandle = mock(DefaultEventHandle.class);
-        final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-        ((InternalEventHandle)eventHandle).addAcknowledgementSet(acknowledgementSet);
-        when(mockRecord.getData()).thenReturn(mockEvent);
-        when(mockEvent.getEventHandle()).thenReturn(eventHandle);
-
-        records.add(mockRecord);
-
-        final CheckpointState checkpointState = mock(CheckpointState.class);
-        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
-        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
-
-        final Processor processor = mock(Processor.class);
-        when(processor.execute(records)).thenReturn(Collections.emptyList());
-        when(processor.isReadyForShutdown()).thenReturn(true);
-
-        final Processor secondProcessor = mock(Processor.class);
-        when(secondProcessor.isReadyForShutdown()).thenReturn(true);
-        when(secondProcessor.execute(Collections.emptyList())).thenReturn(Collections.emptyList());
-        processors = List.of(processor, secondProcessor);
-
-        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
-        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
-
-
-        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
-            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
-                    .thenReturn(futureHelperResult);
-
-            final ProcessWorker processWorker = createObjectUnderTest();
-
-            processWorker.run();
-        }
+        verify(pipelineRunner, atLeastOnce()).runAllProcessorsAndPublishToSinks();
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
@@ -1,27 +1,19 @@
 package org.opensearch.dataprepper.core.pipeline;
 
-import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.opensearch.dataprepper.core.pipeline.exceptions.InvalidEventHandleException;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.processor.Processor;
 
@@ -57,7 +49,10 @@ public class ProcessWorkerTest {
 
     private ProcessWorker createObjectUnderTest(boolean withPipelineRunner) {
         if (withPipelineRunner) {
-            return new ProcessWorker(buffer, processors, pipeline, pipelineRunner);
+            when(pipeline.getProcessors()).thenReturn(processors);
+            when(pipeline.getBuffer()).thenReturn(buffer);
+            when(pipelineRunner.getPipeline()).thenReturn(pipeline);
+            return new ProcessWorker(pipelineRunner);
         }
         return new ProcessWorker(buffer, processors, pipeline);
     }
@@ -103,33 +98,6 @@ public class ProcessWorkerTest {
         processWorker.run();
 
         verify(processor, atLeastOnce()).prepareForShutdown();
-    }
-
-    @Test
-    void testProcessWorkerInvalidEventHandleIncrementsCounter() {
-        processors = List.of(processor);
-        when(pipeline.isStopRequested()).thenReturn(false, true);
-        when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
-        when(buffer.isEmpty()).thenReturn(true);
-        when(processor.isReadyForShutdown()).thenReturn(true);
-
-        // Create a pipelineRunner mock that throws an InvalidEventHandleException on first call.
-        doThrow(new InvalidEventHandleException(""))
-                .doNothing()
-                .when(pipelineRunner).runAllProcessorsAndPublishToSinks();
-
-        try (MockedStatic<PluginMetrics> pluginMetricsStatic = mockStatic(PluginMetrics.class)) {
-            final PluginMetrics pluginMetrics = mock(PluginMetrics.class);
-            final Counter counter = mock(Counter.class);
-            when(pluginMetrics.counter(any())).thenReturn(counter);
-            pluginMetricsStatic.when(() -> PluginMetrics.fromNames("ProcessWorker", pipeline.getName()))
-                    .thenReturn(pluginMetrics);
-
-            final ProcessWorker processWorker = createObjectUnderTest();
-            processWorker.run();
-
-            verify(counter, atLeastOnce()).increment();
-        }
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -82,7 +82,7 @@ public class AggregateProcessorITWithAcks {
     private static final int GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE = 2;
     private static final int NUM_UNIQUE_EVENTS_PER_BATCH = 8;
     private static final int NUM_EVENTS_PER_BATCH = 5;
-    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(30);
 
     @Mock
     private Pipeline pipeline;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate;
 
+import org.opensearch.dataprepper.core.pipeline.PipelineRunner;
+import org.opensearch.dataprepper.core.pipeline.PipelineRunnerImpl;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
@@ -80,7 +82,7 @@ public class AggregateProcessorITWithAcks {
     private static final int GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE = 2;
     private static final int NUM_UNIQUE_EVENTS_PER_BATCH = 8;
     private static final int NUM_EVENTS_PER_BATCH = 5;
-    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
 
     @Mock
     private Pipeline pipeline;
@@ -197,14 +199,15 @@ public class AggregateProcessorITWithAcks {
                 .thenReturn(aggregateAction);
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
 
             processWorker.run();
         }
@@ -228,13 +231,15 @@ public class AggregateProcessorITWithAcks {
 
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
 
             processWorker.run();
         }
@@ -259,13 +264,15 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
 
             processWorker.run();
         }
@@ -290,13 +297,16 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+
 
             processWorker.run();
         }
@@ -316,14 +326,15 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
-
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -346,13 +357,15 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
 
             processWorker.run();
         }
@@ -402,14 +415,15 @@ public class AggregateProcessorITWithAcks {
 
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
-
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -456,15 +470,15 @@ public class AggregateProcessorITWithAcks {
         });
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
-
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -487,15 +501,15 @@ public class AggregateProcessorITWithAcks {
                 .thenReturn(aggregateAction);
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
-
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -520,15 +534,16 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
 
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -555,15 +570,15 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
-
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -583,15 +598,15 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-
+        when(pipeline.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
-
+            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -135,6 +135,7 @@ public class AggregateProcessorITWithAcks {
         when(pipeline.isStopRequested()).thenReturn(false).thenReturn(true);
         when(source.areAcknowledgementsEnabled()).thenReturn(true);
         when(pipeline.getSource()).thenReturn(source);
+        when(pipeline.getBuffer()).thenReturn(buffer);
         when(buffer.isEmpty()).thenReturn(true);
         when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(100));
         when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(500);


### PR DESCRIPTION
### Description
At Present, the functionalities of running a pipeline is encapsulated inside [Process Worker](https://github.com/opensearch-project/data-prepper/issues/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java). While this provides encapsulation, it does not provide a way for a given thread such as in the case of https://github.com/opensearch-project/data-prepper/pull/5416 to execute processors and publish to sinks in a synchronous way without having an instance of Process Worker itself which contains additional responsibilities such as shutting down process for pipeline.

Implemented a concrete class for [Pipeline Runner](data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunner.java) by moving and refactoring the functionalities of reading from buffer, executing processors and publishing to sinks from Process Worker to it, also added additional unit tests for coverage.
 
### Issues Resolved
Resolves #5429
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
