### PR TITLE
Adding enum and range datatype support for postgres

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/PostgresStreamState.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/coordination/state/PostgresStreamState.java
@@ -11,6 +11,9 @@ package org.opensearch.dataprepper.plugins.source.rds.coordination.state;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+import java.util.Set;
+
 public class PostgresStreamState {
 
     @JsonProperty("currentLsn")
@@ -21,6 +24,9 @@ public class PostgresStreamState {
 
     @JsonProperty("replicationSlotName")
     private String replicationSlotName;
+
+    @JsonProperty("enumColumnsByTable")
+    private Map<String, Set<String>> enumColumnsByTable;
 
     public String getCurrentLsn() {
         return currentLsn;
@@ -44,5 +50,13 @@ public class PostgresStreamState {
 
     public void setReplicationSlotName(String replicationSlotName) {
         this.replicationSlotName = replicationSlotName;
+    }
+
+    public Map<String, Set<String>> getEnumColumnsByTable() {
+        return enumColumnsByTable;
+    }
+
+    public void setEnumColumnsByTable(Map<String, Set<String>> enumColumnsByTable) {
+        this.enumColumnsByTable = enumColumnsByTable;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/ColumnType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/ColumnType.java
@@ -32,6 +32,7 @@ public enum ColumnType {
     INTERVAL(1186, "interval"),
     JSON(114, "json"),
     JSONB(3802, "jsonb"),
+    JSONPATH(4072, "jsonpath"),
     MONEY(790,"money"),
     BIT(1560, "bit"),
     VARBIT(1562, "varbit"),
@@ -49,11 +50,19 @@ public enum ColumnType {
     XML(142, "xml"),
     UUID(2950, "uuid"),
     PG_LSN(3220, "pg_lsn"),
+    PG_SNAPSHOT(5038, "pg_snapshot"),
+    TXID_SNAPSHOT(2970, "txid_snapshot"),
     TSVECTOR(3614, "tsvector"),
     TSQUERY(3615, "tsquery"),
-    BYTEA(17, "bytea");
+    BYTEA(17, "bytea"),
+    INT4RANGE(3904, "int4range"),
+    INT8RANGE(3926, "int8range"),
+    TSRANGE(3908, "tsrange"),
+    TSTZRANGE(3910, "tstzrange"),
+    DATERANGE(3912, "daterange"),
+    ENUM(-1,"enum");
 
-
+    public static final int ENUM_TYPE_ID = -1;
     private final int typeId;
     private final String typeName;
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataType.java
@@ -20,6 +20,7 @@ public enum PostgresDataType {
     TEXT("text", DataCategory.STRING),
     VARCHAR("varchar", DataCategory.STRING),
     BPCHAR("bpchar", DataCategory.STRING),
+    ENUM("enum", DataCategory.STRING),
 
     //Bit String Data type
     BIT("bit",DataCategory.BIT_STRING),
@@ -28,6 +29,7 @@ public enum PostgresDataType {
     //Json Data type
     JSON("json",DataCategory.JSON),
     JSONB("jsonb",DataCategory.JSON),
+    JSONPATH("jsonpath", DataCategory.JSON),
 
     //Boolean data type
     BOOLEAN("bool", DataCategory.BOOLEAN),
@@ -61,6 +63,14 @@ public enum PostgresDataType {
     PG_LSN("pg_lsn", DataCategory.SPECIAL),
     TSVECTOR("tsvector", DataCategory.SPECIAL),
     TSQUERY("tsquery", DataCategory.SPECIAL),
+    PG_SNAPSHOT("pg_snapshot", DataCategory.SPECIAL),
+    TXID_SNAPSHOT("txid_snapshot", DataCategory.SPECIAL),
+
+    INT4RANGE("int4range", DataCategory.RANGE),
+    INT8RANGE("int8range", DataCategory.RANGE),
+    TSRANGE("tsrange", DataCategory.RANGE),
+    TSTZRANGE("tstzrange", DataCategory.RANGE),
+    DATERANGE("daterange", DataCategory.RANGE),
 
     //Binary data type
     BYTEA("bytea", DataCategory.BINARY);
@@ -109,7 +119,8 @@ public enum PostgresDataType {
         SPATIAL,
         NETWORK_ADDRESS,
         SPECIAL,
-        BINARY
+        BINARY,
+        RANGE
     }
 
 
@@ -153,5 +164,10 @@ public enum PostgresDataType {
     public boolean isBinary() {
         return category == DataCategory.BINARY;
     }
+
+    public boolean isRange() {
+        return category == DataCategory.RANGE;
+    }
+
 }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataTypeHelper.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataTypeHelper.java
@@ -6,6 +6,7 @@ import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.B
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.JsonTypeHandler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.NetworkAddressTypeHandler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.NumericTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.RangeTypeHandler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.SpatialTypeHandler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.SpecialTypeHandler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.StringTypeHandler;
@@ -15,17 +16,21 @@ import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler.T
 import java.util.Map;
 
 public class PostgresDataTypeHelper {
-    private static final Map<PostgresDataType.DataCategory, PostgresDataTypeHandler> typeHandlers = Map.of(
-            PostgresDataType.DataCategory.NUMERIC, new NumericTypeHandler(),
-            PostgresDataType.DataCategory.STRING, new StringTypeHandler(),
-            PostgresDataType.DataCategory.BIT_STRING, new BitStringTypeHandler(),
-            PostgresDataType.DataCategory.JSON, new JsonTypeHandler(),
-            PostgresDataType.DataCategory.BOOLEAN, new BooleanTypeHandler(),
-            PostgresDataType.DataCategory.TEMPORAL, new TemporalTypeHandler(),
-            PostgresDataType.DataCategory.SPATIAL, new SpatialTypeHandler(),
-            PostgresDataType.DataCategory.NETWORK_ADDRESS, new NetworkAddressTypeHandler(),
-            PostgresDataType.DataCategory.SPECIAL, new SpecialTypeHandler(),
-            PostgresDataType.DataCategory.BINARY, new BinaryTypeHandler()
+    private static final NumericTypeHandler numericTypeHandler = new NumericTypeHandler();
+    private static final TemporalTypeHandler temporalTypeHandler = new TemporalTypeHandler();
+
+    private static final Map<PostgresDataType.DataCategory, PostgresDataTypeHandler> typeHandlers = Map.ofEntries(
+            Map.entry(PostgresDataType.DataCategory.NUMERIC, numericTypeHandler),
+            Map.entry(PostgresDataType.DataCategory.STRING, new StringTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.BIT_STRING, new BitStringTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.JSON, new JsonTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.BOOLEAN, new BooleanTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.TEMPORAL, temporalTypeHandler),
+            Map.entry(PostgresDataType.DataCategory.SPATIAL, new SpatialTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.NETWORK_ADDRESS, new NetworkAddressTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.SPECIAL, new SpecialTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.BINARY, new BinaryTypeHandler()),
+            Map.entry(PostgresDataType.DataCategory.RANGE, new RangeTypeHandler(numericTypeHandler, temporalTypeHandler))
     );
 
     public static Object getDataByColumnType(final PostgresDataType columnType, final String columnName, final Object value

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/RangeTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/RangeTypeHandler.java
@@ -1,0 +1,109 @@
+package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
+
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RangeTypeHandler implements PostgresDataTypeHandler {
+
+    public static final String EMPTY = "empty";
+    public static final String GREATER_THAN = "gt";
+    public static final String GREATER_THAN_OR_EQUAL_TO = "gte";
+    public static final String LESSER_THAN = "lt";
+    public static final String LESSER_THAN_OR_EQUAL_TO = "lte";
+
+    private final NumericTypeHandler numericTypeHandler;
+    private final TemporalTypeHandler temporalTypeHandler;
+
+    public RangeTypeHandler(NumericTypeHandler numericTypeHandler, TemporalTypeHandler temporalTypeHandler) {
+        this.numericTypeHandler = numericTypeHandler;
+        this.temporalTypeHandler = temporalTypeHandler;
+    }
+
+    @Override
+    public Object handle(PostgresDataType columnType, String columnName, Object value) {
+        if (!columnType.isRange()) {
+            throw new IllegalArgumentException("ColumnType is not range: " + columnType);
+        }
+
+        return parseRangeValue(columnType, columnName, value.toString());
+    }
+
+    private Object parseRangeValue(PostgresDataType columnType,String columnName, String rangeString) {
+
+        if(rangeString.equals(EMPTY))
+            return null;
+
+        String cleanRangeString = rangeString.substring(1, rangeString.length() - 1);
+        String[] rangeValues = cleanRangeString.split(",",-1);
+
+        if (rangeValues.length == 2)  {
+            String lowerBound = trimQuotes(rangeValues[0]);
+            String upperBound = trimQuotes(rangeValues[1]);
+            String lowerBoundInclusivity = String.valueOf(rangeString.charAt(0));
+            String upperBoundInclusivity = String.valueOf(rangeString.charAt(rangeString.length() - 1));
+            switch (columnType) {
+                case INT4RANGE:
+                    return handleNumericRange(PostgresDataType.INTEGER, columnName, lowerBoundInclusivity, lowerBound, upperBound, upperBoundInclusivity);
+                case INT8RANGE:
+                    return handleNumericRange(PostgresDataType.BIGINT, columnName, lowerBoundInclusivity, lowerBound, upperBound, upperBoundInclusivity);
+               case TSRANGE:
+                    return handleTemporalRange(PostgresDataType.TIMESTAMP, columnName, lowerBoundInclusivity, lowerBound, upperBound, upperBoundInclusivity);
+                case TSTZRANGE:
+                    return handleTemporalRange(PostgresDataType.TIMESTAMPTZ, columnName, lowerBoundInclusivity, lowerBound, upperBound, upperBoundInclusivity);
+                case DATERANGE:
+                    return handleTemporalRange(PostgresDataType.DATE, columnName, lowerBoundInclusivity, lowerBound, upperBound, upperBoundInclusivity);
+                default:
+                    throw new IllegalArgumentException("Unsupported range type: " + columnType);
+            }
+        } else {
+            throw new IllegalArgumentException("Invalid range format: " + rangeString);
+        }
+
+    }
+    private Map<String, Object> handleNumericRange(PostgresDataType columnType, String columnName, String lowerBoundInclusivity, String lowerBound, String upperBound, String upperBoundInclusivity) {
+        Map<String, Object> rangeMap = new HashMap<>();
+
+        if(!lowerBound.isEmpty()) {
+            Object parsedLowerBound = numericTypeHandler.handle(columnType, columnName, lowerBound);
+            rangeMap.put(lowerBoundInclusivity.equals("[") ? GREATER_THAN_OR_EQUAL_TO : GREATER_THAN, parsedLowerBound);
+        }
+        if(!upperBound.isEmpty()) {
+            Object parsedUpperBound = numericTypeHandler.handle(columnType, columnName, upperBound);
+            rangeMap.put(upperBoundInclusivity.equals("]") ? LESSER_THAN_OR_EQUAL_TO : LESSER_THAN, parsedUpperBound);
+        }
+        return rangeMap;
+    }
+
+    private Map<String, Object> handleTemporalRange(PostgresDataType columnType, String columnName, String lowerBoundInclusivity, String lowerBound, String upperBound, String upperBoundInclusivity) {
+        Map<String, Object> rangeMap = new HashMap<>();
+
+        if(!lowerBound.isEmpty()) {
+            Object parsedLowerBound = temporalTypeHandler.handle(columnType, columnName, lowerBound);
+            rangeMap.put(lowerBoundInclusivity.equals("[") ? GREATER_THAN_OR_EQUAL_TO : GREATER_THAN, parsedLowerBound);
+        }
+
+        if (!upperBound.isEmpty()) {
+            Object parsedUpperBound = temporalTypeHandler.handle(columnType, columnName, upperBound);
+            rangeMap.put(upperBoundInclusivity.equals("]") ? LESSER_THAN_OR_EQUAL_TO : LESSER_THAN, parsedUpperBound);
+        }
+        return rangeMap;
+    }
+
+
+    private String trimQuotes(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        String trimmed = input;
+
+        if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+            trimmed = trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/leader/LeaderScheduler.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -180,6 +181,14 @@ public class LeaderScheduler implements Runnable {
                 ));
     }
 
+    private Map<String, Set<String>> getPostgresEnumColumnsByTable() {
+        return sourceConfig.getTableNames().stream()
+                .collect(Collectors.toMap(
+                        fullTableName -> fullTableName,
+                        fullTableName -> ((PostgresSchemaManager)schemaManager).getEnumColumns(fullTableName)
+                ));
+    }
+
     private void createStreamPartition(RdsSourceConfig sourceConfig) {
         final StreamProgressState progressState = new StreamProgressState();
         progressState.setEngineType(sourceConfig.getEngine().toString());
@@ -199,6 +208,7 @@ public class LeaderScheduler implements Runnable {
             final PostgresStreamState postgresStreamState = new PostgresStreamState();
             postgresStreamState.setPublicationName(publicationName);
             postgresStreamState.setReplicationSlotName(slotName);
+            postgresStreamState.setEnumColumnsByTable(getPostgresEnumColumnsByTable());
             progressState.setPostgresStreamState(postgresStreamState);
         }
         streamPartition = new StreamPartition(sourceConfig.getDbIdentifier(), progressState);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/MessageType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/MessageType.java
@@ -18,7 +18,8 @@ public enum MessageType {
     INSERT('I'),
     UPDATE('U'),
     DELETE('D'),
-    COMMIT('C');
+    COMMIT('C'),
+    TYPE('Y');
 
     private final char value;
 
@@ -28,7 +29,8 @@ public enum MessageType {
             INSERT.getValue(), INSERT,
             UPDATE.getValue(), UPDATE,
             DELETE.getValue(), DELETE,
-            COMMIT.getValue(), COMMIT
+            COMMIT.getValue(), COMMIT,
+            TYPE.getValue(), TYPE
     );
 
     MessageType(char value) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManager.java
@@ -91,6 +91,7 @@ public class MySqlSchemaManager implements SchemaManager {
                         );
                     }
                 }
+                return columnsToDataType;
             } catch (final Exception e) {
                 LOG.error("Failed to get dataTypes for database {} table {}, retrying", database, tableName, e);
                 if (retry == NUM_OF_RETRIES) {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/RangeTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/RangeTypeHandlerTest.java
@@ -1,0 +1,116 @@
+package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class RangeTypeHandlerTest {
+
+    @Mock
+    private NumericTypeHandler numericTypeHandler;
+
+    @Mock
+    private TemporalTypeHandler temporalTypeHandler;
+
+    private RangeTypeHandler rangeTypeHandler;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        rangeTypeHandler = new RangeTypeHandler(numericTypeHandler, temporalTypeHandler);
+    }
+
+    @Test
+    void testHandleInt4Range() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn(10, 20);
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGE, "test_column", "[10,20)");
+        assertTrue(result instanceof Map);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals(10, rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals(20, rangeMap.get(RangeTypeHandler.LESSER_THAN));
+    }
+
+    @Test
+    void testHandleInt8Range() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn(100L, 200L);
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT8RANGE, "test_column", "(100,200]");
+        assertTrue(result instanceof Map);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals(100L, rangeMap.get(RangeTypeHandler.GREATER_THAN));
+        assertEquals(200L, rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleDateRange() {
+        when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704067200000", "1706659200000");
+        Object result = rangeTypeHandler.handle(PostgresDataType.DATERANGE, "test_column", "[2024-01-01,2024-01-31]");
+        assertTrue(result instanceof Map);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals("1704067200000", rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1706659200000", rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleTsRange() {
+        when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704103200000", "1704110400000");
+        Object result = rangeTypeHandler.handle(PostgresDataType.TSRANGE, "test_column", "[2024-01-01 10:00:00,2024-01-01 12:00:00)");
+        assertTrue(result instanceof Map);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals("1704103200000", rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1704110400000", rangeMap.get(RangeTypeHandler.LESSER_THAN));
+    }
+
+    @Test
+    void testHandleTstzRange() {
+        when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704103200000", "1704110400000");
+        Object result = rangeTypeHandler.handle(PostgresDataType.TSTZRANGE, "test_column", "[2024-01-01 10:00:00+00,2024-01-01 12:00:00+00]");
+        assertTrue(result instanceof Map);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals("1704103200000", rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1704110400000", rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleEmptyRange() {
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGE, "test_column", RangeTypeHandler.EMPTY);
+        assertNull(result);
+    }
+
+    @Test
+    void testHandleInfiniteRange() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn(10);
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGE, "test_column", "[10,)");
+        assertTrue(result instanceof Map);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals(10, rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertFalse(rangeMap.containsKey(RangeTypeHandler.LESSER_THAN));
+        assertFalse(rangeMap.containsKey(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleInvalidRangeFormat() {
+        assertThrows(IllegalArgumentException.class, () ->
+                rangeTypeHandler.handle(PostgresDataType.INT4RANGE, "test_column", "1020")
+        );
+    }
+
+    @Test
+    void testHandleNonRangeType() {
+        assertThrows(IllegalArgumentException.class, () ->
+                rangeTypeHandler.handle(PostgresDataType.INTEGER, "test_column", "[10,20)")
+        );
+    }
+}
+

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -140,6 +140,16 @@ class LogicalReplicationEventProcessorTest {
     }
 
     @Test
+    void test_correct_process_method_invoked_for_type_message() {
+        setMessageType(MessageType.TYPE);
+        doNothing().when(objectUnderTest).processTypeMessage(message);
+
+        objectUnderTest.process(message);
+
+        verify(objectUnderTest).processTypeMessage(message);
+    }
+
+    @Test
     void test_unsupported_message_type_throws_exception() {
         message = ByteBuffer.allocate(1);
         message.put((byte) 'A');


### PR DESCRIPTION
### Description

- Adding enum and range datatype support for Postgres. 
- As enum does not have a fixed type_id, the enum columns are first fetched from the database and stored in Postgres Stream State and then the data type mapping is done. The enum type is not stored as user-defined enum type, instead we overwrite it to `enum` while storing.
- Range datatype has been added without including numeric range data type and multirange. Opensource does not support the high precision and scale of numeric postgres data type hence the mapping cannot be done here. 
- No corresponding multirange data type is supported in Opensource.

### Issues Resolved
Contributes to https://github.com/opensearch-project/data-prepper/issues/5309
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
