### PR TITLE
Data type mapping for postgres export

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/ColumnType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/ColumnType.java
@@ -14,12 +14,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum ColumnType {
-    BOOLEAN(16, "boolean"),
-    SMALLINT(21, "smallint"),
-    INTEGER(23, "integer"),
-    BIGINT(20, "bigint"),
-    REAL(700, "real"),
-    DOUBLE_PRECISION(701, "double precision"),
+    BOOLEAN(16, "bool"),
+    SMALLINT(21, "int2"),
+    INTEGER(23, "int4"),
+    BIGINT(20, "int8"),
+    REAL(700, "float4"),
+    DOUBLE_PRECISION(701, "float8"),
     NUMERIC(1700, "numeric"),
     TEXT(25, "text"),
     BPCHAR(1042, "bpchar"),

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataType.java
@@ -5,14 +5,14 @@ import java.util.Map;
 
 public enum PostgresDataType {
     // Numeric types
-    SMALLINT("smallint", DataCategory.NUMERIC),
-    INTEGER("integer", DataCategory.NUMERIC),
-    BIGINT("bigint", DataCategory.NUMERIC),
-    SMALLSERIAL("small", DataCategory.NUMERIC),
-    SERIAL("mediumint unsigned", DataCategory.NUMERIC),
-    BIGSERIAL("int", DataCategory.NUMERIC),
-    REAL("real", DataCategory.NUMERIC),
-    DOUBLE_PRECISION("double precision", DataCategory.NUMERIC),
+    SMALLINT("int2", DataCategory.NUMERIC),
+    INTEGER("int4", DataCategory.NUMERIC),
+    BIGINT("int8", DataCategory.NUMERIC),
+    SMALLSERIAL("smallserial", DataCategory.NUMERIC),
+    SERIAL("serial", DataCategory.NUMERIC),
+    BIGSERIAL("bigserial", DataCategory.NUMERIC),
+    REAL("float4", DataCategory.NUMERIC),
+    DOUBLE_PRECISION("float8", DataCategory.NUMERIC),
     NUMERIC("numeric", DataCategory.NUMERIC),
     MONEY("money", DataCategory.NUMERIC),
 
@@ -30,7 +30,7 @@ public enum PostgresDataType {
     JSONB("jsonb",DataCategory.JSON),
 
     //Boolean data type
-    BOOLEAN("boolean", DataCategory.BOOLEAN),
+    BOOLEAN("bool", DataCategory.BOOLEAN),
 
     //Date-time data types
     DATE("date", DataCategory.TEMPORAL),

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataTypeHandler.java
@@ -6,6 +6,8 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres;
  * to appropriate object representations based on their data types.
  */
 public interface PostgresDataTypeHandler {
+    String BYTES_KEY = "bytes";
+
     default Object process(final PostgresDataType columnType, final String columnName, final Object value) {
         if(value == null)
             return null;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandler.java
@@ -3,6 +3,11 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.opensearch.dataprepper.plugins.source.rds.utils.BytesHexConverter.bytesToHex;
+
 
 public class BinaryTypeHandler implements PostgresDataTypeHandler {
     @Override
@@ -10,6 +15,12 @@ public class BinaryTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isBinary()) {
             throw new IllegalArgumentException("ColumnType is not Binary : " + columnType);
         }
+        if (value instanceof Map) {
+            Object data = ((Map<?, ?>)value).get(BYTES_KEY);
+            byte[] bytes = ((String) data).getBytes(StandardCharsets.ISO_8859_1);
+            return "\\x" + bytesToHex(bytes);
+        }
         return value.toString();
     }
+
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandler.java
@@ -3,14 +3,13 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
 
-import java.util.Objects;
-
 public class BooleanTypeHandler implements PostgresDataTypeHandler {
     @Override
     public Object handle(PostgresDataType columnType, String columnName, Object value) {
         if (!columnType.isBoolean()) {
             throw new IllegalArgumentException("ColumnType is not Boolean: " + columnType);
         }
-        return (Objects.equals(value.toString(), "t")) ? Boolean.TRUE: Boolean.FALSE;
+        final String booleanValue = value.toString();
+        return booleanValue.equals("t") || booleanValue.equals("true") ? Boolean.TRUE : Boolean.FALSE;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -22,6 +22,8 @@ import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.Data
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.DataFileProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.mysql.MySQLDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.mysql.MySQLDataTypeHelper;
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHelper;
 import org.opensearch.dataprepper.plugins.source.rds.model.DbTableMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,12 +177,19 @@ public class DataFileLoader implements Runnable {
     }
 
     private void transformEvent(final Event event, final String fullTableName, final EngineType engineType) {
-        // TODO: support data type mapping in Postgres
         if (engineType == EngineType.MYSQL) {
             Map<String, String> columnDataTypeMap = dbTableMetadata.getTableColumnDataTypeMap().get(fullTableName);
             for (Map.Entry<String, Object> entry : event.toMap().entrySet()) {
                 final Object data = MySQLDataTypeHelper.getDataByColumnType(MySQLDataType.byDataType(columnDataTypeMap.get(entry.getKey())), entry.getKey(),
                         entry.getValue(), null);
+                event.put(entry.getKey(), data);
+            }
+        }
+        if (engineType == EngineType.POSTGRES) {
+            Map<String, String> columnDataTypeMap = dbTableMetadata.getTableColumnDataTypeMap().get(fullTableName);
+            for (Map.Entry<String, Object> entry : event.toMap().entrySet()) {
+                final Object data = PostgresDataTypeHelper.getDataByColumnType(PostgresDataType.byDataType(columnDataTypeMap.get(entry.getKey())), entry.getKey(),
+                        entry.getValue());
                 event.put(entry.getKey(), data);
             }
         }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManager.java
@@ -74,7 +74,9 @@ public class MySqlSchemaManager implements SchemaManager {
         return List.of();
     }
 
-    public Map<String, String> getColumnDataTypes(final String database, final String tableName) {
+    public Map<String, String> getColumnDataTypes(final String fullTableName) {
+        final String database = fullTableName.split("\\.")[0];
+        final String tableName = fullTableName.split("\\.")[1];
         final Map<String, String> columnsToDataType =  new HashMap<>();
         for (int retry = 0; retry <= NUM_OF_RETRIES; retry++) {
             try (Connection connection = connectionManager.getConnection()) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/PostgresSchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/PostgresSchemaManager.java
@@ -16,11 +16,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+
 
 public class PostgresSchemaManager implements SchemaManager {
     private static final Logger LOG = LoggerFactory.getLogger(PostgresSchemaManager.class);
@@ -29,6 +33,7 @@ public class PostgresSchemaManager implements SchemaManager {
     static final int NUM_OF_RETRIES = 3;
     static final int BACKOFF_IN_MILLIS = 500;
     static final String COLUMN_NAME = "COLUMN_NAME";
+    static final String TYPE_NAME = "TYPE_NAME";
     static final String PGOUTPUT = "pgoutput";
 
     public PostgresSchemaManager(ConnectionManager connectionManager) {
@@ -115,6 +120,38 @@ public class PostgresSchemaManager implements SchemaManager {
             retry++;
         }
         throw new RuntimeException("Failed to get primary keys for table " + fullTableName);
+    }
+
+
+    public Map<String, String> getColumnDataTypes(final String fullTableName) {
+        final String[] splits = fullTableName.split("\\.");
+        final String database = splits[0];
+        final String schema = splits[1];
+        final String table = splits[2];
+        final Map<String, String> columnsToDataType =  new HashMap<>();
+        for (int retry = 0; retry <= NUM_OF_RETRIES; retry++) {
+            try (Connection connection = connectionManager.getConnection()) {
+                final DatabaseMetaData metaData = connection.getMetaData();
+                // Retrieve column metadata
+                try (ResultSet columns = metaData.getColumns(database, schema, table, null)) {
+                    while (columns.next()) {
+                        columnsToDataType.put(
+                                columns.getString(COLUMN_NAME),
+                                columns.getString(TYPE_NAME)
+                        );
+                    }
+                }
+                return columnsToDataType;
+            } catch (final Exception e) {
+                LOG.error("Failed to get dataTypes for database {} schema {} table {}, retrying", database, schema, table, e);
+                if (retry == NUM_OF_RETRIES) {
+                    throw new RuntimeException(String.format("Failed to get dataTypes for database %s schema %s table %s after " +
+                            "%d retries", database, schema, table, retry), e);
+                }
+            }
+            applyBackoff();
+        }
+        return columnsToDataType;
     }
 
     private void applyBackoff() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/SchemaManager.java
@@ -1,6 +1,7 @@
 package org.opensearch.dataprepper.plugins.source.rds.schema;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface for manager classes that are used to get metadata of a database, such as table schemas
@@ -12,4 +13,10 @@ public interface SchemaManager {
      * @return List of primary keys
      */
     List<String> getPrimaryKeys(final String fullTableName);
+    /**
+     * Get the mapping of columns to data types for a table
+     * @param fullTableName The full table name
+     * @return Map of column names to data types
+     */
+    Map<String,String> getColumnDataTypes(final String fullTableName);
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/BytesHexConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/BytesHexConverter.java
@@ -1,0 +1,13 @@
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+public class BytesHexConverter {
+    public static String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandlerTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,5 +27,20 @@ public class BinaryTypeHandlerTest {
         Object result = handler.process(columnType, columnName, value);
         assertThat(result, is(instanceOf(String.class)));
         assertThat(result, is(value));
+    }
+
+    @Test
+    public void test_handle_map_value_byte() {
+        final PostgresDataType columnType = PostgresDataType.BYTEA;
+        final String columnName = "test_column";
+        final Map<String, Object> value = new HashMap<>();
+        final String testData = "Text with a single quote: O'Reilly";
+        final String expected = "\\x54657874207769746820612073696e676c652071756f74653a204f275265696c6c79";
+        value.put("bytes", testData);
+
+        final Object result = handler.handle(columnType, columnName, value);
+
+        assertThat(result, is(instanceOf(String.class)));
+        assertThat(result, is(expected));
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandlerTest.java
@@ -3,7 +3,12 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -18,12 +23,12 @@ public class BooleanTypeHandlerTest {
         handler = new BooleanTypeHandler();
     }
 
-    @Test
-    void test_handle_true_values() {
-        String value = "t";
+    @ParameterizedTest
+    @MethodSource("provideTrueData")
+    void test_handle_true_values(String value, Boolean expected) {
         Object result = handler.process(PostgresDataType.BOOLEAN, "testColumn", value);
         assertThat(result, is(instanceOf(Boolean.class)));
-        assertThat(result, is(Boolean.TRUE));
+        assertThat(result, is(expected));
     }
 
     @Test
@@ -37,6 +42,13 @@ public class BooleanTypeHandlerTest {
     void test_handle_non_boolean_type() {
         assertThrows(IllegalArgumentException.class, () ->
                 handler.process(PostgresDataType.INTEGER, "testColumn", 123)
+        );
+    }
+
+    private static Stream<Arguments> provideTrueData() {
+        return Stream.of(
+                Arguments.of("t", Boolean.TRUE),
+                Arguments.of("true",  Boolean.TRUE)
         );
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManagerTest.java
@@ -134,7 +134,7 @@ class MySqlSchemaManagerTest {
         when(connection.getMetaData()).thenReturn(databaseMetaData);
         when(databaseMetaData.getColumns(database, null, tableName, null)).thenThrow(new SQLException("Test exception"));
 
-        assertThrows(RuntimeException.class, () -> schemaManager.getColumnDataTypes(database, tableName));
+        assertThrows(RuntimeException.class, () -> schemaManager.getColumnDataTypes(database + "." + tableName));
     }
 
     @Test
@@ -144,7 +144,7 @@ class MySqlSchemaManagerTest {
 
         when(connectionManager.getConnection()).thenThrow(new SQLException("Connection failed"));
 
-        assertThrows(RuntimeException.class, () -> schemaManager.getColumnDataTypes(database, tableName));
+        assertThrows(RuntimeException.class, () -> schemaManager.getColumnDataTypes(database + "." + tableName));
     }
 
     @Test
@@ -171,7 +171,7 @@ class MySqlSchemaManagerTest {
         when(resultSet.getString(TYPE_NAME))
                 .thenReturn("INTEGER", "VARCHAR", "TIMESTAMP");
 
-        Map<String, String> result = schemaManager.getColumnDataTypes(database, tableName);
+        Map<String, String> result = schemaManager.getColumnDataTypes(database + "." + tableName);
 
         assertThat(result, notNullValue());
         assertThat(result.size(), is(expectedColumnTypes.size()));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/BytesHexConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/BytesHexConverterTest.java
@@ -1,0 +1,20 @@
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import org.junit.jupiter.api.Test;
+
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BytesHexConverterTest {
+    @Test
+    void test_bytes_to_hex_string() {
+        final String testData = "Text with a single quote: O'Reilly";
+        byte[] bytes = testData.getBytes(StandardCharsets.ISO_8859_1);
+        final String expected = "54657874207769746820612073696e676c652071756f74653a204f275265696c6c79";
+        final String result = BytesHexConverter.bytesToHex(bytes);
+        assertThat(result, equalTo(expected));
+    }
+}


### PR DESCRIPTION
Data type mapping for postgres export

### Description

- Added support for data type mapping for postgres export. 
- Added conversion to hexadecimal representation for binary data type for uniformity between rds stream and export. 
- Refactored the numeric and boolean data type names in postgres to represent its internal names.

### Issues Resolved
Contributes to https://github.com/opensearch-project/data-prepper/issues/5309
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
