### PR TITLE
support for endpoint_url in pipeline config for dynamodb source

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/ClientFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/ClientFactory.java
@@ -13,8 +13,12 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
+import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
 
 public class ClientFactory {
 
@@ -37,18 +41,28 @@ public class ClientFactory {
 
 
     public DynamoDbStreamsClient buildDynamoDbStreamClient() {
-        return DynamoDbStreamsClient.builder()
+        DynamoDbStreamsClientBuilder clientBuilder = DynamoDbStreamsClient.builder()
                 .credentialsProvider(awsCredentialsProvider)
-                .region(awsAuthenticationConfig.getAwsRegion())
-                .build();
+                .region(awsAuthenticationConfig.getAwsRegion());
+
+        if (awsAuthenticationConfig.getEndpointUrl() != null && !awsAuthenticationConfig.getEndpointUrl().isEmpty()) {
+            clientBuilder.endpointOverride(URI.create(awsAuthenticationConfig.getEndpointUrl()));
+        }
+
+        return clientBuilder.build();
     }
 
 
     public DynamoDbClient buildDynamoDBClient() {
-        return DynamoDbClient.builder()
+        DynamoDbClientBuilder clientBuilder = DynamoDbClient.builder()
                 .region(awsAuthenticationConfig.getAwsRegion())
-                .credentialsProvider(awsCredentialsProvider)
-                .build();
+                .credentialsProvider(awsCredentialsProvider);
+
+        if (awsAuthenticationConfig.getEndpointUrl() != null && !awsAuthenticationConfig.getEndpointUrl().isEmpty()) {
+            clientBuilder.endpointOverride(URI.create(awsAuthenticationConfig.getEndpointUrl()));
+        }
+
+        return clientBuilder.build();
     }
 
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/AwsAuthenticationConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/AwsAuthenticationConfig.java
@@ -29,6 +29,10 @@ public class AwsAuthenticationConfig {
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
 
+    @JsonProperty("endpoint_url")
+    @Size(min = 10, max = 2048, message = "endpoint_url length should be between 10 and 2048 characters")
+    private String endpoint_url;
+
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
     }
@@ -43,6 +47,10 @@ public class AwsAuthenticationConfig {
 
     public Map<String, String> getAwsStsHeaderOverrides() {
         return awsStsHeaderOverrides;
+    }
+
+    public String getEndpointUrl() {
+        return endpoint_url;
     }
 }
 


### PR DESCRIPTION
Long time watcher, first time contributor. 

### Description
For DynamoDBLocal <> data-prepper <> OpenSearch local development, data-prepper needs to be pointed to the DynamoDB local installation, which generally is `http://localhost:8000` or a docker container, part of a `docker-compose.yaml` stack.
Currently, `data-prepper-config.yaml` only takes in `region`, `sts_role_arn`, `sts_external_id`, and `sts_header_overrides` as AWS Auth parameters. There is no way to point data-prepper to a locally running DynamoDB installation for dev/test of the zero-ETL pipeline.
Adding a `endpoint_url` parameter in [AWSAuthenticatioConfig](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/AwsAuthenticationConfig.java) will add support for local dev/test.

Will also need to add this to the docs - https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/dynamo-db/ 
 
### Issues Resolved
None
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

I could not find tests for other parameters within `org.opensearch.dataprepper.plugins.source.dynamodb.configuration`. If the maintainers could point me towards where I need to add tests for it, would appreciate the help. I have tested the setup with this change for DynamoDBLocal <> data-prepper <> OpenSearch. This also works for the source-coordination DDB table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
