### PR TITLE
Confluence pagination handling

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
@@ -18,11 +18,20 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 
 @Getter
 public class ConfluenceSourceConfig extends AtlassianSourceConfig implements CrawlerSourceConfig {
+
+    private static final int DEFAULT_BATCH_SIZE = 50;
+    
     /**
      * Filter Config to filter what tickets get ingested
      */
     @JsonProperty("filter")
     private FilterConfig filterConfig;
+
+    /**
+     * Batch size for fetching tickets
+     */
+    @JsonProperty("batch_size")
+    private int batchSize = DEFAULT_BATCH_SIZE;
 
 
     /**

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
@@ -20,19 +20,12 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 public class ConfluenceSourceConfig extends AtlassianSourceConfig implements CrawlerSourceConfig {
 
     private static final int DEFAULT_BATCH_SIZE = 50;
-    
+
     /**
      * Filter Config to filter what tickets get ingested
      */
     @JsonProperty("filter")
     private FilterConfig filterConfig;
-
-    /**
-     * Batch size for fetching tickets
-     */
-    @JsonProperty("batch_size")
-    private int batchSize = DEFAULT_BATCH_SIZE;
-
 
     /**
      * Boolean property indicating end to end acknowledgments state

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluencePaginationLinks.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluencePaginationLinks.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.confluence.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Setter
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConfluencePaginationLinks {
+
+    /**
+     * base url
+     */
+    @JsonProperty("base")
+    private String base = null;
+
+    /**
+     * url context
+     */
+    @JsonProperty("context")
+    private String context = null;
+
+    /**
+     * next page link if available
+     */
+    @JsonProperty("next")
+    private String next = null;
+
+    /**
+     * previous page link if available
+     */
+    @JsonProperty("previous")
+    private String previous = null;
+
+    /**
+     * current page link
+     */
+    @JsonProperty("self")
+    private String self = null;
+
+}

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluenceSearchResults.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluenceSearchResults.java
@@ -37,4 +37,7 @@ public class ConfluenceSearchResults {
     @JsonProperty("results")
     private List<ConfluenceItem> results = null;
 
+    @JsonProperty("_links")
+    private ConfluencePaginationLinks links = null;
+
 }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
@@ -40,7 +40,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
     //public static final String REST_API_SPACES = "/rest/api/api/spaces";
     public static final String FIFTY = "50";
     public static final String START_AT = "startAt";
-    public static final String MAX_RESULT = "limit";
+    public static final String LIMIT = "limit";
     private static final String PAGE_FETCH_LATENCY_TIMER = "pageFetchLatency";
     private static final String SEARCH_CALL_LATENCY_TIMER = "searchCallLatency";
     private static final String SPACES_FETCH_LATENCY_TIMER = "spacesFetchLatency";
