### PR TITLE
Add support for Scope metrics

### DIFF
--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [11, 17, 21, docker]
-        otelVersion: ['1.3.2-alpha']
+        otelVersion: ['0.16.0-alpha', '1.3.2-alpha']
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsProtoBufDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsProtoBufDecoderTest.java
@@ -36,7 +36,7 @@ public class OTelLogsProtoBufDecoderTest {
     private static final String TEST_REQUEST_LOGS_FILE = "test-otel-log.protobuf";
     // This protobuf format file is generated using OTEL collector and file exporter and then sending multiple log events to the collector
     private static final String TEST_REQUEST_MULTI_LOGS_FILE = "test-otel-multi-log.protobuf";
-    
+
     public OTelLogsProtoBufDecoder createObjectUnderTest(boolean lengthPrefixedEncoding) {
         return new OTelLogsProtoBufDecoder(lengthPrefixedEncoding);
     }
@@ -53,8 +53,8 @@ public class OTelLogsProtoBufDecoderTest {
         assertThat(logRecord.getSeverityText(), is("Information"));
         assertThat(logRecord.getSpanId(), is(spanId));
         assertThat(logRecord.getTraceId(), is("5b8efff798038103d269b633813fc60c"));
-        Map<String, Object> mergedAttributes = logRecord.getAttributes(); 
-        assertThat(mergedAttributes.keySet().size(), is(9)); 
+        Map<String, Object> mergedAttributes = logRecord.getAttributes();
+        assertThat(mergedAttributes.keySet().size(), is(10));
     }
 
     @Test
@@ -63,7 +63,6 @@ public class OTelLogsProtoBufDecoderTest {
         createObjectUnderTest(false).parse(inputStream, Instant.now(), (record) -> {
             assertLog((OpenTelemetryLog)record.getData(), 50, "2025-01-26T20:07:20Z", "eee19b7ec3c1b174");
         });
-        
     }
 
     @Test
@@ -120,10 +119,10 @@ public class OTelLogsProtoBufDecoderTest {
             assertLogFromRequest((OpenTelemetryLog)record.getData());
         });
     }
-        
+
     @Test
     public void testParseWithLargeDynamicRequest_ThrowsException() throws Exception {
-        
+
         // Create a request larger than 8MB
         List<LogRecord> records = new ArrayList<>();
         for (int i = 0; i < 4 * 1024 * 1024; i++) {

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-gauge-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-gauge-metrics.json
@@ -13,7 +13,18 @@
       },
       "scopeMetrics": [
         {
-          "scope": {},
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "gauge scope attribute"
+                }
+              }
+            ]
+          },
           "metrics": [
             {
               "name": "counter-int",

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics-no-explicit-bounds.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics-no-explicit-bounds.json
@@ -13,7 +13,18 @@
       },
       "scopeMetrics": [
         {
-          "scope": {},
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "histogram scope attribute"
+                }
+              }
+            ]
+          },
           "metrics": [
             {
               "name": "histogram-int",

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics.json
@@ -13,7 +13,18 @@
       },
       "scopeMetrics": [
         {
-          "scope": {},
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "histogram scope attribute"
+                }
+              }
+            ]
+          },
           "metrics": [
             {
               "name": "histogram-int",

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log.json
@@ -9,6 +9,18 @@
       }]
     },
     "scopeLogs": [{
+      "scope": {
+        "name": "my.library",
+        "version": "1.0.0",
+        "attributes": [
+          {
+            "key": "my.scope.attribute",
+            "value": {
+              "stringValue": "log scope attribute"
+            }
+          }
+        ]
+      },
       "logRecords": [{
         "timeUnixNano": "1590328800000000000",
         "severityNumber": "SEVERITY_NUMBER_DEBUG",

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request.json
@@ -73,7 +73,15 @@
         {
           "scope": {
             "name": "io.opentelemetry.auto.spring-webmvc-3.1",
-            "version": ""
+            "version": "",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "span scope attribute"
+                }
+              }
+            ]
           },
           "spans": [
             {
@@ -101,7 +109,15 @@
         {
           "scope": {
             "name": "io.opentelemetry.auto.apache-httpasyncclient-4.0",
-            "version": ""
+            "version": "",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "span scope attribute"
+                }
+              }
+            ]
           },
           "spans": [
             {
@@ -148,7 +164,15 @@
         {
           "scope": {
             "name": "io.opentelemetry.auto.servlet-3.0",
-            "version": ""
+            "version": "",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "span scope attribute"
+                }
+              }
+            ]
           },
           "spans": [
             {

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-sum-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-sum-metrics.json
@@ -13,7 +13,18 @@
       },
       "scopeMetrics": [
         {
-          "scope": {},
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "sum scope attribute"
+                }
+              }
+            ]
+          },
           "metrics": [
             {
               "name": "sum-int",


### PR DESCRIPTION
### Description
Add support for Scope metrics. 
New OTEL version adds attributes in Scope and OTEL logs/traces/metrics is updated to support that.
Also, modified e2e test to use previous version 0.16.0-alpha 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
