### PR TITLE
Extracting Confluence page history

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/AtlassianRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/AtlassianRestClient.java
@@ -50,7 +50,7 @@ public class AtlassianRestClient {
             } catch (HttpClientErrorException ex) {
                 HttpStatus statusCode = ex.getStatusCode();
                 String statusMessage = ex.getMessage();
-                log.error("An exception has occurred while getting response from Jira search API  {}", ex.getMessage());
+                log.error("An exception has occurred while getting response from search API  {}", ex.getMessage());
                 if (statusCode == HttpStatus.FORBIDDEN) {
                     throw new UnauthorizedException(statusMessage);
                 } else if (statusCode == HttpStatus.UNAUTHORIZED) {

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/build.gradle
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
     testImplementation project(path: ':data-prepper-test-common')
+    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
 
     implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
@@ -42,7 +42,7 @@ import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlCons
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.CONTENT_TYPE_IN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.CONTENT_TYPE_NOT_IN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.DELIMITER;
-import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.GREATER_THAN_EQUALS;
+import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.GREATER_THAN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.PREFIX;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.SPACE_IN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.SPACE_NOT_IN;
@@ -148,7 +148,7 @@ public class ConfluenceService {
 
         String formattedTimeStamp = LocalDateTime.ofInstant(ts, ZoneId.systemDefault())
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-        StringBuilder cQl = new StringBuilder(LAST_MODIFIED + GREATER_THAN_EQUALS + "\"" + formattedTimeStamp + "\"");
+        StringBuilder cQl = new StringBuilder(LAST_MODIFIED + GREATER_THAN + "\"" + formattedTimeStamp + "\"");
         if (!CollectionUtils.isEmpty(ConfluenceConfigHelper.getSpacesNameIncludeFilter(configuration))) {
             cQl.append(SPACE_IN).append(ConfluenceConfigHelper.getSpacesNameIncludeFilter(configuration).stream()
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
@@ -169,7 +169,7 @@ public class ConfluenceService {
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))
                     .append(CLOSING_ROUND_BRACKET);
         }
-
+        cQl.append(" order by " + LAST_MODIFIED);
         log.info("Created content filter criteria ConfluenceQl query: {}", cQl);
         return cQl;
     }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluenceItem.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluenceItem.java
@@ -57,11 +57,17 @@ public class ConfluenceItem {
 
     @JsonIgnore
     public long getCreatedTimeMillis() {
+        if (history == null) {
+            return 0L;
+        }
         return history.getCreatedDateInMillis();
     }
 
     @JsonIgnore
     public long getUpdatedTimeMillis() {
+        if (history == null) {
+            return 0L;
+        }
         return history.getLastUpdatedInMillis();
     }
 

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluenceItem.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ConfluenceItem.java
@@ -52,14 +52,17 @@ public class ConfluenceItem {
     @JsonProperty("space")
     private SpaceItem spaceItem;
 
+    @JsonProperty("history")
+    private ContentHistory history;
+
     @JsonIgnore
     public long getCreatedTimeMillis() {
-        return 0L;
+        return history.getCreatedDateInMillis();
     }
 
     @JsonIgnore
     public long getUpdatedTimeMillis() {
-        return 0L;
+        return history.getLastUpdatedInMillis();
     }
 
 }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistory.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistory.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
 package org.opensearch.dataprepper.plugins.source.confluence.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistory.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistory.java
@@ -1,0 +1,56 @@
+package org.opensearch.dataprepper.plugins.source.confluence.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+public class ContentHistory {
+
+    // Example format "createdDate": "2025-02-17T23:34:44.633Z"
+    @JsonProperty("createdDate")
+    String createdDate;
+
+    @JsonProperty("lastUpdated")
+    LastUpdated lastUpdated;
+
+    /**
+     * Converts the createdDate ISO 8601 timestamp to milliseconds since epoch
+     *
+     * @return milliseconds since epoch, or 0 if createdDate is null or invalid
+     */
+    public long getCreatedDateInMillis() {
+        try {
+            if (createdDate != null) {
+                return Instant.parse(createdDate).toEpochMilli();
+            }
+        } catch (Exception e) {
+            return 0L;
+        }
+        return 0L;
+    }
+
+    public long getLastUpdatedInMillis() {
+        try {
+            if (lastUpdated != null && lastUpdated.when != null) {
+                return Instant.parse(lastUpdated.when).toEpochMilli();
+            }
+        } catch (Exception e) {
+            return 0L;
+        }
+        return 0L;
+    }
+
+    @Setter
+    @Getter
+    public static class LastUpdated {
+        // Example format  "when": "2025-02-17T23:34:44.633Z"
+        @JsonProperty("when")
+        String when;
+    }
+
+
+}

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistory.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistory.java
@@ -20,37 +20,22 @@ import java.time.Instant;
 public class ContentHistory {
 
     // Example format "createdDate": "2025-02-17T23:34:44.633Z"
+    // Jackson converts to Instant type
     @JsonProperty("createdDate")
-    String createdDate;
+    Instant createdDate;
 
     @JsonProperty("lastUpdated")
     LastUpdated lastUpdated;
 
     /**
-     * Converts the createdDate ISO 8601 timestamp to milliseconds since epoch
-     *
      * @return milliseconds since epoch, or 0 if createdDate is null or invalid
      */
     public long getCreatedDateInMillis() {
-        try {
-            if (createdDate != null) {
-                return Instant.parse(createdDate).toEpochMilli();
-            }
-        } catch (Exception e) {
-            return 0L;
-        }
-        return 0L;
+        return (createdDate != null) ? createdDate.toEpochMilli() : 0L;
     }
 
     public long getLastUpdatedInMillis() {
-        try {
-            if (lastUpdated != null && lastUpdated.when != null) {
-                return Instant.parse(lastUpdated.when).toEpochMilli();
-            }
-        } catch (Exception e) {
-            return 0L;
-        }
-        return 0L;
+        return (lastUpdated != null && lastUpdated.when != null) ? lastUpdated.when.toEpochMilli() : 0L;
     }
 
     @Setter
@@ -58,7 +43,7 @@ public class ContentHistory {
     public static class LastUpdated {
         // Example format  "when": "2025-02-17T23:34:44.633Z"
         @JsonProperty("when")
-        String when;
+        Instant when;
     }
 
 

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
@@ -38,6 +38,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
     public static final String REST_API_FETCH_CONTENT = "wiki/rest/api/content/";
     public static final String REST_API_CONTENT_EXPAND_PARAM = "?expand=body.view";
     //public static final String REST_API_SPACES = "/rest/api/api/spaces";
+    public static final String WIKI_PARAM = "wiki";
     public static final String FIFTY = "50";
     public static final String START_AT = "startAt";
     public static final String LIMIT_PARAM = "limit";
@@ -78,7 +79,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
         URI uri;
         if (null != paginationLinks && null != paginationLinks.getNext()) {
             try {
-                uri = new URI(authConfig.getUrl() + paginationLinks.getNext());
+                uri = new URI(authConfig.getUrl() + WIKI_PARAM + paginationLinks.getNext());
             } catch (URISyntaxException e) {
                 throw new RuntimeException("Failed to construct pagination url.", e);
             }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
@@ -23,9 +23,11 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.inject.Named;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static org.opensearch.dataprepper.plugins.source.confluence.utils.ConfluenceNextLinkValidator.validateAndSanitizeURL;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.CQL_FIELD;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.EXPAND_FIELD;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.EXPAND_VALUE;
@@ -79,8 +81,10 @@ public class ConfluenceRestClient extends AtlassianRestClient {
         URI uri;
         if (null != paginationLinks && null != paginationLinks.getNext()) {
             try {
-                uri = new URI(authConfig.getUrl() + WIKI_PARAM + paginationLinks.getNext());
-            } catch (URISyntaxException e) {
+                String urlString = authConfig.getUrl() + WIKI_PARAM + paginationLinks.getNext();
+                urlString = validateAndSanitizeURL(urlString);
+                uri = new URI(urlString);
+            } catch (URISyntaxException | MalformedURLException e) {
                 throw new RuntimeException("Failed to construct pagination url.", e);
             }
         } else {

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceNextLinkValidator.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceNextLinkValidator.java
@@ -1,0 +1,68 @@
+package org.opensearch.dataprepper.plugins.source.confluence.utils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ConfluenceNextLinkValidator {
+    // Define allowed parameters and their patterns
+    private static final Map<String, Pattern> ALLOWED_PARAMS = Map.of(
+            "next", Pattern.compile("^(true|false)$"),
+            "cursor", Pattern.compile("^[A-Za-z0-9+/=_%\\-]+$"),
+            "expand", Pattern.compile("^[A-Za-z0-9+/=_%\\-.,]+$"),
+            "limit", Pattern.compile("^\\d{1,3}$"),
+            "start", Pattern.compile("^\\d+$"),
+            "startAt", Pattern.compile("^\\d+$"),
+            "maxResults", Pattern.compile("^\\d+$"),
+            "cql", Pattern.compile("^[\\w\\s=\"()><%\\-.:]+$")
+    );
+
+    public static String validateAndSanitizeURL(String urlString) throws MalformedURLException {
+        URL url = new URL(urlString);
+        String query = url.getQuery();
+
+        if (query == null || query.isEmpty()) {
+            return urlString;
+        }
+
+        // Parse and validate parameters
+        Map<String, String> validatedParams = new HashMap<>();
+        String[] pairs = query.split("&");
+
+        for (String pair : pairs) {
+
+            String key = URLDecoder.decode(pair.substring(0, pair.indexOf("=")), StandardCharsets.UTF_8);
+            String value = URLDecoder.decode(pair.substring(pair.indexOf("=") + 1), StandardCharsets.UTF_8);
+
+            // Check if parameter is allowed and matches pattern
+            if (ALLOWED_PARAMS.containsKey(key) &&
+                    ALLOWED_PARAMS.get(key).matcher(value).matches()) {
+                validatedParams.put(key, value);
+            }
+        }
+
+        // Rebuild URL with validated parameters
+        StringBuilder sanitizedURL = new StringBuilder();
+        sanitizedURL.append(url.getProtocol()).append("://")
+                .append(url.getHost())
+                .append(url.getPath())
+                .append("?");
+
+        // Add validated parameters
+        String params = validatedParams.entrySet().stream()
+                .map(e -> URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8) + "=" +
+                        URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+
+        sanitizedURL.append(params);
+
+        return sanitizedURL.toString();
+    }
+}
+

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/CqlConstants.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/CqlConstants.java
@@ -11,7 +11,7 @@
 package org.opensearch.dataprepper.plugins.source.confluence.utils;
 
 public class CqlConstants {
-    public static final String GREATER_THAN_EQUALS = ">=";
+    public static final String GREATER_THAN = ">";
     public static final String CLOSING_ROUND_BRACKET = ")";
 
     public static final String SPACE_IN = " AND space in (";

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/CqlConstants.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/CqlConstants.java
@@ -23,5 +23,5 @@ public class CqlConstants {
     public static final String CONTENT_TYPE_NOT_IN = " AND type not in (";
     public static final String CQL_FIELD = "cql";
     public static final String EXPAND_FIELD = "expand";
-    public static final String EXPAND_VALUE = "all,space";
+    public static final String EXPAND_VALUE = "all,space,history.lastUpdated";
 }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/ContentHistoryTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/ContentHistoryTest.java
@@ -1,0 +1,43 @@
+package org.opensearch.dataprepper.plugins.source.confluence.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.source.confluence.models.ContentHistory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContentHistoryTest {
+
+    @Test
+    void testGetCreatedDateInMillis_ValidDate() {
+        ContentHistory history = new ContentHistory();
+        history.setCreatedDate("2025-02-17T23:34:44.633Z");
+
+        long expectedMillis = 1739835284633L; // Pre-calculated value for this timestamp
+        assertEquals(expectedMillis, history.getCreatedDateInMillis());
+    }
+
+    @Test
+    void testGetLastModifiedInMillis_ValidDate() {
+        ContentHistory history = new ContentHistory();
+        ContentHistory.LastUpdated lastUpdated = new ContentHistory.LastUpdated();
+        lastUpdated.setWhen("2025-02-17T23:34:44.633Z");
+        history.setLastUpdated(lastUpdated);
+        long expectedMillis = 1739835284633L; // Pre-calculated value for this timestamp
+        assertEquals(expectedMillis, history.getLastUpdatedInMillis());
+    }
+
+    @Test
+    void testGetCreatedDateInMillis_NullDate() {
+        ContentHistory history = new ContentHistory();
+        history.setCreatedDate(null);
+        assertEquals(0L, history.getCreatedDateInMillis());
+    }
+
+    @Test
+    void testGetCreatedDateInMillis_InvalidDate() {
+        ContentHistory history = new ContentHistory();
+        history.setCreatedDate("invalid-date");
+        assertEquals(0L, history.getCreatedDateInMillis());
+    }
+}
+

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/NameConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/NameConfigTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
 package org.opensearch.dataprepper.plugins.source.confluence.configuration;
 
 

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistoryTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/models/ContentHistoryTest.java
@@ -1,7 +1,15 @@
-package org.opensearch.dataprepper.plugins.source.confluence.configuration;
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.dataprepper.plugins.source.confluence.models;
 
 import org.junit.jupiter.api.Test;
-import org.opensearch.dataprepper.plugins.source.confluence.models.ContentHistory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClientTest.java
@@ -138,7 +138,7 @@ public class ConfluenceRestClientTest {
         doReturn(oauthUrlHost).when(authConfig).getUrl();
         doReturn(new ResponseEntity<>(mockConfluenceSearchResults, HttpStatus.OK))
                 .when(restTemplate)
-                .getForEntity(new URI(oauthUrlHost + paginationNextLink), ConfluenceSearchResults.class);
+                .getForEntity(new URI(oauthUrlHost + ConfluenceRestClient.WIKI_PARAM + paginationNextLink), ConfluenceSearchResults.class);
         ConfluenceSearchResults results = confluenceRestClient.getAllContent(jql, 0, paginationLinks);
         assertNotNull(results);
     }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClientTest.java
@@ -131,7 +131,7 @@ public class ConfluenceRestClientTest {
         ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(restTemplate, authConfig, pluginMetrics);
         ConfluenceSearchResults mockConfluenceSearchResults = mock(ConfluenceSearchResults.class);
         String oauthUrlHost = "http://mock-service.jira.com/cloud-id/";
-        String paginationNextLink = "/Search?next-token=adsflkajdsflakdjflkasfdmdsfad";
+        String paginationNextLink = "/Search?cursor=adsflkajdsflakdjflkasfdmdsfad";
         ConfluencePaginationLinks paginationLinks = new ConfluencePaginationLinks();
         paginationLinks.setNext(paginationNextLink);
         paginationLinks.setBase("http://base-host-name/");

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceNextLinkValidatorTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceNextLinkValidatorTest.java
@@ -1,0 +1,122 @@
+package org.opensearch.dataprepper.plugins.source.confluence.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.MalformedURLException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfluenceNextLinkValidatorTest {
+
+    @Test
+    void testValidURL() throws Exception {
+        String validUrl = "http://hostname/rest/api/content/search?next=true&limit=25&start=25";
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(validUrl);
+        assertNotNull(sanitized);
+        assertTrue(sanitized.contains("next=true"));
+        assertTrue(sanitized.contains("limit=25"));
+        assertTrue(sanitized.contains("start=25"));
+    }
+
+    @Test
+    void testComplexValidURL() throws Exception {
+        String validUrl = "http://hostname/rest/api/content/search?next=true&cursor=_f_MjU%3D_sa_WyJcdDUxNTk1NDM5IHIhXCJgKEM%2BOz1bT2UpR0dpQ3BIKiBjcCJd&limit=25&start=25&cql=lastModified%3E=%222024-02-25%2010:50%22%20AND%20space%20in%20(%22SD%22)";
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(validUrl);
+        assertNotNull(sanitized);
+        assertTrue(sanitized.contains("cursor="));
+        assertTrue(sanitized.contains("cql="));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://hostname/api?next=invalid",
+            "http://hostname/api?limit=abc",
+            "http://hostname/api?start=abc",
+            "http://hostname/api?unknown=value"
+    })
+    void testInvalidParameters(String invalidUrl) throws Exception {
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(invalidUrl);
+        assertFalse(sanitized.endsWith("invalid"));
+        assertFalse(sanitized.contains("unknown=value"));
+    }
+
+    @Test
+    void testMalformedURL() {
+        assertThrows(MalformedURLException.class, () ->
+                ConfluenceNextLinkValidator.validateAndSanitizeURL("not-a-url")
+        );
+    }
+
+    @Test
+    void testNullURL() {
+        assertThrows(MalformedURLException.class, () ->
+                ConfluenceNextLinkValidator.validateAndSanitizeURL(null)
+        );
+    }
+
+    @Test
+    void testEmptyParameters() throws Exception {
+        String url = "http://hostname/api?";
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(url);
+        assertEquals("http://hostname/api?", sanitized);
+    }
+
+    @Test
+    void testUrlWithInjectionAttempts() throws Exception {
+        String maliciousUrl = "http://hostname/api?next=true&evil=<script>alert(1)</script>&limit=25";
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(maliciousUrl);
+        assertFalse(sanitized.contains("<script>"));
+        assertFalse(sanitized.contains("evil="));
+    }
+
+
+    @Test
+    void testCQLParameterValidation() throws Exception {
+        // Valid CQL
+        String validCql = "lastModified>=\"2024-02-25 10:50\" AND space in (\"SD\")";
+        String url = "http://hostname/api?cql=" + URLEncoder.encode(validCql, StandardCharsets.UTF_8);
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(url);
+        assertTrue(sanitized.contains("cql="));
+
+        // Invalid CQL with SQL injection attempt
+        String invalidCql = "lastModified>=\"2024-02-25\"; DROP TABLE users;";
+        url = "http://hostname/api?cql=" + URLEncoder.encode(invalidCql, StandardCharsets.UTF_8);
+        sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(url);
+        assertFalse(sanitized.contains("DROP TABLE"));
+    }
+
+    @Test
+    void testCursorParameterValidation() throws Exception {
+        // Valid cursor
+        assertTrue(ConfluenceNextLinkValidator.validateAndSanitizeURL("http://hostname/api?cursor=abc123_ABC")
+                .contains("cursor=abc123_ABC"));
+
+        // Invalid cursor
+        assertFalse(ConfluenceNextLinkValidator.validateAndSanitizeURL("http://hostname/api?cursor=<>\"'")
+                .contains("<>\"'"));
+    }
+
+    @Test
+    void testMultipleIdenticalParameters() throws Exception {
+        String url = "http://hostname/api?limit=25&limit=50";
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(url);
+        // Verify only one limit parameter is preserved
+        assertEquals(1, sanitized.split("limit=").length - 1);
+    }
+
+    @Test
+    void testURLEncoding() throws Exception {
+        String url = "http://hostname/api?cql=space=\"My Space\"";
+        String sanitized = ConfluenceNextLinkValidator.validateAndSanitizeURL(url);
+        assertTrue(sanitized.contains(URLEncoder.encode("\"", StandardCharsets.UTF_8)));
+    }
+}
+

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.UPDATED;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.CLOSING_ROUND_BRACKET;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.DELIMITER;
-import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.GREATER_THAN_EQUALS;
+import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.GREATER_THAN;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.ISSUE_TYPE_IN;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.ISSUE_TYPE_NOT_IN;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.PREFIX;
@@ -136,7 +136,7 @@ public class JiraService {
         if (!CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameIncludeFilter(configuration)) || !CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameExcludeFilter(configuration))) {
             validateProjectFilters(configuration);
         }
-        StringBuilder jiraQl = new StringBuilder(UPDATED + GREATER_THAN_EQUALS + ts.toEpochMilli());
+        StringBuilder jiraQl = new StringBuilder(UPDATED + GREATER_THAN + ts.toEpochMilli());
         if (!CollectionUtils.isEmpty(JiraConfigHelper.getProjectNameIncludeFilter(configuration))) {
             jiraQl.append(PROJECT_IN).append(JiraConfigHelper.getProjectNameIncludeFilter(configuration).stream()
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -167,7 +167,7 @@ public class JiraService {
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))
                     .append(CLOSING_ROUND_BRACKET);
         }
-        jiraQl.append(" order by updated");
+        jiraQl.append(" order by " + UPDATED);
         log.info("Created issue filter criteria JiraQl query: {}", jiraQl);
         return jiraQl;
     }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -167,6 +167,7 @@ public class JiraService {
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))
                     .append(CLOSING_ROUND_BRACKET);
         }
+        jiraQl.append(" order by updated");
         log.info("Created issue filter criteria JiraQl query: {}", jiraQl);
         return jiraQl;
     }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/utils/JqlConstants.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/utils/JqlConstants.java
@@ -11,7 +11,7 @@
 package org.opensearch.dataprepper.plugins.source.jira.utils;
 
 public class JqlConstants {
-    public static final String GREATER_THAN_EQUALS = ">=";
+    public static final String GREATER_THAN = ">";
     public static final String CLOSING_ROUND_BRACKET = ")";
 
     public static final String SLASH = "/";

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/Crawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/Crawler.java
@@ -73,12 +73,11 @@ public class Crawler {
             }
 
         } while (itemInfoIterator.hasNext());
-        Instant startTimeInstant = Instant.ofEpochMilli(startTime);
-        updateLeaderProgressState(leaderPartition, startTimeInstant, coordinator);
+        updateLeaderProgressState(leaderPartition, latestModifiedTime, coordinator);
         long crawlTimeMillis = System.currentTimeMillis() - startTime;
         log.debug("Crawling completed in {} ms", crawlTimeMillis);
         crawlingTimer.record(crawlTimeMillis, TimeUnit.MILLISECONDS);
-        return startTimeInstant;
+        return latestModifiedTime;
     }
 
     public void executePartition(SaasWorkerProgressState state, Buffer<Record<Event>> buffer, AcknowledgementSet acknowledgementSet) {

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/model/ItemInfoTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/model/ItemInfoTest.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ItemInfoTest {
@@ -18,7 +17,7 @@ public class ItemInfoTest {
         String itemId = UUID.randomUUID().toString();
         TestItemInfo itemInfo = new TestItemInfo(itemId);
         assertEquals(itemId, itemInfo.getItemId());
-        assertNull(itemInfo.getMetadata());
+        assertEquals(0, itemInfo.getMetadata().size());
         assertEquals("partitionKey", itemInfo.getPartitionKey());
         assertEquals("id", itemInfo.getId());
         assertTrue(itemInfo.getKeyAttributes().isEmpty());

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/model/TestItemInfo.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/model/TestItemInfo.java
@@ -17,6 +17,7 @@ public class TestItemInfo implements ItemInfo {
 
     public TestItemInfo(String itemId) {
         this.itemId = itemId;
+        this.metadata = Map.of();
     }
 
     @Override


### PR DESCRIPTION
Extracting Confluence page history in the pagination API for checking pointing the date and time navigated so far.
 

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
