### PR TITLE
Fix/opensearch action validation

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -919,7 +919,7 @@ public class OpenSearchSinkIT {
         metadata.put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         metadata.put(IndexConfiguration.ACTION, "unknown");
         final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfigByMetadata(metadata);
-        assertThrows(NullPointerException.class, () -> createObjectUnderTest(openSearchSinkConfig, true));
+        assertThrows(IllegalArgumentException.class, () -> createObjectUnderTest(openSearchSinkConfig, true));
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -150,20 +150,9 @@ public class OpenSearchSinkConfig {
     @JsonProperty("ism_policy_file")
     private String ismPolicyFile = null;
 
+    @Getter
     @JsonProperty("action")
-    private OpenSearchBulkActions action = OpenSearchBulkActions.INDEX;
-
-    @AssertTrue(message = "action must be one of index, create, update, upsert, delete")
-    boolean isActionValid() {
-        if (action == null) {         //action will be null if the string doesn't match one of the enums
-            return false;
-        }
-        return true;
-    }
-
-    public String getAction() {
-        return action.toString();
-    }
+    private String action = OpenSearchBulkActions.INDEX.toString();
 
     @Getter
     @Valid

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateType;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class OpenSearchSinkConfig {
     public static final long DEFAULT_BULK_SIZE = 5L;
@@ -153,6 +154,13 @@ public class OpenSearchSinkConfig {
     @Getter
     @JsonProperty("action")
     private String action = OpenSearchBulkActions.INDEX.toString();
+
+    @AssertTrue(message = "action must be either one of index, create, update, upsert, delete, " +
+            "or using data prepper expression.")
+    boolean isActionValid() {
+        return (action != null && action.contains("${")) ||
+                Set.of(OpenSearchBulkActions.values()).contains(action);
+    }
 
     @Getter
     @Valid

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -17,7 +17,6 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateType;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class OpenSearchSinkConfig {
     public static final long DEFAULT_BULK_SIZE = 5L;
@@ -154,13 +153,6 @@ public class OpenSearchSinkConfig {
     @Getter
     @JsonProperty("action")
     private String action = OpenSearchBulkActions.INDEX.toString();
-
-    @AssertTrue(message = "action must be either one of index, create, update, upsert, delete, " +
-            "or using data prepper expression.")
-    boolean isActionValid() {
-        return (action != null && action.contains("${")) ||
-                Set.of(OpenSearchBulkActions.values()).contains(action);
-    }
 
     @Getter
     @Valid

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -45,7 +45,7 @@ public class OpenSearchSinkConfigurationTests {
         assertEquals(OpenSearchBulkActions.INDEX.toString(), openSearchSinkConfiguration.getIndexConfiguration().getAction());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidAction() throws IOException {
         OpenSearchSinkConfiguration.readOSConfig(generateOpenSearchSinkConfig(INVALID_ACTION_CONFIG));
     }
@@ -56,7 +56,7 @@ public class OpenSearchSinkConfigurationTests {
 
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidActionWithExpression() throws IOException {
         expressionEvaluator = mock(ExpressionEvaluator.class);
         when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(false);


### PR DESCRIPTION
### Description
This PR fixes the opensearchBulkAction validation to allow data prepper expression
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
