### PR TITLE
Add support for Opensearch Mode to OTEL logs/traces/metrics

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
@@ -112,4 +112,20 @@ public interface OpenTelemetryLog extends Log {
      * @since 2.1
      */
     Object getBody();
+
+    /**
+     * Gets the scope of this log event.
+     *
+     * @return the scope
+     * @since 2.11
+     */
+    Map<String, Object> getScope();
+
+    /**
+     * Gets the resource of this log event.
+     *
+     * @return the resource
+     * @since 2.11
+     */
+    Map<String, Object> getResource();
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
@@ -27,27 +27,33 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
     private static final String COUNT_KEY = "count";
     private static final String SCALE_KEY = "scale";
     private static final String AGGREGATION_TEMPORALITY_KEY = "aggregationTemporality";
+    private static final String OTLP_AGGREGATION_TEMPORALITY_KEY = "aggregation_temporality";
     private static final String ZERO_COUNT_KEY = "zeroCount";
+    private static final String OTLP_ZERO_COUNT_KEY = "zero_ount";
     public static final String POSITIVE_BUCKETS_KEY = "positiveBuckets";
+    public static final String OTLP_POSITIVE_BUCKETS_KEY = "positive_buckets";
     public static final String NEGATIVE_BUCKETS_KEY = "negativeBuckets";
+    public static final String OTLP_NEGATIVE_BUCKETS_KEY = "negative_buckets";
     private static final String NEGATIVE_KEY = "negative";
     private static final String POSITIVE_KEY = "positive";
     private static final String NEGATIVE_OFFSET_KEY = "negativeOffset";
+    private static final String OTLP_NEGATIVE_OFFSET_KEY = "negative_offset";
     private static final String POSITIVE_OFFSET_KEY = "positiveOffset";
+    private static final String OTLP_POSITIVE_OFFSET_KEY = "positive_offset";
 
     private static final List<String> REQUIRED_KEYS = new ArrayList<>();
     private static final List<String> REQUIRED_NON_EMPTY_KEYS = Arrays.asList(NAME_KEY, KIND_KEY, TIME_KEY);
     private static final List<String> REQUIRED_NON_NULL_KEYS = Collections.singletonList(SUM_KEY);
 
 
-    protected JacksonExponentialHistogram(JacksonExponentialHistogram.Builder builder, boolean flattenAttributes) {
-        super(builder, flattenAttributes);
+    protected JacksonExponentialHistogram(JacksonExponentialHistogram.Builder builder, boolean opensearchMode) {
+        super(builder, opensearchMode);
 
         checkArgument(this.getMetadata().getEventType().equals(EventType.METRIC.toString()), "eventType must be of type Metric");
     }
 
-    public static JacksonExponentialHistogram.Builder builder() {
-        return new JacksonExponentialHistogram.Builder();
+    public static JacksonExponentialHistogram.Builder builder(final boolean opensearchMode) {
+        return new JacksonExponentialHistogram.Builder(opensearchMode);
     }
 
     @Override
@@ -62,17 +68,20 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
 
     @Override
     public String getAggregationTemporality() {
-        return this.get(AGGREGATION_TEMPORALITY_KEY, String.class);
+        final String key = getOpensearchMode() ? AGGREGATION_TEMPORALITY_KEY : OTLP_AGGREGATION_TEMPORALITY_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public List<? extends Bucket> getNegativeBuckets() {
-        return this.getList(NEGATIVE_BUCKETS_KEY, DefaultBucket.class);
+        final String key = getOpensearchMode() ? NEGATIVE_BUCKETS_KEY : OTLP_NEGATIVE_BUCKETS_KEY;
+        return this.getList(key, DefaultBucket.class);
     }
 
     @Override
     public List<? extends Bucket> getPositiveBuckets() {
-        return this.getList(POSITIVE_BUCKETS_KEY, DefaultBucket.class);
+        final String key = getOpensearchMode() ? POSITIVE_BUCKETS_KEY : OTLP_POSITIVE_BUCKETS_KEY;
+        return this.getList(key, DefaultBucket.class);
     }
 
     @Override
@@ -87,7 +96,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
 
     @Override
     public Long getZeroCount() {
-        return this.get(ZERO_COUNT_KEY, Long.class);
+        final String key = getOpensearchMode() ? ZERO_COUNT_KEY : OTLP_ZERO_COUNT_KEY;
+        return this.get(key, Long.class);
     }
 
     @Override
@@ -97,12 +107,14 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
 
     @Override
     public Integer getNegativeOffset() {
-        return this.get(NEGATIVE_OFFSET_KEY, Integer.class);
+        final String key = getOpensearchMode() ? NEGATIVE_OFFSET_KEY : OTLP_NEGATIVE_OFFSET_KEY;
+        return this.get(key, Integer.class);
     }
 
     @Override
     public Integer getPositiveOffset() {
-        return this.get(POSITIVE_OFFSET_KEY, Integer.class);
+        final String key = getOpensearchMode() ? POSITIVE_OFFSET_KEY : OTLP_POSITIVE_OFFSET_KEY;
+        return this.get(key, Integer.class);
     }
 
     /**
@@ -111,6 +123,10 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
      * @since 1.4
      */
     public static class Builder extends JacksonMetric.Builder<JacksonExponentialHistogram.Builder> {
+
+        public Builder(final boolean opensearchMode) {
+            super(opensearchMode);
+        }
 
         @Override
         public JacksonExponentialHistogram.Builder getThis() {
@@ -162,7 +178,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram.Builder withZeroCount(long zeroCount) {
-            put(ZERO_COUNT_KEY, zeroCount);
+            final String key = getOpensearchMode() ? ZERO_COUNT_KEY : OTLP_ZERO_COUNT_KEY;
+            put(key, zeroCount);
             return this;
         }
 
@@ -174,7 +191,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram.Builder withAggregationTemporality(String aggregationTemporality) {
-            put(AGGREGATION_TEMPORALITY_KEY, aggregationTemporality);
+            final String key = getOpensearchMode() ? AGGREGATION_TEMPORALITY_KEY : OTLP_AGGREGATION_TEMPORALITY_KEY;
+            put(key, aggregationTemporality);
             return this;
         }
 
@@ -186,7 +204,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram.Builder  withPositiveBuckets(List<Bucket> exponentialBuckets) {
-            put(POSITIVE_BUCKETS_KEY, exponentialBuckets);
+            final String key = getOpensearchMode() ? POSITIVE_BUCKETS_KEY : OTLP_POSITIVE_BUCKETS_KEY;
+            put(key, exponentialBuckets);
             return this;
         }
 
@@ -198,7 +217,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram.Builder withNegativeBuckets(List<Bucket> exponentialBuckets) {
-            put(NEGATIVE_BUCKETS_KEY, exponentialBuckets);
+            final String key = getOpensearchMode() ? NEGATIVE_BUCKETS_KEY : OTLP_NEGATIVE_BUCKETS_KEY;
+            put(key, exponentialBuckets);
             return this;
         }
 
@@ -234,7 +254,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram.Builder withPositiveOffset(int offset) {
-            put(POSITIVE_OFFSET_KEY, offset);
+            final String key = getOpensearchMode() ? POSITIVE_OFFSET_KEY : OTLP_POSITIVE_OFFSET_KEY;
+            put(key, offset);
             return this;
         }
 
@@ -258,7 +279,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram.Builder withNegativeOffset(int offset) {
-            put(NEGATIVE_OFFSET_KEY, offset);
+            final String key = getOpensearchMode() ? NEGATIVE_OFFSET_KEY : OTLP_NEGATIVE_OFFSET_KEY;
+            put(key, offset);
             return this;
         }
 
@@ -269,24 +291,13 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
          * @since 1.4
          */
         public JacksonExponentialHistogram build() {
-            return build(true);
-        }
-
-        /**
-         * Returns a newly created {@link JacksonExponentialHistogram}
-         *
-         * @param flattenAttributes flag indicating if the attributes should be flattened or not
-         * @return a JacksonExponentialHistogram
-         * @since 2.1
-         */
-        public JacksonExponentialHistogram build(boolean flattenAttributes) {
             this.withData(data);
             this.withEventKind(KIND.EXPONENTIAL_HISTOGRAM.toString());
             this.withEventType(EventType.METRIC.toString());
             checkAndSetDefaultValues();
             new ParameterValidator().validate(REQUIRED_KEYS, REQUIRED_NON_EMPTY_KEYS, REQUIRED_NON_NULL_KEYS, (HashMap<String, Object>)data);
 
-            return new JacksonExponentialHistogram(this, flattenAttributes);
+            return new JacksonExponentialHistogram(this, opensearchMode);
         }
 
         private void checkAndSetDefaultValues() {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonGauge.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonGauge.java
@@ -29,13 +29,13 @@ public class JacksonGauge extends JacksonMetric implements Gauge {
     private static final List<String> REQUIRED_NON_EMPTY_KEYS = Arrays.asList(NAME_KEY, KIND_KEY, TIME_KEY);
     private static final List<String> REQUIRED_NON_NULL_KEYS = Collections.singletonList(VALUE_KEY);
 
-    protected JacksonGauge(Builder builder, boolean flattenAttributes) {
-        super(builder, flattenAttributes);
+    protected JacksonGauge(Builder builder, boolean opensearchMode) {
+        super(builder, opensearchMode);
         checkArgument(this.getMetadata().getEventType().equals(EventType.METRIC.toString()), "eventType must be of type Metric");
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public static Builder builder(final boolean opensearchMode) {
+        return new Builder(opensearchMode);
     }
 
     @Override
@@ -49,6 +49,10 @@ public class JacksonGauge extends JacksonMetric implements Gauge {
      * @since 1.4
      */
     public static class Builder extends JacksonMetric.Builder<JacksonGauge.Builder> {
+
+        public Builder(final boolean opensearchMode) {
+            super(opensearchMode);
+        }
 
         @Override
         public Builder getThis() {
@@ -86,22 +90,14 @@ public class JacksonGauge extends JacksonMetric implements Gauge {
          * @since 1.4
          */
         public JacksonGauge build() {
-            return build(true);
-        }
-
-        /**
-         * Returns a newly created {@link JacksonGauge}
-         * @param flattenAttributes flag indicating if the attributes should be flattened or not
-         * @return a JacksonGauge
-         * @since 2.1
-         */
-        public JacksonGauge build(boolean flattenAttributes) {
             this.withEventKind(Metric.KIND.GAUGE.toString());
             this.withData(data);
             this.withEventType(EventType.METRIC.toString());
             checkAndSetDefaultValues();
-            new ParameterValidator().validate(REQUIRED_KEYS, REQUIRED_NON_EMPTY_KEYS, REQUIRED_NON_NULL_KEYS, (HashMap<String, Object>)data);
-            return new JacksonGauge(this, flattenAttributes);
+            if (getOpensearchMode()) {
+                new ParameterValidator().validate(REQUIRED_KEYS, REQUIRED_NON_EMPTY_KEYS, REQUIRED_NON_NULL_KEYS, (HashMap<String, Object>)data);
+            }
+            return new JacksonGauge(this, opensearchMode);
         }
 
         private void checkAndSetDefaultValues() {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
@@ -28,24 +28,29 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
     private static final String MIN_KEY = "min";
     private static final String COUNT_KEY = "count";
     private static final String AGGREGATION_TEMPORALITY_KEY = "aggregationTemporality";
+    private static final String OTLP_AGGREGATION_TEMPORALITY_KEY = "aggregation_temporality";
     private static final String BUCKET_COUNTS_KEY = "bucketCounts";
+    private static final String OTLP_BUCKET_COUNTS_KEY = "bucket_counts";
     private static final String EXPLICIT_BOUNDS_COUNT_KEY = "explicitBoundsCount";
+    private static final String OTLP_EXPLICIT_BOUNDS_COUNT_KEY = "explicit_bounds_count";
     public static final String BUCKETS_KEY = "buckets";
     private static final String BUCKET_COUNTS_LIST_KEY = "bucketCountsList";
+    private static final String OTLP_BUCKET_COUNTS_LIST_KEY = "bucket_counts_list";
     private static final String EXPLICIT_BOUNDS_KEY = "explicitBounds";
+    private static final String OTLP_EXPLICIT_BOUNDS_KEY = "explicit_bounds";
 
     private static final List<String> REQUIRED_KEYS = new ArrayList<>();
     private static final List<String> REQUIRED_NON_EMPTY_KEYS = Arrays.asList(NAME_KEY, KIND_KEY, TIME_KEY);
     private static final List<String> REQUIRED_NON_NULL_KEYS = Collections.singletonList(SUM_KEY);
 
 
-    protected JacksonHistogram(JacksonHistogram.Builder builder, boolean flattenAttributes) {
-        super(builder, flattenAttributes);
+    protected JacksonHistogram(JacksonHistogram.Builder builder, boolean opensearchMode) {
+        super(builder, opensearchMode);
 
         checkArgument(this.getMetadata().getEventType().equals(EventType.METRIC.toString()), "eventType must be of type Metric");
     }
-    public static JacksonHistogram.Builder builder() {
-        return new JacksonHistogram.Builder();
+    public static JacksonHistogram.Builder builder(final boolean opensearchMode) {
+        return new JacksonHistogram.Builder(opensearchMode);
     }
 
     @Override
@@ -70,17 +75,20 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
 
     @Override
     public String getAggregationTemporality() {
-        return this.get(AGGREGATION_TEMPORALITY_KEY, String.class);
+        final String key = getOpensearchMode() ? AGGREGATION_TEMPORALITY_KEY : OTLP_AGGREGATION_TEMPORALITY_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public Integer getBucketCount() {
-        return this.get(BUCKET_COUNTS_KEY, Integer.class);
+        final String key = getOpensearchMode() ? BUCKET_COUNTS_KEY : OTLP_BUCKET_COUNTS_KEY;
+        return this.get(key, Integer.class);
     }
 
     @Override
     public Integer getExplicitBoundsCount() {
-        return this.get(EXPLICIT_BOUNDS_COUNT_KEY, Integer.class);
+        final String key = getOpensearchMode() ? EXPLICIT_BOUNDS_COUNT_KEY : OTLP_EXPLICIT_BOUNDS_COUNT_KEY;
+        return this.get(key, Integer.class);
     }
 
     @Override
@@ -90,12 +98,14 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
 
     @Override
     public List<Long> getBucketCountsList() {
-        return this.getList(BUCKET_COUNTS_LIST_KEY, Long.class);
+        final String key = getOpensearchMode() ? BUCKET_COUNTS_LIST_KEY : OTLP_BUCKET_COUNTS_LIST_KEY;
+        return this.getList(key, Long.class);
     }
 
     @Override
     public List<Double> getExplicitBoundsList() {
-        return this.getList(EXPLICIT_BOUNDS_KEY, Double.class);
+        final String key = getOpensearchMode() ? EXPLICIT_BOUNDS_KEY : OTLP_EXPLICIT_BOUNDS_KEY;
+        return this.getList(key, Double.class);
     }
 
     /**
@@ -104,6 +114,10 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
      * @since 1.4
      */
     public static class Builder extends JacksonMetric.Builder<JacksonHistogram.Builder> {
+
+        public Builder(final boolean opensearchMode) {
+            super(opensearchMode);
+        }
 
         @Override
         public JacksonHistogram.Builder getThis() {
@@ -165,7 +179,8 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          * @since 1.4
          */
         public JacksonHistogram.Builder withBucketCount(int bucketCount) {
-            put(BUCKET_COUNTS_KEY, bucketCount);
+            final String key = getOpensearchMode() ? BUCKET_COUNTS_KEY : OTLP_BUCKET_COUNTS_KEY;
+            put(key, bucketCount);
             return this;
         }
 
@@ -176,7 +191,8 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          * @since 1.4
          */
         public JacksonHistogram.Builder withExplicitBoundsCount(int explicitBoundsCount) {
-            put(EXPLICIT_BOUNDS_COUNT_KEY, explicitBoundsCount);
+            final String key = getOpensearchMode() ? EXPLICIT_BOUNDS_COUNT_KEY : OTLP_EXPLICIT_BOUNDS_COUNT_KEY;
+            put(key, explicitBoundsCount);
             return this;
         }
 
@@ -187,7 +203,8 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          * @since 1.4
          */
         public  JacksonHistogram.Builder withAggregationTemporality(String aggregationTemporality) {
-            put(AGGREGATION_TEMPORALITY_KEY, aggregationTemporality);
+            final String key = getOpensearchMode() ? AGGREGATION_TEMPORALITY_KEY : OTLP_AGGREGATION_TEMPORALITY_KEY;
+            put(key, aggregationTemporality);
             return this;
         }
 
@@ -221,7 +238,8 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          * @since 1.4
          */
         public JacksonHistogram.Builder withBucketCountsList(List<Long> bucketCountsList) {
-            put(BUCKET_COUNTS_LIST_KEY, bucketCountsList);
+            final String key = getOpensearchMode() ? BUCKET_COUNTS_LIST_KEY : OTLP_BUCKET_COUNTS_LIST_KEY;
+            put(key, bucketCountsList);
             return this;
         }
 
@@ -232,7 +250,8 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          * @since 1.4
          */
         public JacksonHistogram.Builder withExplicitBoundsList(List<Double> explicitBoundsList) {
-            put(EXPLICIT_BOUNDS_KEY, explicitBoundsList);
+            final String key = getOpensearchMode() ? EXPLICIT_BOUNDS_KEY : OTLP_EXPLICIT_BOUNDS_KEY;
+            put(key, explicitBoundsList);
             return this;
         }
 
@@ -242,23 +261,15 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          * @since 1.4
          */
         public JacksonHistogram build() {
-            return build(true);
-        }
-
-        /**
-         * Returns a newly created {@link JacksonHistogram}
-         * @param flattenAttributes flag indicating if the attributes should be flattened or not
-         * @return a JacksonHistogram
-         * @since 2.1
-         */
-        public JacksonHistogram build(boolean flattenAttributes) {
             this.withData(data);
             this.withEventKind(KIND.HISTOGRAM.toString());
             this.withEventType(EventType.METRIC.toString());
             checkAndSetDefaultValues();
-            new ParameterValidator().validate(REQUIRED_KEYS, REQUIRED_NON_EMPTY_KEYS, REQUIRED_NON_NULL_KEYS, (HashMap<String, Object>)data);
+            if (getOpensearchMode()) {
+                new ParameterValidator().validate(REQUIRED_KEYS, REQUIRED_NON_EMPTY_KEYS, REQUIRED_NON_NULL_KEYS, (HashMap<String, Object>)data);
+            }
 
-            return new JacksonHistogram(this, flattenAttributes);
+            return new JacksonHistogram(this, opensearchMode);
         }
 
         private void checkAndSetDefaultValues() {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -27,32 +27,37 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     protected static final String NAME_KEY = "name";
     protected static final String DESCRIPTION_KEY = "description";
     protected static final String START_TIME_KEY = "startTime";
+    protected static final String OTLP_START_TIME_KEY = "start_time";
     protected static final String TIME_KEY = "time";
     protected static final String SERVICE_NAME_KEY = "serviceName";
+    protected static final String OTLP_SERVICE_NAME_KEY = "service_name";
     protected static final String KIND_KEY = "kind";
     protected static final String UNIT_KEY = "unit";
     public static final String ATTRIBUTES_KEY = "attributes";
     protected static final String SCHEMA_URL_KEY = "schemaUrl";
+    protected static final String OTLP_SCHEMA_URL_KEY = "schema_url";
     protected static final String EXEMPLARS_KEY = "exemplars";
     protected static final String FLAGS_KEY = "flags";
-    private boolean flattenAttributes;
+    protected static final String SCOPE_KEY = "scope";
+    protected static final String RESOURCE_KEY = "resource";
+    private boolean opensearchMode;
 
-    protected JacksonMetric(Builder builder, boolean flattenAttributes) {
+    protected JacksonMetric(Builder builder, boolean opensearchMode) {
         super(builder);
-        this.flattenAttributes = flattenAttributes;
+        this.opensearchMode = opensearchMode;
     }
 
-    public void setFlattenAttributes(boolean flattenAttributes) {
-        this.flattenAttributes = flattenAttributes;
+    public void setOpensearchMode(boolean opensearchMode) {
+        this.opensearchMode = opensearchMode;
     }
 
-    boolean getFlattenAttributes() {
-        return flattenAttributes;
+    public boolean getOpensearchMode() {
+        return opensearchMode;
     }
 
     @Override
     public String toJsonString() {
-        if (!flattenAttributes) {
+        if (!opensearchMode) {
             return getJsonNode().toString();
         }
         final ObjectNode attributesNode = (ObjectNode) getJsonNode().get(ATTRIBUTES_KEY);
@@ -72,7 +77,8 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
 
     @Override
     public String getServiceName() {
-        return this.get(SERVICE_NAME_KEY, String.class);
+        final String key = (opensearchMode) ? SERVICE_NAME_KEY : OTLP_SERVICE_NAME_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
@@ -97,7 +103,8 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
 
     @Override
     public String getStartTime() {
-        return this.get(START_TIME_KEY, String.class);
+        final String key = (opensearchMode) ? START_TIME_KEY : OTLP_START_TIME_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
@@ -111,8 +118,19 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     }
 
     @Override
+    public Map<String, Object> getScope() {
+        return this.get(SCOPE_KEY, Map.class);
+    }
+
+    @Override
+    public Map<String, Object> getResource() {
+        return this.get(RESOURCE_KEY, Map.class);
+    }
+
+    @Override
     public String getSchemaUrl() {
-        return this.get(SCHEMA_URL_KEY, String.class);
+        final String key = (opensearchMode) ? SCHEMA_URL_KEY : OTLP_SCHEMA_URL_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
@@ -133,18 +151,24 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     public abstract static class Builder<T extends JacksonEvent.Builder<T>> extends JacksonEvent.Builder<T> {
 
         private final Map<String, Object> mdata;
+        protected final boolean opensearchMode;
 
-        public Builder() {
+        public Builder(final boolean opensearchMode) {
             if (data == null) {
                 data = new HashMap<String, Object>();
             }
+            this.opensearchMode = opensearchMode;
             mdata = (HashMap<String, Object>)data;
             eventHandle = null;
         }
 
-	public void put(String key, Object value) {
+        public boolean getOpensearchMode() {
+            return opensearchMode;
+        }
+
+        public void put(String key, Object value) {
             mdata.put(key, value);
-	}
+        }
 
         public void computeIfAbsent(String key, Function<? super String,? extends Object> f) {
             mdata.computeIfAbsent(key, f);
@@ -188,6 +212,16 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
             return getThis();
         }
 
+        public T withScope(final Map<String, Object> scope) {
+            put(SCOPE_KEY, scope);
+            return getThis();
+        }
+
+        public T withResource(final Map<String, Object> resource) {
+            put(RESOURCE_KEY, resource);
+            return getThis();
+        }
+
         /**
          * Sets the gauge name
          * @param name the name
@@ -217,7 +251,8 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
          * @since 1.4
          */
         public T withStartTime(final String startTime) {
-            put(START_TIME_KEY, startTime);
+            final String key = (opensearchMode) ? START_TIME_KEY : OTLP_START_TIME_KEY;
+            put(key, startTime);
             return getThis();
         }
 
@@ -239,7 +274,8 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
          * @since 1.4
          */
         public T withServiceName(final String serviceName) {
-            put(SERVICE_NAME_KEY, serviceName);
+            final String key = (opensearchMode) ? SERVICE_NAME_KEY : OTLP_SERVICE_NAME_KEY;
+            put(key, serviceName);
             return getThis();
         }
 
@@ -250,7 +286,8 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
          * @since 1.4
          */
         public T withSchemaUrl(final String schemaUrl) {
-            put(SCHEMA_URL_KEY, schemaUrl);
+            final String key = (opensearchMode) ? SCHEMA_URL_KEY : OTLP_SCHEMA_URL_KEY;
+            put(key, schemaUrl);
             return getThis();
         }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Metric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Metric.java
@@ -106,6 +106,8 @@ public interface Metric extends Event {
      */
     List<? extends Exemplar> getExemplars();
 
+    public Map<String, Object> getScope();
+    public Map<String, Object> getResource();
 
     /**
      * Gets the associated flags for this metric event.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -35,23 +35,39 @@ import static com.google.common.base.Preconditions.checkState;
 public class JacksonSpan extends JacksonEvent implements Span {
 
     private static final String TRACE_ID_KEY = "traceId";
+    private static final String OTLP_TRACE_ID_KEY = "trace_id";
     private static final String SPAN_ID_KEY = "spanId";
+    private static final String OTLP_SPAN_ID_KEY = "span_id";
     private static final String TRACE_STATE_KEY = "traceState";
+    private static final String OTLP_TRACE_STATE_KEY = "trace_state";
     private static final String PARENT_SPAN_ID_KEY = "parentSpanId";
+    private static final String OTLP_PARENT_SPAN_ID_KEY = "parent_span_id";
     private static final String NAME_KEY = "name";
     private static final String KIND_KEY = "kind";
+    private static final String STATUS_KEY = "status";
+    private static final String SCOPE_KEY = "scope";
+    private static final String RESOURCE_KEY = "resource";
     private static final String START_TIME_KEY = "startTime";
+    private static final String OTLP_START_TIME_KEY = "start_time";
     private static final String END_TIME_KEY = "endTime";
+    private static final String OTLP_END_TIME_KEY = "end_time";
     private static final String ATTRIBUTES_KEY = "attributes";
     private static final String DROPPED_ATTRIBUTES_COUNT_KEY = "droppedAttributesCount";
+    private static final String OTLP_DROPPED_ATTRIBUTES_COUNT_KEY = "dropped_attributes_count";
     private static final String EVENTS_KEY = "events";
     private static final String DROPPED_EVENTS_COUNT_KEY = "droppedEventsCount";
+    private static final String OTLP_DROPPED_EVENTS_COUNT_KEY = "dropped_events_count";
     private static final String LINKS_KEY = "links";
     private static final String DROPPED_LINKS_COUNT_KEY = "droppedLinksCount";
+    private static final String OTLP_DROPPED_LINKS_COUNT_KEY = "dropped_links_count";
     private static final String SERVICE_NAME_KEY = "serviceName";
+    private static final String OTLP_SERVICE_NAME_KEY = "service_name";
     private static final String TRACE_GROUP_KEY = "traceGroup";
+    private static final String OTLP_TRACE_GROUP_KEY = "trace_group";
     private static final String DURATION_IN_NANOS_KEY = "durationInNanos";
+    private static final String OTLP_DURATION_IN_NANOS_KEY = "duration_in_nanos";
     private static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
+    private static final String OTLP_TRACE_GROUP_FIELDS_KEY = "trace_group_fields";
 
     private static final List<String> REQUIRED_KEYS = Arrays.asList(TRACE_GROUP_KEY);
     private static final List<String>
@@ -62,9 +78,11 @@ public class JacksonSpan extends JacksonEvent implements Span {
             .registerModule(new JavaTimeModule());
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
     };
+    private boolean opensearchMode;
 
-    protected JacksonSpan(final Builder builder) {
+    protected JacksonSpan(final Builder builder, boolean opensearchMode) {
         super(builder);
+        this.opensearchMode = opensearchMode;
 
         checkArgument(this.getMetadata().getEventType().equals("TRACE"), "eventType must be of type Trace");
     }
@@ -73,24 +91,37 @@ public class JacksonSpan extends JacksonEvent implements Span {
         super(otherSpan);
     }
 
+    public void setOpensearchMode(final boolean opensearchMode) {
+        this.opensearchMode = opensearchMode;
+    }
+
+    @Override
+    public boolean getOpensearchMode() {
+        return opensearchMode;
+    }
+
     @Override
     public String getTraceId() {
-        return this.get(TRACE_ID_KEY, String.class);
+        final String key = (opensearchMode) ? TRACE_ID_KEY : OTLP_TRACE_ID_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public String getSpanId() {
-        return this.get(SPAN_ID_KEY, String.class);
+        final String key = (opensearchMode) ? SPAN_ID_KEY : OTLP_SPAN_ID_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public String getTraceState() {
-        return this.get(TRACE_STATE_KEY, String.class);
+        final String key = (opensearchMode) ? TRACE_STATE_KEY : OTLP_TRACE_STATE_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public String getParentSpanId() {
-        return this.get(PARENT_SPAN_ID_KEY, String.class);
+        final String key = (opensearchMode) ? PARENT_SPAN_ID_KEY : OTLP_PARENT_SPAN_ID_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
@@ -105,12 +136,14 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public String getStartTime() {
-        return this.get(START_TIME_KEY, String.class);
+        final String key = (opensearchMode) ? START_TIME_KEY : OTLP_START_TIME_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public String getEndTime() {
-        return this.get(END_TIME_KEY, String.class);
+        final String key = (opensearchMode) ? END_TIME_KEY : OTLP_END_TIME_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
@@ -119,8 +152,24 @@ public class JacksonSpan extends JacksonEvent implements Span {
     }
 
     @Override
+    public Map<String, Object> getScope() {
+        return this.get(SCOPE_KEY, Map.class);
+    }
+
+    @Override
+    public Map<String, Object> getResource() {
+        return this.get(RESOURCE_KEY, Map.class);
+    }
+
+    @Override
+    public Map<String, Object> getStatus() {
+        return this.get(STATUS_KEY, Map.class);
+    }
+
+    @Override
     public Integer getDroppedAttributesCount() {
-        return this.get(DROPPED_ATTRIBUTES_COUNT_KEY, Integer.class);
+        final String key = (opensearchMode) ? DROPPED_ATTRIBUTES_COUNT_KEY : OTLP_DROPPED_ATTRIBUTES_COUNT_KEY;
+        return this.get(key, Integer.class);
     }
 
     @Override
@@ -130,7 +179,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public Integer getDroppedEventsCount() {
-        return this.get(DROPPED_EVENTS_COUNT_KEY, Integer.class);
+        final String key = (opensearchMode) ? DROPPED_EVENTS_COUNT_KEY : OTLP_DROPPED_EVENTS_COUNT_KEY;
+        return this.get(key, Integer.class);
     }
 
     @Override
@@ -140,48 +190,55 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public Integer getDroppedLinksCount() {
-        return this.get(DROPPED_LINKS_COUNT_KEY, Integer.class);
+        final String key = (opensearchMode) ? DROPPED_LINKS_COUNT_KEY : OTLP_DROPPED_LINKS_COUNT_KEY;
+        return this.get(key, Integer.class);
     }
 
     @Override
     public String getTraceGroup() {
-        return this.get(TRACE_GROUP_KEY, String.class);
+        final String key = (opensearchMode) ? TRACE_GROUP_KEY : OTLP_TRACE_GROUP_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public Long getDurationInNanos() {
-        return this.get(DURATION_IN_NANOS_KEY, Long.class);
+        final String key = (opensearchMode) ? DURATION_IN_NANOS_KEY : OTLP_DURATION_IN_NANOS_KEY;
+        return this.get(key, Long.class);
     }
 
     @Override
     public TraceGroupFields getTraceGroupFields() {
-        return this.get(TRACE_GROUP_FIELDS_KEY, DefaultTraceGroupFields.class);
+        final String key = (opensearchMode) ? TRACE_GROUP_FIELDS_KEY : OTLP_TRACE_GROUP_FIELDS_KEY;
+        return this.get(key, DefaultTraceGroupFields.class);
     }
 
     @Override
     public String getServiceName() {
-        return this.get(SERVICE_NAME_KEY, String.class);
+        final String key = (opensearchMode) ? SERVICE_NAME_KEY : OTLP_SERVICE_NAME_KEY;
+        return this.get(key, String.class);
     }
 
     @Override
     public void setTraceGroup(final String traceGroup) {
-        this.put(TRACE_GROUP_KEY, traceGroup);
+        final String key = (opensearchMode) ? TRACE_GROUP_KEY : OTLP_TRACE_GROUP_KEY;
+        this.put(key, traceGroup);
     }
 
     @Override
     public void setTraceGroupFields(final TraceGroupFields traceGroupFields) {
-        this.put(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
+        final String key = (opensearchMode) ? TRACE_GROUP_FIELDS_KEY : OTLP_TRACE_GROUP_FIELDS_KEY;
+        this.put(key, traceGroupFields);
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public static Builder builder(final boolean opensearchMode) {
+        return new Builder(opensearchMode);
     }
 
     public static JacksonSpan fromSpan(final Span span) {
         if (span instanceof JacksonSpan) {
             return new JacksonSpan((JacksonSpan) span);
         } else {
-            return JacksonSpan.builder()
+            return JacksonSpan.builder(span.getOpensearchMode())
                     .withData(span.toMap())
                     .withEventMetadata(span.getMetadata())
                     .build();
@@ -190,10 +247,13 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public String toJsonString() {
-        final ObjectNode attributesNode = (ObjectNode) getJsonNode().get("attributes");
+        if (!opensearchMode) {
+            return getJsonNode().toString();
+        }
+        final ObjectNode attributesNode = (ObjectNode) getJsonNode().get(ATTRIBUTES_KEY);
         final ObjectNode flattenedJsonNode = getJsonNode().deepCopy();
         if (attributesNode != null) {
-            flattenedJsonNode.remove("attributes");
+            flattenedJsonNode.remove(ATTRIBUTES_KEY);
             for (Iterator<Map.Entry<String, JsonNode>> it = attributesNode.fields(); it.hasNext(); ) {
                 Map.Entry<String, JsonNode> entry = it.next();
                 String field = entry.getKey();
@@ -213,9 +273,11 @@ public class JacksonSpan extends JacksonEvent implements Span {
     public static class Builder extends JacksonEvent.Builder<Builder> {
 
         private final Map<String, Object> data;
+        private boolean opensearchMode;
 
-        public Builder() {
+        public Builder(final boolean opensearchMode) {
             data = new HashMap();
+            this.opensearchMode = opensearchMode;
         }
 
         @Override
@@ -273,7 +335,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withSpanId(final String spanId) {
-            data.put(SPAN_ID_KEY, spanId);
+            final String key = (opensearchMode) ? SPAN_ID_KEY : OTLP_SPAN_ID_KEY;
+            data.put(key, spanId);
             return this;
         }
 
@@ -285,7 +348,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceId(final String traceId) {
-            data.put(TRACE_ID_KEY, traceId);
+            final String key = (opensearchMode) ? TRACE_ID_KEY : OTLP_TRACE_ID_KEY;
+            data.put(key, traceId);
             return this;
         }
 
@@ -297,7 +361,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceState(final String traceState) {
-            data.put(TRACE_STATE_KEY, traceState);
+            final String key = (opensearchMode) ? TRACE_STATE_KEY : OTLP_TRACE_STATE_KEY;
+            data.put(key, traceState);
             return this;
         }
 
@@ -309,7 +374,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withParentSpanId(final String parentSpanId) {
-            data.put(PARENT_SPAN_ID_KEY, parentSpanId);
+            final String key = (opensearchMode) ? PARENT_SPAN_ID_KEY : OTLP_PARENT_SPAN_ID_KEY;
+            data.put(key, parentSpanId);
             return this;
         }
 
@@ -345,7 +411,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withStartTime(final String startTime) {
-            data.put(START_TIME_KEY, startTime);
+            final String key = (opensearchMode) ? START_TIME_KEY : OTLP_START_TIME_KEY;
+            data.put(key, startTime);
             return this;
         }
 
@@ -357,7 +424,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withEndTime(final String endTime) {
-            data.put(END_TIME_KEY, endTime);
+            final String key = (opensearchMode) ? END_TIME_KEY : OTLP_END_TIME_KEY;
+            data.put(key, endTime);
             return this;
         }
 
@@ -373,6 +441,21 @@ public class JacksonSpan extends JacksonEvent implements Span {
             return this;
         }
 
+        public Builder withScope(final Map<String, Object> scope) {
+            data.put(SCOPE_KEY, scope);
+            return this;
+        }
+
+        public Builder withResource(final Map<String, Object> resource) {
+            data.put(RESOURCE_KEY, resource);
+            return this;
+        }
+
+        public Builder withStatus(final Map<String, Object> status) {
+            data.put(STATUS_KEY, status);
+            return this;
+        }
+
         /**
          * Optional - sets the dropped attribute count for {@link JacksonSpan}. Default is 0.
          *
@@ -381,7 +464,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDroppedAttributesCount(final Integer droppedAttributesCount) {
-            data.put(DROPPED_ATTRIBUTES_COUNT_KEY, droppedAttributesCount);
+            final String key = (opensearchMode) ? DROPPED_ATTRIBUTES_COUNT_KEY : OTLP_DROPPED_ATTRIBUTES_COUNT_KEY;
+            data.put(key, droppedAttributesCount);
             return this;
         }
 
@@ -405,7 +489,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDroppedEventsCount(final Integer droppedEventsCount) {
-            data.put(DROPPED_EVENTS_COUNT_KEY, droppedEventsCount);
+            final String key = (opensearchMode) ? DROPPED_EVENTS_COUNT_KEY : OTLP_DROPPED_EVENTS_COUNT_KEY;
+            data.put(key, droppedEventsCount);
             return this;
         }
 
@@ -429,7 +514,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDroppedLinksCount(final Integer droppedLinksCount) {
-            data.put(DROPPED_LINKS_COUNT_KEY, droppedLinksCount);
+        final String key = (opensearchMode) ? DROPPED_LINKS_COUNT_KEY : OTLP_DROPPED_LINKS_COUNT_KEY;
+            data.put(key, droppedLinksCount);
             return this;
         }
 
@@ -441,7 +527,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceGroup(final String traceGroup) {
-            data.put(TRACE_GROUP_KEY, traceGroup);
+            final String key = (opensearchMode) ? TRACE_GROUP_KEY : OTLP_TRACE_GROUP_KEY;
+            data.put(key, traceGroup);
             return this;
         }
 
@@ -465,7 +552,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDurationInNanos(final Long durationInNanos) {
-            data.put(DURATION_IN_NANOS_KEY, durationInNanos);
+            final String key = (opensearchMode) ? DURATION_IN_NANOS_KEY : OTLP_DURATION_IN_NANOS_KEY;
+            data.put(key, durationInNanos);
             return this;
         }
 
@@ -477,7 +565,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceGroupFields(final TraceGroupFields traceGroupFields) {
-            data.put(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
+            final String key = (opensearchMode) ? TRACE_GROUP_FIELDS_KEY : OTLP_TRACE_GROUP_FIELDS_KEY;
+            data.put(key, traceGroupFields);
             return this;
         }
 
@@ -489,7 +578,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.3
          */
         public Builder withServiceName(final String serviceName) {
-            data.put(SERVICE_NAME_KEY, serviceName);
+            final String key = (opensearchMode) ? SERVICE_NAME_KEY : OTLP_SERVICE_NAME_KEY;
+            data.put(key, serviceName);
             return this;
         }
 
@@ -499,39 +589,44 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @return a JacksonSpan
          * @since 1.2
          */
+
         @Override
         public JacksonSpan build() {
             validateParameters();
             checkAndSetDefaultValues();
             super.withData(data);
             this.withEventType(EventType.TRACE.toString());
-            return new JacksonSpan(this);
+            return new JacksonSpan(this, opensearchMode);
         }
 
         private void validateParameters() {
-            REQUIRED_KEYS.forEach(key -> {
-                checkState(data.containsKey(key), key + " need to be assigned");
-            });
+            if (opensearchMode) {
+                REQUIRED_KEYS.forEach(key -> {
+                    checkState(data.containsKey(key), key + " need to be assigned");
+                });
 
-            REQUIRED_NON_EMPTY_KEYS.forEach(key -> {
-                final String value = (String) data.get(key);
-                checkNotNull(value, key + " cannot be null");
-                checkArgument(!value.isEmpty(), key + " cannot be an empty string");
-            });
+                REQUIRED_NON_EMPTY_KEYS.forEach(key -> {
+                    final String value = (String) data.get(key);
+                    checkNotNull(value, key + " cannot be null");
+                    checkArgument(!value.isEmpty(), key + " cannot be an empty string");
+                });
 
-            REQUIRED_NON_NULL_KEYS.forEach(key -> {
-                final Object value = data.get(key);
-                checkNotNull(value, key + " cannot be null");
-            });
+                REQUIRED_NON_NULL_KEYS.forEach(key -> {
+                    final Object value = data.get(key);
+                    checkNotNull(value, key + " cannot be null");
+                });
+            }
         }
 
         private void checkAndSetDefaultValues() {
-            data.computeIfAbsent(ATTRIBUTES_KEY, k -> new HashMap<>());
-            data.putIfAbsent(DROPPED_ATTRIBUTES_COUNT_KEY, 0);
-            data.computeIfAbsent(LINKS_KEY, k -> new LinkedList<>());
-            data.putIfAbsent(DROPPED_LINKS_COUNT_KEY, 0);
-            data.computeIfAbsent(EVENTS_KEY, k -> new LinkedList<>());
-            data.putIfAbsent(DROPPED_EVENTS_COUNT_KEY, 0);
+            if (opensearchMode) {
+                data.computeIfAbsent(ATTRIBUTES_KEY, k -> new HashMap<>());
+                data.putIfAbsent(DROPPED_ATTRIBUTES_COUNT_KEY, 0);
+                data.computeIfAbsent(LINKS_KEY, k -> new LinkedList<>());
+                data.putIfAbsent(DROPPED_LINKS_COUNT_KEY, 0);
+                data.computeIfAbsent(EVENTS_KEY, k -> new LinkedList<>());
+                data.putIfAbsent(DROPPED_EVENTS_COUNT_KEY, 0);
+            }
         }
 
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
@@ -65,6 +65,30 @@ public interface Span extends Event {
     String getStartTime();
 
     /**
+     * Gets the scope of this log event.
+     *
+     * @return the scope
+     * @since 2.11
+     */
+    Map<String, Object> getScope();
+
+    /**
+     * Gets the resource of this log event.
+     *
+     * @return the resource
+     * @since 2.11
+     */
+    Map<String, Object> getResource();
+
+    /**
+     * Gets the resource of this log event.
+     *
+     * @return the resource
+     * @since 2.11
+     */
+    Map<String, Object> getStatus();
+
+    /**
      * Gets ISO8601 representation of the end time.
      * @return the end time
      * @since 1.2
@@ -153,4 +177,11 @@ public interface Span extends Event {
      * @since 1.3
      */
     void setTraceGroupFields(TraceGroupFields traceGroupFields);
+
+    /**
+     * gets opensearch mode flag
+     * @return the value of flatten attributes
+     * @since 2.11
+     */
+    boolean getOpensearchMode();
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
@@ -11,11 +11,14 @@ import org.json.JSONException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -24,6 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class JacksonOtelLogTest {
 
@@ -33,6 +37,8 @@ public class JacksonOtelLogTest {
             "key1", TEST_TIME_KEY1,
             "key2", TEST_KEY2);
 
+    private static final Map<String, Object> TEST_SCOPE = ImmutableMap.of("name", UUID.randomUUID().toString(), "version", UUID.randomUUID().toString(), "attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
+    private static final Map<String, Object> TEST_RESOURCE = ImmutableMap.of("attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
     private static final String TEST_SERVICE_NAME = "service";
     private static final String TEST_OBSERVED_TIME = "2022-01-01T00:00:00Z";
     private static final String TEST_TIME = "2022-01-02T00:00:00Z";
@@ -46,11 +52,15 @@ public class JacksonOtelLogTest {
     private static final Object TEST_BODY = Map.of("log", "message");
 
     private JacksonOtelLog log;
-    private JacksonOtelLog.Builder builder = JacksonOtelLog.builder();
+    private JacksonOtelLog.Builder builder;
 
     @BeforeEach
     public void setup() {
-        builder = builder
+        createObjectUnderTest(true);
+    }
+
+    private JacksonOtelLog.Builder createBuilder(final boolean opensearchMode) {
+        builder = JacksonOtelLog.builder(opensearchMode)
                 .withTime(TEST_TIME)
                 .withObservedTime(TEST_OBSERVED_TIME)
                 .withServiceName(TEST_SERVICE_NAME)
@@ -59,12 +69,19 @@ public class JacksonOtelLogTest {
                 .withFlags(TEST_FLAGS)
                 .withTraceId(TEST_TRACE_ID)
                 .withSpanId(TEST_SPAN_ID)
+                .withScope(TEST_SCOPE)
+                .withResource(TEST_RESOURCE)
                 .withSeverityNumber(TEST_SEVERITY_NUMBER)
                 .withSeverityText(TEST_SEVERITY_TEXT)
                 .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
                 .withBody(TEST_BODY);
+        return builder;
+    }
 
+    private JacksonOtelLog createObjectUnderTest(final boolean opensearchMode) {
+        createBuilder(opensearchMode);
         log = builder.build();
+        return log;
     }
 
     @Test
@@ -73,16 +90,47 @@ public class JacksonOtelLogTest {
         assertThat(time, is(equalTo(TEST_TIME)));
     }
 
-    @Test
-    public void testGetObservedTime() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetObservedTime(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final String observedTime = log.getObservedTime();
         assertThat(observedTime, is(equalTo(TEST_OBSERVED_TIME)));
     }
 
-    @Test
-    public void testGetServiceName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetServiceName(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final String name = log.getServiceName();
         assertThat(name, is(equalTo(TEST_SERVICE_NAME)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetScope(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
+        final Map<String, Object> scope = log.getScope();
+        assertThat(scope, is(equalTo(TEST_SCOPE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetResource(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
+        final Map<String, Object> resource = log.getResource();
+        assertThat(resource, is(equalTo(TEST_RESOURCE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOpensearchMode(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
+        boolean mode = log.getOpensearchMode();
+        assertThat(mode, is(equalTo(opensearchMode)));
+        log.setOpensearchMode(!opensearchMode);
+        mode = log.getOpensearchMode();
+        assertThat(mode, is(equalTo(!opensearchMode)));
     }
 
     @Test
@@ -93,8 +141,10 @@ public class JacksonOtelLogTest {
         assertThat(((DefaultEventHandle)log.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
-    @Test
-    public void testGetSchemaUrl() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetSchemaUrl(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final String schemaUrl = log.getSchemaUrl();
         assertThat(schemaUrl, is(equalTo(TEST_SCHEMA_URL)));
     }
@@ -105,32 +155,42 @@ public class JacksonOtelLogTest {
         assertThat(flags, is(equalTo(TEST_FLAGS)));
     }
 
-    @Test
-    public void testGetTraceId() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTraceId(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final String traceId = log.getTraceId();
         assertThat(traceId, is(equalTo(TEST_TRACE_ID)));
     }
 
-    @Test
-    public void testGetSpanId() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetSpanId(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final String spanId = log.getSpanId();
         assertThat(spanId, is(equalTo(TEST_SPAN_ID)));
     }
 
-    @Test
-    public void testGetServerityText() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetServerityText(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final String severityText = log.getSeverityText();
         assertThat(severityText, is(equalTo(TEST_SEVERITY_TEXT)));
     }
 
-    @Test
-    public void testGetServerityNumber() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetServerityNumber(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final Integer observedTime = log.getSeverityNumber();
         assertThat(observedTime, is(equalTo(TEST_SEVERITY_NUMBER)));
     }
 
-    @Test
-    public void testGetDroppedAttributesCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDroppedAttributesCount(final boolean opensearchMode) {
+        log = createObjectUnderTest(opensearchMode);
         final Integer droppedAttributesCount = log.getDroppedAttributesCount();
         assertThat(droppedAttributesCount, is(equalTo(TEST_DROPPED_ATTRIBUTES_COUNT)));
     }
@@ -169,8 +229,20 @@ public class JacksonOtelLogTest {
     }
 
     @Test
+    public void testHistogramToJsonStringNoOpensearchMode() throws JSONException {
+        log = createObjectUnderTest(false);
+        final String str = log.toJsonString();
+        assertThat(str.indexOf(JacksonOtelLog.OTLP_SERVICE_NAME_KEY), not(equalTo(-1)));
+        assertThat(str.indexOf(JacksonOtelLog.OTLP_OBSERVED_TIME_KEY), not(equalTo(-1)));
+        assertThat(str.indexOf(JacksonOtelLog.OTLP_SCHEMA_URL_KEY), not(equalTo(-1)));
+        assertThat(str.indexOf(JacksonOtelLog.OTLP_TRACE_ID_KEY), not(equalTo(-1)));
+        assertThat(str.indexOf(JacksonOtelLog.OTLP_SPAN_ID_KEY), not(equalTo(-1)));
+        
+    }
+
+    @Test
     public void test_non_object_attributes_toJsonString_serializes_as_is() {
-        JacksonOtelLog testLog = JacksonOtelLog.builder()
+        JacksonOtelLog testLog = JacksonOtelLog.builder(true)
                 .withAttributes(Map.of("key", "value"))
                 .build();
         assertThat(testLog.toJsonString(), equalTo("{\"key\":\"value\"}"));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
@@ -8,8 +8,9 @@ package org.opensearch.dataprepper.model.metric;
 import com.google.common.collect.ImmutableMap;
 import io.micrometer.core.instrument.util.IOUtils;
 import org.json.JSONException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.event.TestObject;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
@@ -47,6 +48,8 @@ public class JacksonExponentialHistogramTest {
     private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of(
             "key1", TEST_KEY1_TIME,
             "key2", TEST_KEY2);
+    private static final Map<String, Object> TEST_SCOPE = ImmutableMap.of("name", UUID.randomUUID().toString(), "version", UUID.randomUUID().toString(), "attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
+    private static final Map<String, Object> TEST_RESOURCE = ImmutableMap.of("attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
     private static final String TEST_SERVICE_NAME = "service";
     private static final String TEST_NAME = "name";
     private static final String TEST_DESCRIPTION = "description";
@@ -78,9 +81,8 @@ public class JacksonExponentialHistogramTest {
 
     private JacksonExponentialHistogram.Builder builder;
 
-    @BeforeEach
-    public void setup() {
-        builder = JacksonExponentialHistogram.builder()
+    private JacksonExponentialHistogram.Builder createBuilder(final boolean opensearchMode) {
+        builder = JacksonExponentialHistogram.builder(opensearchMode)
                 .withAttributes(TEST_ATTRIBUTES)
                 .withName(TEST_NAME)
                 .withDescription(TEST_DESCRIPTION)
@@ -91,6 +93,8 @@ public class JacksonExponentialHistogramTest {
                 .withServiceName(TEST_SERVICE_NAME)
                 .withSum(TEST_SUM)
                 .withCount(TEST_COUNT)
+                .withScope(TEST_SCOPE)
+                .withResource(TEST_RESOURCE)
                 .withNegativeBuckets(TEST_NEGATIVE_BUCKETS)
                 .withPositiveBuckets(TEST_POSITIVE_BUCKETS)
                 .withAggregationTemporality(TEST_AGGREGATION_TEMPORALITY)
@@ -101,12 +105,18 @@ public class JacksonExponentialHistogramTest {
                 .withNegativeOffset(TEST_NEGATIVE_OFFSET)
                 .withNegative(TEST_NEGATIVE)
                 .withPositive(TEST_POSITIVE);
-
-        histogram = builder.build();
+        return builder;
     }
 
-    @Test
-    public void testGetAttributes() {
+    private JacksonExponentialHistogram createObjectUnderTest(final boolean opensearchMode) {
+        createBuilder(opensearchMode);
+        return builder.build();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetAttributes(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final Map<String, Object> attributes = histogram.getAttributes();
         TEST_ATTRIBUTES.keySet().forEach(key -> {
                     assertThat(attributes, hasKey(key));
@@ -115,8 +125,10 @@ public class JacksonExponentialHistogramTest {
         );
     }
 
-    @Test
-    public void testGetDefaultEventHandle() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDefaultEventHandle(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         EventHandle eventHandle = new DefaultEventHandle(Instant.now());
         builder.withEventHandle(eventHandle);
         histogram = builder.build();
@@ -124,8 +136,10 @@ public class JacksonExponentialHistogramTest {
         assertThat(handle, is(sameInstance(eventHandle)));
     }
 
-    @Test
-    public void testGetAggregateEventHandle() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetAggregateEventHandle(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         EventHandle eventHandle = new AggregateEventHandle(Instant.now());
         builder.withEventHandle(eventHandle);
         histogram = builder.build();
@@ -133,59 +147,85 @@ public class JacksonExponentialHistogramTest {
         assertThat(handle, is(sameInstance(eventHandle)));
     }
 
-    @Test
-    public void testGetName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetName(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final String name = histogram.getName();
         assertThat(name, is(equalTo(TEST_NAME)));
     }
 
-    @Test
-    public void testGetDescription() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDescription(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final String description = histogram.getDescription();
         assertThat(description, is(equalTo(TEST_DESCRIPTION)));
     }
 
-    @Test
-    public void testGetKind() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetKind(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final String kind = histogram.getKind();
         assertThat(kind, is(equalTo(TEST_EVENT_KIND)));
     }
 
-    @Test
-    public void testGetSum() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetSum(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final Double sum = histogram.getSum();
         assertThat(sum, is(equalTo(TEST_SUM)));
     }
 
-    @Test
-    public void testGetCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetCount(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final Long count = histogram.getCount();
         assertThat(count, is(equalTo(TEST_COUNT)));
     }
 
-    @Test
-    public void testGetServiceName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetServiceName(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final String name = histogram.getServiceName();
         assertThat(name, is(equalTo(TEST_SERVICE_NAME)));
     }
 
-    @Test
-    public void testGetScale() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOpensearchMode(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
+        boolean mode = histogram.getOpensearchMode();
+        assertThat(mode, is(equalTo(opensearchMode)));
+        histogram.setOpensearchMode(!opensearchMode);
+        mode = histogram.getOpensearchMode();
+        assertThat(mode, is(equalTo(!opensearchMode)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetScale(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         Integer scale = histogram.getScale();
         assertThat(scale, is(equalTo(TEST_SCALE)));
     }
 
-    @Test
-    public void testZeroCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testZeroCount(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         Long zeroCount = histogram.getZeroCount();
         assertThat(zeroCount, is(equalTo(TEST_ZERO_COUNT)));
-        assertThat(((JacksonMetric)histogram).getFlattenAttributes(), equalTo(true));
-        ((JacksonMetric)histogram).setFlattenAttributes(false);
-        assertThat(((JacksonMetric)histogram).getFlattenAttributes(), equalTo(false));
     }
 
-    @Test
-    public void testGetNegativeBuckets() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetNegativeBuckets(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final List<? extends Bucket> buckets = histogram.getNegativeBuckets();
         assertThat(buckets.size(), is(equalTo(2)));
         Bucket firstBucket = buckets.get(0);
@@ -200,8 +240,10 @@ public class JacksonExponentialHistogramTest {
         assertThat(secondBucket.getCount(), is(equalTo(5L)));
     }
 
-    @Test
-    public void testGetPositiveBuckets() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetPositiveBuckets(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final List<? extends Bucket> buckets = histogram.getPositiveBuckets();
         assertThat(buckets.size(), is(equalTo(2)));
         Bucket firstBucket = buckets.get(0);
@@ -216,69 +258,117 @@ public class JacksonExponentialHistogramTest {
         assertThat(secondBucket.getCount(), is(equalTo(5L)));
     }
 
-    @Test
-    public void testGetNegative() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetNegative(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         List<Long> negativeBucketCounts = histogram.getNegative();
         assertThat(negativeBucketCounts.size(), is(equalTo(3)));
         assertEquals(negativeBucketCounts, TEST_NEGATIVE);
     }
 
-    @Test
-    public void testGetPositive() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetPositive(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         List<Long> negativeBucketCounts = histogram.getPositive();
         assertThat(negativeBucketCounts.size(), is(equalTo(2)));
         assertEquals(negativeBucketCounts, TEST_POSITIVE);
     }
 
-    @Test
-    public void testGetPositiveOffset() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetSchemaUrl(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
+        String schemaUrl = histogram.getSchemaUrl();
+        assertEquals(schemaUrl, TEST_SCHEMA_URL);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetStartTime(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
+        String startTime = histogram.getStartTime();
+        assertEquals(startTime, TEST_START_TIME);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetScope(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
+        Map<String, Object> scope = histogram.getScope();
+        assertEquals(scope, TEST_SCOPE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetResource(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
+        Map<String, Object> resource = histogram.getResource();
+        assertEquals(resource, TEST_RESOURCE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetPositiveOffset(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         Integer positiveOffset = histogram.getPositiveOffset();
         assertThat(positiveOffset, is(TEST_POSITIVE_OFFSET));
     }
 
-    @Test
-    public void testGetNegativeOffset() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetNegativeOffset(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         Integer negativeOffset = histogram.getNegativeOffset();
         assertThat(negativeOffset, is(TEST_NEGATIVE_OFFSET));
     }
 
-    @Test
-    public void testGetAggregationTemporality() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetAggregationTemporality(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         final String aggregationTemporality = histogram.getAggregationTemporality();
         assertThat(aggregationTemporality, is(equalTo(TEST_AGGREGATION_TEMPORALITY)));
     }
 
     @Test
     public void testBuilder_missingNonNullParameters_throwsNullPointerException() {
-        final JacksonSum.Builder builder = JacksonSum.builder();
+        final JacksonSum.Builder builder = JacksonSum.builder(true);
         builder.withValue(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyTime_throwsIllegalArgumentException() {
+        histogram = createObjectUnderTest(true);
         builder.withTime("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testGetAttributes_withNull_mustBeEmpty() {
+        histogram = createObjectUnderTest(true);
         builder.withAttributes(null);
         JacksonExponentialHistogram histogram = builder.build();
         histogram.toJsonString();
         assertThat(histogram.getAttributes(), is(anEmptyMap()));
     }
 
-    @Test
-    public void testGetTimeReceived() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTimeReceived(final boolean opensearchMode) {
+        histogram = createObjectUnderTest(opensearchMode);
         Instant now = Instant.now();
         builder.withTimeReceived(now);
         JacksonExponentialHistogram histogram = builder.build();
         assertThat(((DefaultEventHandle)histogram.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
-    @Test
-    public void testHistogramToJsonString() throws JSONException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true})
+    public void testHistogramToJsonString(final boolean opensearchMode) throws JSONException {
+        histogram = createObjectUnderTest(opensearchMode);
         histogram.put("foo", "bar");
         final String value = UUID.randomUUID().toString();
         histogram.put("testObject", new TestObject(value));
@@ -290,19 +380,25 @@ public class JacksonExponentialHistogramTest {
         JSONAssert.assertEquals(expected, result, false);
         final Map<String, Object> attributes = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         histogram.put("attributes", attributes);
+        // For attributes test, remove resource and scope
+        histogram.delete("resource");
+        histogram.delete("scope");
         final String resultAttr = histogram.toJsonString();
         assertThat(resultAttr.indexOf("attributes"), equalTo(-1));
     }
 
     @Test
     public void testHistogramToJsonStringWithAttributes() throws JSONException {
-        histogram = builder.build(false);
+        histogram = createObjectUnderTest(false);
         histogram.put("foo", "bar");
         final String value = UUID.randomUUID().toString();
         histogram.put("testObject", new TestObject(value));
         histogram.put("list", Arrays.asList(1, 4, 5));
         final Map<String, Object> attributes = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         histogram.put("attributes", attributes);
+        // For attributes test, remove resource and scope
+        histogram.delete("resource");
+        histogram.delete("scope");
         final String resultAttr = histogram.toJsonString();
         assertThat(resultAttr.indexOf("attributes"), not(equalTo(-1)));
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
@@ -58,9 +58,8 @@ class JacksonGaugeTest {
 
     private JacksonGauge.Builder builder;
 
-    @BeforeEach
-    public void setup() {
-        builder = JacksonGauge.builder()
+    private JacksonGauge createObjectUnderTest(boolean opensearchMode) {
+        builder = JacksonGauge.builder(opensearchMode)
                 .withAttributes(TEST_ATTRIBUTES)
                 .withName(TEST_NAME)
                 .withDescription(TEST_DESCRIPTION)
@@ -74,8 +73,12 @@ class JacksonGaugeTest {
                 .withSchemaUrl(TEST_SCHEMA_URL)
                 .withFlags(TEST_FLAGS);
 
-        gauge = builder.build();
+        return builder.build();
+    }
 
+    @BeforeEach
+    public void setup() {
+        gauge = createObjectUnderTest(true);
     }
 
     @Test
@@ -182,7 +185,7 @@ class JacksonGaugeTest {
 
     @Test
     public void testBuilder_missingNonNullParameters_throwsNullPointerException() {
-        final JacksonGauge.Builder builder = JacksonGauge.builder();
+        final JacksonGauge.Builder builder = JacksonGauge.builder(true);
         builder.withValue(null);
         assertThrows(NullPointerException.class, builder::build);
     }
@@ -215,7 +218,7 @@ class JacksonGaugeTest {
 
     @Test
     public void testGaugeToJsonStringWithAttributes() throws JSONException {
-        gauge = builder.build(false);
+        gauge = createObjectUnderTest(false);
         gauge.put("foo", "bar");
         final String value = UUID.randomUUID().toString();
         gauge.put("testObject", new TestObject(value));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSumTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSumTest.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.model.metric;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
@@ -47,9 +49,8 @@ public class JacksonSumTest {
 
     private JacksonSum.Builder builder;
 
-    @BeforeEach
-    public void setup() {
-        builder = JacksonSum.builder()
+    private JacksonSum createObjectUnderTest(boolean opensearchMode) {
+        builder = JacksonSum.builder(opensearchMode)
                 .withAttributes(TEST_ATTRIBUTES)
                 .withName(TEST_NAME)
                 .withDescription(TEST_DESCRIPTION)
@@ -62,9 +63,12 @@ public class JacksonSumTest {
                 .withValue(TEST_VALUE)
                 .withServiceName(TEST_SERVICE_NAME)
                 .withSchemaUrl(TEST_SCHEMA_URL);
+        return builder.build();
+    }
 
-        sum = builder.build();
-
+    @BeforeEach
+    public void setup() {
+        sum = createObjectUnderTest(true);
     }
 
     @Test
@@ -127,8 +131,10 @@ public class JacksonSumTest {
         assertThat(((DefaultEventHandle)sum.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
-    @Test
-    public void testGetAggregationTemporality() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetAggregationTemporality(final boolean opensearchMode) {
+        sum = createObjectUnderTest(opensearchMode);
         final String aggregationTemporality = sum.getAggregationTemporality();
         assertThat(aggregationTemporality, is(equalTo(TEST_AGGREGATION_TEMPORALITY)));
     }
@@ -152,8 +158,10 @@ public class JacksonSumTest {
         assertThat(unit, is(equalTo(TEST_UNIT_NAME)));
     }
 
-    @Test
-    public void testGetMonotonic() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetMonotonic(final boolean opensearchMode) {
+        sum = createObjectUnderTest(opensearchMode);
         final boolean monotonic = sum.isMonotonic();
         assertThat(monotonic, is(equalTo(TEST_IS_MONOTONIC)));
     }
@@ -166,7 +174,7 @@ public class JacksonSumTest {
 
     @Test
     public void testBuilder_missingNonNullParameters_throwsNullPointerException() {
-        final JacksonSum.Builder builder = JacksonSum.builder();
+        final JacksonSum.Builder builder = JacksonSum.builder(true);
         builder.withValue(null);
         assertThrows(NullPointerException.class, builder::build);
     }
@@ -196,7 +204,7 @@ public class JacksonSumTest {
 
     @Test
     public void testSumJsonToStringWithAttributes() {
-        sum = builder.build(false);
+        sum = createObjectUnderTest(false);
         String attrKey = UUID.randomUUID().toString();
         String attrVal = UUID.randomUUID().toString();
         final Map<String, Object> attributes = Map.of(attrKey, attrVal);

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -12,6 +12,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
@@ -50,6 +52,9 @@ public class JacksonSpanTest {
     private static final String TEST_END_TIME =  UUID.randomUUID().toString();
     private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", new Date().getTime(), "key2", UUID.randomUUID().toString());
     private static final Integer TEST_DROPPED_ATTRIBUTES_COUNT = 8;
+    private static final Map<String, Object> TEST_STATUS = ImmutableMap.of("statusKey1", UUID.randomUUID().toString(), "statusKey2", UUID.randomUUID().toString());
+    private static final Map<String, Object> TEST_SCOPE = ImmutableMap.of("name", UUID.randomUUID().toString(), "version", UUID.randomUUID().toString(), "attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
+    private static final Map<String, Object> TEST_RESOURCE = ImmutableMap.of("attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
     private static final Integer TEST_DROPPED_EVENTS_COUNT =  45;
     private static final Integer TEST_DROPPED_LINKS_COUNT =  21;
     private static final String TEST_TRACE_GROUP =  UUID.randomUUID().toString();
@@ -87,8 +92,10 @@ public class JacksonSpanTest {
                 .withStatusCode(201)
                 .withEndTime("the End")
                 .build();
-        
-        builder = JacksonSpan.builder()
+    }
+
+    private void createBuilder(final boolean opensearchMode) {
+        builder = JacksonSpan.builder(opensearchMode)
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)
@@ -96,7 +103,10 @@ public class JacksonSpanTest {
                 .withName(TEST_NAME)
                 .withServiceName(TEST_SERVICE_NAME)
                 .withKind(TEST_KIND)
+                .withScope(TEST_SCOPE)
+                .withResource(TEST_RESOURCE)
                 .withStartTime(TEST_START_TIME)
+                .withStatus(TEST_STATUS)
                 .withEndTime(TEST_END_TIME)
                 .withAttributes(TEST_ATTRIBUTES)
                 .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
@@ -108,65 +118,124 @@ public class JacksonSpanTest {
                 .withDurationInNanos(TEST_DURATION_IN_NANOS)
                 .withTraceGroupFields(defaultTraceGroupFields);
 
-        jacksonSpan = builder.build();
     }
 
-    @Test
-    public void testGetSpanId() {
+    private JacksonSpan createObjectUnderTest(final boolean opensearchMode) {
+        createBuilder(opensearchMode);
+        return builder.build();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetSpanId(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String spanId = jacksonSpan.getSpanId();
         assertThat(spanId, is(equalTo(TEST_SPAN_ID)));
     }
 
-    @Test
-    public void testGetTraceId() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTraceId(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String traceId = jacksonSpan.getTraceId();
         assertThat(traceId, is(equalTo(TEST_TRACE_ID)));
     }
 
-    @Test
-    public void testGetTraceState() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTraceState(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String traceState = jacksonSpan.getTraceState();
         assertThat(traceState, is(equalTo(TEST_TRACE_STATE)));
     }
 
-    @Test
-    public void testGetParentSpanId() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetParentSpanId(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String parentSpanId = jacksonSpan.getParentSpanId();
         assertThat(parentSpanId, is(equalTo(TEST_PARENT_SPAN_ID)));
     }
 
-    @Test
-    public void testGetName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetName(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String name = jacksonSpan.getName();
         assertThat(name, is(equalTo(TEST_NAME)));
     }
 
-    @Test
-    public void testGetServiceName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetServiceName(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String name = jacksonSpan.getServiceName();
         assertThat(name, is(equalTo(TEST_SERVICE_NAME)));
     }
 
-    @Test
-    public void testGetKind() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetScope(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
+        final Map<String, Object> scope = jacksonSpan.getScope();
+        assertThat(scope, is(equalTo(TEST_SCOPE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetResource(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
+        final Map<String, Object> resource = jacksonSpan.getResource();
+        assertThat(resource, is(equalTo(TEST_RESOURCE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetStatus(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
+        final Map<String, Object> status = jacksonSpan.getStatus();
+        assertThat(status, is(equalTo(TEST_STATUS)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetOpensearchMode(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
+        boolean mode = jacksonSpan.getOpensearchMode();
+        assertThat(mode, is(equalTo(opensearchMode)));
+        jacksonSpan.setOpensearchMode(!opensearchMode);
+        mode = jacksonSpan.getOpensearchMode();
+        assertThat(mode, is(equalTo(!opensearchMode)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetKind(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String kind = jacksonSpan.getKind();
         assertThat(kind, is(equalTo(TEST_KIND)));
     }
 
-    @Test
-    public void testGetStartTime() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetStartTime(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String GetStartTime = jacksonSpan.getStartTime();
         assertThat(GetStartTime, is(equalTo(TEST_START_TIME)));
     }
 
-    @Test
-    public void testGetEndTime() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetEndTime(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String endTime = jacksonSpan.getEndTime();
         assertThat(endTime, is(equalTo(TEST_END_TIME)));
     }
 
-    @Test
-    public void testGetAttributes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetAttributes(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final Map<String,Object> attributes = jacksonSpan.getAttributes();
 
         TEST_ATTRIBUTES.keySet().forEach(key -> {
@@ -176,65 +245,85 @@ public class JacksonSpanTest {
         );
     }
 
-    @Test
-    public void testGetDroppedAttributesCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDroppedAttributesCount(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final Integer droppedAttributesCount = jacksonSpan.getDroppedAttributesCount();
         assertThat(droppedAttributesCount, is(equalTo(TEST_DROPPED_ATTRIBUTES_COUNT)));
     }
 
-    @Test
-    public void testGetEvents() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetEvents(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final List events = jacksonSpan.getEvents();
         assertThat(events, is(equalTo(Arrays.asList(defaultSpanEvent))));
     }
 
-    @Test
-    public void testGetDroppedEventsCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDroppedEventsCount(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final Integer droppedEventsCount = jacksonSpan.getDroppedEventsCount();
         assertThat(droppedEventsCount, is(equalTo(TEST_DROPPED_EVENTS_COUNT)));
     }
 
-    @Test
-    public void testGetLinks() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetLinks(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final List links = jacksonSpan.getLinks();
         assertThat(links, is(equalTo(Arrays.asList(defaultLink))));
     }
 
-    @Test
-    public void testGetDroppedLinksCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDroppedLinksCount(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final Integer droppedLinksCount = jacksonSpan.getDroppedLinksCount();
         assertThat(droppedLinksCount, is(equalTo(TEST_DROPPED_LINKS_COUNT)));
     }
 
-    @Test
-    public void testGetTraceGroup() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTraceGroup(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String traceGroup = jacksonSpan.getTraceGroup();
         assertThat(traceGroup, is(equalTo(TEST_TRACE_GROUP)));
     }
 
-    @Test
-    public void testGetDurationInNanos() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetDurationInNanos(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final Long durationInNanos = jacksonSpan.getDurationInNanos();
 
         assertThat(durationInNanos, is(TEST_DURATION_IN_NANOS));
     }
 
-    @Test
-    public void testGetTraceGroupFields() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTraceGroupFields(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final TraceGroupFields traceGroupFields = jacksonSpan.getTraceGroupFields();
         assertThat(traceGroupFields, is(equalTo(traceGroupFields)));
     }
 
-    @Test
-    public void testSetAndGetTraceGroup() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSetAndGetTraceGroup(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String testTraceGroup = "testTraceGroup";
         jacksonSpan.setTraceGroup(testTraceGroup);
         final String traceGroup = jacksonSpan.getTraceGroup();
         assertThat(traceGroup, is(equalTo(testTraceGroup)));
     }
 
-    @Test
-    public void testSetAndGetTraceGroupFields() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSetAndGetTraceGroupFields(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final TraceGroupFields testTraceGroupFields = DefaultTraceGroupFields.builder()
                 .withDurationInNanos(200L)
                 .withStatusCode(404)
@@ -246,30 +335,45 @@ public class JacksonSpanTest {
         assertThat(traceGroupFields, is(equalTo(testTraceGroupFields)));
     }
 
-    @Test
-    public void testToJsonStringAllParameters() throws JsonProcessingException {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testToJsonStringAllParameters(final boolean opensearchMode) throws JsonProcessingException {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final String jsonResult = jacksonSpan.toJsonString();
         final Map<String, Object> resultMap = mapper.readValue(jsonResult, new TypeReference<Map<String, Object>>() {});
 
-        assertThat(resultMap.containsKey("key1"), is(true));
-        assertThat(resultMap.containsKey("key2"), is(true));
-        assertThat(resultMap.containsKey("attributes"), is(false));
+        if (opensearchMode) {
+            assertThat(resultMap.containsKey("key1"), is(true));
+            assertThat(resultMap.containsKey("key2"), is(true));
+            assertThat(resultMap.containsKey("attributes"), is(false));
+        } else {
+            assertThat(resultMap.containsKey("attributes"), is(true));
+            Map<String, Object> attributes = (Map<String, Object>)resultMap.get("attributes");
+            assertThat(attributes.containsKey("key1"), is(true));
+            assertThat(attributes.containsKey("key2"), is(true));
+        }
     }
 
-    @Test
-    public void testToJsonStringWithoutAttributes() throws JsonProcessingException {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testToJsonStringWithoutAttributes(final boolean opensearchMode) throws JsonProcessingException {
+        createBuilder(opensearchMode);
         builder.withAttributes(null);
         final String jsonResult = builder.build().toJsonString();
         final Map<String, Object> resultMap = mapper.readValue(jsonResult, new TypeReference<Map<String, Object>>() {});
 
         assertThat(resultMap.containsKey("key1"), is(false));
         assertThat(resultMap.containsKey("key2"), is(false));
-        assertThat(resultMap.containsKey("attributes"), is(false));
+        assertThat(resultMap.containsKey("attributes"), is(!opensearchMode));
+        if (!opensearchMode) {
+           assertThat(resultMap.get("attributes"), is(equalTo(null)));
+        }
     }
 
-    @Test
-    public void testBuilder_withAllParameters_createsSpan() {
-        final JacksonSpan result = JacksonSpan.builder()
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testBuilder_withAllParameters_createsSpan(final boolean opensearchMode) {
+        final JacksonSpan result = JacksonSpan.builder(opensearchMode)
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)
@@ -295,86 +399,98 @@ public class JacksonSpanTest {
 
     @Test
     public void testBuilder_missingNonNullParameters_throwsNullPointerException() {
-        final JacksonSpan.Builder builder = JacksonSpan.builder();
+        final JacksonSpan.Builder builder = JacksonSpan.builder(true);
         builder.withTraceGroup(null);
         assertThrows(NullPointerException.class, builder::build);
     }
     
     @Test
     public void testBuilder_withoutTraceId_throwsNullPointerException() {
+        createBuilder(true);
         builder.withTraceId(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyTraceId_throwsIllegalArgumentException() {
+        createBuilder(true);
         builder.withTraceId("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutSpanId_throwsNullPointerException() {
+        createBuilder(true);
         builder.withSpanId(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptySpanId_throwsIllegalArgumentException() {
+        createBuilder(true);
         builder.withSpanId("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutName_throwsNullPointerException() {
+        createBuilder(true);
         builder.withName(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyName_throwsIllegalArgumentException() {
+        createBuilder(true);
         builder.withName("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutKind_throwsNullPointerException() {
+        createBuilder(true);
         builder.withKind(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyKind_throwsIllegalArgumentException() {
+        createBuilder(true);
         builder.withKind("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutStartTime_throwsNullPointerException() {
+        createBuilder(true);
         builder.withStartTime(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyStartTime_throwsIllegalArgumentException() {
+        createBuilder(true);
         builder.withStartTime("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutEndTime_throwsNullPointerException() {
+        createBuilder(true);
         builder.withEndTime(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyEndTime_throwsIllegalArgumentException() {
+        createBuilder(true);
         builder.withEndTime("");
         assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_missingTraceGroupKey_throwsIllegalStateException() {
-        builder = JacksonSpan.builder()
+        final JacksonSpan.Builder builder = JacksonSpan.builder(true)
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)
@@ -397,14 +513,14 @@ public class JacksonSpanTest {
 
     @Test
     public void testBuilder_withoutTraceGroupFields_throwsNullPointerException() {
+        createBuilder(true);
         builder.withTraceGroupFields(null);
         assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_allRequiredParameters_createsSpanWithDefaultValues() {
-
-        final JacksonSpan span = JacksonSpan.builder()
+        final JacksonSpan span = JacksonSpan.builder(true)
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)
@@ -431,51 +547,58 @@ public class JacksonSpanTest {
 
     @Test
     public void testBuilder_withNullAttributes_createsSpanWithDefaultValue() {
+        createBuilder(true);
         final JacksonSpan span = builder.withAttributes(null).build();
         assertThat(span.getAttributes(), is(equalTo(new HashMap<>())));
     }
 
     @Test
     public void testBuilder_withNullDroppedAttributesCount_createsSpanWithDefaultValue() {
+        createBuilder(true);
         final JacksonSpan span = builder.withDroppedAttributesCount(null).build();
         assertThat(span.getDroppedAttributesCount(), is(equalTo(0)));
     }
 
-    @Test
-    public void testGetTimeReceived() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGetTimeReceived(final boolean opensearchMode) {
         Instant now = Instant.now();
+        createBuilder(opensearchMode);
         final JacksonSpan span = builder.withTimeReceived(now).build();
         assertThat(((DefaultEventHandle)span.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test
     public void testBuilder_withNullEvents_createsSpanWithDefaultValue() {
+        createBuilder(true);
         final JacksonSpan span = builder.withEvents(null).build();
         assertThat(span.getEvents(), is(equalTo(new LinkedList<>())));
     }
 
     @Test
     public void testBuilder_withNullDroppedEventsCount_createsSpanWithDefaultValue() {
+        createBuilder(true);
         final JacksonSpan span = builder.withDroppedEventsCount(null).build();
         assertThat(span.getDroppedEventsCount(), is(equalTo(0)));
     }
 
     @Test
     public void testBuilder_withNullLinks_createsSpanWithDefaultValue() {
+        createBuilder(true);
         final JacksonSpan span = builder.withLinks(null).build();
         assertThat(span.getLinks(), is(equalTo(new LinkedList<>())));
     }
 
     @Test
     public void testBuilder_withNullDroppedLinksCount_createsSpanWithDefaultValue() {
+        createBuilder(true);
         final JacksonSpan span = builder.withDroppedLinksCount(null).build();
         assertThat(span.getDroppedLinksCount(), is(equalTo(0)));
     }
 
     @Test
     public void testBuilder_missingRequiredParameters_throwsNullPointerException() {
-
-        final JacksonEvent.Builder builder = JacksonSpan.builder()
+        final JacksonEvent.Builder builder = JacksonSpan.builder(true)
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)
@@ -492,8 +615,9 @@ public class JacksonSpanTest {
 
     @Nested
     class JacksonSpanBuilder {
-        @Test
-        void testWithJsonData_with_valid_json_data() {
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testWithJsonData_with_valid_json_data(final boolean opensearchMode) {
             final String data = "{\n" +
                     "  \"traceId\": \"414243\",\n" +
                     "  \"droppedLinksCount\": 0,\n" +
@@ -519,7 +643,8 @@ public class JacksonSpanTest {
                     "  \"resource.attributes.service@name\": \"ServiceA\",\n" +
                     "  \"status.code\": 0\n" +
                     "}";
-            final JacksonSpan jacksonSpan = JacksonSpan.builder()
+            final JacksonSpan.Builder builder = JacksonSpan.builder(opensearchMode);
+            final JacksonSpan jacksonSpan = JacksonSpan.builder(true)
                     .withJsonData(data)
                     .build();
 
@@ -534,7 +659,7 @@ public class JacksonSpanTest {
         @Test
         void testBuilder_withJsonData_missingTraceGroupKey_throwsIllegalStateException() {
             final String object = "{\"traceId\": \"414243\"}";
-            final JacksonSpan.Builder builder = JacksonSpan.builder()
+            final JacksonSpan.Builder builder = JacksonSpan.builder(true)
                     .withJsonData(object);
 
             assertThrows(IllegalStateException.class, builder::build);
@@ -543,7 +668,7 @@ public class JacksonSpanTest {
         @Test
         void testBuilder_withJsonData_missing_non_empty_keys_throwsNullPointerException() {
             final String object = "{\"traceGroup\": \"FRUITS\"}";
-            final JacksonSpan.Builder builder = JacksonSpan.builder()
+            final JacksonSpan.Builder builder = JacksonSpan.builder(true)
                     .withJsonData(object);
 
             assertThrows(NullPointerException.class, builder::build);
@@ -556,7 +681,7 @@ public class JacksonSpanTest {
                     "  \"traceId\": \"\" \n" +
                     "}";
 
-            final JacksonSpan.Builder builder = JacksonSpan.builder()
+            final JacksonSpan.Builder builder = JacksonSpan.builder(true)
                     .withJsonData(object);
 
             assertThrows(IllegalArgumentException.class, builder::build);
@@ -574,22 +699,24 @@ public class JacksonSpanTest {
                     "  \"endTime\": \"1970-01-01T00:00:00Z\" " +
                     "}";
 
-            final JacksonSpan.Builder builder = JacksonSpan.builder()
+            final JacksonSpan.Builder builder = JacksonSpan.builder(true)
                     .withJsonData(object);
 
             assertThrows(NullPointerException.class, builder::build);
         }
 
-        @Test
-        void testBuilder_withJsonData_with_invalid_json_data_should_throw() {
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testBuilder_withJsonData_with_invalid_json_data_should_throw(final boolean opensearchMode) {
             String invalidJsonData = "{\"traceGroup\": \"FRUITS}";
-            final JacksonSpan.Builder builder = JacksonSpan.builder();
+            final JacksonSpan.Builder builder = JacksonSpan.builder(opensearchMode);
 
             assertThrows(RuntimeException.class, () -> builder.withJsonData(invalidJsonData));
         }
 
-        @Test
-        void testBuilder_withEventMetadata_with_event_metadata_with_valid_metadata() {
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testBuilder_withEventMetadata_with_event_metadata_with_valid_metadata(final boolean opensearchMode) {
             final String data = "{\n" +
                     "  \"traceId\": \"414243\",\n" +
                     "  \"kind\": \"SPAN_KIND_INTERNAL\",\n" +
@@ -611,7 +738,7 @@ public class JacksonSpanTest {
             when(eventMetadata.getEventType()).thenReturn(String.valueOf(EventType.TRACE));
             when(eventMetadata.getTimeReceived()).thenReturn(now);
 
-            final JacksonSpan jacksonSpan = JacksonSpan.builder()
+            final JacksonSpan jacksonSpan = JacksonSpan.builder(opensearchMode)
                     .withJsonData(data)
                     .withEventMetadata(eventMetadata)
                     .build();
@@ -621,8 +748,9 @@ public class JacksonSpanTest {
             assertThat(jacksonSpan.getMetadata().getTimeReceived(), equalTo(now));
         }
 
-        @Test
-        void testBuilder_withEventMetadata_with_event_invalid_event_metadata_should_throw() {
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testBuilder_withEventMetadata_with_event_invalid_event_metadata_should_throw(final boolean opensearchMode) {
             final String data = "{\n" +
                     "  \"traceId\": \"414243\",\n" +
                     "  \"kind\": \"SPAN_KIND_INTERNAL\",\n" +
@@ -644,34 +772,35 @@ public class JacksonSpanTest {
             when(eventMetadata.getEventType()).thenReturn(String.valueOf(EventType.LOG));
             when(eventMetadata.getTimeReceived()).thenReturn(now);
 
-            final JacksonEvent.Builder builder = JacksonSpan.builder()
+            final JacksonEvent.Builder builder = JacksonSpan.builder(opensearchMode)
                     .withJsonData(data)
                     .withEventMetadata(eventMetadata);
 
             assertThrows(IllegalArgumentException.class, builder::build);
         }
 
-        @Test
-        void testBuilder_withData_with_event_valid_data() {
-	    final Map<String, Object> data = new HashMap<String, Object>();
-	    final String traceId = "414243";
-	    final String kind = "SPAN_KIND_INTERNAL";
-	    final String traceGroup = "FRUITSGroup";
-	    final String traceGroupFields = "{\"endTime\":\"1970-01-01T00:00:00Z\",\"durationInNanos\": 0,\"statusCode\": 0}";
-	    final String spanId = "313030";
-	    final String name = "FRUITS";
-	    final String startTime = "1970-01-01T00:00:00Z";
-	    final String endTime = "1970-01-02T00:00:00Z";
-	    final String durationInNanos = "100";
-	    data.put("traceId", traceId);
-	    data.put("kind", kind);
-	    data.put("traceGroup", traceGroup);
-	    data.put("traceGroupFields", traceGroupFields);
-	    data.put("spanId", spanId);
-	    data.put("name", name);
-	    data.put("startTime", startTime);
-	    data.put("endTime", endTime);
-	    data.put("durationInNanos", durationInNanos);
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testBuilder_withData_with_event_valid_data(final boolean opensearchMode) {
+            final Map<String, Object> data = new HashMap<String, Object>();
+            final String traceId = "414243";
+            final String kind = "SPAN_KIND_INTERNAL";
+            final String traceGroup = "FRUITSGroup";
+            final String traceGroupFields = "{\"endTime\":\"1970-01-01T00:00:00Z\",\"durationInNanos\": 0,\"statusCode\": 0}";
+            final String spanId = "313030";
+            final String name = "FRUITS";
+            final String startTime = "1970-01-01T00:00:00Z";
+            final String endTime = "1970-01-02T00:00:00Z";
+            final String durationInNanos = "100";
+            data.put("traceId", traceId);
+            data.put("kind", kind);
+            data.put("traceGroup", traceGroup);
+            data.put("traceGroupFields", traceGroupFields);
+            data.put("spanId", spanId);
+            data.put("name", name);
+            data.put("startTime", startTime);
+            data.put("endTime", endTime);
+            data.put("durationInNanos", durationInNanos);
 
             EventMetadata eventMetadata = mock(EventMetadata.class);
             final Instant now = Instant.now();
@@ -679,7 +808,7 @@ public class JacksonSpanTest {
             when(eventMetadata.getTimeReceived()).thenReturn(now);
 
 
-            final JacksonSpan jacksonSpan = JacksonSpan.builder()
+            final JacksonSpan jacksonSpan = JacksonSpan.builder(opensearchMode)
                     .withData(data)
                     .withEventMetadata(eventMetadata)
                     .build();
@@ -698,8 +827,10 @@ public class JacksonSpanTest {
         }
     }
 
-    @Test
-    void fromSpan_with_a_Jackson_Span() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void fromSpan_with_a_Jackson_Span(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final JacksonEvent createdEvent = JacksonSpan.fromSpan(jacksonSpan);
 
         assertThat(createdEvent, notNullValue());
@@ -712,8 +843,10 @@ public class JacksonSpanTest {
         assertThat(createdEvent.getMetadata(), equalTo(jacksonSpan.getMetadata()));
     }
 
-    @Test
-    void fromSpan_with_a_non_JacksonSpan() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void fromSpan_with_a_non_JacksonSpan(final boolean opensearchMode) {
+        jacksonSpan = createObjectUnderTest(opensearchMode);
         final EventMetadata eventMetadata = mock(EventMetadata.class);
         final Span originalSpan = mock(Span.class);
         when(originalSpan.toMap()).thenReturn(jacksonSpan.toMap());

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/codec/JacksonPeerForwarderCodec.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/codec/JacksonPeerForwarderCodec.java
@@ -67,7 +67,7 @@ public class JacksonPeerForwarderCodec implements PeerForwarderCodec {
         Event event;
 
         if (wireEvent.getEventType().equalsIgnoreCase(TRACE_EVENT_TYPE)) {
-            event = JacksonSpan.builder()
+            event = JacksonSpan.builder(false)
                     .withJsonData(wireEvent.getEventData())
                     .withEventMetadata(eventMetadata)
                     .build();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/codec/PeerForwarderCodecAppConfig_SerializationFilterIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/codec/PeerForwarderCodecAppConfig_SerializationFilterIT.java
@@ -524,7 +524,7 @@ class PeerForwarderCodecAppConfig_SerializationFilterIT {
         public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
             return Stream.of(
                     arguments(JacksonEvent.builder()),
-                    arguments(JacksonSpan.builder()
+                    arguments(JacksonSpan.builder(true)
                             .withTraceId(UUID.randomUUID().toString())
                             .withTraceGroup(UUID.randomUUID().toString())
                             .withSpanId(UUID.randomUUID().toString())
@@ -536,33 +536,33 @@ class PeerForwarderCodecAppConfig_SerializationFilterIT {
                             .withTraceGroupFields(DefaultTraceGroupFields.builder().build())
                     ),
                     arguments(JacksonLog.builder()),
-                    arguments(JacksonOtelLog.builder()),
-                    arguments(JacksonExponentialHistogram.builder()
+                    arguments(JacksonOtelLog.builder(true)),
+                    arguments(JacksonExponentialHistogram.builder(true)
                             .withName(UUID.randomUUID().toString())
                             .withEventKind(UUID.randomUUID().toString())
                             .withTime(Instant.now().toString())
                             .withSum(10.0)
                     ),
-                    arguments(JacksonGauge.builder()
+                    arguments(JacksonGauge.builder(true)
                             .withName(UUID.randomUUID().toString())
                             .withEventKind(UUID.randomUUID().toString())
                             .withTime(Instant.now().toString())
                             .withValue(10.0)
                     ),
-                    arguments(JacksonHistogram.builder()
+                    arguments(JacksonHistogram.builder(true)
                             .withName(UUID.randomUUID().toString())
                             .withEventKind(UUID.randomUUID().toString())
                             .withTime(Instant.now().toString())
                             .withSum(10.0)
                     ),
-                    arguments(JacksonSum.builder()
+                    arguments(JacksonSum.builder(true)
                             .withName(UUID.randomUUID().toString())
                             .withEventKind(UUID.randomUUID().toString())
                             .withTime(Instant.now().toString())
                             .withValue(10.0)
                             .withIsMonotonic(true)
                     ),
-                    arguments(JacksonSummary.builder()
+                    arguments(JacksonSummary.builder(true)
                             .withName(UUID.randomUUID().toString())
                             .withEventKind(UUID.randomUUID().toString())
                             .withTime(Instant.now().toString())

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineConnectorTest.java
@@ -121,7 +121,7 @@ public class PipelineConnectorTest {
                 .withStatusCode(201)
                 .withEndTime("the End")
                 .build();
-        final JacksonSpan span = JacksonSpan.builder()
+        final JacksonSpan span = JacksonSpan.builder(true)
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -158,7 +158,7 @@ public class CountAggregateAction implements AggregateAction {
             long startTimeNanos = getTimeNanos(startTime);
             Map<String, Object> attr = new HashMap<String, Object>();
             groupState.forEach((k, v) -> attr.put((String)k, v));
-            JacksonSum sum = JacksonSum.builder()
+            JacksonSum sum = JacksonSum.builder(false)
                 .withName(this.metricName)
                 .withDescription(SUM_METRIC_DESCRIPTION)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
@@ -170,7 +170,7 @@ public class CountAggregateAction implements AggregateAction {
                 .withExemplars(List.of(exemplar))
                 .withAttributes(attr)
                 .withEventHandle(aggregateActionInput.getEventHandle())
-                .build(false);
+                .build();
             event = (Event)sum;
         }
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -245,7 +245,7 @@ public class HistogramAggregateAction implements AggregateAction {
             Double min = (Double)groupState.get(minKey);
             Integer count = (Integer)groupState.get(countKey);
             String description = String.format("Histogram of %s in the events", key);
-            JacksonHistogram histogram = JacksonHistogram.builder()
+            JacksonHistogram histogram = JacksonHistogram.builder(false)
                 .withName(this.metricName)
                 .withDescription(description)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
@@ -264,7 +264,7 @@ public class HistogramAggregateAction implements AggregateAction {
                 .withExemplars(exemplarList)
                 .withAttributes(attr)
                 .withEventHandle(aggregateActionInput.getEventHandle())
-                .build(false);
+                .build();
             event = (Event)histogram;
         }
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -120,8 +120,8 @@ public class CountAggregateActionTest {
         expectedEventMap.put("value", (double)testCount);
         expectedEventMap.put("name", "count");
         expectedEventMap.put("description", "Number of events");
-        expectedEventMap.put("isMonotonic", true);
-        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
+        expectedEventMap.put("is_monotonic", true);
+        expectedEventMap.put("aggregation_temporality", "AGGREGATION_TEMPORALITY_DELTA");
         expectedEventMap.put("unit", "1");
         expectedEventMap.put("name", testName);
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));
@@ -205,8 +205,8 @@ public class CountAggregateActionTest {
         expectedEventMap.put("value", (double)testCount);
         expectedEventMap.put("name", testName);
         expectedEventMap.put("description", "Number of events");
-        expectedEventMap.put("isMonotonic", true);
-        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
+        expectedEventMap.put("is_monotonic", true);
+        expectedEventMap.put("aggregation_temporality", "AGGREGATION_TEMPORALITY_DELTA");
         expectedEventMap.put("unit", "1");
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
@@ -270,8 +270,8 @@ public class CountAggregateActionTest {
         double expectedCount = (testCount >= 3) ? 3 : testCount;
         expectedEventMap.put("value", expectedCount);
         expectedEventMap.put("description", "Number of events");
-        expectedEventMap.put("isMonotonic", true);
-        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
+        expectedEventMap.put("is_monotonic", true);
+        expectedEventMap.put("aggregation_temporality", "AGGREGATION_TEMPORALITY_DELTA");
         expectedEventMap.put("unit", "1");
         expectedEventMap.put("name", testName);
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.hasKey;
 
 @ExtendWith(MockitoExtension.class)
 public class CountAggregateActionTest {
+    private static String START_TIME_KEY = "start_time";
     AggregateActionInput aggregateActionInput;
 
     private AggregateAction countAggregateAction;
@@ -127,7 +128,7 @@ public class CountAggregateActionTest {
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
-        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
         List<Map<String, Object>> exemplars = (List <Map<String, Object>>)result.get(0).toMap().get("exemplars");
         assertThat(exemplars.size(), equalTo(1));
@@ -211,10 +212,10 @@ public class CountAggregateActionTest {
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
-        assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
+        assertThat(result.get(0).get(START_TIME_KEY, String.class), equalTo(testTime.toString()));
         assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(100).toString()));
 
-        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
         List<Map<String, Object>> exemplars = (List <Map<String, Object>>)result.get(0).toMap().get("exemplars");
         assertThat(exemplars.size(), equalTo(1));
@@ -277,7 +278,7 @@ public class CountAggregateActionTest {
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
-        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
         List<Map<String, Object>> exemplars = (List <Map<String, Object>>)result.get(0).toMap().get("exemplars");
         assertThat(exemplars.size(), equalTo(1));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -46,6 +46,7 @@ import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setFie
 
 @ExtendWith(MockitoExtension.class)
 public class HistogramAggregateActionTests {
+    private static String START_TIME_KEY = "start_time";
     private AggregateAction histogramAggregateAction;
     private HistogramAggregateActionConfig histogramAggregateActionConfig;
 
@@ -209,7 +210,7 @@ public class HistogramAggregateActionTests {
         expectedEventMap.put("explicitBoundsCount", expectedBucketCounts.length-1);
         
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
-        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
         final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucketCountsList");
         for (int i = 0; i < expectedBucketCounts.length; i++) {
@@ -334,7 +335,7 @@ public class HistogramAggregateActionTests {
         expectedEventMap.put("explicitBoundsCount", expectedBucketCounts.length-1);
 
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
-        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
         final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucketCountsList");
         for (int i = 0; i < expectedBucketCounts.length; i++) {
@@ -368,7 +369,7 @@ public class HistogramAggregateActionTests {
             }
         }
 
-        assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
+        assertThat(result.get(0).get(START_TIME_KEY, String.class), equalTo(testTime.toString()));
         assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(100).toString()));
     }
 
@@ -436,10 +437,10 @@ public class HistogramAggregateActionTests {
         final List<Event> result = actionOutput.getEvents();
         assertThat(result.size(), equalTo(1));
 
-        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
 
-        final String actualStartTime = result.get(0).get("startTime", String.class);
+        final String actualStartTime = result.get(0).get(START_TIME_KEY, String.class);
         assertThat(actualStartTime, notNullValue());
         final Instant startTimeInstant = Instant.parse(actualStartTime).truncatedTo(ChronoUnit.MILLIS);
         assertThat(startTimeInstant, equalTo(expectedFirstStartTime));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -206,13 +206,13 @@ public class HistogramAggregateActionTests {
         expectedEventMap.put("sum", expectedSum);
         expectedEventMap.put("min", expectedMin);
         expectedEventMap.put("max", expectedMax);
-        expectedEventMap.put("bucketCounts", expectedBucketCounts.length);
-        expectedEventMap.put("explicitBoundsCount", expectedBucketCounts.length-1);
+        expectedEventMap.put("bucket_counts", expectedBucketCounts.length);
+        expectedEventMap.put("explicit_bounds_count", expectedBucketCounts.length-1);
         
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
         assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
-        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucketCountsList");
+        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucket_counts_list");
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
@@ -224,7 +224,7 @@ public class HistogramAggregateActionTests {
         assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasKey(expectedDurationKey));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
-        final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get(0).toMap().get("explicitBounds");
+        final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get(0).toMap().get("explicit_bounds");
         double bucketVal = TEST_VALUE_RANGE_MIN;
         for (int i = 0; i < explicitBoundsFromResult.size(); i++) {
             assertThat(explicitBoundsFromResult.get(i), equalTo(bucketVal));
@@ -331,13 +331,13 @@ public class HistogramAggregateActionTests {
         expectedEventMap.put("sum", expectedSum);
         expectedEventMap.put("min", expectedMin);
         expectedEventMap.put("max", expectedMax);
-        expectedEventMap.put("bucketCounts", expectedBucketCounts.length);
-        expectedEventMap.put("explicitBoundsCount", expectedBucketCounts.length-1);
+        expectedEventMap.put("bucket_counts", expectedBucketCounts.length);
+        expectedEventMap.put("explicit_bounds_count", expectedBucketCounts.length-1);
 
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
         assertThat(result.get(0).toMap(), hasKey(START_TIME_KEY));
         assertThat(result.get(0).toMap(), hasKey("time"));
-        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucketCountsList");
+        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucket_counts_list");
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
@@ -349,7 +349,7 @@ public class HistogramAggregateActionTests {
         assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasKey(expectedDurationKey));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
-        final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get(0).toMap().get("explicitBounds");
+        final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get(0).toMap().get("explicit_bounds");
         double bucketVal = TEST_VALUE_RANGE_MIN;
         for (int i = 0; i < explicitBoundsFromResult.size(); i++) {
             assertThat(explicitBoundsFromResult.get(i), equalTo(bucketVal));

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferOTelIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferOTelIT.java
@@ -293,7 +293,7 @@ public class KafkaBufferOTelIT {
 
     @Test
     void test_otel_metrics_with_kafka_buffer() throws Exception {
-        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelMetricDecoder(), null, null);
+        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelMetricDecoder(true), null, null);
         buffer = new KafkaDelegatingBuffer(kafkaBuffer);
         final ExportMetricsServiceRequest request = createExportMetricsServiceRequest();
         buffer.writeBytes(request.toByteArray(), null, 10_000);
@@ -365,7 +365,7 @@ public class KafkaBufferOTelIT {
 
     @Test
     void test_otel_logs_with_kafka_buffer() throws Exception {
-        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelLogsDecoder(), null, null);
+        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelLogsDecoder(true), null, null);
         buffer = new KafkaDelegatingBuffer(kafkaBuffer);
         final ExportLogsServiceRequest request = createExportLogsRequest();
         buffer.writeBytes(request.toByteArray(), null, 10_000);
@@ -436,7 +436,7 @@ public class KafkaBufferOTelIT {
 
     @Test
     void test_otel_traces_with_kafka_buffer() throws Exception {
-        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelTraceDecoder(), null, null);
+        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelTraceDecoder(true), null, null);
         buffer = new KafkaDelegatingBuffer(kafkaBuffer);
         final ExportTraceServiceRequest request = createExportTraceRequest();
         buffer.writeBytes(request.toByteArray(), null, 10_000);

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -48,14 +48,17 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
     private final Counter successRequestsCounter;
     private final DistributionSummary payloadSizeSummary;
     private final Timer requestProcessDuration;
+    private final boolean opensearchMode;
 
 
     public OTelLogsGrpcService(int bufferWriteTimeoutInMillis,
                                final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
                                final Buffer<Record<Object>> buffer,
+                               final boolean opensearchMode,
                                final PluginMetrics pluginMetrics) {
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
+        this.opensearchMode = opensearchMode;
         this.oTelProtoDecoder = oTelProtoDecoder;
 
         requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
@@ -85,7 +88,7 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
         final List<OpenTelemetryLog> logs;
 
         try {
-            logs = oTelProtoDecoder.parseExportLogsServiceRequest(request, Instant.now());
+            logs = oTelProtoDecoder.parseExportLogsServiceRequest(request, Instant.now(), opensearchMode);
         } catch (Exception e) {
             LOG.error("Failed to parse the request {} due to:", request, e);
             throw new BadRequestException(e.getMessage(), e);

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -87,7 +87,7 @@ public class OTelLogsSource implements Source<Record<Object>> {
         this.certificateProviderFactory = certificateProviderFactory;
         this.pipelineName = pipelineDescription.getPipelineName();
         this.authenticationProvider = createAuthenticationProvider(pluginFactory);
-        this.byteDecoder = new OTelLogsDecoder();
+        this.byteDecoder = new OTelLogsDecoder(oTelLogsSourceConfig.getOpensearchMode());
     }
 
     @Override
@@ -107,6 +107,7 @@ public class OTelLogsSource implements Source<Record<Object>> {
                     (int) (oTelLogsSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     new OTelProtoCodec.OTelProtoDecoder(),
                     buffer,
+                    oTelLogsSourceConfig.getOpensearchMode(),
                     pluginMetrics
             );
 

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
@@ -33,6 +33,7 @@ public class OTelLogsSourceConfig {
     static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
     static final String COMPRESSION = "compression";
     static final String RETRY_INFO = "retry_info";
+    static final String OPENSEARCH_MODE = "opensearch_mode";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21892;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -54,6 +55,9 @@ public class OTelLogsSourceConfig {
     @JsonProperty(PATH)
     @Size(min = 1, message = "path length should be at least 1")
     private String path;
+
+    @JsonProperty(OPENSEARCH_MODE)
+    private boolean opensearchMode = true;
 
     @JsonProperty(HEALTH_CHECK_SERVICE)
     private boolean healthCheck = DEFAULT_HEALTH_CHECK;
@@ -146,6 +150,10 @@ public class OTelLogsSourceConfig {
 
     public int getRequestTimeoutInMillis() {
         return requestTimeoutInMillis;
+    }
+
+    public boolean getOpensearchMode() {
+        return opensearchMode;
     }
 
     public int getPort() {

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
@@ -190,7 +190,7 @@ public class OTelLogsGrpcServiceTest {
     public void export_BadRequest_responseObserverOnError() {
         final String testMessage = "test message";
         final RuntimeException testException = new RuntimeException(testMessage);
-        when(mockOTelProtoDecoder.parseExportLogsServiceRequest(any(), any(Instant.class))).thenThrow(testException);
+        when(mockOTelProtoDecoder.parseExportLogsServiceRequest(any(), any(Instant.class), any(Boolean.class))).thenThrow(testException);
         objectUnderTest = generateOTelLogsGrpcService(mockOTelProtoDecoder);
 
         try (MockedStatic<ServiceRequestContext> mockedStatic = mockStatic(ServiceRequestContext.class)) {
@@ -253,6 +253,6 @@ public class OTelLogsGrpcServiceTest {
 
     private OTelLogsGrpcService generateOTelLogsGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder) {
         return new OTelLogsGrpcService(
-                bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);
+                bufferWriteTimeoutInMillis, decoder, buffer, true, mockPluginMetrics);
     }
 }

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -9,6 +9,7 @@ import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec.DEFAU
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -17,9 +18,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "sent from the <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/\">OTel metrics source</a> into a collection of string records.")
 public class OtelMetricsRawProcessorConfig {
 
+    @JsonAlias(value = "opensearch_mode")
     @JsonProperty(value = "flatten_attributes", defaultValue = "true")
     @JsonPropertyDescription("Whether or not to flatten the <code>attributes</code> field in the JSON data. Default value is <code>true</code>.")
-    boolean flattenAttributesFlag = true;
+    boolean opensearchMode = true;
 
     @JsonProperty(defaultValue = "true")
     @JsonPropertyDescription("Whether or not to calculate histogram buckets. Default value is <code>true</code>.")
@@ -45,7 +47,8 @@ public class OtelMetricsRawProcessorConfig {
         return exponentialHistogramMaxAllowedScale;
     }
 
-    public Boolean getFlattenAttributesFlag() {
-        return flattenAttributesFlag;
+    public Boolean getOpensearchMode() {
+        return opensearchMode;
     }
+
 }

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginExponentialHistogramTest.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginExponentialHistogramTest.java
@@ -67,6 +67,7 @@ class MetricsPluginExponentialHistogramTest {
     void init() {
         PluginSetting testsettings = new PluginSetting("testsettings", Collections.emptyMap());
         testsettings.setPipelineName("testpipeline");
+        lenient().when(config.getOpensearchMode()).thenReturn(true);
         rawProcessor = new OTelMetricsRawProcessor(testsettings, config);
     }
 

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginHistogramTest.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginHistogramTest.java
@@ -60,7 +60,7 @@ class MetricsPluginHistogramTest {
     void init() {
         PluginSetting testsettings = new PluginSetting("testsettings", Collections.emptyMap());
         testsettings.setPipelineName("testpipeline");
-        when(config.getFlattenAttributesFlag()).thenReturn(true);
+        when(config.getOpensearchMode()).thenReturn(true);
         rawProcessor = new OTelMetricsRawProcessor(testsettings, config);
     }
 
@@ -101,7 +101,7 @@ class MetricsPluginHistogramTest {
     void testWithConfigFlagDisabledAndNoFlattenedAttributes() throws JsonProcessingException {
         PluginSetting testsettings = new PluginSetting("testsettings", Collections.emptyMap());
         testsettings.setPipelineName("testpipeline");
-        when(config.getFlattenAttributesFlag()).thenReturn(false);
+        when(config.getOpensearchMode()).thenReturn(false);
         rawProcessor = new OTelMetricsRawProcessor(testsettings, config);
         Histogram histogram = Histogram.newBuilder().addDataPoints(HISTOGRAM_DATA_POINT).build();
 

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfigTest.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfigTest.java
@@ -20,6 +20,6 @@ public class OtelMetricsRawProcessorConfigTest {
         assertThat(dateProcessorConfig.getCalculateExponentialHistogramBuckets(), equalTo(true));
         assertThat(dateProcessorConfig.getCalculateHistogramBuckets(), equalTo(true));
         assertThat(dateProcessorConfig.getExponentialHistogramMaxAllowedScale(), equalTo(10));
-        assertThat(dateProcessorConfig.getFlattenAttributesFlag(), equalTo(true));
+        assertThat(dateProcessorConfig.getOpensearchMode(), equalTo(true));
     }
 }

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -88,7 +88,7 @@ public class OTelMetricsSource implements Source<Record<? extends Metric>> {
         this.certificateProviderFactory = certificateProviderFactory;
         this.pipelineName = pipelineDescription.getPipelineName();
         this.authenticationProvider = createAuthenticationProvider(pluginFactory);
-        this.byteDecoder = new OTelMetricDecoder();
+        this.byteDecoder = new OTelMetricDecoder(oTelMetricsSourceConfig.getOpensearchMode());
     }
 
     @Override
@@ -107,6 +107,7 @@ public class OTelMetricsSource implements Source<Record<? extends Metric>> {
                     (int) (oTelMetricsSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     new OTelProtoCodec.OTelProtoDecoder(),
                     buffer,
+                    oTelMetricsSourceConfig.getOpensearchMode(),
                     pluginMetrics
             );
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
@@ -32,6 +32,7 @@ public class OTelMetricsSourceConfig {
     static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
     static final String COMPRESSION = "compression";
     static final String RETRY_INFO = "retry_info";
+    static final String OPENSEARCH_MODE = "opensearch_mode";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21891;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -60,6 +61,9 @@ public class OTelMetricsSourceConfig {
 
     @JsonProperty(PROTO_REFLECTION_SERVICE)
     private boolean protoReflectionService = DEFAULT_PROTO_REFLECTION_SERVICE;
+
+    @JsonProperty(OPENSEARCH_MODE)
+    private boolean opensearchMode = true;
 
     @JsonProperty(ENABLE_UNFRAMED_REQUESTS)
     private boolean enableUnframedRequests = DEFAULT_ENABLED_UNFRAMED_REQUESTS;
@@ -155,6 +159,9 @@ public class OTelMetricsSourceConfig {
         return port;
     }
 
+    public boolean getOpensearchMode() {
+        return opensearchMode;
+    }
     public String getPath() {
         return path;
     }

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcServiceTest.java
@@ -116,7 +116,7 @@ public class OTelMetricsGrpcServiceTest {
 
         when(serviceRequestContext.isTimedOut()).thenReturn(false);
 
-        sut = new OTelMetricsGrpcService(bufferWriteTimeoutInMillis, new OTelProtoCodec.OTelProtoDecoder(), buffer, mockPluginMetrics);
+        sut = new OTelMetricsGrpcService(bufferWriteTimeoutInMillis, new OTelProtoCodec.OTelProtoDecoder(), buffer, true, mockPluginMetrics);
     }
 
     @Test

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoder.java
@@ -21,13 +21,15 @@ import java.time.Instant;
 
 public class OTelLogsDecoder implements ByteDecoder {
     private final OTelProtoCodec.OTelProtoDecoder otelProtoDecoder;
-    public OTelLogsDecoder() {
+    private final boolean opensearchMode;
+    public OTelLogsDecoder(final boolean opensearchMode) {
+        this.opensearchMode = opensearchMode;
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
     }
     public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
         ExportLogsServiceRequest request = ExportLogsServiceRequest.parseFrom(inputStream);
         AtomicInteger droppedCounter = new AtomicInteger(0);
-        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs);
+        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs, opensearchMode);
         for (OpenTelemetryLog log: logs) {
             eventConsumer.accept(new Record<>(log));
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsInputCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsInputCodec.java
@@ -25,9 +25,9 @@ public class OTelLogsInputCodec implements InputCodec {
     public OTelLogsInputCodec(final OTelLogsInputCodecConfig config) {
         Objects.requireNonNull(config);
         if (config.getFormat() == OTelLogsFormatOption.JSON) {
-            decoder = new OTelLogsJsonDecoder();
+            decoder = new OTelLogsJsonDecoder(config.getOpensearchMode());
         } else if (config.getFormat() == OTelLogsFormatOption.PROTOBUF) {
-            decoder = new OTelLogsProtoBufDecoder(config.getLengthPrefixedEncoding());
+            decoder = new OTelLogsProtoBufDecoder(config.getOpensearchMode(), config.getLengthPrefixedEncoding());
         } else {
             throw new RuntimeException("The codec " + config.getFormat() + " is not supported.");
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsInputCodecConfig.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsInputCodecConfig.java
@@ -29,17 +29,28 @@ public class OTelLogsInputCodecConfig {
     @JsonPropertyDescription("Specifies if the length precedes the data in otlp_proto format")
     private boolean lengthPrefixedEncoding;
 
+    @JsonProperty(value = "opensearch_mode", defaultValue = "true")
+    @JsonPropertyDescription("Specifies if opensearch mode is enabled or not.")
+    private boolean opensearchMode = true;
+
     public OTelLogsFormatOption getFormat() {
          return format;
     }
 
-    @AssertTrue(message = "Not a valid format.")
+    @AssertTrue(message = "Not a valid format or JSON format used with length_prefixed_encoding")
     boolean isValidFormat() {
-        return format != null;
+        if (format == null)
+            return false;
+        if (format == OTelLogsFormatOption.JSON && lengthPrefixedEncoding == true)
+            return false;
+        return true;
     }    
 
     public boolean getLengthPrefixedEncoding() {
         return lengthPrefixedEncoding;
     }
 
+    public boolean getOpensearchMode() {
+        return opensearchMode;
+    }
 }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsJsonDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsJsonDecoder.java
@@ -23,8 +23,10 @@ import java.time.Instant;
  
 public class OTelLogsJsonDecoder implements ByteDecoder {
     private final OTelProtoCodec.OTelProtoDecoder otelProtoDecoder;
+    private boolean opensearchMode;
     
-    public OTelLogsJsonDecoder() {
+    public OTelLogsJsonDecoder(final boolean opensearchMode) {
+        this.opensearchMode = opensearchMode;
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
     }
 
@@ -33,7 +35,7 @@ public class OTelLogsJsonDecoder implements ByteDecoder {
         ExportLogsServiceRequest.Builder builder = ExportLogsServiceRequest.newBuilder();
         JsonFormat.parser().merge(reader, builder);
         ExportLogsServiceRequest request = builder.build(); 
-        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs);
+        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs, opensearchMode);
         for (OpenTelemetryLog log: logs) {
             eventConsumer.accept(new Record<>(log));
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsProtoBufDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsProtoBufDecoder.java
@@ -28,14 +28,16 @@ public class OTelLogsProtoBufDecoder implements ByteDecoder {
     private static final int MAX_REQUEST_LEN = (8 * 1024 * 1024);
     private final OTelProtoCodec.OTelProtoDecoder otelProtoDecoder;
     private final boolean lengthPrefixedEncoding;
+    private final boolean opensearchMode;
     
-    public OTelLogsProtoBufDecoder(boolean lengthPrefixedEncoding) {
+    public OTelLogsProtoBufDecoder(boolean opensearchMode, boolean lengthPrefixedEncoding) {
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
         this.lengthPrefixedEncoding = lengthPrefixedEncoding;
+        this.opensearchMode = opensearchMode;
     }
 
     private void parseRequest(final ExportLogsServiceRequest request, final Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
-        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs);
+        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs, opensearchMode);
         for (OpenTelemetryLog log: logs) {
             eventConsumer.accept(new Record<>(log));
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
@@ -22,14 +22,16 @@ import java.util.function.Consumer;
 
 public class OTelMetricDecoder implements ByteDecoder {
     private final OTelProtoCodec.OTelProtoDecoder otelProtoDecoder;
-    public OTelMetricDecoder() {
+    private final boolean opensearchMode;
+    public OTelMetricDecoder(final boolean opensearchMode) {
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
+        this.opensearchMode = opensearchMode;
     }
     public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
         ExportMetricsServiceRequest request = ExportMetricsServiceRequest.parseFrom(inputStream);
         AtomicInteger droppedCounter = new AtomicInteger(0);
         Collection<Record<? extends Metric>> records =
-            otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, timeReceivedMs, true, true, false);
+            otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, timeReceivedMs, true, true, opensearchMode);
         for (Record<? extends Metric> record: records) {
             eventConsumer.accept((Record)record);
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -1141,6 +1141,7 @@ public class OTelProtoCodec {
      * Converts an {@link AnyValue} into its appropriate data type
      *
      * @param value The value to convert
+     * @param opensearchMode opensearch mode flag
      * @return the converted value as object
      */
     public static Object convertAnyValue(final AnyValue value, final boolean opensearchMode) {
@@ -1203,6 +1204,7 @@ public class OTelProtoCodec {
      * Also, casts the underlying data into its actual type
      *
      * @param numberDataPoint The point to process
+     * @param opensearchMode opensearch mode flag
      * @return A Map containing all attributes of `numberDataPoint` with keys converted into an OS-friendly format
      */
     public static Map<String, Object> convertKeysOfDataPointAttributes(final NumberDataPoint numberDataPoint, final boolean opensearchMode) {
@@ -1221,6 +1223,7 @@ public class OTelProtoCodec {
      * Converts the keys into an os friendly format and casts the underlying data into its actual type?
      *
      * @param attributesList The list of {@link KeyValue} objects to process
+     * @param opensearchMode opensearch mode flag
      * @return A Map containing unpacked {@link KeyValue} data
      */
     public static Map<String, Object> unpackKeyValueListMetric(List<KeyValue> attributesList, final boolean opensearchMode) {
@@ -1249,6 +1252,7 @@ public class OTelProtoCodec {
      * Converts the keys into an os friendly format and casts the underlying data into its actual type?
      *
      * @param attributesList The list of {@link KeyValue} objects to process
+     * @param opensearchMode opensearch mode flag
      * @return A Map containing unpacked {@link KeyValue} data
      */
     public static Map<String, Object> unpackKeyValueListLog(List<KeyValue> attributesList, final boolean opensearchMode) {
@@ -1268,6 +1272,7 @@ public class OTelProtoCodec {
      * Converts the keys into an os friendly format and casts the underlying data into its actual type?
      *
      * @param attributesList The list of {@link KeyValue} objects to process
+     * @param opensearchMode opensearch mode flag
      * @return A Map containing unpacked {@link KeyValue} data
      */
     public static Map<String, Object> unpackExemplarValueList(List<KeyValue> attributesList, final boolean opensearchMode) {
@@ -1331,6 +1336,7 @@ public class OTelProtoCodec {
      * Extracts the name and version of the used instrumentation scope used
      *
      * @param  instrumentationScope the instrumentation scope
+     * @param opensearchMode opensearch mode flag
      * @return A map, containing information about the instrumentation scope
      */
     public static Map<String, Object> getInstrumentationScopeAttributes(final InstrumentationScope instrumentationScope, final boolean opensearchMode) {
@@ -1450,6 +1456,7 @@ public class OTelProtoCodec {
      * internal representation for Data Prepper
      *
      * @param exemplarsList the List of Exemplars
+     * @param opensearchMode opensearch mode flag
      * @return a mapped list of DefaultExemplars
      */
     public static List<Exemplar> convertExemplars(List<io.opentelemetry.proto.metrics.v1.Exemplar> exemplarsList, final boolean opensearchMode) {

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoder.java
@@ -23,13 +23,15 @@ import java.time.Instant;
 
 public class OTelTraceDecoder implements ByteDecoder {
     private final OTelProtoCodec.OTelProtoDecoder otelProtoDecoder;
-    public OTelTraceDecoder() {
+    private final boolean opensearchMode;
+    public OTelTraceDecoder(final boolean opensearchMode) {
+        this.opensearchMode = opensearchMode;
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
     }
     public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
         ExportTraceServiceRequest request = ExportTraceServiceRequest.parseFrom(inputStream);
         AtomicInteger droppedCounter = new AtomicInteger(0);
-        List<Span> spans = otelProtoDecoder.parseExportTraceServiceRequest(request, timeReceivedMs);
+        List<Span> spans = otelProtoDecoder.parseExportTraceServiceRequest(request, timeReceivedMs, opensearchMode);
         for (Span span: spans) {
             eventConsumer.accept(new Record<>(span));
         }

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoderTest.java
@@ -26,7 +26,7 @@ public class OTelLogsDecoderTest {
     private static final String TEST_REQUEST_LOGS_FILE = "test-request-multiple-logs.json";
     
     public OTelLogsDecoder createObjectUnderTest() {
-        return new OTelLogsDecoder();
+        return new OTelLogsDecoder(true);
     }
 
     private String getFileAsJsonString(String requestJsonFileName) throws IOException {

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsJsonDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsJsonDecoderTest.java
@@ -17,7 +17,7 @@ public class OTelLogsJsonDecoderTest {
     private static final String TEST_REQUEST_LOGS_FILE = "test-request-multiple-logs.json";
     
     public OTelLogsJsonDecoder createObjectUnderTest() {
-        return new OTelLogsJsonDecoder();
+        return new OTelLogsJsonDecoder(true);
     }
 
     private void validateLog(OpenTelemetryLog logRecord) {

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsProtoBufDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsProtoBufDecoderTest.java
@@ -38,7 +38,7 @@ public class OTelLogsProtoBufDecoderTest {
     private static final String TEST_REQUEST_MULTI_LOGS_FILE = "test-otel-multi-log.protobuf";
 
     public OTelLogsProtoBufDecoder createObjectUnderTest(boolean lengthPrefixedEncoding) {
-        return new OTelLogsProtoBufDecoder(lengthPrefixedEncoding);
+        return new OTelLogsProtoBufDecoder(true, lengthPrefixedEncoding);
     }
 
     private void assertLog(OpenTelemetryLog logRecord, final int severityNumber, final String time, final String spanId) {

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricsDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricsDecoderTest.java
@@ -36,7 +36,7 @@ public class OTelMetricsDecoderTest {
     private static final String TEST_REQUEST_METRICS_FILE = "test-request-multiple-metrics.json";
     
     public OTelMetricDecoder createObjectUnderTest() {
-        return new OTelMetricDecoder();
+        return new OTelMetricDecoder(true);
     }
 
     private String getFileAsJsonString(String requestJsonFileName) throws IOException {

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoderTest.java
@@ -26,7 +26,7 @@ public class OTelTraceDecoderTest {
     private static final String TEST_REQUEST_TRACES_FILE = "test-request-multiple-traces.json";
     
     public OTelTraceDecoder createObjectUnderTest() {
-        return new OTelTraceDecoder();
+        return new OTelTraceDecoder(true);
     }
 
     private String getFileAsJsonString(String requestJsonFileName) throws IOException {

--- a/data-prepper-plugins/otel-trace-group-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessorTests.java
+++ b/data-prepper-plugins/otel-trace-group-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessorTests.java
@@ -299,7 +299,7 @@ class OTelTraceGroupProcessorTests {
     }
 
     private Record<Span> buildSpanRecordFromJsonFile(final String jsonFileName) throws IOException {
-        JacksonSpan.Builder spanBuilder = JacksonSpan.builder();
+        JacksonSpan.Builder spanBuilder = JacksonSpan.builder(true);
         try (final InputStream inputStream = Objects.requireNonNull(
                 OTelTraceGroupProcessorTests.class.getClassLoader().getResourceAsStream(jsonFileName))){
             final Map<String, Object> spanMap = OBJECT_MAPPER.readValue(inputStream, new TypeReference<Map<String, Object>>() {});

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessorTest.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessorTest.java
@@ -299,7 +299,7 @@ class OTelTraceRawProcessorTest {
     }
 
     private static Span buildSpanFromJsonFile(final String jsonFileName) {
-        JacksonSpan.Builder spanBuilder = JacksonSpan.builder();
+        JacksonSpan.Builder spanBuilder = JacksonSpan.builder(true);
         try (final InputStream inputStream = Objects.requireNonNull(
                 OTelTraceRawProcessorTest.class.getClassLoader().getResourceAsStream(jsonFileName))){
             final Map<String, Object> spanMap = OBJECT_MAPPER.readValue(inputStream, new TypeReference<Map<String, Object>>() {});

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -52,15 +52,17 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
     private final Counter successRequestsCounter;
     private final DistributionSummary payloadSizeSummary;
     private final Timer requestProcessDuration;
-
+    private final boolean opensearchMode;
 
     public OTelTraceGrpcService(int bufferWriteTimeoutInMillis,
                                 final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
                                 final Buffer<Record<Object>> buffer,
+                                final boolean opensearchMode,
                                 final PluginMetrics pluginMetrics) {
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
         this.oTelProtoDecoder = oTelProtoDecoder;
+        this.opensearchMode = opensearchMode;
 
         requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
         successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
@@ -89,7 +91,7 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
         final Collection<Span> spans;
 
         try {
-            spans = oTelProtoDecoder.parseExportTraceServiceRequest(request, Instant.now());
+            spans = oTelProtoDecoder.parseExportTraceServiceRequest(request, Instant.now(), opensearchMode);
         } catch (final Exception e) {
             LOG.warn(DataPrepperMarkers.SENSITIVE, "Failed to parse request with error '{}'. Request body: {}.", e.getMessage(), request);
             throw new BadRequestException(e.getMessage(), e);

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -87,7 +87,7 @@ public class OTelTraceSource implements Source<Record<Object>> {
         this.certificateProviderFactory = certificateProviderFactory;
         this.pipelineName = pipelineDescription.getPipelineName();
         this.authenticationProvider = createAuthenticationProvider(pluginFactory);
-        this.byteDecoder = new OTelTraceDecoder();
+        this.byteDecoder = new OTelTraceDecoder(oTelTraceSourceConfig.getOpensearchMode());
     }
 
     @Override
@@ -107,6 +107,7 @@ public class OTelTraceSource implements Source<Record<Object>> {
                     (int)(oTelTraceSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     new OTelProtoCodec.OTelProtoDecoder(),
                     buffer,
+                    oTelTraceSourceConfig.getOpensearchMode(),
                     pluginMetrics
             );
 

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -24,6 +24,7 @@ public class OTelTraceSourceConfig {
     static final String PROTO_REFLECTION_SERVICE = "proto_reflection_service";
     static final String SSL_KEY_CERT_FILE = "sslKeyCertChainFile";
     static final String SSL_KEY_FILE = "sslKeyFile";
+    static final String OPENSEARCH_MODE = "opensearch_mode";
     static final String ACM_CERT_ARN = "acmCertificateArn";
     static final String ACM_PRIVATE_KEY_PASSWORD = "acmPrivateKeyPassword";
     static final String AWS_REGION = "awsRegion";
@@ -63,6 +64,9 @@ public class OTelTraceSourceConfig {
 
     @JsonProperty(ENABLE_UNFRAMED_REQUESTS)
     private boolean enableUnframedRequests = DEFAULT_ENABLED_UNFRAMED_REQUESTS;
+
+    @JsonProperty(OPENSEARCH_MODE)
+    private boolean opensearchMode = true;
 
     @JsonProperty(SSL)
     private boolean ssl = DEFAULT_SSL;
@@ -153,6 +157,10 @@ public class OTelTraceSourceConfig {
 
     public int getPort() {
         return port;
+    }
+
+    public boolean getOpensearchMode() {
+        return opensearchMode;
     }
 
     public String getPath() {

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -200,7 +200,7 @@ public class OTelTraceGrpcServiceTest {
     public void export_BadRequest_responseObserverOnError() throws Exception {
         final String testMessage = "test message";
         final RuntimeException testException = new RuntimeException(testMessage);
-        when(mockOTelProtoDecoder.parseExportTraceServiceRequest(any(), any(Instant.class))).thenThrow(testException);
+        when(mockOTelProtoDecoder.parseExportTraceServiceRequest(any(), any(Instant.class), any(Boolean.class))).thenThrow(testException);
         objectUnderTest = generateOTelTraceGrpcService(mockOTelProtoDecoder);
 
         try (MockedStatic<ServiceRequestContext> mockedStatic = mockStatic(ServiceRequestContext.class)) {
@@ -262,6 +262,6 @@ public class OTelTraceGrpcServiceTest {
 
     private OTelTraceGrpcService generateOTelTraceGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder) {
         return new OTelTraceGrpcService(
-                bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);
+                bufferWriteTimeoutInMillis, decoder, buffer, true, mockPluginMetrics);
     }
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -221,6 +221,7 @@ class OTelTraceSourceTest {
         when(oTelTraceSourceConfig.getThreadCount()).thenReturn(5);
         when(oTelTraceSourceConfig.getCompression()).thenReturn(CompressionOption.NONE);
         when(oTelTraceSourceConfig.getRetryInfo()).thenReturn(TEST_RETRY_INFO);
+        when(oTelTraceSourceConfig.getOpensearchMode()).thenReturn(true);
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);
@@ -280,6 +281,7 @@ class OTelTraceSourceTest {
         settingsMap.put("useAcmCertForSSL", false);
         settingsMap.put("sslKeyCertChainFile", "data/certificate/test_cert.crt");
         settingsMap.put("sslKeyFile", "data/certificate/test_decrypted_key.key");
+        settingsMap.put("opensearch_mode", "true");
         pluginSetting = new PluginSetting("otel_trace", settingsMap);
         pluginSetting.setPipelineName("pipeline");
 

--- a/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapTestUtils.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/org/opensearch/dataprepper/plugins/processor/ServiceMapTestUtils.java
@@ -62,7 +62,7 @@ public class ServiceMapTestUtils {
             spanId, final String parentId, final String traceId, final io.opentelemetry.proto.trace.v1.Span.SpanKind spanKind) {
         final Instant endInstant = Instant.now();
         final String endTime = endInstant.toString();
-        final JacksonSpan.Builder builder = JacksonSpan.builder()
+        final JacksonSpan.Builder builder = JacksonSpan.builder(true)
                 .withSpanId(spanId)
                 .withTraceId(traceId)
                 .withTraceState("")


### PR DESCRIPTION
### Description
Add an option to process OTEL logs/traces/metrics in standard OTEL mode in addition to default/current "opensearch" mode.
Added "opensearch" mode as an option with default value of true, which keeps the current opensearch mode
 
### Issues Resolved
Resolves #5259 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
