### PR TITLE
Validations based on the validation service checks instead of plugin service checks

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
@@ -230,7 +230,7 @@ public class ConfluenceService {
         ConfluenceConfigHelper.getSpacesNameIncludeFilter(configuration).forEach(spaceFilter -> {
             Matcher matcher = regex.matcher(spaceFilter);
             includedSpaces.add(spaceFilter);
-            if (matcher.find() || spaceFilter.length() <= 1 || spaceFilter.length() > 10) {
+            if (matcher.find() || spaceFilter.length() <= 1 || spaceFilter.length() > 100) {
                 badFilters.add(spaceFilter);
             }
         });
@@ -239,7 +239,7 @@ public class ConfluenceService {
             if (includedSpaces.contains(spaceFilter)) {
                 includedAndExcludedSpaces.add(spaceFilter);
             }
-            if (matcher.find() || spaceFilter.length() <= 1 || spaceFilter.length() > 10) {
+            if (matcher.find() || spaceFilter.length() <= 1 || spaceFilter.length() > 100) {
                 badFilters.add(spaceFilter);
             }
         });

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/NameConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/NameConfig.java
@@ -12,19 +12,38 @@
 package org.opensearch.dataprepper.plugins.source.confluence.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Getter
 public class NameConfig {
+
+    Pattern projectKeysRegex = Pattern.compile("^[A-Z0-9]+$");
+
     @JsonProperty("include")
-    @Size(max = 1000, message = "Space name type filter should not be more than 1000")
-    private List<String> include = new ArrayList<>();
+    @Size(max = 100, message = "Space name type filter should not be more than 100")
+    List<String> include = new ArrayList<>();
 
     @JsonProperty("exclude")
-    @Size(max = 1000, message = "Space name type filter should not be more than 1000")
-    private List<String> exclude = new ArrayList<>();
+    @Size(max = 100, message = "Space name type filter should not be more than 100")
+    List<String> exclude = new ArrayList<>();
+
+    @AssertTrue(message = "Confluence Space keys should be alphanumeric")
+    boolean isValidSpaceKeys() {
+        return checkGivenListForRegex(include) && checkGivenListForRegex(exclude);
+    }
+
+    boolean checkGivenListForRegex(List<String> list) {
+        for (String value : list) {
+            if (value != null && !projectKeysRegex.matcher(value).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/NameConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/NameConfigTest.java
@@ -1,0 +1,57 @@
+package org.opensearch.dataprepper.plugins.source.confluence.configuration;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NameConfigTest {
+
+    @Test
+    void testValidSpaceKeys_WithValidInput() {
+        NameConfig nameConfig = new NameConfig();
+        nameConfig.include.add("ABC123");
+        nameConfig.include.add("XYZ789");
+        nameConfig.exclude.add("TEST123");
+
+        assertTrue(nameConfig.isValidSpaceKeys());
+    }
+
+    @Test
+    void testValidSpaceKeys_WithEmptyLists() {
+        NameConfig nameConfig = new NameConfig();
+        assertTrue(nameConfig.isValidSpaceKeys());
+    }
+
+    @Test
+    void testValidSpaceKeys_WithInvalidInclude() {
+        NameConfig nameConfig = new NameConfig();
+        nameConfig.include.add("ABC-123"); // Contains invalid character
+        nameConfig.exclude.add("TEST123");
+
+        assertFalse(nameConfig.isValidSpaceKeys());
+    }
+
+    @Test
+    void testValidSpaceKeys_WithInvalidExclude() {
+        NameConfig nameConfig = new NameConfig();
+        nameConfig.include.add("ABC123");
+        nameConfig.exclude.add("TEST@123"); // Contains invalid character
+
+        assertFalse(nameConfig.isValidSpaceKeys());
+    }
+
+    @Test
+    void testCheckGivenListForRegex_WithNullValue() {
+        NameConfig nameConfig = new NameConfig();
+        List<String> testList = new ArrayList<>();
+        testList.add(null);
+
+        assertTrue(nameConfig.checkGivenListForRegex(testList));
+    }
+
+}

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -185,7 +185,7 @@ public class JiraService {
         JiraConfigHelper.getProjectNameIncludeFilter(configuration).forEach(projectFilter -> {
             Matcher matcher = regex.matcher(projectFilter);
             includedProjects.add(projectFilter);
-            if (matcher.find() || projectFilter.length() <= 1 || projectFilter.length() > 10) {
+            if (matcher.find() || projectFilter.length() <= 1 || projectFilter.length() > 100) {
                 badFilters.add(projectFilter);
             }
         });
@@ -194,7 +194,7 @@ public class JiraService {
             if (includedProjects.contains(projectFilter)) {
                 includedAndExcludedProjects.add(projectFilter);
             }
-            if (matcher.find() || projectFilter.length() <= 1 || projectFilter.length() > 10) {
+            if (matcher.find() || projectFilter.length() <= 1 || projectFilter.length() > 100) {
                 badFilters.add(projectFilter);
             }
         });

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/configuration/NameConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/configuration/NameConfig.java
@@ -12,19 +12,38 @@
 package org.opensearch.dataprepper.plugins.source.jira.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Getter
 public class NameConfig {
+
+    Pattern projectKeysRegex = Pattern.compile("^[A-Z0-9]+$");
+
     @JsonProperty("include")
-    @Size(max = 1000, message = "Project name type filter should not be more than 1000")
-    private List<String> include = new ArrayList<>();
+    @Size(max = 100, message = "Project name type filter should not be more than 100")
+    List<String> include = new ArrayList<>();
 
     @JsonProperty("exclude")
-    @Size(max = 1000, message = "Project name type filter should not be more than 1000")
-    private List<String> exclude = new ArrayList<>();
+    @Size(max = 100, message = "Project name type filter should not be more than 100")
+    List<String> exclude = new ArrayList<>();
+
+    @AssertTrue(message = "Jira Project keys should be alphanumeric")
+    boolean isValidProjectKeys() {
+        return checkGivenListForRegex(include) && checkGivenListForRegex(exclude);
+    }
+
+    boolean checkGivenListForRegex(List<String> list) {
+        for (String value : list) {
+            if (value != null && !projectKeysRegex.matcher(value).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/configuration/NameConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/configuration/NameConfigTest.java
@@ -1,0 +1,57 @@
+package org.opensearch.dataprepper.plugins.source.jira.configuration;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NameConfigTest {
+
+    @Test
+    void testValidProjectKeys_WithValidInput() {
+        NameConfig nameConfig = new NameConfig();
+        nameConfig.include.add("ABC123");
+        nameConfig.include.add("XYZ789");
+        nameConfig.exclude.add("TEST123");
+
+        assertTrue(nameConfig.isValidProjectKeys());
+    }
+
+    @Test
+    void testValidProjectKeys_WithEmptyLists() {
+        NameConfig nameConfig = new NameConfig();
+        assertTrue(nameConfig.isValidProjectKeys());
+    }
+
+    @Test
+    void testValidProjectKeys_WithInvalidInclude() {
+        NameConfig nameConfig = new NameConfig();
+        nameConfig.include.add("ABC-123"); // Contains invalid character
+        nameConfig.exclude.add("TEST123");
+
+        assertFalse(nameConfig.isValidProjectKeys());
+    }
+
+    @Test
+    void testValidProjectKeys_WithInvalidExclude() {
+        NameConfig nameConfig = new NameConfig();
+        nameConfig.include.add("ABC123");
+        nameConfig.exclude.add("TEST@123"); // Contains invalid character
+
+        assertFalse(nameConfig.isValidProjectKeys());
+    }
+
+    @Test
+    void testCheckGivenListForRegex_WithNullValue() {
+        NameConfig nameConfig = new NameConfig();
+        List<String> testList = new ArrayList<>();
+        testList.add(null);
+
+        assertTrue(nameConfig.checkGivenListForRegex(testList));
+    }
+
+}


### PR DESCRIPTION
Currently, we have some of these validations in the plugin service class but it is too late to validate. Pushing some of those validations to happen early on using our validation service checks

Also, Atlassian Jira doesn't allow more than 100 projects in an account so adjusted the validation accordingly. Put in a similar check for the Confluence as well.


 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
