### PR TITLE
Fix opensearch sink

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('software.amazon.awssdk:bom:2.25.11')
+        implementation platform('software.amazon.awssdk:bom:2.30.23')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     }
 }


### PR DESCRIPTION
### Description
After updating opensearch-java to 2.20 in #5426, we start to see this error in opensearch sink when writing to AWS OpenSearch domain:
```
org.opensearch.dataprepper.core.pipeline.common.FutureHelper - FutureTask failed due to: 
java.util.concurrent.ExecutionException: java.lang.NoSuchMethodError: 'software.amazon.awssdk.http.ContentStreamProvider software.amazon.awssdk.http.ContentStreamProvider.fromByteArrayUnsafe(byte[])'
...
Caused by: java.lang.NoSuchMethodError: 'software.amazon.awssdk.http.ContentStreamProvider software.amazon.awssdk.http.ContentStreamProvider.fromByteArrayUnsafe(byte[])'
	at org.opensearch.client.transport.aws.AwsSdk2Transport.prepareRequest(AwsSdk2Transport.java:347) ~[opensearch-java-2.20.0.jar:?]
	at org.opensearch.client.transport.aws.AwsSdk2Transport.performRequest(AwsSdk2Transport.java:214) ~[opensearch-java-2.20.0.jar:?]
	at org.opensearch.client.opensearch.OpenSearchClient.bulk(OpenSearchClient.java:224) ~[opensearch-java-2.20.0.jar:?]
	at org.opensearch.dataprepper.plugins.sink.opensearch.bulk.OpenSearchDefaultBulkApiWrapper.bulk(OpenSearchDefaultBulkApiWrapper.java:19) ~[opensearch-2.x.451.jar:?]
```

The SDK version we use currently, 2.25.11, doesn't support the method mentioned in the error message.
This PR updates SDK to latest version. I was able to reproduce the error and confirm the fix locally.

 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
