### PR TITLE
Minor changes to logging, add ability to get partition with custom partition type

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourceCoordinator.java
@@ -116,6 +116,8 @@ public interface EnhancedSourceCoordinator {
      */
     Optional<EnhancedSourcePartition> getPartition(final String partitionKey);
 
+    Optional<EnhancedSourcePartition> getPartition(final String partitionKey, final String partitionType);
+
     /**
      * This method is to perform initialization for the coordinator
      */

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/sourcecoordination/enhanced/EnhancedLeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/sourcecoordination/enhanced/EnhancedLeaseBasedSourceCoordinatorTest.java
@@ -237,4 +237,14 @@ class EnhancedLeaseBasedSourceCoordinatorTest {
         Optional<EnhancedSourcePartition> sourcePartition = coordinator.getPartition(partitionKey);
         assertThat(sourcePartition.isPresent(), equalTo(true));
     }
+
+    @Test
+    void getPartition_with_custom_partition_type() {
+        String partitionKey = UUID.randomUUID().toString();
+        String partitionType = UUID.randomUUID().toString();
+        given(sourceCoordinationStore.getSourcePartitionItem(eq(sourceIdentifier + "|" + partitionType), eq(partitionKey))).willReturn(Optional.of(sourcePartitionStoreItem));
+        coordinator = createObjectUnderTest();
+        Optional<EnhancedSourcePartition> sourcePartition = coordinator.getPartition(partitionKey, partitionType);
+        assertThat(sourcePartition.isPresent(), equalTo(true));
+    }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -165,7 +165,7 @@ public class DynamoDbClientWrapper {
         try {
             tryUpdateItem(dynamoDbSourcePartitionItem);
         } catch (final PartitionUpdateException e) {
-            LOG.warn(e.getMessage(), e);
+            LOG.debug(e.getMessage(), e);
             throw e;
         }
     }


### PR DESCRIPTION
### Description
* Adds ability to get partition by type with enhanced source coordinator API `getPartition(String partitionKey, String partitionType)`
* Adds log for when partitions are created in enhanced source coordinator
* Remove verbose log for conditional checks on updates. If this is important the source will already log this, and in many cases this log is just a distraction as there are cases where conditional exceptions are expected often, for example DDB export processing
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
