### PR TITLE
Only add s3 object to be deleted if optional is present for sqs message

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
@@ -311,7 +311,7 @@ public class SqsWorker implements Runnable {
             final Optional<DeleteMessageBatchRequestEntry> deleteMessageBatchRequestEntry = processS3Object(parsedMessage, s3ObjectReference, acknowledgementSet);
             if (endToEndAcknowledgementsEnabled) {
                 deleteMessageBatchRequestEntry.ifPresent(waitingForAcknowledgements::add);
-                if (s3SourceConfig.isDeleteS3ObjectsOnRead()) {
+                if (deleteMessageBatchRequestEntry.isPresent() && s3SourceConfig.isDeleteS3ObjectsOnRead()) {
                     s3ObjectDeletionsWaitingForAcknowledgments.add(s3ObjectReference);
                 }
                 acknowledgementSet.complete();


### PR DESCRIPTION
### Description
S3-SQS delete objects on read adds an S3 object to the batch waiting for deletion unecessarily if the sqs message was not properly processed. While it is still only deleted if all SQS messages were deleted successfully (https://github.com/opensearch-project/data-prepper/blob/837d1a9a4bee8d1cb05e1f539bb41fa37c6fc070/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java#L272), it should still not be marked for deletion at all
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