@@ -84,7 +84,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
             }
         } else {
             uri = UriComponentsBuilder.fromHttpUrl(authConfig.getUrl() + REST_API_SEARCH)
-                    .queryParam(MAX_RESULT, FIFTY)
+                    .queryParam(LIMIT, FIFTY)
                     .queryParam(START_AT, startAt)
                     .queryParam(CQL_FIELD, cql)
                     .queryParam(EXPAND_FIELD, EXPAND_VALUE)

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
@@ -40,7 +40,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
     //public static final String REST_API_SPACES = "/rest/api/api/spaces";
     public static final String FIFTY = "50";
     public static final String START_AT = "startAt";
-    public static final String LIMIT = "limit";
+    public static final String LIMIT_PARAM = "limit";
     private static final String PAGE_FETCH_LATENCY_TIMER = "pageFetchLatency";
     private static final String SEARCH_CALL_LATENCY_TIMER = "searchCallLatency";
     private static final String SPACES_FETCH_LATENCY_TIMER = "spacesFetchLatency";
@@ -84,7 +84,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
             }
         } else {
             uri = UriComponentsBuilder.fromHttpUrl(authConfig.getUrl() + REST_API_SEARCH)
-                    .queryParam(LIMIT, FIFTY)
+                    .queryParam(LIMIT_PARAM, FIFTY)
                     .queryParam(START_AT, startAt)
                     .queryParam(CQL_FIELD, cql)
                     .queryParam(EXPAND_FIELD, EXPAND_VALUE)

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceIteratorTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceIteratorTest.java
@@ -59,7 +59,7 @@ public class ConfluenceIteratorTest {
         confluenceIterator = createObjectUnderTest();
         assertNotNull(confluenceIterator);
         confluenceIterator.initialize(Instant.ofEpochSecond(0));
-        doReturn(mockConfluenceSearchResults).when(confluenceRestClient).getAllContent(any(StringBuilder.class), anyInt());
+        doReturn(mockConfluenceSearchResults).when(confluenceRestClient).getAllContent(any(StringBuilder.class), anyInt(), any());
         assertFalse(confluenceIterator.hasNext());
     }
 

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceServiceTest.java
@@ -23,6 +23,7 @@ import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationExcepti
 import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.Oauth2Config;
 import org.opensearch.dataprepper.plugins.source.confluence.models.ConfluenceItem;
+import org.opensearch.dataprepper.plugins.source.confluence.models.ConfluencePaginationLinks;
 import org.opensearch.dataprepper.plugins.source.confluence.models.ConfluenceSearchResults;
 import org.opensearch.dataprepper.plugins.source.confluence.models.SpaceItem;
 import org.opensearch.dataprepper.plugins.source.confluence.rest.ConfluenceRestClient;
@@ -188,11 +189,15 @@ public class ConfluenceServiceTest {
         mockPages.add(item2);
         ConfluenceItem item3 = createConfluenceItemBean();
         mockPages.add(item3);
+        ConfluencePaginationLinks paginationLinks = mock(ConfluencePaginationLinks.class);
 
         ConfluenceSearchResults mockConfluenceSearchResults = mock(ConfluenceSearchResults.class);
         when(mockConfluenceSearchResults.getResults()).thenReturn(mockPages);
+        when(mockConfluenceSearchResults.getLinks()).thenReturn(paginationLinks);
+        //End the pagination.
+        when(paginationLinks.getNext()).thenReturn(null);
 
-        doReturn(mockConfluenceSearchResults).when(confluenceRestClient).getAllContent(any(StringBuilder.class), anyInt());
+        doReturn(mockConfluenceSearchResults).when(confluenceRestClient).getAllContent(any(StringBuilder.class), anyInt(), any());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
@@ -217,7 +222,7 @@ public class ConfluenceServiceTest {
         ConfluenceSearchResults mockConfluenceSearchResults = mock(ConfluenceSearchResults.class);
         when(mockConfluenceSearchResults.getResults()).thenReturn(mockIssues);
 
-        doReturn(mockConfluenceSearchResults).when(confluenceRestClient).getAllContent(any(StringBuilder.class), anyInt());
+        doReturn(mockConfluenceSearchResults).when(confluenceRestClient).getAllContent(any(StringBuilder.class), anyInt(), any());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClientTest.java
@@ -118,7 +118,7 @@ public class ConfluenceRestClientTest {
         ConfluenceSearchResults mockConfluenceSearchResults = mock(ConfluenceSearchResults.class);
         doReturn("http://mock-service.jira.com/").when(authConfig).getUrl();
         doReturn(new ResponseEntity<>(mockConfluenceSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
-        ConfluenceSearchResults results = confluenceRestClient.getAllContent(jql, 0);
+        ConfluenceSearchResults results = confluenceRestClient.getAllContent(jql, 0, null);
         assertNotNull(results);
     }
 
@@ -130,7 +130,7 @@ public class ConfluenceRestClientTest {
         ConfluenceSearchResults mockConfluenceSearchResults = mock(ConfluenceSearchResults.class);
         when(authConfig.getUrl()).thenReturn("https://example.com/");
         doReturn(new ResponseEntity<>(mockConfluenceSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
-        ConfluenceSearchResults results = confluenceRestClient.getAllContent(jql, 0);
+        ConfluenceSearchResults results = confluenceRestClient.getAllContent(jql, 0, null);
         assertNotNull(results);
     }
 


### PR DESCRIPTION
### Description
With each search call, Confluence API returns the cursors for the next page that we should use to navigate through the search results. Enhanced the code to follow through these cursor based navigation
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
