### PR TITLE
Deal with Control Characters in DynamoDB

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,12 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
-import io.netty.handler.codec.base64.Base64Encoder;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
@@ -19,8 +16,6 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamCo
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
-import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BigDecimalAttributeConverter;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.OperationType;
 import software.amazon.awssdk.services.dynamodb.model.Record;

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
@@ -40,9 +39,6 @@ public class StreamRecordConverter extends RecordConverter {
     static final String BYTES_PROCESSED = "bytesProcessed";
 
     private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
-
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
-    };
 
     private final StreamConfig streamConfig;
 
@@ -127,44 +123,43 @@ public class StreamRecordConverter extends RecordConverter {
 
         data.forEach(((attributeName, attributeValue) -> {
             //dealing with all dynamo db attribute types
-            if (attributeValue.type() == AttributeValue.Type.N) {
-                // N for number
-                result.put(attributeName, new BigDecimal(attributeValue.n()));
-            } else if (attributeValue.type() == AttributeValue.Type.B) {
-                // B for Binary
-                result.put(attributeName, BASE64_ENCODER.encodeToString(attributeValue.b().asByteArray()));
-            } else if (attributeValue.type() == AttributeValue.Type.S) {
-                // S for String
-                result.put(attributeName, attributeValue.s());
-            } else if (attributeValue.type() == AttributeValue.Type.BOOL) {
-                // BOOL for Boolean
-                result.put(attributeName, attributeValue.bool());
-            } else if (attributeValue.type() == AttributeValue.Type.NS) {
-                // NS for Number Set
-                result.put(attributeName,
-                        attributeValue.ns().stream()
-                                .map(BigDecimal::new)
-                                .collect(Collectors.toSet())
-                );
-            } else if (attributeValue.type() == AttributeValue.Type.BS) {
-                // BS for Binary Set
-                result.put(attributeName, attributeValue.bs().stream()
-                        .map(buffer -> BASE64_ENCODER.encodeToString(buffer.asByteArray()))
-                        .collect(Collectors.toSet()));
-            } else if (attributeValue.type() == AttributeValue.Type.SS) {
-                // SS for String Set
-                result.put(attributeName, attributeValue.ss());
-            } else if (attributeValue.type() == AttributeValue.Type.L) {
-                // L for List
-                result.put(attributeName, convertListData(attributeValue.l()));
-            } else if (attributeValue.type() == AttributeValue.Type.M) {
-                // M for Map
-                result.put(attributeName, convertData(attributeValue.m()));
-            } else if (attributeValue.type() == AttributeValue.Type.NUL) {
-                // NUL for Null
-                result.put(attributeName, null);
-            } else {
-                throw new IllegalStateException("Unsupported attribute type: " + attributeValue.type());
+            switch (attributeValue.type()){
+                case N:     // N for number
+                    result.put(attributeName, new BigDecimal(attributeValue.n()));
+                    break;
+                case B:     // B for Binary
+                    result.put(attributeName, BASE64_ENCODER.encodeToString(attributeValue.b().asByteArray()));
+                    break;
+                case S:     // S for String
+                    result.put(attributeName, attributeValue.s());
+                    break;
+                case BOOL:  // BOOL for Boolean
+                    result.put(attributeName, attributeValue.bool());
+                    break;
+                case NS:    // NS for Number Set
+                    result.put(attributeName,
+                            attributeValue.ns().stream()
+                                    .map(BigDecimal::new).collect(Collectors.toSet()));
+                    break;
+                case BS:    // BS for Binary Set
+                    result.put(attributeName, attributeValue.bs().stream()
+                            .map(buffer -> BASE64_ENCODER.encodeToString(buffer.asByteArray()))
+                            .collect(Collectors.toSet()));
+                    break;
+                case SS:    // SS for String Set
+                    result.put(attributeName, attributeValue.ss());
+                    break;
+                case L:     // L for List
+                    result.put(attributeName, convertListData(attributeValue.l()));
+                    break;
+                case M:     // M for Map
+                    result.put(attributeName, convertData(attributeValue.m()));
+                    break;
+                case NUL:  // NUL for Null
+                    result.put(attributeName, null);
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported attribute type: " + attributeValue.type());
             }
         }));
         return result;
@@ -175,43 +170,42 @@ public class StreamRecordConverter extends RecordConverter {
 
         data.forEach(((attributeValue) -> {
             //dealing with all dynamo db attribute types
-            if (attributeValue.type() == AttributeValue.Type.N) {
-                // N for number
-                result.add(new BigDecimal(attributeValue.n()));
-            } else if (attributeValue.type() == AttributeValue.Type.B) {
-                // B for Binary
-                result.add(BASE64_ENCODER.encodeToString(attributeValue.b().asByteArray()));
-            } else if (attributeValue.type() == AttributeValue.Type.S) {
-                // S for String
-                result.add(attributeValue.s());
-            } else if (attributeValue.type() == AttributeValue.Type.BOOL) {
-                // BOOL for Boolean
-                result.add(attributeValue.bool());
-            } else if (attributeValue.type() == AttributeValue.Type.NS) {
-                // NS for Number Set
-                result.add(attributeValue.ns().stream()
-                                .map(BigDecimal::new)
-                                .collect(Collectors.toSet())
-                );
-            } else if (attributeValue.type() == AttributeValue.Type.BS) {
-                // BS for Binary Set
-                result.add(attributeValue.bs().stream()
-                        .map(buffer -> BASE64_ENCODER.encodeToString(buffer.asByteArray()))
-                        .collect(Collectors.toSet()));
-            } else if (attributeValue.type() == AttributeValue.Type.SS) {
-                // SS for String Set
-                result.add(attributeValue.ss());
-            } else if (attributeValue.type() == AttributeValue.Type.L) {
-                // L for List
-                result.add(convertListData(attributeValue.l()));
-            } else if (attributeValue.type() == AttributeValue.Type.M) {
-                // M for Map
-                result.add(convertData(attributeValue.m()));
-            } else if (attributeValue.type() == AttributeValue.Type.NUL) {
-                // NUL for Null
-                result.add(null);
-            } else {
-                throw new IllegalStateException("Unsupported attribute type: " + attributeValue.type());
+            switch (attributeValue.type()) {
+                case N:     // N for number
+                    result.add(new BigDecimal(attributeValue.n()));
+                    break;
+                case B:     // B for Binary
+                    result.add(BASE64_ENCODER.encodeToString(attributeValue.b().asByteArray()));
+                    break;
+                case S:      // S for String
+                    result.add(attributeValue.s());
+                    break;
+                case BOOL:   // BOOL for Boolean
+                    result.add(attributeValue.bool());
+                    break;
+                case NS:     // NS for Number Set
+                    result.add(attributeValue.ns().stream()
+                            .map(BigDecimal::new).collect(Collectors.toSet()));
+                    break;
+                case BS:    // BS for Binary Set
+                    result.add(attributeValue.bs().stream()
+                            .map(buffer -> BASE64_ENCODER.encodeToString(buffer.asByteArray()))
+                            .collect(Collectors.toSet()));
+                    break;
+                case SS:    // SS for String Set
+                    result.add(attributeValue.ss());
+                    break;
+                case L:     // L for List
+                    result.add(convertListData(attributeValue.l()));
+                    break;
+                case M:     // M for Map
+                    result.add(convertData(attributeValue.m()));
+                    break;
+                case NUL:   // NUL for Null
+                    result.add(null);
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported attribute type: " + attributeValue.type());
             }
         }));
         return result;

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,6 +68,7 @@ public class StreamRecordConverter extends RecordConverter {
         this.bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
         this.streamConfig = streamConfig;
 
+        MAPPER.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
     }
 
     @Override

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -163,6 +163,8 @@ public class StreamRecordConverter extends RecordConverter {
             } else if (attributeValue.type() == AttributeValue.Type.NUL) {
                 // NUL for Null
                 result.put(attributeName, null);
+            } else {
+                throw new IllegalStateException("Unsupported attribute type: " + attributeValue.type());
             }
         }));
         return result;
@@ -208,6 +210,8 @@ public class StreamRecordConverter extends RecordConverter {
             } else if (attributeValue.type() == AttributeValue.Type.NUL) {
                 // NUL for Null
                 result.add(null);
+            } else {
+                throw new IllegalStateException("Unsupported attribute type: " + attributeValue.type());
             }
         }));
         return result;

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -188,7 +188,9 @@ class StreamRecordConverterTest {
             "and/or",
             "c:\\Home",
             "I take\nup multiple\nlines",
-            "String with some \"backquotes\"."
+            "String with some \"backquotes\".",
+            "\u0003 \u0002 \u0001 \u0000 control characters",
+            "\b control characters"
     })
     void test_writeSingleRecordToBuffer_with_other_data(final String additionalString) throws Exception {
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -247,7 +247,6 @@ class StreamRecordConverterTest {
         final Map<String, AttributeValue> data = Map.of("Data", attributeValue);
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(1, Instant.now(), data);
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
-        software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
         final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
         doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
 


### PR DESCRIPTION
### Description
Manually Parse DDB Records

- Tested by adding control characters to test_writeSingleRecordToBuffer_with_other_data in StreamRecordConveterTest
- Tested by running DynamoDB source pipeline on local and ingesting records with control characters successfully.
- Tested by running DynamoDB source pipeline on local and ingesting records with more complex data structures like lists, maps, lists and maps in lists, and lists and maps in maps as well as every other ddb data type.  Compared output to output of unchanged dataprepper.

 
### Issues Resolved
Resolves #5027 .  Bug ingesting control characters from dynamo db
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
