### PR TITLE
ENH: error message in pipeline and plugin deserialization

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
 import org.opensearch.dataprepper.plugins.TestObjectPlugin;
 import org.opensearch.dataprepper.plugins.configtest.TestComponentWithConfigInject;
 import org.opensearch.dataprepper.plugins.configtest.TestDISourceWithConfig;
@@ -82,6 +83,7 @@ class DefaultPluginFactoryIT {
         coreContext.register(PluginBeanFactoryProvider.class);
         coreContext.registerBean(PluginErrorCollector.class, PluginErrorCollector::new);
         coreContext.registerBean(PluginErrorsHandler.class, LoggingPluginErrorsHandler::new);
+        coreContext.registerBean(DataPrepperDeserializationProblemHandler.class, DataPrepperDeserializationProblemHandler::new);
         coreContext.registerBean(ExtensionsConfiguration.class, () -> extensionsConfiguration);
         coreContext.registerBean(PipelinesDataFlowModel.class, () -> pipelinesDataFlowModel);
         coreContext.registerBean(ExperimentalConfigurationContainer.class, () -> experimentalConfigurationContainer);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
@@ -40,6 +40,7 @@ import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
 import org.opensearch.dataprepper.pipeline.parser.PipelineConfigurationFileReader;
 import org.opensearch.dataprepper.pipeline.parser.PipelinesDataflowModelParser;
 import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
@@ -98,7 +99,8 @@ class PipelineTransformerTests {
     private CircuitBreakerManager circuitBreakerManager;
     @Mock
     private PluginErrorsHandler pluginErrorsHandler;
-
+    @Mock
+    private DataPrepperDeserializationProblemHandler dataPrepperDeserializationProblemHandler;
     @Mock
     private ExpressionEvaluator expressionEvaluator;
     @Captor
@@ -131,6 +133,8 @@ class PipelineTransformerTests {
         coreContext.scan(DefaultPluginFactory.class.getPackage().getName());
         coreContext.registerBean(PluginErrorCollector.class, () -> pluginErrorCollector);
         coreContext.registerBean(PluginErrorsHandler.class, () -> pluginErrorsHandler);
+        coreContext.registerBean(DataPrepperDeserializationProblemHandler.class,
+                () -> dataPrepperDeserializationProblemHandler);
         coreContext.registerBean(DataPrepperConfiguration.class, () -> dataPrepperConfiguration);
         coreContext.registerBean(PipelinesDataFlowModel.class, () -> pipelinesDataFlowModel);
         coreContext.refresh();

--- a/data-prepper-pipeline-parser/build.gradle
+++ b/data-prepper-pipeline-parser/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'org.apache.commons:commons-collections4:4.4'
+    implementation 'org.apache.commons:commons-text:1.13.0'
     implementation 'org.projectlombok:lombok:1.18.22'
     implementation 'com.jayway.jsonpath:json-path:2.6.0'
     implementation 'javax.inject:javax.inject:1'

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDeserializationProblemHandler.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDeserializationProblemHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.parser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.deser.ValueInstantiator;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.IOException;
+
+@Named
+public class DataPrepperDeserializationProblemHandler extends DeserializationProblemHandler {
+
+    @Inject
+    public DataPrepperDeserializationProblemHandler() {
+        super();
+    }
+
+    @Override
+    public Object handleWeirdStringValue(DeserializationContext ctxt, Class<?> targetType, String valueToConvert, String failureMsg) throws IOException {
+        throw new IOException(
+                String.format("Cannot deserialize value of type %s from String \"%s\": %s",
+                        ClassUtil.nameOf(targetType), valueToConvert, failureMsg));
+    }
+
+    @Override
+    public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType, JsonToken t, JsonParser p, String failureMsg) throws IOException {
+        throw JsonMappingException.from(ctxt.getParser(),
+                String.format("Cannot deserialize value of type %s from %s.",
+                        ClassUtil.getTypeDescription(targetType), JsonToken.valueDescFor(t)));
+    }
+
+    @Override
+    public Object handleMissingInstantiator(DeserializationContext ctxt, Class<?> instClass, ValueInstantiator valueInsta, JsonParser p, String msg) throws IOException {
+        throw JsonMappingException.from(ctxt.getParser(),
+                String.format("Cannot deserialize '%s' into '%s'.", p.getText(), instClass.getName()));
+    }
+}

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDurationParser.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDurationParser.java
@@ -20,14 +20,19 @@ import java.util.regex.Pattern;
 public class DataPrepperDurationParser {
     private static final String SIMPLE_DURATION_REGEX = "^(0|[1-9]\\d*)(s|ms)$";
     private static final Pattern SIMPLE_DURATION_PATTERN = Pattern.compile(SIMPLE_DURATION_REGEX);
+    private static final String INVALID_DURATION_ERROR_MESSAGE =
+            "Durations must use either ISO 8601 notation or simple notations for seconds (60s) or milliseconds (100ms). Whitespace is ignored.";
 
     public static Duration parse(final String durationString) {
+        if (durationString == null) {
+            throw new IllegalArgumentException(INVALID_DURATION_ERROR_MESSAGE);
+        }
         try {
             return Duration.parse(durationString);
         } catch (final DateTimeParseException e) {
             final Duration duration = parseSimpleDuration(durationString);
             if (duration == null) {
-                throw new IllegalArgumentException("Durations must use either ISO 8601 notation or simple notations for seconds (60s) or milliseconds (100ms). Whitespace is ignored.");
+                throw new IllegalArgumentException(INVALID_DURATION_ERROR_MESSAGE);
             }
             return duration;
         }

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/PipelinesDataflowModelParser.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/PipelinesDataflowModelParser.java
@@ -26,7 +26,8 @@ import java.util.stream.Collectors;
 public class PipelinesDataflowModelParser {
     private static final Logger LOG = LoggerFactory.getLogger(PipelinesDataflowModelParser.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory())
-            .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
+            .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+            .addHandler(new DataPrepperDeserializationProblemHandler());
 
     private final PipelineConfigurationReader pipelineConfigurationReader;
 

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDeserializationProblemHandlerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDeserializationProblemHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.parser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.ValueInstantiator;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataPrepperDeserializationProblemHandlerTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Class<?> TEST_TARGET_TYPE = Boolean.class;
+    private static final String TEST_VALUE = UUID.randomUUID().toString();
+    private static final String TEST_FAILURE_MESSAGE = UUID.randomUUID().toString();
+
+    @Mock
+    private DeserializationContext deserializationContext;
+
+    @Mock
+    private JsonParser jsonParser;
+
+    @Mock
+    private ValueInstantiator valueInstantiator;
+
+    private final DataPrepperDeserializationProblemHandler objectUnderTest = new DataPrepperDeserializationProblemHandler();
+
+    @Test
+    void testHandleWeirdStringValue() {
+        final IOException exception = assertThrows(IOException.class, () -> objectUnderTest.handleWeirdStringValue(
+                deserializationContext, TEST_TARGET_TYPE, TEST_VALUE, TEST_FAILURE_MESSAGE));
+        assertThat(exception.getMessage(), containsString(ClassUtil.nameOf(TEST_TARGET_TYPE)));
+        assertThat(exception.getMessage(), containsString(TEST_VALUE));
+        assertThat(exception.getMessage(), containsString(TEST_FAILURE_MESSAGE));
+    }
+
+    @Test
+    void testHandleUnexpectedToken() {
+        when(deserializationContext.getParser()).thenReturn(jsonParser);
+        final JavaType javaType = OBJECT_MAPPER.constructType(TEST_TARGET_TYPE);
+        final JsonToken jsonToken = JsonToken.END_OBJECT;
+        final JsonMappingException exception = assertThrows(JsonMappingException.class, () -> objectUnderTest.handleUnexpectedToken(
+                deserializationContext, javaType, jsonToken, jsonParser, TEST_FAILURE_MESSAGE));
+        assertThat(exception.getMessage(), containsString(ClassUtil.getTypeDescription(javaType)));
+        assertThat(exception.getMessage(), not(containsString(TEST_FAILURE_MESSAGE)));
+    }
+
+    @Test
+    void testHandleMissingInstantiator() throws IOException {
+        when(deserializationContext.getParser()).thenReturn(jsonParser);
+        when(jsonParser.getText()).thenReturn(UUID.randomUUID().toString());
+        final JsonMappingException exception = assertThrows(JsonMappingException.class, () -> objectUnderTest.handleMissingInstantiator(
+                deserializationContext, TEST_TARGET_TYPE, valueInstantiator, jsonParser, TEST_FAILURE_MESSAGE));
+        assertThat(exception.getMessage(), containsString(jsonParser.getText()));
+        assertThat(exception.getMessage(), containsString(TEST_TARGET_TYPE.getName()));
+        assertThat(exception.getMessage(), not(containsString(TEST_FAILURE_MESSAGE)));
+    }
+}

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDurationParserTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/DataPrepperDurationParserTest.java
@@ -17,6 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DataPrepperDurationParserTest {
 
+    @Test
+    void nullValueThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> DataPrepperDurationParser.parse(null));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"6s1s", "60ms 100s", "20.345s", "-1s", "06s", "100m", "100sm", "100"})
     void invalidDurationStringsThrowIllegalArgumentException(final String durationString) {

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.pipeline.parser.ByteCountDeserializer;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
 import org.opensearch.dataprepper.pipeline.parser.DataPrepperDurationDeserializer;
 import org.opensearch.dataprepper.pipeline.parser.EnumDeserializer;
 import org.opensearch.dataprepper.pipeline.parser.EventKeyDeserializer;
@@ -32,7 +33,8 @@ public class ObjectMapperConfiguration {
             Boolean.class, Character.class, PluginConfigVariable.class);
 
     @Bean(name = "extensionPluginConfigObjectMapper")
-    ObjectMapper extensionPluginConfigObjectMapper() {
+    ObjectMapper extensionPluginConfigObjectMapper(
+            final DataPrepperDeserializationProblemHandler dataPrepperDeserializationProblemHandler) {
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
         simpleModule.addDeserializer(Enum.class, new EnumDeserializer());
@@ -41,13 +43,15 @@ public class ObjectMapperConfiguration {
 
         return new ObjectMapper()
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-                .registerModule(simpleModule);
+                .registerModule(simpleModule)
+                .addHandler(dataPrepperDeserializationProblemHandler);
     }
 
     @Bean(name = "pluginConfigObjectMapper")
     ObjectMapper pluginConfigObjectMapper(
             final VariableExpander variableExpander,
-            final EventKeyFactory eventKeyFactory) {
+            final EventKeyFactory eventKeyFactory,
+            final DataPrepperDeserializationProblemHandler dataPrepperDeserializationProblemHandler) {
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
         simpleModule.addDeserializer(ByteCount.class, new ByteCountDeserializer());
@@ -58,6 +62,7 @@ public class ObjectMapperConfiguration {
 
         return new ObjectMapper()
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-                .registerModule(simpleModule);
+                .registerModule(simpleModule)
+                .addHandler(dataPrepperDeserializationProblemHandler);
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationConverterTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationConverterTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
 import org.opensearch.dataprepper.plugins.test.TestExtension;
 import org.opensearch.dataprepper.plugins.test.TestExtensionConfig;
 
@@ -43,7 +44,8 @@ class ExtensionPluginConfigurationConverterTest {
     @Mock
     private ConstraintViolation<Object> constraintViolation;
 
-    private final ObjectMapper objectMapper = new ObjectMapperConfiguration().extensionPluginConfigObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapperConfiguration()
+            .extensionPluginConfigObjectMapper(new DataPrepperDeserializationProblemHandler());
     private ExtensionPluginConfigurationConverter objectUnderTest;
 
     @BeforeEach

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ObjectMapperConfigurationTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ObjectMapperConfigurationTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.event.EventKey;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -38,10 +39,14 @@ class ObjectMapperConfigurationTest {
     @Mock
     private EventKeyFactory eventKeyFactory;
 
+    @Mock
+    private DataPrepperDeserializationProblemHandler dataPrepperDeserializationProblemHandler;
+
     @Test
     void test_duration_with_pluginConfigObjectMapper() {
         final String durationTestString = "10s";
-        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(variableExpander, eventKeyFactory);
+        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(
+                variableExpander, eventKeyFactory, dataPrepperDeserializationProblemHandler);
         final Duration duration = objectMapper.convertValue(durationTestString, Duration.class);
         assertThat(duration, equalTo(Duration.ofSeconds(10)));
     }
@@ -49,7 +54,8 @@ class ObjectMapperConfigurationTest {
     @Test
     void test_enum_with_pluginConfigObjectMapper() throws JsonProcessingException {
         final String testModelAsString = "{ \"name\": \"my-name\", \"test_type\": \"test\" }";
-        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(variableExpander, eventKeyFactory);
+        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(
+                variableExpander, eventKeyFactory, dataPrepperDeserializationProblemHandler);
         final TestModel testModel = objectMapper.readValue(testModelAsString, TestModel.class);
         assertThat(testModel, notNullValue());
         assertThat(testModel.getTestType(), equalTo(TestType.TEST));
@@ -58,7 +64,8 @@ class ObjectMapperConfigurationTest {
     @Test
     void test_duration_with_extensionPluginConfigObjectMapper() {
         final String durationTestString = "10s";
-        final ObjectMapper objectMapper = objectMapperConfiguration.extensionPluginConfigObjectMapper();
+        final ObjectMapper objectMapper = objectMapperConfiguration.extensionPluginConfigObjectMapper(
+                dataPrepperDeserializationProblemHandler);
         final Duration duration = objectMapper.convertValue(durationTestString, Duration.class);
         assertThat(duration, equalTo(Duration.ofSeconds(10)));
     }
@@ -66,7 +73,8 @@ class ObjectMapperConfigurationTest {
     @Test
     void test_enum_with_extensionPluginConfigObjectMapper() throws JsonProcessingException {
         final String testModelAsString = "{ \"name\": \"my-name\", \"test_type\": \"test\" }";
-        final ObjectMapper objectMapper = objectMapperConfiguration.extensionPluginConfigObjectMapper();
+        final ObjectMapper objectMapper = objectMapperConfiguration.extensionPluginConfigObjectMapper(
+                dataPrepperDeserializationProblemHandler);
         final TestModel testModel = objectMapper.readValue(testModelAsString, TestModel.class);
         assertThat(testModel, notNullValue());
         assertThat(testModel.getTestType(), equalTo(TestType.TEST));
@@ -77,7 +85,8 @@ class ObjectMapperConfigurationTest {
         final String testKey = "test";
         final EventKey eventKey = mock(EventKey.class);
         when(eventKeyFactory.createEventKey(testKey, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey);
-        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(variableExpander, eventKeyFactory);
+        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(
+                variableExpander, eventKeyFactory, dataPrepperDeserializationProblemHandler);
         final EventKey actualEventKey = objectMapper.convertValue(testKey, EventKey.class);
         assertThat(actualEventKey, equalTo(eventKey));
     }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
 import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -38,7 +39,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class VariableExpanderTest {
-    static final ObjectMapper OBJECT_MAPPER = new ObjectMapperConfiguration().extensionPluginConfigObjectMapper();
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapperConfiguration()
+            .extensionPluginConfigObjectMapper(new DataPrepperDeserializationProblemHandler());
     static final JsonFactory JSON_FACTORY = new MappingJsonFactory();
 
     @Mock


### PR DESCRIPTION
### Description
This PR enhances the error message in pipeline and plugin deserialization.
* fix null value handling in DataPrepperDurationParser
before
```
waf-access-log-pipeline.source.s3: caused by: Parameter "sqs.visibility_timeout" for plugin "s3" is invalid: text
```
after
```
waf-access-log-pipeline.source.s3: caused by: Parameter "sqs.visibility_timeout" for plugin "s3" is invalid: Durations must use either ISO 8601 notation or simple notations for seconds (60s) or milliseconds (100ms). Whitespace is ignored.
```
* simplify pipeline and plugin deserialization error message from Jackson by adding DataPrepperDeserializationProblemHandler
   1. handleWeirdStringValue
before:
```
waf-access-log-pipeline.source.s3: caused by: Parameter "sqs.visibility_duplication_protection" for plugin "s3" is invalid: Cannot deserialize value of type `java.lang.Boolean` from String "xy": only "true" or "false" recognized
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
```
after:
```
waf-access-log-pipeline.source.s3: caused by: Parameter "sqs.visibility_duplication_protection" for plugin "s3" is invalid: Cannot deserialize value of type `java.lang.Boolean` from String "xy": only "true" or "false" recognized
```
    2. handleMissingInstantiator
before:
```
waf-access-log-pipeline.processor.truncate: caused by: Parameter "entries.null" for plugin "truncate" is invalid: Cannot construct instance of `org.opensearch.dataprepper.plugins.processor.truncate.TruncateProcessorConfig$Entry` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('rand')
```
after:
```
waf-access-log-pipeline.processor.truncate: caused by: Parameter "entries.null" for plugin "truncate" is invalid: Cannot deserialize 'rand' into 'org.opensearch.dataprepper.plugins.processor.truncate.TruncateProcessorConfig$Entry'
```
    3. handleUnexpectedToken
before:
```
waf-access-log-pipeline.source.s3: caused by: Parameter "sqs.visibility_duplication_protection" for plugin "s3" is invalid: Cannot deserialize value of type `java.lang.Boolean` from Array value (token `JsonToken.START_ARRAY`)
```
after:
```
waf-access-log-pipeline.source.s3: caused by: Parameter "sqs.visibility_duplication_protection" for plugin "s3" is invalid: Cannot deserialize value of type `java.lang.Boolean` from Array value.
```

### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
