### PR TITLE
Handle Mongo Binary data type when subtype is UUID_STANDARD (value 4).

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -33,6 +33,7 @@ import static com.mongodb.client.model.Filters.gte;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lte;
 import static com.mongodb.client.model.Filters.or;
+import static org.bson.BsonBinarySubType.UUID_STANDARD;
 
 public class BsonHelper {
     static final String PARTITION_FORMAT = "%s-%s";
@@ -107,7 +108,7 @@ public class BsonHelper {
         .build();
 
     private static String getStringFromBsonBinary(final BsonBinary bsonBinary) {
-        if (bsonBinary.getType() == 4) {
+        if (bsonBinary.getType() == UUID_STANDARD.getValue()) {
             return bsonBinary.asUuid().toString();
         } else {
             return Base64.getEncoder().encodeToString(bsonBinary.getData());

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -91,7 +91,7 @@ public class BsonHelper {
     public static final JsonWriterSettings JSON_WRITER_SETTINGS = JsonWriterSettings.builder()
         .outputMode(JsonMode.RELAXED)
         .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
-        .binaryConverter((value, writer) ->  writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
+        .binaryConverter((value, writer) ->  writer.writeString(getStringFromBsonBinary(value)))
         .dateTimeConverter((value, writer) -> writer.writeNumber(String.valueOf(value.longValue())))
         .decimal128Converter((value, writer) -> writer.writeString(value.bigDecimalValue().toPlainString()))
         .maxKeyConverter((value, writer) -> writer.writeNull())
@@ -106,6 +106,14 @@ public class BsonHelper {
         .undefinedConverter((value, writer) -> writer.writeNull())
         .build();
 
+    private static String getStringFromBsonBinary(final BsonBinary bsonBinary) {
+        if (bsonBinary.getType() == 4) {
+            return bsonBinary.asUuid().toString();
+        } else {
+            return Base64.getEncoder().encodeToString(bsonBinary.getData());
+        }
+    }
+
     public static String getPartitionStringFromMongoDBId(Object id, String className) {
         switch (className) {
             case "org.bson.Document":
@@ -114,7 +122,7 @@ public class BsonHelper {
                 final byte type = ((Binary) id).getType();
                 final byte[] data = ((Binary) id).getData();
                 final String typeString = String.valueOf(type);
-                final String dataString = new String(data);
+                final String dataString = Base64.getEncoder().encodeToString(data);
                 return String.format(PARTITION_FORMAT, typeString, dataString);
             case "java.util.Date":
                 return String.valueOf(((Date) id).getTime());
@@ -158,7 +166,8 @@ public class BsonHelper {
                 return function.apply(Document.parse(value));
             case "org.bson.types.Binary":
                 String[] binaryString = value.split(PARTITION_SPLITTER, 2);
-                return function.apply(new Binary(Byte.parseByte(binaryString[0]), binaryString[1].getBytes()));
+                return function.apply(new Binary(Byte.parseByte(binaryString[0]), Base64.getDecoder()
+                        .decode(binaryString[1])));
             case "org.bson.types.ObjectId":
                 return function.apply(new ObjectId(value));
             case "java.lang.Boolean":

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.Random;
 import java.util.UUID;
@@ -27,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.JSON_WRITER_SETTINGS;
 import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.PARTITION_FORMAT;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,7 +51,7 @@ public class BsonHelperTest {
         when(document.getType()).thenReturn(type);
         when(document.getData()).thenReturn(byteData);
         final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, Binary.class.getName());
-        assertThat(partition, is(String.format("%s-%s", type, new String(byteData))));
+        assertThat(partition, is(String.format("%s-%s", type, Base64.getEncoder().encodeToString(byteData))));
     }
 
     @Test
@@ -222,13 +224,15 @@ public class BsonHelperTest {
     @Test
     public void buildAndQueryForBinaryClass() {
         final String bytes1String = UUID.randomUUID().toString();
-        final String bytes1 = new String(Base64.getEncoder().encode(bytes1String.getBytes()));
-        final String bytes1Type = String.format("%02x",(Math.abs(new Random().nextInt(10))));
+        final String bytes1 = Base64.getEncoder().encodeToString(bytes1String.getBytes());
+        int value1 = new Random().nextInt(10);
+        final String bytes1Type = String.format("%02x",(Math.abs(value1)));
+        int value2 = new Random().nextInt(10);
         final String bytes2String = UUID.randomUUID().toString();
-        final String bytes2 = new String(Base64.getEncoder().encode(bytes2String.getBytes()));
-        final String bytes2Type = String.format("%02x",(Math.abs(new Random().nextInt(10))));
-        final String gteValue = String.format(PARTITION_FORMAT, bytes1Type, bytes1String);
-        final String lteValue = String.format(PARTITION_FORMAT, bytes2Type, bytes2String);
+        final String bytes2 = Base64.getEncoder().encodeToString(bytes2String.getBytes());
+        final String bytes2Type = String.format("%02x",(Math.abs(value2)));
+        final String gteValue = String.format(PARTITION_FORMAT, bytes1Type, bytes1);
+        final String lteValue = String.format(PARTITION_FORMAT, bytes2Type, bytes2);
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}", bytes1, bytes1Type);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}", bytes2, bytes2Type);
         final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Binary.class.getName(), Binary.class.getName());
@@ -237,11 +241,25 @@ public class BsonHelperTest {
     }
 
     @Test
+    public void buildAndQueryForBinaryUUIDClass() {
+        final UUID uuid = UUID.randomUUID();
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        String base64String = Base64.getEncoder().encodeToString(bb.array());
+        System.out.println(base64String);
+        final Document document = Document.parse(String.format("{\"_id\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}", base64String, "04"));
+        final String record = document.toJson(JSON_WRITER_SETTINGS);
+        assertThat(record, is(String.format("{\"_id\": \"%s\"}", uuid)));
+    }
+
+    @Test
     public void buildAndQueryForIntegerAndBinaryClass() {
         final String gteValue = String.valueOf(Math.abs(new Random(10_000).nextInt()));
-        final String bytesString = UUID.randomUUID().toString();
-        final String bytes = new String(Base64.getEncoder().encode(bytesString.getBytes()));
-        final String bytesType = String.format("%02x",(Math.abs(new Random().nextInt(10))));
+        final String uuid = UUID.randomUUID().toString();
+        final String bytesString = Base64.getEncoder().encodeToString(uuid.getBytes());
+        int value = new Random().nextInt(10);
+        final String bytesType = String.format("%02x",(Math.abs(value)));
         final String lteValue = String.format(PARTITION_FORMAT, bytesType, bytesString);
         final String expectedValueString = String.format("{\"$or\": [{\"$or\": [" +
                 "{\"$or\": [{\"_id\": {\"$gte\": %s}}, " +
@@ -249,7 +267,7 @@ public class BsonHelperTest {
                 "{\"_id\": {\"$gte\": {}}}]}, " +
                 "{\"_id\": {\"$lte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}" +
                 "]}",
-                gteValue, bytes, bytesType);
+                gteValue, bytesString, bytesType);
         final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Integer.class.getName(), Binary.class.getName());
         assertThat(bson.toBsonDocument().toJson(), is(expectedValueString));
     }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
@@ -246,11 +246,21 @@ public class BsonHelperTest {
         ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
         bb.putLong(uuid.getMostSignificantBits());
         bb.putLong(uuid.getLeastSignificantBits());
-        String base64String = Base64.getEncoder().encodeToString(bb.array());
-        System.out.println(base64String);
+        final String base64String = Base64.getEncoder().encodeToString(bb.array());
         final Document document = Document.parse(String.format("{\"_id\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}", base64String, "04"));
         final String record = document.toJson(JSON_WRITER_SETTINGS);
         assertThat(record, is(String.format("{\"_id\": \"%s\"}", uuid)));
+    }
+
+    @Test
+    public void buildAndQueryForBinaryNonUUIDClass() {
+        final String base64String = Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
+        int value = new Random().nextInt(10);
+        if (value == 4) value++;
+        final String bytesType = String.format("%02x",(Math.abs(value)));
+        final Document document = Document.parse(String.format("{\"_id\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}", base64String, bytesType));
+        final String record = document.toJson(JSON_WRITER_SETTINGS);
+        assertThat(record, is(String.format("{\"_id\": \"%s\"}", base64String)));
     }
 
     @Test


### PR DESCRIPTION
We have identified an issue in the way we are handling MongoDB binary values for UUID_STANDARD type (4). 
The current implementation doesn't properly handle base64 encoding for UUID values when constructing queries.

Current Behavior:
- UUID values are not properly encoded when constructing queries
- Results in incorrect query conditions for UUID_STANDARD binary types
- Affects document retrieval when querying by UUID fields
- OpenSearch DocumentIDs are always base64 encoded for binary types

Root Cause:
- Binary type 4 (UUID_STANDARD) requires special handling
- Current code doesn't convert UUID to proper 16-byte format
- Missing base64 encoding step for UUID binary values

Fix:
- Add proper UUID to binary conversion
- Implement base64 encoding for UUID values
- Update query construction logic
- Use UUID string format for DocumentID when binary type is UUID_STANDARD

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
