### PR TITLE
Add NOISY marker to opensearch sink failure logs

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -86,6 +86,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
 @DataPrepperPlugin(name = "opensearch", pluginType = Sink.class)
 public class OpenSearchSink extends AbstractSink<Record<Event>> {
   public static final String BULKREQUEST_LATENCY = "bulkRequestLatency";
@@ -399,7 +401,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       try {
           indexName = indexManager.getIndexName(event.formatString(indexName, expressionEvaluator));
       } catch (final Exception e) {
-          LOG.error("There was an exception when constructing the index name. Check the dlq if configured to see details about the affected Event: {}", e.getMessage());
+          LOG.error(NOISY, "There was an exception when constructing the index name. Check the dlq if configured to see details about the affected Event: {}", e.getMessage());
           dynamicIndexDroppedEvents.increment();
           logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
           continue;
@@ -558,7 +560,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
                   BulkOperationWriter.dlqObjectToString(dlqObject), message));
           dlqObject.releaseEventHandle(true);
         } catch (final IOException e) {
-        LOG.error("Failed to write a document to the DLQ", e);
+        LOG.error(NOISY, "Failed to write a document to the DLQ", e);
           dlqObject.releaseEventHandle(false);
         }
       });
@@ -570,7 +572,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         });
       } catch (final IOException e) {
         dlqObjects.forEach(dlqObject -> {
-          LOG.error("Failed to write a document to the DLQ", e);
+          LOG.error(NOISY, "Failed to write a document to the DLQ", e);
           dlqObject.releaseEventHandle(false);
         });
       }


### PR DESCRIPTION
### Description
Add NOISY marker to opensearch sink failure logs

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
