### PR TITLE
S3-Source Bug Fix: Handle null object size for non S3-Create Events

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
@@ -37,7 +37,8 @@ public class ParsedMessage {
          // S3EventNotification contains only one S3EventNotificationRecord
         this.bucketName = notificationRecords.get(0).getS3().getBucket().getName();
         this.objectKey = notificationRecords.get(0).getS3().getObject().getUrlDecodedKey();
-        this.objectSize = notificationRecords.get(0).getS3().getObject().getSizeAsLong();
+        Long size = notificationRecords.get(0).getS3().getObject().getSizeAsLong();
+        this.objectSize = (size != null) ? size : 0L;
         this.eventName = notificationRecords.get(0).getEventName();
         this.eventTime = notificationRecords.get(0).getEventTime();
         this.failedParsing = false;

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
@@ -134,6 +134,13 @@ class ParsedMessageTest {
             assertThat(actualString, containsString(messageId));
             assertThat(actualString, containsString(testDecodedObjectKey));
         }
+
+        @Test
+        void test_parsed_message_with_null_object_size_defaults_to_zero() {
+            when(s3ObjectEntity.getSizeAsLong()).thenReturn(null);
+            final ParsedMessage parsedMessage = createObjectUnderTest();
+            assertThat(parsedMessage.getObjectSize(), equalTo(0L));
+        }
     }
 
     @Nested


### PR DESCRIPTION
### Description
This PR fixes a NullPointerException that occurs when processing non S3-create events such as S3-delete due to the absence of an object size in the event notification. The `getSizeAsLong()` method can return null for delete events, which caused the application to throw an error.
 
### Issues Resolved
Resolves #5448
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
