### PR TITLE
Fix secrets rotation handling in Rds source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/MessageType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/model/MessageType.java
@@ -10,28 +10,29 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.model;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public enum MessageType {
     BEGIN('B'),
-    RELATION('R'),
-    INSERT('I'),
-    UPDATE('U'),
-    DELETE('D'),
     COMMIT('C'),
-    TYPE('Y');
+    DELETE('D'),
+    INSERT('I'),
+    MESSAGE('M'),
+    ORIGIN('O'),
+    RELATION('R'),
+    TRUNCATE('T'),
+    TYPE('Y'),
+    UPDATE('U');
 
     private final char value;
 
-    private static final Map<Character, MessageType> MESSAGE_TYPE_MAP = Map.of(
-            BEGIN.getValue(), BEGIN,
-            RELATION.getValue(), RELATION,
-            INSERT.getValue(), INSERT,
-            UPDATE.getValue(), UPDATE,
-            DELETE.getValue(), DELETE,
-            COMMIT.getValue(), COMMIT,
-            TYPE.getValue(), TYPE
-    );
+    private static final Map<Character, MessageType> MESSAGE_TYPE_MAP = Arrays.stream(values())
+            .collect(Collectors.toMap(
+                    messageType -> messageType.value,
+                    messageType -> messageType
+            ));
 
     MessageType(char value) {
         this.value = value;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ReplicationLogClientFactory.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/ReplicationLogClientFactory.java
@@ -26,9 +26,9 @@ import java.util.NoSuchElementException;
 
 public class ReplicationLogClientFactory {
 
-    private final RdsSourceConfig sourceConfig;
     private final RdsClient rdsClient;
     private final DbMetadata dbMetadata;
+    private RdsSourceConfig sourceConfig;
     private String username;
     private String password;
     private SSLMode sslMode = SSLMode.REQUIRED;
@@ -82,9 +82,10 @@ public class ReplicationLogClientFactory {
         this.sslMode = sslMode;
     }
 
-    public void setCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
+    public void updateCredentials(RdsSourceConfig sourceConfig) {
+        this.sourceConfig = sourceConfig;
+        this.username = sourceConfig.getAuthenticationConfig().getUsername();
+        this.password = sourceConfig.getAuthenticationConfig().getPassword();
     }
 
     private String getDatabaseName(List<String> tableNames) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -69,8 +69,16 @@ public class StreamWorker {
             try {
                 replicationLogClient.disconnect();
             } catch (Exception e) {
-                LOG.error("Binary log client failed to disconnect.", e);
+                LOG.error("Replication log client failed to disconnect.", e);
             }
+        }
+    }
+
+    public void shutdown() {
+        try {
+            replicationLogClient.disconnect();
+        } catch (Exception e) {
+            LOG.error("Replication log client failed to disconnect.", e);
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -66,11 +66,7 @@ public class StreamWorker {
             sourceCoordinator.giveUpPartition(streamPartition);
             throw new RuntimeException(e);
         } finally {
-            try {
-                replicationLogClient.disconnect();
-            } catch (Exception e) {
-                LOG.error("Replication log client failed to disconnect.", e);
-            }
+            shutdown();
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -48,6 +48,7 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
 
     private ExecutorService executorService;
     private RdsSourceConfig currentSourceConfig;
+    private StreamWorker streamWorker;
 
     public StreamWorkerTaskRefresher(final EnhancedSourceCoordinator sourceCoordinator,
                                      final StreamPartition streamPartition,
@@ -96,10 +97,10 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
             LOG.info("Database credentials were updated. Refreshing stream worker...");
             credentialsChangeCounter.increment();
             try {
+                streamWorker.shutdown();
                 executorService.shutdownNow();
                 executorService = executorServiceSupplier.get();
-                replicationLogClientFactory.setCredentials(
-                        sourceConfig.getAuthenticationConfig().getUsername(), sourceConfig.getAuthenticationConfig().getPassword());
+                replicationLogClientFactory.updateCredentials(sourceConfig);
 
                 refreshTask(sourceConfig);
 
@@ -132,7 +133,7 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
                     streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics, logicalReplicationClient,
                     streamCheckpointer, acknowledgementSetManager));
         }
-        final StreamWorker streamWorker = StreamWorker.create(sourceCoordinator, replicationLogClient, pluginMetrics);
+        streamWorker = StreamWorker.create(sourceCoordinator, replicationLogClient, pluginMetrics);
         executorService.submit(() -> streamWorker.processStream(streamPartition));
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationClientTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationClientTest.java
@@ -119,6 +119,7 @@ class LogicalReplicationClientTest {
         when(logicalStreamBuilder.start()).thenReturn(stream);
         when(stream.readPending()).thenReturn(message).thenReturn(null);
         when(stream.getLastReceiveLSN()).thenReturn(lsn);
+        when(stream.isClosed()).thenReturn(false, true);
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> logicalReplicationClient.connect());
@@ -155,6 +156,7 @@ class LogicalReplicationClientTest {
         when(logicalStreamBuilder.start()).thenReturn(stream);
         when(stream.readPending()).thenReturn(message).thenReturn(null);
         when(stream.getLastReceiveLSN()).thenReturn(lsn);
+        when(stream.isClosed()).thenReturn(false, true);
 
         // First connect
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -174,6 +176,7 @@ class LogicalReplicationClientTest {
 
         // Second connect
         when(stream.readPending()).thenReturn(message).thenReturn(null);
+        when(stream.isClosed()).thenReturn(false, true);
         executorService.submit(() -> logicalReplicationClient.connect());
         await().atMost(Duration.ofSeconds(1))
                 .untilAsserted(() -> verify(eventProcessor, times(2)).process(message));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -14,6 +14,8 @@ import io.micrometer.core.instrument.Metrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,7 +32,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
@@ -149,13 +151,21 @@ class LogicalReplicationEventProcessorTest {
         verify(objectUnderTest).processTypeMessage(message);
     }
 
+    @ParameterizedTest
+    @ValueSource(chars = {'M', 'O', 'T'})
+    void test_unsupported_message_type_not_throw_exception(char typeChar) {
+        setMessageType(MessageType.from(typeChar));
+
+        assertDoesNotThrow(() -> objectUnderTest.process(message));
+    }
+
     @Test
-    void test_unsupported_message_type_throws_exception() {
+    void test_unknown_message_type_not_throw_exception() {
         message = ByteBuffer.allocate(1);
         message.put((byte) 'A');
         message.flip();
 
-        assertThrows(IllegalArgumentException.class, () -> objectUnderTest.process(message));
+        assertDoesNotThrow(() -> objectUnderTest.process(message));
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
@@ -89,6 +89,12 @@ class StreamWorkerTest {
         verify(binlogClientWrapper).connect();
     }
 
+    @Test
+    void test_shutdown() throws IOException {
+        streamWorker.shutdown();
+        verify(binlogClientWrapper).disconnect();
+    }
+
     private StreamWorker createObjectUnderTest() {
         return new StreamWorker(sourceCoordinator, binlogClientWrapper, pluginMetrics);
     }


### PR DESCRIPTION
### Description
This PR fixes secrets rotation handling in Rds source. Before this PR, the credentials were not refreshed correctly and the stream was not closed properly to allow for reconnection.

Also updated the replication message type model and do not throw exception when unknown or unsupported types are received.
 
### Issues Resolved
Contributes to #5309 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
