### PR TITLE
Confluence oauth2 pagination fix

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
@@ -78,7 +78,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
         URI uri;
         if (null != paginationLinks && null != paginationLinks.getNext()) {
             try {
-                uri = new URI(paginationLinks.getBase() + paginationLinks.getNext());
+                uri = new URI(authConfig.getUrl() + paginationLinks.getNext());
             } catch (URISyntaxException e) {
                 throw new RuntimeException("Failed to construct pagination url.", e);
             }


### PR DESCRIPTION
### Description
When pagination in the OAuth2 flow, confluence host name should be constructed based on the OAuth2 cloud-id

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
