### PR TITLE
Support proxy in OpenSearch source

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -493,6 +493,7 @@ opensearch-source-pipeline:
         cert: "/path/to/cert.crt"
         socket_timeout: "100ms"
         connection_timeout: "100ms"
+        proxy: "https://localhost:8080"
       hosts: [ "https://localhost:9200" ]
       username: "username"
       password: "password"
@@ -684,6 +685,8 @@ and then every hour after the first time the index is processed.
 
 
 * `connection_timeout` (Optional) : A String that indicates the timeout duration used when requesting a connection from the connection manager. Supports ISO_8601 notation Strings ("PT20.345S", "PT15M", etc.) as well as simple notation Strings for seconds ("60s") and milliseconds ("1500ms"). If this timeout value is either negative or not set, the underlying Apache HttpClient would rely on operating system settings for managing connection timeouts.
+
+* `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:\<port\>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
 
 ### <a name="indices_configuration">Indices Configuration</a>
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
@@ -33,6 +33,9 @@ public class ConnectionConfiguration {
   @JsonProperty("insecure")
   private boolean insecure = false;
 
+  @JsonProperty("proxy")
+  private String proxy;
+
   public Path getCertPath() {
     return certPath;
   }
@@ -51,6 +54,10 @@ public class ConnectionConfiguration {
 
   public boolean isInsecure() {
     return insecure;
+  }
+
+  public String getProxy() {
+    return proxy;
   }
 
   @AssertTrue(message = "cert and certificate both are configured. " +

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
@@ -50,19 +50,23 @@ public class ConnectionConfigurationTest {
         assertThat(connectionConfiguration.getSocketTimeout(), equalTo(null));
         assertThat(connectionConfiguration.getCertPath(), equalTo(null));
         assertThat(connectionConfiguration.isInsecure(), equalTo(false));
+        assertThat(connectionConfiguration.getProxy(), equalTo(null));
     }
     @Test
     void connection_configuration_values_test() throws JsonProcessingException {
 
-        final String connectionYaml =
+        final String testHttpProxy = "121.121.121.121:80";
+        final String connectionYaml = String.format(
                 "  cert: \"cert\"\n" +
-                "  insecure: true\n";
+                "  insecure: true\n" +
+                "  proxy: \"%s\"\n", testHttpProxy);
         final ConnectionConfiguration connectionConfig = objectMapper.readValue(connectionYaml, ConnectionConfiguration.class);
         assertThat(connectionConfig.getCertPath(),equalTo(Path.of("cert")));
         assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
         assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
         assertThat(connectionConfig.isInsecure(),equalTo(true));
         assertThat(connectionConfig.isCertificateValid(), is(true));
+        assertThat(connectionConfig.getProxy(), equalTo(testHttpProxy));
     }
 
     @ParameterizedTest
@@ -72,10 +76,12 @@ public class ConnectionConfigurationTest {
     })
     void connection_configuration_certificate_values_test(final String certificate) throws JsonProcessingException {
 
+        final String testHttpProxy = "http://example.com:4350";
         final String connectionYaml = String.format(
                 "  cert: \"cert\"\n" +
                 "  certificate: \"%s\"\n" +
-                "  insecure: true\n", certificate.replace("\n", "\\n"));
+                "  insecure: true\n" +
+                "  proxy: %s", certificate.replace("\n", "\\n"), testHttpProxy);
         final ConnectionConfiguration connectionConfig = objectMapper.readValue(connectionYaml, ConnectionConfiguration.class);
         assertThat(connectionConfig.getCertPath(),equalTo(Path.of("cert")));
         assertThat(connectionConfig.getCertificate(),equalTo(certificate));
@@ -84,6 +90,7 @@ public class ConnectionConfigurationTest {
         assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
         assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
         assertThat(connectionConfig.isInsecure(),equalTo(true));
+        assertThat(connectionConfig.getProxy(), equalTo(testHttpProxy));
     }
 
     @Test
@@ -98,5 +105,28 @@ public class ConnectionConfigurationTest {
         assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
         assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
         assertThat(connectionConfig.isInsecure(),equalTo(true));
+        assertThat(connectionConfig.getProxy(), equalTo(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com:888888",
+            "socket://example.com:port",
+            "example.com:port",
+            "example.com"
+    })
+    void connection_configuration_invalid_proxy_value(final String proxy) throws JsonProcessingException {
+
+        final String connectionYaml = String.format(
+                "  cert: \"cert\"\n" +
+                "  insecure: true\n" +
+                "  proxy: \"%s\"\n", proxy);
+        final ConnectionConfiguration connectionConfig = objectMapper.readValue(connectionYaml, ConnectionConfiguration.class);
+        assertThat(connectionConfig.getCertPath(),equalTo(Path.of("cert")));
+        assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
+        assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
+        assertThat(connectionConfig.isInsecure(),equalTo(true));
+        assertThat(connectionConfig.isCertificateValid(), is(true));
+        assertThat(connectionConfig.getProxy(), equalTo(proxy));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
@@ -9,6 +9,8 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -36,6 +38,7 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -246,6 +249,39 @@ public class OpenSearchClientFactoryTest {
     }
 
     @Test
+    void provideElasticSearchClient_with_proxy() {
+        when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
+
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+        when(connectionConfiguration.isInsecure()).thenReturn(true);
+        when(connectionConfiguration.getProxy()).thenReturn("http://example.com:4350");
+
+        final ElasticsearchClient elasticsearchClient = createObjectUnderTest().provideElasticSearchClient(openSearchSourceConfiguration);
+        assertThat(elasticsearchClient, notNullValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com:888888",
+            "socket://example.com:port",
+            "example.com:port",
+            "example.com"
+    })
+    void provideElasticSearchClient_with_invalid_proxy(final String proxy) {
+        when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
+
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+        when(connectionConfiguration.isInsecure()).thenReturn(true);
+        when(connectionConfiguration.getProxy()).thenReturn(proxy);
+
+        assertThrows(IllegalArgumentException.class, () -> createObjectUnderTest().provideElasticSearchClient(openSearchSourceConfiguration));
+    }
+
+    @Test
     void provideOpenSearchClient_with_auth_disabled() {
         when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
 
@@ -341,6 +377,39 @@ public class OpenSearchClientFactoryTest {
             trustStoreProviderMockedStatic.verify(() -> TrustStoreProvider.createSSLContext(TEST_CERTIFICATE));
             assertThat(openSearchClient, notNullValue());
         }
+    }
+
+    @Test
+    void provideOpenSearchClient_with_proxy() {
+        when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
+
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+        when(connectionConfiguration.isInsecure()).thenReturn(true);
+        when(connectionConfiguration.getProxy()).thenReturn("http://example.com:4350");
+
+        final OpenSearchClient openSearchClient = createObjectUnderTest().provideOpenSearchClient(openSearchSourceConfiguration);
+        assertThat(openSearchClient, notNullValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com:888888",
+            "socket://example.com:port",
+            "example.com:port",
+            "example.com"
+    })
+    void provideOpenSearchClient_with_invalid_proxy(final String proxy) {
+        when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
+
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+        when(connectionConfiguration.isInsecure()).thenReturn(true);
+        when(connectionConfiguration.getProxy()).thenReturn(proxy);
+
+        assertThrows(IllegalArgumentException.class, () -> createObjectUnderTest().provideOpenSearchClient(openSearchSourceConfiguration));
     }
 
     @Test


### PR DESCRIPTION
### Description
Support HTTP proxy configuration to reach OpenSearch servers configured as source
 
### Issues Resolved
Resolves #5422
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
