### PR TITLE
Adding array data types for rds

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/ColumnType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/ColumnType.java
@@ -10,59 +10,143 @@
 
 package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres;
 
+import org.postgresql.core.Oid;
 import java.util.HashMap;
 import java.util.Map;
 
 public enum ColumnType {
-    BOOLEAN(16, "bool"),
-    SMALLINT(21, "int2"),
-    INTEGER(23, "int4"),
-    BIGINT(20, "int8"),
-    REAL(700, "float4"),
-    DOUBLE_PRECISION(701, "float8"),
-    NUMERIC(1700, "numeric"),
-    TEXT(25, "text"),
-    BPCHAR(1042, "bpchar"),
-    VARCHAR(1043, "varchar"),
-    DATE(1082, "date"),
-    TIME(1083, "time"),
-    TIMETZ(1266, "timetz"),
-    TIMESTAMP(1114, "timestamp"),
-    TIMESTAMPTZ(1184, "timestamptz"),
-    INTERVAL(1186, "interval"),
-    JSON(114, "json"),
-    JSONB(3802, "jsonb"),
+    BOOLEAN(Oid.BOOL, "bool"),
+    SMALLINT(Oid.INT2, "int2"),
+    INTEGER(Oid.INT4, "int4"),
+    BIGINT(Oid.INT8, "int8"),
+    REAL(Oid.FLOAT4, "float4"),
+    DOUBLE_PRECISION(Oid.FLOAT8, "float8"),
+    NUMERIC(Oid.NUMERIC, "numeric"),
+
+    TEXT(Oid.TEXT, "text"),
+    BPCHAR(Oid.BPCHAR, "bpchar"),
+    VARCHAR(Oid.VARCHAR, "varchar"),
+
+    DATE(Oid.DATE, "date"),
+    TIME(Oid.TIME, "time"),
+    TIMETZ(Oid.TIMETZ, "timetz"),
+    TIMESTAMP(Oid.TIMESTAMP, "timestamp"),
+    TIMESTAMPTZ(Oid.TIMESTAMPTZ, "timestamptz"),
+    INTERVAL(Oid.INTERVAL, "interval"),
+
+    JSON(Oid.JSON, "json"),
+    JSONB(Oid.JSONB, "jsonb"),
     JSONPATH(4072, "jsonpath"),
-    MONEY(790,"money"),
-    BIT(1560, "bit"),
-    VARBIT(1562, "varbit"),
-    POINT(600,"point"),
-    LINE(628,"line"),
-    LSEG(601,"lseg"),
-    BOX(603, "box"),
-    PATH(602, "path"),
-    POLYGON(604, "polygon"),
-    CIRCLE(718, "circle"),
-    CIDR(650, "cidr"),
-    INET(869, "inet"),
-    MACADDR(829, "macaddr"),
-    MACADDR8(774, "macaddr8"),
-    XML(142, "xml"),
-    UUID(2950, "uuid"),
+
+    MONEY(Oid.MONEY,"money"),
+
+    BIT(Oid.BIT, "bit"),
+    VARBIT(Oid.VARBIT, "varbit"),
+
+    POINT(Oid.POINT,"point"),
+    LINE(Oid.LINE,"line"),
+    LSEG(Oid.LSEG,"lseg"),
+    BOX(Oid.BOX, "box"),
+    PATH(Oid.PATH, "path"),
+    POLYGON(Oid.POLYGON, "polygon"),
+    CIRCLE(Oid.CIRCLE, "circle"),
+
+    CIDR(Oid.CIDR, "cidr"),
+    INET(Oid.INET, "inet"),
+    MACADDR(Oid.MACADDR, "macaddr"),
+    MACADDR8(Oid.MACADDR8, "macaddr8"),
+
+    XML(Oid.XML, "xml"),
+    UUID(Oid.UUID, "uuid"),
     PG_LSN(3220, "pg_lsn"),
     PG_SNAPSHOT(5038, "pg_snapshot"),
     TXID_SNAPSHOT(2970, "txid_snapshot"),
-    TSVECTOR(3614, "tsvector"),
-    TSQUERY(3615, "tsquery"),
-    BYTEA(17, "bytea"),
+    TSVECTOR(Oid.TSVECTOR, "tsvector"),
+    TSQUERY(Oid.TSQUERY, "tsquery"),
+
+    BYTEA(Oid.BYTEA, "bytea"),
+
     INT4RANGE(3904, "int4range"),
     INT8RANGE(3926, "int8range"),
     TSRANGE(3908, "tsrange"),
     TSTZRANGE(3910, "tstzrange"),
     DATERANGE(3912, "daterange"),
-    ENUM(-1,"enum");
+    NUMRANGE(3906, "numrange"),
+    INT4MULTIRANGE(4451, "int4multirange"),
+    INT8MULTIRANGE(4536, "int8multirange"),
+    NUMMULTIRANGE(4532, "nummultirange"),
+    DATEMULTIRANGE(4535, "datemultirange"),
+    TSMULTIRANGE(4533, "tsmultirange"),
+    TSTZMULTIRANGE(4534, "tstzmultirange"),
+
+    INT2ARRAY(Oid.INT2_ARRAY,"_int2"),
+    INT4ARRAY(Oid.INT4_ARRAY, "_int4"),
+    INT8ARRAY(Oid.INT8_ARRAY, "_int8"),
+    NUMERICARRAY(Oid.NUMERIC_ARRAY, "_numeric"),
+    FLOAT4ARRAY(Oid.FLOAT4_ARRAY, "_float4"),
+    FLOAT8ARRAY(Oid.FLOAT8_ARRAY, "_float8"),
+    MONEYARRAY(Oid.MONEY_ARRAY, "_money"),
+
+    TEXTARRAY(Oid.TEXT_ARRAY, "_text"),
+    BPCHARARRAY(Oid.BPCHAR_ARRAY, "_bpchar"),
+    VARCHARARRAY(Oid.VARCHAR_ARRAY, "_varchar"),
+
+    BITARRAY(Oid.BIT_ARRAY, "_bit"),
+    VARBITARRAY(Oid.VARBIT_ARRAY, "_varbit"),
+
+    BOOLARRAY(Oid.BOOL_ARRAY, "_bool"),
+
+    BYTEAARRAY(Oid.BYTEA_ARRAY, "_bytea"),
+
+    DATEARRAY(Oid.DATE_ARRAY, "_date"),
+    TIMEARRAY(Oid.TIME_ARRAY, "_time"),
+    TIMETZARRAY(Oid.TIMETZ_ARRAY, "_timetz"),
+    TIMESTAMPARRAY(Oid.TIMESTAMP_ARRAY, "_timestamp"),
+    TIMESTAMPTZARRAY(Oid.TIMESTAMPTZ_ARRAY, "_timestamptz"),
+    INTERVALARRAY(Oid.INTERVAL_ARRAY, "_interval"),
+
+    POINTARRAY(Oid.POINT_ARRAY, "_point"),
+    LINEARRAY(629, "_line"),
+    LSEGARRAY(1018, "_lseg"),
+    BOXARRAY(Oid.BOX_ARRAY, "_box"),
+    PATHARRAY(1019, "_path"),
+    POLYGONARRAY(1027, "_polygon"),
+    CIRCLEARRAY(719, "_circle"),
+
+    JSONARRAY(Oid.JSON_ARRAY, "_json"),
+    JSONBARRAY(Oid.JSONB_ARRAY, "_jsonb"),
+
+    CIDRARRAY(651, "_cidr"),
+    INETARRAY(1041, "_inet"),
+    MACADDRARRAY(1040, "_macaddr"),
+    MACADDR8ARRAY(775, "_macaddr8"),
+
+    UUIDARRAY(Oid.UUID_ARRAY, "_uuid"),
+    XMLARRAY(Oid.XML_ARRAY, "_xml"),
+    TSVECTORARRAY(3643, "_tsvector"),
+    TSQUERYARRAY(3645, "_tsquery"),
+    PG_LSNARRAY(3221, "_pg_lsn"),
+    PG_SNAPSHOTARRAY(5039, "_pg_snapshot"),
+    TXID_SNAPSHOTARRAY(2949, "_txid_snapshot"),
+
+    NUMRANGEARRAY(3907, "_numrange"),
+    INT4RANGEARRAY(3905, "_int4range"),
+    INT8RANGEARRAY(3927, "_int8range"),
+    TSRANGEARRAY(3909, "_tsrange"),
+    TSTZRANGEARRAY(3911, "_tstzrange"),
+    DATERANGEARRAY(3913, "_daterange"),
+    INT4MULTIRANGEARRAY(6150, "_int4multirange"),
+    INT8MULTIRANGEARRAY(6157, "_int8multirange"),
+    NUMMULTIRANGEARRAY(6151, "_nummultirange"),
+    DATEMULTIRANGEARRAY(6155, "_datemultirange"),
+    TSMULTIRANGEARRAY(6152, "_tsmultirange"),
+    TSTZMULTIRANGEARRAY(6153, "_tstzmultirange"),
+
+    ENUM(-1,"enum"),
+    UNKNOWN(-2,"unknown");
 
     public static final int ENUM_TYPE_ID = -1;
+    public static final int UNKNOWN_TYPE_ID = -2;
     private final int typeId;
     private final String typeName;
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataType.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/PostgresDataType.java
@@ -1,81 +1,162 @@
 package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public enum PostgresDataType {
     // Numeric types
-    SMALLINT("int2", DataCategory.NUMERIC),
-    INTEGER("int4", DataCategory.NUMERIC),
-    BIGINT("int8", DataCategory.NUMERIC),
-    SMALLSERIAL("smallserial", DataCategory.NUMERIC),
-    SERIAL("serial", DataCategory.NUMERIC),
-    BIGSERIAL("bigserial", DataCategory.NUMERIC),
-    REAL("float4", DataCategory.NUMERIC),
-    DOUBLE_PRECISION("float8", DataCategory.NUMERIC),
-    NUMERIC("numeric", DataCategory.NUMERIC),
-    MONEY("money", DataCategory.NUMERIC),
+    SMALLINT("int2", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    INTEGER("int4", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    BIGINT("int8", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    SMALLSERIAL("smallserial", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    SERIAL("serial", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    BIGSERIAL("bigserial", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    REAL("float4", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    DOUBLE_PRECISION("float8", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    NUMERIC("numeric", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    MONEY("money", DataCategory.NUMERIC, DataSubCategory.SCALAR),
+    INT2ARRAY("_int2", DataCategory.NUMERIC, DataSubCategory.ARRAY),
+    INT4ARRAY("_int4", DataCategory.NUMERIC, DataSubCategory.ARRAY),
+    INT8ARRAY("_int8", DataCategory.NUMERIC, DataSubCategory.ARRAY),
+    FLOAT4ARRAY("_float4", DataCategory.NUMERIC, DataSubCategory.ARRAY),
+    FLOAT8ARRAY("_float8", DataCategory.NUMERIC, DataSubCategory.ARRAY),
+    NUMERICARRAY("_numeric", DataCategory.NUMERIC, DataSubCategory.ARRAY),
+    MONEYARRAY("_money", DataCategory.NUMERIC, DataSubCategory.ARRAY),
 
     //String Data types
-    TEXT("text", DataCategory.STRING),
-    VARCHAR("varchar", DataCategory.STRING),
-    BPCHAR("bpchar", DataCategory.STRING),
+    TEXT("text", DataCategory.STRING, DataSubCategory.SCALAR),
+    VARCHAR("varchar", DataCategory.STRING, DataSubCategory.SCALAR),
+    BPCHAR("bpchar", DataCategory.STRING, DataSubCategory.SCALAR),
+    TEXTARRAY("_text", DataCategory.STRING, DataSubCategory.ARRAY),
+    VARCHARARRAY("_varchar", DataCategory.STRING, DataSubCategory.ARRAY),
+    BPCHARARRAY("_bpchar", DataCategory.STRING, DataSubCategory.ARRAY),
     ENUM("enum", DataCategory.STRING),
 
     //Bit String Data type
-    BIT("bit",DataCategory.BIT_STRING),
-    VARBIT("varbit", DataCategory.BIT_STRING),
+    BIT("bit",DataCategory.BIT_STRING, DataSubCategory.SCALAR),
+    VARBIT("varbit", DataCategory.BIT_STRING, DataSubCategory.SCALAR),
+    BITARRAY("_bit", DataCategory.BIT_STRING, DataSubCategory.ARRAY),
+    VARBITARRAY("_varbit", DataCategory.BIT_STRING, DataSubCategory.ARRAY),
 
     //Json Data type
-    JSON("json",DataCategory.JSON),
-    JSONB("jsonb",DataCategory.JSON),
-    JSONPATH("jsonpath", DataCategory.JSON),
+    JSON("json",DataCategory.JSON, DataSubCategory.SCALAR),
+    JSONB("jsonb",DataCategory.JSON, DataSubCategory.SCALAR),
+    JSONPATH("jsonpath", DataCategory.JSON, DataSubCategory.SCALAR),
+    JSONARRAY("_json", DataCategory.JSON, DataSubCategory.ARRAY),
+    JSONBARRAY("_jsonb", DataCategory.JSON, DataSubCategory.ARRAY),
 
     //Boolean data type
-    BOOLEAN("bool", DataCategory.BOOLEAN),
+    BOOLEAN("bool", DataCategory.BOOLEAN, DataSubCategory.SCALAR),
+    BOOLEANARRAY("_bool", DataCategory.BOOLEAN, DataSubCategory.ARRAY),
 
     //Date-time data types
-    DATE("date", DataCategory.TEMPORAL),
-    TIME("time",DataCategory.TEMPORAL),
-    TIMETZ("timetz",DataCategory.TEMPORAL),
-    TIMESTAMP("timestamp",DataCategory.TEMPORAL),
-    TIMESTAMPTZ("timestamptz",DataCategory.TEMPORAL),
-    INTERVAL("interval", DataCategory.TEMPORAL),
+    DATE("date", DataCategory.TEMPORAL, DataSubCategory.SCALAR),
+    TIME("time",DataCategory.TEMPORAL, DataSubCategory.SCALAR),
+    TIMETZ("timetz",DataCategory.TEMPORAL, DataSubCategory.SCALAR),
+    TIMESTAMP("timestamp",DataCategory.TEMPORAL, DataSubCategory.SCALAR),
+    TIMESTAMPTZ("timestamptz",DataCategory.TEMPORAL, DataSubCategory.SCALAR),
+    INTERVAL("interval", DataCategory.TEMPORAL, DataSubCategory.SCALAR),
+    DATEARRAY("_date", DataCategory.TEMPORAL, DataSubCategory.ARRAY),
+    TIMEARRAY("_time", DataCategory.TEMPORAL, DataSubCategory.ARRAY),
+    TIMETZARRAY("_timetz", DataCategory.TEMPORAL, DataSubCategory.ARRAY),
+    TIMESTAMPARRAY("_timestamp", DataCategory.TEMPORAL, DataSubCategory.ARRAY),
+    TIMESTAMPTZARRAY("_timestamptz", DataCategory.TEMPORAL, DataSubCategory.ARRAY),
+    INTERVALARRAY("_interval", DataCategory.TEMPORAL, DataSubCategory.ARRAY),
 
     //Spatial Data types
-    POINT("point", DataCategory.SPATIAL),
-    LINE("line", DataCategory.SPATIAL),
-    LSEG("lseg", DataCategory.SPATIAL),
-    BOX("box", DataCategory.SPATIAL),
-    PATH("path", DataCategory.SPATIAL),
-    POLYGON("polygon", DataCategory.SPATIAL),
-    CIRCLE("circle", DataCategory.SPATIAL),
+    POINT("point", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    LINE("line", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    LSEG("lseg", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    BOX("box", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    PATH("path", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    POLYGON("polygon", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    CIRCLE("circle", DataCategory.SPATIAL, DataSubCategory.SCALAR),
+    POINTARRAY("_point", DataCategory.SPATIAL, DataSubCategory.ARRAY),
+    LINEARRAY("_line", DataCategory.SPATIAL, DataSubCategory.ARRAY),
+    LSEGARRAY("_lseg", DataCategory.SPATIAL, DataSubCategory.ARRAY),
+    BOXARRAY("_box", DataCategory.SPATIAL, DataSubCategory.ARRAY),
+    PATHARRAY("_path", DataCategory.SPATIAL, DataSubCategory.ARRAY),
+    POLYGONARRAY("_polygon", DataCategory.SPATIAL, DataSubCategory.ARRAY),
+    CIRCLEARRAY("_circle", DataCategory.SPATIAL, DataSubCategory.ARRAY),
 
     //Network Address Data types
-    CIDR("cidr", DataCategory.NETWORK_ADDRESS),
-    INET("inet", DataCategory.NETWORK_ADDRESS),
-    MACADDR("macaddr", DataCategory.NETWORK_ADDRESS),
-    MACADDR8("macaddr8", DataCategory.NETWORK_ADDRESS),
+    CIDR("cidr", DataCategory.NETWORK_ADDRESS, DataSubCategory.SCALAR),
+    INET("inet", DataCategory.NETWORK_ADDRESS, DataSubCategory.SCALAR),
+    MACADDR("macaddr", DataCategory.NETWORK_ADDRESS, DataSubCategory.SCALAR),
+    MACADDR8("macaddr8", DataCategory.NETWORK_ADDRESS, DataSubCategory.SCALAR),
+    CIDRARRAY("_cidr", DataCategory.NETWORK_ADDRESS, DataSubCategory.ARRAY),
+    INETARRAY("_inet", DataCategory.NETWORK_ADDRESS, DataSubCategory.ARRAY),
+    MACADDRARRAY("_macaddr", DataCategory.NETWORK_ADDRESS, DataSubCategory.ARRAY),
+    MACADDR8ARRAY("_macaddr8", DataCategory.NETWORK_ADDRESS, DataSubCategory.ARRAY),
 
     //Special Data types
-    UUID( "uuid",DataCategory.SPECIAL),
-    XML("xml", DataCategory.SPECIAL),
-    PG_LSN("pg_lsn", DataCategory.SPECIAL),
-    TSVECTOR("tsvector", DataCategory.SPECIAL),
-    TSQUERY("tsquery", DataCategory.SPECIAL),
-    PG_SNAPSHOT("pg_snapshot", DataCategory.SPECIAL),
-    TXID_SNAPSHOT("txid_snapshot", DataCategory.SPECIAL),
+    UUID( "uuid",DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    XML("xml", DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    PG_LSN("pg_lsn", DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    TSVECTOR("tsvector", DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    TSQUERY("tsquery", DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    PG_SNAPSHOT("pg_snapshot", DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    TXID_SNAPSHOT("txid_snapshot", DataCategory.SPECIAL, DataSubCategory.SCALAR),
+    UUIDARRAY("_uuid", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    XMLARRAY("_xml", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    PG_LSNARRAY("_pg_lsn", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    TSVECTORARRAY("_tsvector", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    TSQUERYARRAY("_tsquery", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    PG_SNAPSHOTARRAY("_pg_snapshot", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    TXID_SNAPSHOTARRAY("_txid_snapshot", DataCategory.SPECIAL, DataSubCategory.ARRAY),
+    UNKNOWN("unknown", DataCategory.SPECIAL),
 
-    INT4RANGE("int4range", DataCategory.RANGE),
-    INT8RANGE("int8range", DataCategory.RANGE),
-    TSRANGE("tsrange", DataCategory.RANGE),
-    TSTZRANGE("tstzrange", DataCategory.RANGE),
-    DATERANGE("daterange", DataCategory.RANGE),
+    INT4RANGE("int4range", DataCategory.RANGE, DataSubCategory.SCALAR),
+    INT8RANGE("int8range", DataCategory.RANGE, DataSubCategory.SCALAR),
+    NUMRANGE("numrange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    TSRANGE("tsrange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    TSTZRANGE("tstzrange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    DATERANGE("daterange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    INT4MULTIRANGE("int4multirange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    INT8MULTIRANGE("int8multirange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    NUMMULTIRANGE("nummultirange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    DATEMULTIRANGE("datemultirange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    TSMULTIRANGE("tsmultirange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    TSTZMULTIRANGE("tstzmultirange", DataCategory.RANGE, DataSubCategory.SCALAR),
+    NUMRANGEARRAY( "_numrange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    INT4RANGEARRAY("_int4range", DataCategory.RANGE, DataSubCategory.ARRAY),
+    INT8RANGEARRAY("_int8range", DataCategory.RANGE, DataSubCategory.ARRAY),
+    TSRANGEARRAY("_tsrange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    TSTZRANGEARRAY("_tstzrange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    DATERANGEARRAY("_daterange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    INT4MULTIRANGEARRAY("_int4multirange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    INT8MULTIRANGEARRAY("_int8multirange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    NUMMULTIRANGEARRAY("_nummultirange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    DATEMULTIRANGEARRAY("_datemultirange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    TSMULTIRANGEARRAY("_tsmultirange", DataCategory.RANGE, DataSubCategory.ARRAY),
+    TSTZMULTIRANGEARRAY("_tstzmultirange", DataCategory.RANGE, DataSubCategory.ARRAY),
 
     //Binary data type
-    BYTEA("bytea", DataCategory.BINARY);
+    BYTEA("bytea", DataCategory.BINARY, DataSubCategory.SCALAR),
+    BYTEAARRAY("_bytea", DataCategory.BINARY, DataSubCategory.ARRAY);
 
     private static final Map<String, PostgresDataType> TYPE_MAP;
+
+    private static final Map<PostgresDataType, PostgresDataType> ARRAY_TO_SCALAR_MAP;
+
+    static {
+        ARRAY_TO_SCALAR_MAP = new HashMap<>();
+        for (PostgresDataType type : PostgresDataType.values()) {
+            if (type.getSubCategory() == DataSubCategory.ARRAY) {
+                String scalarTypeName = type.getDataType().substring(1);
+                try {
+                    PostgresDataType scalarType = Arrays.stream(PostgresDataType.values())
+                            .filter(t -> t.getDataType().equals(scalarTypeName))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("No matching scalar type found for " + type.name()));
+                    ARRAY_TO_SCALAR_MAP.put(type, scalarType);
+                } catch (IllegalArgumentException e) {
+                    ARRAY_TO_SCALAR_MAP.put(type, PostgresDataType.UNKNOWN);
+                }
+            }
+        }
+    }
 
     static {
         TYPE_MAP = new HashMap<>(values().length);
@@ -86,11 +167,20 @@ public enum PostgresDataType {
 
     private final String dataType;
     private final DataCategory category;
+    private final DataSubCategory subCategory;
 
     PostgresDataType(String dataType, DataCategory category) {
         this.dataType = dataType;
         this.category = category;
+        this.subCategory = null;
     }
+
+    PostgresDataType(String dataType, DataCategory category, DataSubCategory subCategory ) {
+        this.dataType = dataType;
+        this.category = category;
+        this.subCategory = subCategory;
+    }
+
 
     public String getDataType() {
         return dataType;
@@ -100,13 +190,21 @@ public enum PostgresDataType {
         return category;
     }
 
+    public DataSubCategory getSubCategory() {
+        return subCategory;
+    }
+
 
     public static PostgresDataType byDataType(final String dataType) {
-        final PostgresDataType type = TYPE_MAP.get(dataType.toLowerCase());
+        PostgresDataType type = TYPE_MAP.get(dataType.toLowerCase());
         if (type == null) {
-            throw new IllegalArgumentException("Unsupported PostgresDataType data type: " + dataType);
+            type = PostgresDataType.UNKNOWN;
         }
         return type;
+    }
+
+    public static PostgresDataType getScalarType(PostgresDataType arrayType) {
+        return ARRAY_TO_SCALAR_MAP.get(arrayType);
     }
 
     public enum DataCategory {
@@ -122,6 +220,12 @@ public enum PostgresDataType {
         BINARY,
         RANGE
     }
+
+    public enum DataSubCategory {
+        SCALAR,
+        ARRAY
+    }
+
 
 
     public boolean isNumeric() {
@@ -169,5 +273,8 @@ public enum PostgresDataType {
         return category == DataCategory.RANGE;
     }
 
+    public boolean isSubCategoryArray() {
+        return subCategory == DataSubCategory.ARRAY;
+    }
 }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -15,6 +16,13 @@ public class BinaryTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isBinary()) {
             throw new IllegalArgumentException("ColumnType is not Binary : " + columnType);
         }
+       if(columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseBinaryValue);
+       return parseBinaryValue(columnType, value);
+    }
+
+    private Object parseBinaryValue(PostgresDataType columnType, Object value) {
         if (value instanceof Map) {
             Object data = ((Map<?, ?>)value).get(BYTES_KEY);
             byte[] bytes = ((String) data).getBytes(StandardCharsets.ISO_8859_1);
@@ -22,5 +30,4 @@ public class BinaryTypeHandler implements PostgresDataTypeHandler {
         }
         return value.toString();
     }
-
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BitStringTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BitStringTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 import java.math.BigInteger;
 
@@ -11,6 +12,15 @@ public class BitStringTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isBitString()) {
             throw new IllegalArgumentException("ColumnType is not Bit String: " + columnType);
         }
-        return new BigInteger(value.toString(), 2);
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseBitString);
+        return parseBitString(columnType, value.toString());
     }
+
+    private Object parseBitString(PostgresDataType columnType, String textValue) {
+        if (textValue.isEmpty()) return null;
+        return new BigInteger(textValue, 2);
+    }
+
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 public class BooleanTypeHandler implements PostgresDataTypeHandler {
     @Override
@@ -9,7 +10,13 @@ public class BooleanTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isBoolean()) {
             throw new IllegalArgumentException("ColumnType is not Boolean: " + columnType);
         }
-        final String booleanValue = value.toString();
-        return booleanValue.equals("t") || booleanValue.equals("true") ? Boolean.TRUE : Boolean.FALSE;
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseBooleanValue);
+        return parseBooleanValue(columnType, value.toString());
+    }
+
+    private Object parseBooleanValue(PostgresDataType columnType, String textValue) {
+        return textValue.equals("t") || textValue.equals("true") ? Boolean.TRUE : Boolean.FALSE;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/JsonTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/JsonTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 public class JsonTypeHandler implements PostgresDataTypeHandler {
     @Override
@@ -9,6 +10,14 @@ public class JsonTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isJson()) {
             throw new IllegalArgumentException("ColumnType is not Json: " + columnType);
         }
-        return value.toString();
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseJsonValue);
+        return parseJsonValue(columnType, value.toString());
     }
+
+    private Object parseJsonValue(PostgresDataType columnType, String textValue) {
+        return textValue;
+    }
+
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NetworkAddressTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NetworkAddressTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 public class NetworkAddressTypeHandler implements PostgresDataTypeHandler {
     @Override
@@ -9,6 +10,13 @@ public class NetworkAddressTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isNetworkAddress()) {
             throw new IllegalArgumentException("ColumnType is not Network Address: " + columnType);
         }
-        return value.toString();
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseNetworkAddressValue);
+        return parseNetworkAddressValue(columnType, value.toString());
+    }
+
+    private Object parseNetworkAddressValue(PostgresDataType columnType, String textValue) {
+        return textValue;
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NumericTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NumericTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 import org.postgresql.util.PGmoney;
 
 import java.sql.SQLException;
@@ -10,11 +11,19 @@ import java.util.Map;
 
 
 public class NumericTypeHandler implements PostgresDataTypeHandler {
+
+    private static final String NAN = "nan";
+    private static final String INFINITY = "infinity";
+    private static final String NEGATIVE_INFINITY = "-infinity";
+
     @Override
     public Object handle(PostgresDataType columnType, String columnName, Object value) {
         if (!columnType.isNumeric()) {
             throw new IllegalArgumentException("ColumnType is not numeric: " + columnType);
         }
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseNumericValue);
         return parseNumericValue(columnType, value.toString());
     }
 
@@ -30,15 +39,41 @@ public class NumericTypeHandler implements PostgresDataTypeHandler {
             case BIGSERIAL:
                 return Long.parseLong(textValue);
             case REAL:
-                return Float.parseFloat(textValue);
+                return parseRealValue(textValue);
             case DOUBLE_PRECISION:
-                return Double.parseDouble(textValue);
+                return parseDoublePrecisionValue(textValue);
             case NUMERIC:
                 return textValue;
             case MONEY:
                 return parseMoney(textValue);
             default:
-                throw new IllegalArgumentException("Unsupported numeric type: " + columnType);
+                return textValue;
+        }
+    }
+
+    private Object parseRealValue(String textValue) {
+        switch (textValue.toLowerCase()) {
+            case NAN:
+                return Float.NaN;
+            case INFINITY:
+                return Float.POSITIVE_INFINITY;
+            case NEGATIVE_INFINITY:
+                return Float.NEGATIVE_INFINITY;
+            default:
+                return Float.parseFloat(textValue);
+        }
+    }
+
+    private Object parseDoublePrecisionValue(String textValue) {
+        switch (textValue.toLowerCase()) {
+            case NAN:
+                return Double.NaN;
+            case INFINITY:
+                return Double.POSITIVE_INFINITY;
+            case NEGATIVE_INFINITY:
+                return Double.NEGATIVE_INFINITY;
+            default:
+                return Double.parseDouble(textValue);
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpatialTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpatialTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 import org.postgresql.geometric.PGbox;
 import org.postgresql.geometric.PGcircle;
 import org.postgresql.geometric.PGline;
@@ -20,37 +21,30 @@ public class SpatialTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isSpatial()) {
             throw new IllegalArgumentException("ColumnType is not spatial: " + columnType);
         }
-        final String val = value.toString();
-        final String dataType = columnType.getDataType();
-        return parseGeometry(val, columnName, dataType);
+        if(columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseGeometry);
+        return parseGeometry(columnType, value.toString());
     }
 
-    private Object parseGeometry(final String val, final String columnName, final String dataType) {
-        try {
-            return parseGeometry(val, dataType);
-        } catch (Exception e) {
-            throw new RuntimeException("Error processing the geometry data type value for columnName: " + columnName, e);
-        }
-    }
-
-    private Object parseGeometry(final String val, final String dataType) {
-        switch (dataType) {
-            case "point":
+    private Object parseGeometry(final PostgresDataType columnType, final String val) {
+        switch (columnType) {
+            case POINT:
                 return parsePoint(val);
-            case "line":
+            case LINE:
                 return parseLine(val);
-            case "lseg":
+            case LSEG:
                 return parseLseg(val);
-            case "box":
+            case BOX:
                 return parseBox(val);
-            case "path":
+            case PATH:
                 return parsePath(val);
-            case "polygon":
+            case POLYGON:
                 return parsePolygon(val);
-            case "circle":
+            case CIRCLE:
                 return parseCircle(val);
             default:
-                throw new IllegalArgumentException("Unsupported spatial data type: " + dataType);
+                return val;
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpecialTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpecialTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 
 public class SpecialTypeHandler implements PostgresDataTypeHandler {
@@ -10,7 +11,14 @@ public class SpecialTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isSpecial()) {
             throw new IllegalArgumentException("ColumnType is not special: " + columnType);
         }
-        return value.toString();
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseSpecialValue);
+        return parseSpecialValue(columnType, value.toString());
+    }
+
+    private Object parseSpecialValue(PostgresDataType columnType, String textValue) {
+        return textValue;
     }
 
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/StringTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/StringTypeHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataTypeHandler;
+import org.opensearch.dataprepper.plugins.source.rds.utils.PgArrayParser;
 
 public class StringTypeHandler implements PostgresDataTypeHandler {
     @Override
@@ -9,6 +10,14 @@ public class StringTypeHandler implements PostgresDataTypeHandler {
         if (!columnType.isString()) {
             throw new IllegalArgumentException("ColumnType is not string: " + columnType);
         }
-        return value.toString();
+        if (columnType.isSubCategoryArray())
+            return PgArrayParser.parseTypedArray(value.toString(), PostgresDataType.getScalarType(columnType),
+                    this::parseStringValue);
+        return parseStringValue(columnType, value.toString());
     }
+
+    private Object parseStringValue(PostgresDataType columnType, String textValue) {
+        return textValue;
+    }
+
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
@@ -244,7 +244,9 @@ public class LogicalReplicationEventProcessor {
                 final Set<String> enumColumns = getEnumColumns(databaseName, schemaName, tableName);
                 if (enumColumns != null && enumColumns.contains(columnName)) {
                     columnType = ColumnType.getByTypeId(ColumnType.ENUM_TYPE_ID);
-                } else throw e;
+                } else {
+                    columnType = ColumnType.UNKNOWN;
+                }
             }
             String columnTypeName = columnType.getTypeName();
             columnTypes.add(columnTypeName);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/PgArrayParser.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/PgArrayParser.java
@@ -1,0 +1,151 @@
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PgArrayParser {
+
+    public static Object parseTypedArray(String arrayString, PostgresDataType elementType, ValueParser valueParser) {
+        char delimiter = getDelimiterForType(elementType);
+        Object parsed = PgArrayParser.parseRawArray(arrayString, delimiter);
+        if (parsed instanceof List) {
+            List<Object> parsedList = (List<Object>) parsed;
+            List<Object> answer = parsedList.stream()
+                    .map(element -> parseTypedArrayElement(element, elementType, valueParser))
+                    .collect(Collectors.toList());
+            return answer;
+        } else {
+            throw new IllegalArgumentException("Unexpected structure from PgArrayParser");
+        }
+    }
+
+    private static char getDelimiterForType(PostgresDataType elementType) {
+        return elementType == PostgresDataType.BOX ? ';' : ',';
+    }
+
+    private static Object parseTypedArrayElement(Object arrayElement, PostgresDataType elementType, ValueParser valueParser) {
+        if (arrayElement == null) {
+            return null;
+        } else if (arrayElement instanceof List) {
+            List<Object> nestedArray = (List<Object>) arrayElement;
+            return nestedArray.stream()
+                    .map(element -> parseTypedArrayElement(element, elementType, valueParser))
+                    .collect(Collectors.toList());
+        } else {
+            return valueParser.parse(elementType, arrayElement.toString());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ValueParser {
+        Object parse(PostgresDataType elementType, String value);
+    }
+
+    public static List<Object> parseRawArray(String arrayString, char delimiter) {
+        if (arrayString == null) {
+            return null;
+        }
+        return parseArrayString(arrayString, delimiter);
+    }
+
+    private static List<Object> parseArrayString(String arrayString, char delimiter) {
+        if (arrayString == null || arrayString.isEmpty()) {
+            return new ArrayList<>();
+        }
+        if (arrayString.charAt(0) != '{' || arrayString.charAt(arrayString.length() - 1) != '}') {
+            throw new IllegalArgumentException("Array string must start and end with curly braces.");
+        }
+
+        return parseArrayElements(arrayString, 1, arrayString.length() - 1, delimiter);
+    }
+
+    private static List<Object> parseArrayElements(String arrayString, int offset, int end, char delimiter) {
+        List<Object> result = new ArrayList<>();
+        StringBuilder currentElement = new StringBuilder();
+        boolean inQuotes = false;
+        int nestedLevel = 0;
+        boolean escaped = false;
+
+        for (int i = offset; i <= end; i++) {
+            char c = (i < end) ? arrayString.charAt(i) : '\0'; // Use '\0' as a sentinel for the end
+
+            if (escaped) {
+                currentElement.append(c);
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\') {
+                escaped = true;
+                currentElement.append(c);
+                continue;
+            }
+
+            if (c == '"') {
+                if (!inQuotes) {
+                    inQuotes = true;
+                } else if (i + 1 < end && (arrayString.charAt(i + 1) == delimiter)) {
+                    inQuotes = false;
+                }
+                currentElement.append(c);
+                continue;
+            }
+
+            if (!inQuotes) {
+                nestedLevel = updateNestedLevel(c, nestedLevel);
+                if (isElementEnd(c, delimiter, nestedLevel) || c == '\0') {
+                    addElement(result, currentElement.toString().trim(), delimiter);
+                    currentElement.setLength(0);
+                    continue;
+                }
+            }
+            currentElement.append(c);
+        }
+
+        if (currentElement.length() > 0) {
+            addElement(result, currentElement.toString().trim(), delimiter);
+        }
+
+        return result;
+    }
+
+    private static int updateNestedLevel(char c, int nestedLevel) {
+        if (c == '{') return nestedLevel + 1;
+        if (c == '}') return nestedLevel - 1;
+        return nestedLevel;
+    }
+
+    private static boolean isElementEnd(char c, char delimiter, int nestedLevel) {
+        return c == delimiter && nestedLevel == 0;
+    }
+
+    private static void addElement(List<Object> result, String element, char delimiter){
+        if (element.isEmpty()) {
+            return;
+        }
+        if (element.equalsIgnoreCase("NULL")) {
+            result.add(null);
+        } else if (element.startsWith("{") && element.endsWith("}")) {
+            result.add(parseArrayElements(element, 1, element.length() - 1, delimiter));
+        } else {
+            result.add(unquoteString(element));
+        }
+    }
+
+    private static String unquoteString(String s) {
+        s = s.trim();
+        if (s.startsWith("\"") && s.endsWith("\"")) {
+            s = s.substring(1, s.length() - 1);
+            // Unescape any embedded escaped characters
+            s = s.replace("\\\\", "\\")
+                    .replace("\\\"", "\"")
+                    .replace("\\'", "'")
+                    .replace("\\,", ",");
+        }
+        return s;
+    }
+
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BinaryTypeHandlerTest.java
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BinaryTypeHandlerTest {
     private BinaryTypeHandler handler;
@@ -43,4 +45,29 @@ public class BinaryTypeHandlerTest {
         assertThat(result, is(instanceOf(String.class)));
         assertThat(result, is(expected));
     }
+
+    @Test
+    void test_handle_bytea_array() {
+        String columnName = "testColumn";
+        PostgresDataType columnType = PostgresDataType.BYTEAARRAY;
+        String value = "{\\xDEADBEEF,\\xCAFEBABE}";
+        Object result = handler.process(columnType, columnName, value);
+        assertThat(result, is(instanceOf(List.class)));
+        List<String> byteaList = (List<String>) result;
+        assertEquals(2, byteaList.size());
+        assertEquals("\\xDEADBEEF", byteaList.get(0));
+        assertEquals("\\xCAFEBABE", byteaList.get(1));
+    }
+
+    @Test
+    void test_handle_empty_bytea_array() {
+        String columnName = "testColumn";
+        PostgresDataType columnType = PostgresDataType.BYTEAARRAY;
+        String value = "{}";
+        Object result = handler.process(columnType, columnName, value);
+        assertThat(result, is(instanceOf(List.class)));
+        List<String> byteaList = (List<String>) result;
+        assertEquals(0, byteaList.size());
+    }
+
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BitStringTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BitStringTypeHandlerTest.java
@@ -8,15 +8,71 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BitStringTypeHandlerTest {
     private BitStringTypeHandler handler;
+
+    private static Stream<Arguments> provideBitTypeData() {
+        return Stream.of(
+                Arguments.of(PostgresDataType.BIT, "10101", BigInteger.valueOf(21)),
+                Arguments.of(PostgresDataType.VARBIT, "1010111", BigInteger.valueOf(87))
+        );
+    }
+
+    private static Stream<Arguments> provideBitAndVarBitArrayData() {
+        return Stream.of(
+                // BITARRAY cases
+                Arguments.of(
+                        PostgresDataType.BITARRAY,
+                        "bit_array_col",
+                        "{1010,1100,1111}",
+                        Arrays.asList(new BigInteger("1010", 2), new BigInteger("1100", 2), new BigInteger("1111", 2))
+                ),
+                Arguments.of(
+                        PostgresDataType.BITARRAY,
+                        "bit_array_col",
+                        "{}",
+                        Collections.emptyList()
+                ),
+                Arguments.of(
+                        PostgresDataType.BITARRAY,
+                        "bit_array_col",
+                        null,
+                        null
+                ),
+
+                // VARBITARRAY cases
+                Arguments.of(
+                        PostgresDataType.VARBITARRAY,
+                        "varbit_array_col",
+                        "{101010,11001100,111100001111}",
+                        Arrays.asList(new BigInteger("101010", 2), new BigInteger("11001100", 2), new BigInteger("111100001111", 2))
+                ),
+                Arguments.of(
+                        PostgresDataType.VARBITARRAY,
+                        "varbit_array_col",
+                        "{}",
+                        Collections.emptyList()
+                ),
+                Arguments.of(
+                        PostgresDataType.VARBITARRAY,
+                        "varbit_array_col",
+                        null,
+                        null
+                )
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -32,17 +88,27 @@ public class BitStringTypeHandlerTest {
         assertThat(result, is(expected));
     }
 
+    @ParameterizedTest
+    @MethodSource("provideBitAndVarBitArrayData")
+    public void test_handle_bit_and_varbit_array(final PostgresDataType postgresDataType, final String columnName, final String value, final List<BigInteger> expectedValue) {
+        Object result = handler.process(postgresDataType, columnName, value);
+
+        if (result != null) {
+            assertThat(result, instanceOf(List.class));
+            List<BigInteger> resultList = (List<BigInteger>) result;
+            assertEquals(expectedValue.size(), resultList.size());
+            for (int i = 0; i < expectedValue.size(); i++) {
+                assertEquals(expectedValue.get(i), resultList.get(i));
+            }
+        } else {
+            assertNull(expectedValue);
+        }
+    }
+
     @Test
     public void test_handleInvalidType() {
         assertThrows(IllegalArgumentException.class, () -> {
             handler.process(PostgresDataType.INTEGER, "invalid_col", 123);
         });
-    }
-
-    private static Stream<Arguments> provideBitTypeData() {
-        return Stream.of(
-                Arguments.of(PostgresDataType.BIT, "10101", BigInteger.valueOf(21)),
-                Arguments.of(PostgresDataType.VARBIT, "1010111",  BigInteger.valueOf(87))
-        );
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/BooleanTypeHandlerTest.java
@@ -8,15 +8,34 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BooleanTypeHandlerTest {
     private BooleanTypeHandler handler;
+
+    private static Stream<Arguments> provideBooleanArrayData() {
+        return Stream.of(
+                Arguments.of("{t,f,t}", Arrays.asList(true, false, true)),
+                Arguments.of("{true,false,true}", Arrays.asList(true, false, true)),
+                Arguments.of("{}", Collections.emptyList())
+        );
+    }
+
+    private static Stream<Arguments> provideTrueData() {
+        return Stream.of(
+                Arguments.of("t", Boolean.TRUE),
+                Arguments.of("true", Boolean.TRUE)
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -36,7 +55,8 @@ public class BooleanTypeHandlerTest {
         String value = "f";
         Object result = handler.process(PostgresDataType.BOOLEAN, "testColumn", value);
         assertThat(result, is(instanceOf(Boolean.class)));
-        assertThat(result, is(Boolean.FALSE));}
+        assertThat(result, is(Boolean.FALSE));
+    }
 
     @Test
     void test_handle_non_boolean_type() {
@@ -45,11 +65,20 @@ public class BooleanTypeHandlerTest {
         );
     }
 
-    private static Stream<Arguments> provideTrueData() {
-        return Stream.of(
-                Arguments.of("t", Boolean.TRUE),
-                Arguments.of("true",  Boolean.TRUE)
-        );
+    @ParameterizedTest
+    @MethodSource("provideBooleanArrayData")
+    void test_handle_boolean_array(String value, List<Boolean> expected) {
+        Object result = handler.process(PostgresDataType.BOOLEANARRAY, "testColumn", value);
+        assertThat(result, is(instanceOf(List.class)));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void test_handle_boolean_array_with_null_elements() {
+        String value = "{t,NULL,f}";
+        Object result = handler.process(PostgresDataType.BOOLEANARRAY, "testColumn", value);
+        assertThat(result, is(instanceOf(List.class)));
+        assertEquals(Arrays.asList(true, null, false), result);
     }
 
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/JsonTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/JsonTypeHandlerTest.java
@@ -3,16 +3,56 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class JsonTypeHandlerTest {
+public class
+JsonTypeHandlerTest {
     private JsonTypeHandler handler;
+
+    private static Stream<Arguments> provideJsonArrayData() {
+        return Stream.of(
+                // JSON array cases
+                Arguments.of(
+                        PostgresDataType.JSONARRAY,
+                        "{\"[{\"key\": \"value1\"}]\",\"[{\"key\": \"value2\"}]\"}",
+                        Arrays.asList("[{\"key\": \"value1\"}]", "[{\"key\": \"value2\"}]")
+                ),
+                Arguments.of(
+                        PostgresDataType.JSONARRAY,
+                        "{\"[1, 2, 3]\",\"[4, 5, 6]\"}",
+                        Arrays.asList("[1, 2, 3]", "[4, 5, 6]")
+                ),
+                Arguments.of(PostgresDataType.JSONARRAY, "{}", Collections.emptyList()),
+
+                // JSONB array cases
+                Arguments.of(
+                        PostgresDataType.JSONBARRAY,
+                        "{\"[{\"nested\": {\"array\": [1, 2, 3]}}]\",\"[{\"nested\": {\"array\": [4, 5, 6]}}]\"}",
+                        Arrays.asList("[{\"nested\": {\"array\": [1, 2, 3]}}]", "[{\"nested\": {\"array\": [4, 5, 6]}}]")
+                ),
+                Arguments.of(
+                        PostgresDataType.JSONBARRAY,
+                        "{\"[true, false]\",\"[null, \"string\"]\"}",
+                        Arrays.asList("[true, false]", "[null, \"string\"]")
+                ),
+                Arguments.of(PostgresDataType.JSONBARRAY, "{}", Collections.emptyList())
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -36,5 +76,25 @@ public class JsonTypeHandlerTest {
         assertThrows(IllegalArgumentException.class, () -> {
             handler.process(PostgresDataType.INTEGER, "invalid_col", 123);
         });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideJsonArrayData")
+    public void test_handle_json_array(PostgresDataType columnType, String value, List<String> expected) {
+        String columnName = "testColumn";
+        Object result = handler.process(columnType, columnName, value);
+
+        assertThat(result, is(instanceOf(List.class)));
+        List<String> resultList = (List<String>) result;
+        assertEquals(expected.size(), resultList.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i), resultList.get(i));
+        }
+    }
+
+    @Test
+    public void test_handle_null_json_array() {
+        assertNull(handler.process(PostgresDataType.JSONARRAY, "testColumn", null));
+        assertNull(handler.process(PostgresDataType.JSONBARRAY, "testColumn", null));
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NetworkAddressTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NetworkAddressTypeHandlerTest.java
@@ -3,21 +3,44 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NetworkAddressTypeHandlerTest {
     private NetworkAddressTypeHandler handler;
 
+    private static Stream<Arguments> provideNetworkAddressArrayData() {
+        return Stream.of(
+                Arguments.of(PostgresDataType.INETARRAY, "{192.168.0.1,2001:db8::1234}",
+                        Arrays.asList("192.168.0.1", "2001:db8::1234")),
+                Arguments.of(PostgresDataType.CIDRARRAY, "{192.168.0.0/24,2001:db8::/32}",
+                        Arrays.asList("192.168.0.0/24", "2001:db8::/32")),
+                Arguments.of(PostgresDataType.MACADDRARRAY, "{08:00:2b:01:02:03,01:23:45:67:89:ab}",
+                        Arrays.asList("08:00:2b:01:02:03", "01:23:45:67:89:ab")),
+                Arguments.of(PostgresDataType.MACADDR8ARRAY, "{08:00:2b:01:02:03:04:05,01:23:45:67:89:ab:cd:ef}",
+                        Arrays.asList("08:00:2b:01:02:03:04:05", "01:23:45:67:89:ab:cd:ef")),
+                Arguments.of(PostgresDataType.INETARRAY, "{}", Collections.emptyList())
+        );
+    }
+
     @BeforeEach
     void setUp() {
         handler = new NetworkAddressTypeHandler();
     }
+
     @ParameterizedTest
     @CsvSource({
             "INET, 192.168.0.1",
@@ -32,6 +55,22 @@ public class NetworkAddressTypeHandlerTest {
         Object result = handler.process(columnType, columnName, value);
         assertThat(result, is(instanceOf(String.class)));
         assertThat(result, is(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNetworkAddressArrayData")
+    void test_handle_network_address_array(PostgresDataType columnType, String value, List<String> expected) {
+        Object result = handler.process(columnType, "testColumn", value);
+        assertThat(result, is(instanceOf(List.class)));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void test_handle_network_address_array_with_null_elements() {
+        String value = "{192.168.0.1,NULL,2001:db8::1234}";
+        Object result = handler.process(PostgresDataType.INETARRAY, "testColumn", value);
+        assertThat(result, is(instanceOf(List.class)));
+        assertEquals(Arrays.asList("192.168.0.1", null, "2001:db8::1234"), result);
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NumericTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/NumericTypeHandlerTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -16,9 +19,140 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class NumericTypeHandlerTest {
     private NumericTypeHandler handler;
+
+    private static Stream<Arguments> provideNumericTypeData() {
+        return Stream.of(
+                // SMALLINT tests (-32768 to 32767)
+                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", "1", (short) 1),
+                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", "-32768", (short) -32768),
+                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", "32767", (short) 32767),
+                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", null, null),
+
+                // SMALLSERIAL tests (1 to 32767)
+                Arguments.of(PostgresDataType.SMALLSERIAL, "smallserial_col", "1", (short) 1),
+                Arguments.of(PostgresDataType.SMALLSERIAL, "smallserial_col", "32767", (short) 32767),
+                Arguments.of(PostgresDataType.SMALLSERIAL, "smallserial_col", null, null),
+
+                // INTEGER tests (-2,147,483,648 to 2,147,483,647)
+                Arguments.of(PostgresDataType.INTEGER, "int_col", "2147483647", 2147483647),
+                Arguments.of(PostgresDataType.INTEGER, "int_col", "-2147483648", -2147483648),
+                Arguments.of(PostgresDataType.INTEGER, "int_col", "0", 0),
+                Arguments.of(PostgresDataType.INTEGER, "int_col", null, null),
+
+                // SERIAL tests ( 1 to 2,147,483,647)
+                Arguments.of(PostgresDataType.SERIAL, "serial_col", "2147483647", 2147483647),
+                Arguments.of(PostgresDataType.SERIAL, "serial_col", "1", 1),
+                Arguments.of(PostgresDataType.SERIAL, "serial_col", null, null),
+
+                // BIGINT tests (-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807)
+                Arguments.of(PostgresDataType.BIGINT, "bigint_col", "9223372036854775807", 9223372036854775807L),
+                Arguments.of(PostgresDataType.BIGINT, "bigint_col", "-9223372036854775808", -9223372036854775808L),
+                Arguments.of(PostgresDataType.BIGINT, "bigint_col", "0", 0L),
+                Arguments.of(PostgresDataType.BIGINT, "bigint_col", null, null),
+
+                // BIGSERIAL tests (1 to 9,223,372,036,854,775,807)
+                Arguments.of(PostgresDataType.BIGSERIAL, "bigserial_col", "9223372036854775807", 9223372036854775807L),
+                Arguments.of(PostgresDataType.BIGSERIAL, "bigserial_col", "1", 1L),
+                Arguments.of(PostgresDataType.BIGSERIAL, "bigserial_col", null, null),
+
+                // REAL tests
+                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(123.451234f), 123.451234f),
+                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(-123.45f), -123.45f),
+                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(0.0f), 0.0f),
+                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(Float.MAX_VALUE), Float.MAX_VALUE),
+                Arguments.of(PostgresDataType.REAL, "real_col", "-Infinity", Float.NEGATIVE_INFINITY),
+                Arguments.of(PostgresDataType.REAL, "real_col", "Infinity", Float.POSITIVE_INFINITY),
+                Arguments.of(PostgresDataType.REAL, "real_col", "NaN", Float.NaN),
+                Arguments.of(PostgresDataType.REAL, "real_col", null, null),
+
+
+                // DOUBLE PRECISION tests
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", 123.4567890123412345, 123.4567890123412345),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", -123.45678901234, -123.45678901234),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", 0.0, 0.0),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", Double.MAX_VALUE, Double.MAX_VALUE),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", "-Infinity", Double.NEGATIVE_INFINITY),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", "Infinity", Double.POSITIVE_INFINITY),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", "NaN", Double.NaN),
+                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", null, null),
+
+                // NUMERIC tests
+                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", "123.45", "123.45"),
+                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", "-123.45", "-123.45"),
+                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", "0", "0"),
+                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", null, null)
+
+        );
+    }
+
+    private static Stream<Arguments> provideNumericArrayTypeData() {
+        return Stream.of(
+                // SMALLINT array tests
+                Arguments.of(PostgresDataType.INT2ARRAY, "smallint_array_col", "{1,2,3}", Arrays.asList((short) 1, (short) 2, (short) 3)),
+                Arguments.of(PostgresDataType.INT2ARRAY, "smallint_array_col", "{-32768,0,32767}", Arrays.asList((short) -32768, (short) 0, (short) 32767)),
+                Arguments.of(PostgresDataType.INT2ARRAY, "smallint_array_col", "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.INT2ARRAY, "smallint_array_col", null, null),
+
+                // INTEGER array tests
+                Arguments.of(PostgresDataType.INT4ARRAY, "int_array_col", "{2147483647,-2147483648,0}", Arrays.asList(2147483647, -2147483648, 0)),
+                Arguments.of(PostgresDataType.INT4ARRAY, "int_array_col", "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.INT4ARRAY, "int_array_col", null, null),
+
+                // BIGINT array tests
+                Arguments.of(PostgresDataType.INT8ARRAY, "bigint_array_col", "{9223372036854775807,-9223372036854775808,0}", Arrays.asList(9223372036854775807L, -9223372036854775808L, 0L)),
+                Arguments.of(PostgresDataType.INT8ARRAY, "bigint_array_col", "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.INT8ARRAY, "bigint_array_col", null, null),
+
+                // REAL array tests
+                Arguments.of(PostgresDataType.FLOAT4ARRAY, "real_array_col", "{123.45,-123.45,0.0,Infinity,-Infinity,NaN}", Arrays.asList(123.45f, -123.45f, 0.0f, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN)),
+                Arguments.of(PostgresDataType.FLOAT4ARRAY, "real_array_col", "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.FLOAT4ARRAY, "real_array_col", null, null),
+
+                // DOUBLE PRECISION array tests
+                Arguments.of(PostgresDataType.FLOAT8ARRAY, "double_precision_array_col", "{123.4567890123412345,-123.45678901234,0.0,Infinity,-Infinity,NaN}", Arrays.asList(123.4567890123412345, -123.45678901234, 0.0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN)),
+                Arguments.of(PostgresDataType.FLOAT8ARRAY, "double_precision_array_col", "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.FLOAT8ARRAY, "double_precision_array_col", null, null),
+
+                // NUMERIC array tests
+                Arguments.of(PostgresDataType.NUMERICARRAY, "numeric_array_col", "{123.45,-123.45,0}", Arrays.asList("123.45", "-123.45", "0")),
+                Arguments.of(PostgresDataType.NUMERICARRAY, "numeric_array_col", "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.NUMERICARRAY, "numeric_array_col", null, null)
+        );
+    }
+
+    private static Stream<Arguments> provideMoneyArrayTypeData() {
+        return Stream.of(
+                // Normal money array case
+                Arguments.of(
+                        PostgresDataType.MONEYARRAY,
+                        "money_array_col",
+                        "{\"$1,234.56\",\"-$789.01\",\"$0.00\"}",
+                        Arrays.asList(
+                                Map.of("amount", 1234.56, "currency", '$'),
+                                Map.of("amount", -789.01, "currency", '$'),
+                                Map.of("amount", 0.00, "currency", '$')
+                        )
+                ),
+                // Empty money array case
+                Arguments.of(
+                        PostgresDataType.MONEYARRAY,
+                        "money_array_col",
+                        "{}",
+                        Collections.emptyList()
+                ),
+                // Null money array case
+                Arguments.of(
+                        PostgresDataType.MONEYARRAY,
+                        "money_array_col",
+                        null,
+                        null
+                )
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -55,69 +189,39 @@ public class NumericTypeHandlerTest {
         assertEquals('$', moneyMap.get("currency"));
     }
 
-    private static Stream<Arguments> provideNumericTypeData() {
-        return Stream.of(
-                // SMALLINT tests (-32768 to 32767)
-                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", "1", (short)1),
-                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", "-32768", (short)-32768),
-                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", "32767", (short)32767),
-                Arguments.of(PostgresDataType.SMALLINT, "smallint_col", null, null),
+    @ParameterizedTest
+    @MethodSource("provideNumericArrayTypeData")
+    public void test_handle_array(final PostgresDataType postgresDataType, final String columnName, final Object value, final Object expectedValue) {
+        Object result = handler.process(postgresDataType, columnName, value);
+        if (result != null) {
+            assertThat(result, instanceOf(List.class));
+            assertEquals(expectedValue, result);
+        } else {
+            assertNull(expectedValue);
+        }
+    }
 
-                // SMALLSERIAL tests (1 to 32767)
-                Arguments.of(PostgresDataType.SMALLSERIAL, "smallserial_col", "1", (short)1),
-                Arguments.of(PostgresDataType.SMALLSERIAL, "smallserial_col", "32767", (short)32767),
-                Arguments.of(PostgresDataType.SMALLSERIAL, "smallserial_col", null, null),
+    @ParameterizedTest
+    @MethodSource("provideMoneyArrayTypeData")
+    public void test_handle_money_array(final PostgresDataType postgresDataType, final String columnName, final String value, final List<Map<String, Object>> expectedValue) {
+        Object result = handler.process(postgresDataType, columnName, value);
 
-                // INTEGER tests (-2,147,483,648 to 2,147,483,647)
-                Arguments.of(PostgresDataType.INTEGER, "int_col", "2147483647", 2147483647),
-                Arguments.of(PostgresDataType.INTEGER, "int_col", "-2147483648", -2147483648),
-                Arguments.of(PostgresDataType.INTEGER, "int_col", "0", 0),
-                Arguments.of(PostgresDataType.INTEGER, "int_col", null, null),
+        if (result != null) {
+            assertThat(result, instanceOf(List.class));
 
-                // SERIAL tests ( 1 to 2,147,483,647)
-                Arguments.of(PostgresDataType.SERIAL, "serial_col", "2147483647", 2147483647),
-                Arguments.of(PostgresDataType.SERIAL, "serial_col", "1", 1),
-                Arguments.of(PostgresDataType.SERIAL, "serial_col", null, null),
+            List<Map<String, Object>> resultList = (List<Map<String, Object>>) result;
+            assertEquals(expectedValue.size(), resultList.size());
 
-                // BIGINT tests (-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807)
-                Arguments.of(PostgresDataType.BIGINT, "bigint_col", "9223372036854775807", 9223372036854775807L),
-                Arguments.of(PostgresDataType.BIGINT, "bigint_col", "-9223372036854775808", -9223372036854775808L),
-                Arguments.of(PostgresDataType.BIGINT, "bigint_col", "0", 0L),
-                Arguments.of(PostgresDataType.BIGINT, "bigint_col", null, null),
+            for (int i = 0; i < expectedValue.size(); i++) {
+                Map<String, Object> expectedMap = expectedValue.get(i);
+                Map<String, Object> resultMap = resultList.get(i);
 
-                // BIGSERIAL tests (1 to 9,223,372,036,854,775,807)
-                Arguments.of(PostgresDataType.BIGSERIAL, "bigserial_col", "9223372036854775807", 9223372036854775807L),
-                Arguments.of(PostgresDataType.BIGSERIAL, "bigserial_col", "1", 1L),
-                Arguments.of(PostgresDataType.BIGSERIAL, "bigserial_col", null, null),
-
-                // REAL tests
-                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(123.451234f), 123.451234f),
-                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(-123.45f), -123.45f),
-                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(0.0f), 0.0f),
-                Arguments.of(PostgresDataType.REAL, "real_col", Float.toString(Float.MAX_VALUE), Float.MAX_VALUE),
-                Arguments.of(PostgresDataType.REAL, "real_col", "-Infinity", Float.NEGATIVE_INFINITY),
-                Arguments.of(PostgresDataType.REAL, "real_col", "Infinity", Float.POSITIVE_INFINITY),
-                Arguments.of(PostgresDataType.REAL, "real_col", "NaN", Float.NaN),
-                Arguments.of(PostgresDataType.REAL, "real_col", null,null),
-
-
-                // DOUBLE PRECISION tests
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", 123.4567890123412345, 123.4567890123412345),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", -123.45678901234, -123.45678901234),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", 0.0, 0.0),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", Double.MAX_VALUE, Double.MAX_VALUE),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", "-Infinity", Double.NEGATIVE_INFINITY),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", "Infinity", Double.POSITIVE_INFINITY),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", "NaN", Double.NaN),
-                Arguments.of(PostgresDataType.DOUBLE_PRECISION, "double_precision_col", null, null),
-
-                // NUMERIC tests
-                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", "123.45", "123.45"),
-                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", "-123.45", "-123.45"),
-                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", "0", "0"),
-                Arguments.of(PostgresDataType.NUMERIC, "numeric_col", null, null)
-
-        );
+                assertEquals(expectedMap.get("currency"), resultMap.get("currency"));
+                assertEquals((Double) expectedMap.get("amount"), (Double) resultMap.get("amount"));
+            }
+        } else {
+            assertNull(expectedValue);
+        }
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/RangeTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/RangeTypeHandlerTest.java
@@ -6,10 +6,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,7 +38,7 @@ class RangeTypeHandlerTest {
     void testHandleInt4Range() {
         when(numericTypeHandler.handle(any(), any(), any())).thenReturn(10, 20);
         Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGE, "test_column", "[10,20)");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> rangeMap = (Map<String, Object>) result;
         assertEquals(10, rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
         assertEquals(20, rangeMap.get(RangeTypeHandler.LESSER_THAN));
@@ -46,17 +48,27 @@ class RangeTypeHandlerTest {
     void testHandleInt8Range() {
         when(numericTypeHandler.handle(any(), any(), any())).thenReturn(100L, 200L);
         Object result = rangeTypeHandler.handle(PostgresDataType.INT8RANGE, "test_column", "(100,200]");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> rangeMap = (Map<String, Object>) result;
         assertEquals(100L, rangeMap.get(RangeTypeHandler.GREATER_THAN));
         assertEquals(200L, rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
     }
 
     @Test
+    void testHandleNumRange() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn("1.0", "2.5");
+        Object result = rangeTypeHandler.handle(PostgresDataType.NUMRANGE, "test_column", "(1.0,2.5]");
+        assertInstanceOf(Map.class, result);
+        Map<String, Object> rangeMap = (Map<String, Object>) result;
+        assertEquals("1.0", rangeMap.get(RangeTypeHandler.GREATER_THAN));
+        assertEquals("2.5", rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
     void testHandleDateRange() {
         when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704067200000", "1706659200000");
         Object result = rangeTypeHandler.handle(PostgresDataType.DATERANGE, "test_column", "[2024-01-01,2024-01-31]");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> rangeMap = (Map<String, Object>) result;
         assertEquals("1704067200000", rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
         assertEquals("1706659200000", rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
@@ -66,7 +78,7 @@ class RangeTypeHandlerTest {
     void testHandleTsRange() {
         when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704103200000", "1704110400000");
         Object result = rangeTypeHandler.handle(PostgresDataType.TSRANGE, "test_column", "[2024-01-01 10:00:00,2024-01-01 12:00:00)");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> rangeMap = (Map<String, Object>) result;
         assertEquals("1704103200000", rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
         assertEquals("1704110400000", rangeMap.get(RangeTypeHandler.LESSER_THAN));
@@ -76,10 +88,126 @@ class RangeTypeHandlerTest {
     void testHandleTstzRange() {
         when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704103200000", "1704110400000");
         Object result = rangeTypeHandler.handle(PostgresDataType.TSTZRANGE, "test_column", "[2024-01-01 10:00:00+00,2024-01-01 12:00:00+00]");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> rangeMap = (Map<String, Object>) result;
         assertEquals("1704103200000", rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
         assertEquals("1704110400000", rangeMap.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleInt4RangeArray() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn(10, 20, 30, 40);
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGEARRAY, "test_column", "{\"[10,20)\",\"[30,40]\"}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+
+        assertEquals(2, rangeList.size());
+
+        Map<String, Object> range1 = rangeList.get(0);
+        assertEquals(10, range1.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals(20, range1.get(RangeTypeHandler.LESSER_THAN));
+
+        Map<String, Object> range2 = rangeList.get(1);
+        assertEquals(30, range2.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals(40, range2.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleInt8RangeArray() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn(100L, 200L, 300L, 400L);
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT8RANGEARRAY, "test_column", "{\"(100,200]\",\"(300,400)\"}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+
+        assertEquals(2, rangeList.size());
+
+        Map<String, Object> range1 = rangeList.get(0);
+        assertEquals(100L, range1.get(RangeTypeHandler.GREATER_THAN));
+        assertEquals(200L, range1.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+
+        Map<String, Object> range2 = rangeList.get(1);
+        assertEquals(300L, range2.get(RangeTypeHandler.GREATER_THAN));
+        assertEquals(400L, range2.get(RangeTypeHandler.LESSER_THAN));
+    }
+
+    @Test
+    void testHandleNumRangeArray() {
+        when(numericTypeHandler.handle(any(), any(), any())).thenReturn("1.5", "2.0", "3.0", "4.0");
+        Object result = rangeTypeHandler.handle(PostgresDataType.NUMRANGEARRAY, "test_column", "{\"[1.5,2.0)\",\"[3.0,4.0]\"}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+
+        assertEquals(2, rangeList.size());
+
+        Map<String, Object> range1 = rangeList.get(0);
+        assertEquals("1.5", range1.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("2.0", range1.get(RangeTypeHandler.LESSER_THAN));
+
+        Map<String, Object> range2 = rangeList.get(1);
+        assertEquals("3.0", range2.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("4.0", range2.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleDateRangeArray() {
+        when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704067200000", "1706659200000", "1709337600000", "1711929600000");
+        Object result = rangeTypeHandler.handle(PostgresDataType.DATERANGEARRAY, "test_column", "{\"[2024-01-01,2024-01-31]\",\"[2024-03-01,2024-03-31]\"}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+
+        assertEquals(2, rangeList.size());
+
+        Map<String, Object> range1 = rangeList.get(0);
+        assertEquals("1704067200000", range1.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1706659200000", range1.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+
+        Map<String, Object> range2 = rangeList.get(1);
+        assertEquals("1709337600000", range2.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1711929600000", range2.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleTsRangeArray() {
+        when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704103200000", "1704110400000", "1704189600000", "1704196800000");
+        Object result = rangeTypeHandler.handle(PostgresDataType.TSRANGEARRAY, "test_column", "{\"[2024-01-01 10:00:00,2024-01-01 12:00:00)\",\"[2024-01-02 10:00:00,2024-01-02 12:00:00]\"}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+
+        assertEquals(2, rangeList.size());
+
+        Map<String, Object> range1 = rangeList.get(0);
+        assertEquals("1704103200000", range1.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1704110400000", range1.get(RangeTypeHandler.LESSER_THAN));
+
+        Map<String, Object> range2 = rangeList.get(1);
+        assertEquals("1704189600000", range2.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1704196800000", range2.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleTstzRangeArray() {
+        when(temporalTypeHandler.handle(any(), any(), any())).thenReturn("1704103200000", "1704110400000", "1704189600000", "1704196800000");
+        Object result = rangeTypeHandler.handle(PostgresDataType.TSTZRANGEARRAY, "test_column", "{\"[2024-01-01 10:00:00+00,2024-01-01 12:00:00+00)\",\"[2024-01-02 10:00:00+00,2024-01-02 12:00:00+00]\"}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+
+        assertEquals(2, rangeList.size());
+
+        Map<String, Object> range1 = rangeList.get(0);
+        assertEquals("1704103200000", range1.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1704110400000", range1.get(RangeTypeHandler.LESSER_THAN));
+
+        Map<String, Object> range2 = rangeList.get(1);
+        assertEquals("1704189600000", range2.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
+        assertEquals("1704196800000", range2.get(RangeTypeHandler.LESSER_THAN_OR_EQUAL_TO));
+    }
+
+    @Test
+    void testHandleEmptyRangeArray() {
+        Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGEARRAY, "test_column", "{}");
+        assertInstanceOf(List.class, result);
+        List<Map<String, Object>> rangeList = (List<Map<String, Object>>) result;
+        assertTrue(rangeList.isEmpty());
     }
 
     @Test
@@ -92,7 +220,7 @@ class RangeTypeHandlerTest {
     void testHandleInfiniteRange() {
         when(numericTypeHandler.handle(any(), any(), any())).thenReturn(10);
         Object result = rangeTypeHandler.handle(PostgresDataType.INT4RANGE, "test_column", "[10,)");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> rangeMap = (Map<String, Object>) result;
         assertEquals(10, rangeMap.get(RangeTypeHandler.GREATER_THAN_OR_EQUAL_TO));
         assertFalse(rangeMap.containsKey(RangeTypeHandler.LESSER_THAN));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpatialTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpatialTypeHandlerTest.java
@@ -7,16 +7,71 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class SpatialTypeHandlerTest {
     private SpatialTypeHandler handler;
+
+    private static Stream<Arguments> provideSpatialArrayTypeData() {
+        return Stream.of(
+                Arguments.of(PostgresDataType.POINTARRAY,
+                        "{\"(1,2)\",\"(3,4)\"}",
+                        Arrays.asList("POINT(1.000000 2.000000)", "POINT(3.000000 4.000000)")),
+
+                Arguments.of(PostgresDataType.LINEARRAY,
+                        "{\"{1,-1,0}\",\"{0,2,3}\"}",
+                        Arrays.asList("LINESTRING(0.000000 0.000000, 1.000000 1.000000)",
+                                "LINESTRING(0.000000 -1.500000, 1.000000 -1.500000)")),
+
+                Arguments.of(PostgresDataType.LSEGARRAY,
+                        "{\"[(1,1),(2,2)]\",\"[(3,3),(4,4)]\"}",
+                        Arrays.asList("LINESTRING(1.000000 1.000000, 2.000000 2.000000)",
+                                "LINESTRING(3.000000 3.000000, 4.000000 4.000000)")),
+
+                Arguments.of(PostgresDataType.BOXARRAY,
+                        "{\"(1,1),(2,2)\";\"(3,3),(4,4)\"}",
+                        Arrays.asList("POLYGON((1.000000 1.000000, 2.000000 1.000000, 2.000000 2.000000, 1.000000 2.000000, 1.000000 1.000000))",
+                                "POLYGON((3.000000 3.000000, 4.000000 3.000000, 4.000000 4.000000, 3.000000 4.000000, 3.000000 3.000000))")),
+
+                Arguments.of(PostgresDataType.PATHARRAY,
+                        "{\"[(1,1),(2,2),(3,3)]\",\"((4,4),(5,5),(6,6))\"}",
+                        Arrays.asList("LINESTRING(1.000000 1.000000, 2.000000 2.000000, 3.000000 3.000000)",
+                                "POLYGON((4.000000 4.000000, 5.000000 5.000000, 6.000000 6.000000, 4.000000 4.000000))")),
+
+                Arguments.of(PostgresDataType.POLYGONARRAY,
+                        "{\"((0,0),(0,1),(1,1),(1,0))\",\"((2,2),(2,3),(3,3),(3,2))\"}",
+                        Arrays.asList("POLYGON((0.000000 0.000000, 0.000000 1.000000, 1.000000 1.000000, 1.000000 0.000000, 0.000000 0.000000))",
+                                "POLYGON((2.000000 2.000000, 2.000000 3.000000, 3.000000 3.000000, 3.000000 2.000000, 2.000000 2.000000))"))
+
+        );
+    }
+
+    private static Stream<Arguments> provideSpatialTypeData() {
+        return Stream.of(
+                Arguments.of(PostgresDataType.POINT, "(1,2)", "POINT(1.000000 2.000000)"),
+                Arguments.of(PostgresDataType.LINE, "{1,-1,0}", "LINESTRING(0.000000 0.000000, 1.000000 1.000000)"),
+                Arguments.of(PostgresDataType.LINE, "{0,2,3}", "LINESTRING(0.000000 -1.500000, 1.000000 -1.500000)"),
+                Arguments.of(PostgresDataType.LINE, "{2,0,3}", "LINESTRING(-1.500000 0.000000, -1.500000 1.000000)"),
+
+                Arguments.of(PostgresDataType.LSEG, "[(1,1),(2,2)]", "LINESTRING(1.000000 1.000000, 2.000000 2.000000)"),
+                Arguments.of(PostgresDataType.BOX, "(1,1),(2,2)", "POLYGON((1.000000 1.000000, 2.000000 1.000000, 2.000000 2.000000, 1.000000 2.000000, 1.000000 1.000000))"),
+                Arguments.of(PostgresDataType.PATH, "[(1,1),(2,2),(3,3)]", "LINESTRING(1.000000 1.000000, 2.000000 2.000000, 3.000000 3.000000)"),
+                Arguments.of(PostgresDataType.PATH, "((1,1),(2,2),(3,3))", "POLYGON((1.000000 1.000000, 2.000000 2.000000, 3.000000 3.000000, 1.000000 1.000000))"),
+                Arguments.of(PostgresDataType.POLYGON, "((0,0),(0,1),(1,1),(1,0))", "POLYGON((0.000000 0.000000, 0.000000 1.000000, 1.000000 1.000000, 1.000000 0.000000, 0.000000 0.000000))")
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -46,13 +101,53 @@ public class SpatialTypeHandlerTest {
     void testHandleCircle() {
         PostgresDataType dataType = PostgresDataType.CIRCLE;
         Object result = handler.process(dataType, "testColumn", "<(0,0),1>");
-        assertTrue(result instanceof Map);
+        assertInstanceOf(Map.class, result);
         Map<String, Object> circleMap = (Map<String, Object>) result;
         assertEquals(1.0, circleMap.get("radius"));
-        assertTrue(circleMap.get("center") instanceof Map);
+        assertInstanceOf(Map.class, circleMap.get("center"));
         Map<String, Object> centerMap = (Map<String, Object>) circleMap.get("center");
         assertEquals(0.0, centerMap.get("x"));
         assertEquals(0.0, centerMap.get("y"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSpatialArrayTypeData")
+    void testHandleSpatialArrayTypes(PostgresDataType type, String input, List<String> expected) {
+        Object result = handler.process(type, "testColumn", input);
+        assertThat(result, instanceOf(List.class));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testHandleNullSpatialArray() {
+        assertNull(handler.process(PostgresDataType.POINTARRAY, "testColumn", null));
+    }
+
+    @Test
+    void testHandleEmptySpatialArray() {
+        Object result = handler.process(PostgresDataType.POINTARRAY, "testColumn", "{}");
+        assertThat(result, instanceOf(List.class));
+        assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    void testHandleCircleArray() {
+        Object result = handler.process(PostgresDataType.CIRCLEARRAY, "testColumn", "{\"<(0,0),1>\",\"<(2,2),3>\"}");
+        assertThat(result, instanceOf(List.class));
+        List<Map<String, Object>> circleList = (List<Map<String, Object>>) result;
+        assertEquals(2, circleList.size());
+
+        Map<String, Object> circle1 = circleList.get(0);
+        assertEquals(1.0, circle1.get("radius"));
+        Map<String, Object> center1 = (Map<String, Object>) circle1.get("center");
+        assertEquals(0.0, center1.get("x"));
+        assertEquals(0.0, center1.get("y"));
+
+        Map<String, Object> circle2 = circleList.get(1);
+        assertEquals(3.0, circle2.get("radius"));
+        Map<String, Object> center2 = (Map<String, Object>) circle2.get("center");
+        assertEquals(2.0, center2.get("x"));
+        assertEquals(2.0, center2.get("y"));
     }
 
     @Test
@@ -87,21 +182,6 @@ public class SpatialTypeHandlerTest {
     void testParsePolygonWithNoPoints() {
         assertThrows(RuntimeException.class, () ->
                 handler.process(PostgresDataType.POLYGON, "testColumn", "()")
-        );
-    }
-
-    private static Stream<Arguments> provideSpatialTypeData() {
-        return Stream.of(
-                Arguments.of(PostgresDataType.POINT, "(1,2)", "POINT(1.000000 2.000000)" ),
-                Arguments.of(PostgresDataType.LINE, "{1,-1,0}", "LINESTRING(0.000000 0.000000, 1.000000 1.000000)" ),
-                Arguments.of(PostgresDataType.LINE, "{0,2,3}", "LINESTRING(0.000000 -1.500000, 1.000000 -1.500000)" ),
-                Arguments.of(PostgresDataType.LINE, "{2,0,3}", "LINESTRING(-1.500000 0.000000, -1.500000 1.000000)" ),
-
-                Arguments.of(PostgresDataType.LSEG, "[(1,1),(2,2)]", "LINESTRING(1.000000 1.000000, 2.000000 2.000000)"),
-                Arguments.of(PostgresDataType.BOX, "(1,1),(2,2)", "POLYGON((1.000000 1.000000, 2.000000 1.000000, 2.000000 2.000000, 1.000000 2.000000, 1.000000 1.000000))" ),
-                Arguments.of(PostgresDataType.PATH, "[(1,1),(2,2),(3,3)]", "LINESTRING(1.000000 1.000000, 2.000000 2.000000, 3.000000 3.000000)"),
-                Arguments.of(PostgresDataType.PATH, "((1,1),(2,2),(3,3))", "POLYGON((1.000000 1.000000, 2.000000 2.000000, 3.000000 3.000000, 1.000000 1.000000))"),
-                Arguments.of(PostgresDataType.POLYGON, "((0,0),(0,1),(1,1),(1,0))", "POLYGON((0.000000 0.000000, 0.000000 1.000000, 1.000000 1.000000, 1.000000 0.000000, 0.000000 0.000000))")
         );
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpecialTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/SpecialTypeHandlerTest.java
@@ -2,17 +2,64 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SpecialTypeHandlerTest {
     private SpecialTypeHandler handler;
+
+    private static Stream<Arguments> provideMiscArrayData() {
+        return Stream.of(
+                // XMLARRAY cases
+                Arguments.of(PostgresDataType.XMLARRAY,
+                        "{\"<root><child>Test1</child></root>\",\"<root><child>Test2</child></root>\"}",
+                        Arrays.asList("<root><child>Test1</child></root>", "<root><child>Test2</child></root>")),
+                Arguments.of(PostgresDataType.XMLARRAY, "{}", Collections.emptyList()),
+
+                // PG_LSNARRAY cases
+                Arguments.of(PostgresDataType.PG_LSNARRAY,
+                        "{16/B374D848,16/B374D849}",
+                        Arrays.asList("16/B374D848", "16/B374D849")),
+                Arguments.of(PostgresDataType.PG_LSNARRAY, "{}", Collections.emptyList()),
+
+                // UUIDARRAY cases
+                Arguments.of(PostgresDataType.UUIDARRAY,
+                        "{123e4567-e89b-12d3-a456-426614174000,123e4567-e89b-12d3-a456-426614174001}",
+                        Arrays.asList("123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174001")),
+                Arguments.of(PostgresDataType.UUIDARRAY, "{}", Collections.emptyList()),
+
+                // TSVECTORARRAY cases
+                Arguments.of(PostgresDataType.TSVECTORARRAY,
+                        "{\"'word1':1 'word2':2,4,5 'word3':3,6,7\",\"'1':2 '2':6 '3':3 '4':7 '5':4 'word1':1 'word2':5\"}",
+                        Arrays.asList("'word1':1 'word2':2,4,5 'word3':3,6,7", "'1':2 '2':6 '3':3 '4':7 '5':4 'word1':1 'word2':5")),
+                Arguments.of(PostgresDataType.TSVECTORARRAY, "{}", Collections.emptyList()),
+
+                // PG_SNAPSHOT_ARRAY cases
+                Arguments.of(PostgresDataType.PG_SNAPSHOTARRAY, "{123:456:789,987:654:321}",
+                        Arrays.asList("123:456:789", "987:654:321")),
+                Arguments.of(PostgresDataType.PG_SNAPSHOTARRAY, "{}", Collections.emptyList()),
+
+                // TXID_SNAPSHOT_ARRAY cases
+                Arguments.of(PostgresDataType.TXID_SNAPSHOTARRAY, "{123:456:789,987:654:321}",
+                        Arrays.asList("123:456:789", "987:654:321")),
+                Arguments.of(PostgresDataType.TXID_SNAPSHOTARRAY, "{}", Collections.emptyList())
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -57,6 +104,40 @@ public class SpecialTypeHandlerTest {
         Object result = handler.process(PostgresDataType.TSQUERY, "tsqueryColumn", tsquery);
         assertThat(result, is(instanceOf(String.class)));
         assertThat(result, is(tsquery));
+    }
+
+    @Test
+    public void test_handle_pg_snapshot() {
+        String snapshotValue = "123:456:789";
+        Object result = handler.process(PostgresDataType.PG_SNAPSHOT, "pgSnapshotColumn", snapshotValue);
+        assertThat(result, is(instanceOf(String.class)));
+        assertThat(result, is(snapshotValue));
+    }
+
+    @Test
+    public void test_handle_txid_snapshot() {
+        String txidSnapshotValue = "123:456:789";
+        Object result = handler.process(PostgresDataType.TXID_SNAPSHOT, "txidSnapshotColumn", txidSnapshotValue);
+        assertThat(result, is(instanceOf(String.class)));
+        assertThat(result, is(txidSnapshotValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMiscArrayData")
+    public void test_handle_misc_array(PostgresDataType columnType, String value, List<String> expected) {
+        String columnName = "testColumn";
+        Object result = handler.process(columnType, columnName, value);
+
+        assertThat(result, is(instanceOf(List.class)));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void test_handle_null_array() {
+        assertNull(handler.process(PostgresDataType.XMLARRAY, "testColumn", null));
+        assertNull(handler.process(PostgresDataType.PG_LSNARRAY, "testColumn", null));
+        assertNull(handler.process(PostgresDataType.UUIDARRAY, "testColumn", null));
+        assertNull(handler.process(PostgresDataType.TSVECTORARRAY, "testColumn", null));
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/StringTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/StringTypeHandlerTest.java
@@ -3,21 +3,57 @@ package org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.handler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StringTypeHandlerTest {
     private StringTypeHandler handler;
 
+    private static Stream<Arguments> provideCharArrayData() {
+        return Stream.of(
+                // TEXTARRAY cases
+                Arguments.of(PostgresDataType.TEXTARRAY, "{Hello,World}", Arrays.asList("Hello", "World")),
+                Arguments.of(PostgresDataType.TEXTARRAY, "{OpenSearch,DataPrepper}", Arrays.asList("OpenSearch", "DataPrepper")),
+                Arguments.of(PostgresDataType.TEXTARRAY, "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.TEXTARRAY, null, null),
+
+                // VARCHARARRAY cases
+                Arguments.of(PostgresDataType.VARCHARARRAY, "{Hello,World}", Arrays.asList("Hello", "World")),
+                Arguments.of(PostgresDataType.VARCHARARRAY, "{OpenSearch,DataPrepper}", Arrays.asList("OpenSearch", "DataPrepper")),
+                Arguments.of(PostgresDataType.VARCHARARRAY,
+                        "{normal,\"\\\"double quoted\\\"\",\"'single quoted'\",\"\\\\backslashed\\\\\",\"\\\"quoted with \\\\\\\"nested\\\\\\\" quotes\\\"\"}",
+                        Arrays.asList("normal", "\"double quoted\"","'single quoted'","\\backslashed\\","\"quoted " +
+                                "with \\\"nested\\\" quotes\"")),
+                Arguments.of(PostgresDataType.VARCHARARRAY, "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.VARCHARARRAY, null, null),
+
+                // BPCHARARRAY cases
+                Arguments.of(PostgresDataType.BPCHARARRAY, "{Hello ,World }", Arrays.asList("Hello", "World")), // Note the padding spaces
+                Arguments.of(PostgresDataType.BPCHARARRAY, "{OpenSearch ,DataPrepper }", Arrays.asList("OpenSearch", "DataPrepper")),
+                Arguments.of(PostgresDataType.BPCHARARRAY, "{}", Collections.emptyList()),
+                Arguments.of(PostgresDataType.BPCHARARRAY, null, null)
+        );
+    }
+
     @BeforeEach
     void setUp() {
         handler = new StringTypeHandler();
     }
+
     @ParameterizedTest
     @CsvSource({
             "TEXT, Hello, World!",
@@ -29,6 +65,26 @@ public class StringTypeHandlerTest {
         Object result = handler.process(columnType, columnName, value);
         assertThat(result, is(instanceOf(String.class)));
         assertThat(result, is(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCharArrayData")
+    public void test_handle_char_array(PostgresDataType columnType, String value, List<String> expected) {
+        String columnName = "testColumn";
+        Object result = handler.process(columnType, columnName, value);
+
+        if (result != null) {
+            assertThat(result, is(instanceOf(List.class)));
+
+            List<String> resultList = (List<String>) result;
+            assertEquals(expected.size(), resultList.size());
+
+            for (int i = 0; i < expected.size(); i++) {
+                assertEquals(expected.get(i), resultList.get(i));
+            }
+        } else {
+            assertNull(expected);
+        }
     }
 
     @Test

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/postgres/handler/TemporalTypeHandlerTest.java
@@ -11,6 +11,8 @@ import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresD
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,11 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class TemporalTypeHandlerTest {
 
     private TemporalTypeHandler handler;
-
-    @BeforeEach
-    void setUp() {
-        handler = new TemporalTypeHandler();
-    }
 
     private static long getEpochMillisFromDate(final int year, final int month, final int day) {
         return LocalDate.of(year, month, day)
@@ -40,18 +37,6 @@ class TemporalTypeHandlerTest {
                 .toEpochMilli();
     }
 
-    @Test
-    void handle_whenValueIsNull_returnsNull() {
-        assertNull(handler.process(PostgresDataType.DATE, "test_column", null));
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideDateTestCases")
-    void handle_withDateType_returnsCorrectEpochMillis(String input, Long expected) {
-        Object result = handler.process(PostgresDataType.DATE, "date_column", input);
-        assertEquals(expected, result);
-    }
-
     private static Stream<Arguments> provideDateTestCases() {
         return Stream.of(
                 Arguments.of("2023-12-25", getEpochMillisFromDate(2023, 12, 25)),
@@ -59,13 +44,6 @@ class TemporalTypeHandlerTest {
                 Arguments.of("2024-02-29", getEpochMillisFromDate(2024, 2, 29)), // Leap year
                 Arguments.of("infinity", getEpochMillisFromDate(9999, 12, 31))
         );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideTimeWithoutTimeZoneTestCases")
-    void handle_withTimeWithoutTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
-        Object result = handler.process(PostgresDataType.TIME, "time_column", input);
-        assertEquals(result, expected);
     }
 
     private static Stream<Arguments> provideTimeWithoutTimeZoneTestCases() {
@@ -83,13 +61,6 @@ class TemporalTypeHandlerTest {
         );
     }
 
-    @ParameterizedTest
-    @MethodSource("provideTimeStampWithoutTimeZoneTestCases")
-    void handle_withTimeStampWithoutTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
-        Object result = handler.process(PostgresDataType.TIMESTAMP, "timestamp_column", input);
-        assertEquals(expected, result);
-    }
-
     private static Stream<Arguments> provideTimeStampWithoutTimeZoneTestCases() {
         return Stream.of(
                 Arguments.of("2023-12-25 14:30:00.123456", getEpochMillis(2023, 12, 25, 14, 30, 0, 123456000)),
@@ -100,13 +71,6 @@ class TemporalTypeHandlerTest {
         );
     }
 
-    @ParameterizedTest
-    @MethodSource("provideTimeWithTimeZoneTestCases")
-    void handle_withTimeWithTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
-        Object result = handler.process(PostgresDataType.TIMETZ, "timetz_column", input);
-        assertEquals(expected, result);
-    }
-
     private static Stream<Arguments> provideTimeWithTimeZoneTestCases() {
         return Stream.of(
                 Arguments.of("14:30:00+01", getEpochMillis(1970, 1, 1, 13, 30, 0, 0)),
@@ -114,13 +78,6 @@ class TemporalTypeHandlerTest {
                 Arguments.of("00:00:00-08:00", getEpochMillis(1970, 1, 1, 8, 0, 0, 0)),
                 Arguments.of("12:34:56.789+01:00", getEpochMillis(1970, 1, 1, 11, 34, 56, 789000000))
         );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideTimeStampWithTimeZoneTestCases")
-    void handle_withTimeStampWithTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
-        Object result = handler.process(PostgresDataType.TIMESTAMPTZ, "timestamptz_column", input);
-        assertEquals(expected, result);
     }
 
     private static Stream<Arguments> provideTimeStampWithTimeZoneTestCases() {
@@ -134,6 +91,130 @@ class TemporalTypeHandlerTest {
         );
     }
 
+    private static Stream<Arguments> provideIntervalTestCases() {
+        return Stream.of(
+                Arguments.of("1 year 2 mons 3 days 04:05:06", "P1Y2M3DT4H5M6S"),
+                Arguments.of("3 days 04:05:06", "P3DT4H5M6S"),
+                Arguments.of("1 year", "P1Y")
+        );
+    }
+
+    private static Stream<Arguments> provideDateArrayTestCases() {
+        return Stream.of(
+                Arguments.of("{2023-12-25,2024-02-29}",
+                        Arrays.asList(
+                                getEpochMillisFromDate(2023, 12, 25),
+                                getEpochMillisFromDate(2024, 2, 29)
+                        )),
+                Arguments.of("{-infinity,infinity}",
+                        Arrays.asList(
+                                getEpochMillisFromDate(1970, 1, 1),
+                                getEpochMillisFromDate(9999, 12, 31)
+                        ))
+        );
+    }
+
+    private static Stream<Arguments> provideTimeArrayTestCases() {
+        return Stream.of(
+                Arguments.of("{14:30:00,23:59:59.123456}",
+                        Arrays.asList(
+                                getEpochMillis(1970, 1, 1, 14, 30, 0, 0),
+                                getEpochMillis(1970, 1, 1, 23, 59, 59, 123456000)
+                        ))
+        );
+    }
+
+    private static Stream<Arguments> provideTimeTZArrayTestCases() {
+        return Stream.of(
+                Arguments.of("{14:30:00+01,23:59:59.999999+05:30}",
+                        Arrays.asList(
+                                getEpochMillis(1970, 1, 1, 13, 30, 0, 0),
+                                getEpochMillis(1970, 1, 1, 18, 29, 59, 999999000)
+                        ))
+        );
+    }
+
+    private static Stream<Arguments> provideTimestampArrayTestCases() {
+        return Stream.of(
+                Arguments.of("{2023-12-25 14:30:00.123456,1970-01-01 00:00:00}",
+                        Arrays.asList(
+                                getEpochMillis(2023, 12, 25, 14, 30, 0, 123456000),
+                                getEpochMillis(1970, 1, 1, 0, 0, 0, 0)
+                        )),
+                Arguments.of("{-infinity,infinity}",
+                        Arrays.asList(
+                                getEpochMillis(1970, 1, 1, 0, 0, 0, 0),
+                                getEpochMillis(9999, 12, 31, 23, 59, 59, 0)
+                        ))
+        );
+    }
+
+    private static Stream<Arguments> provideTimestampTZArrayTestCases() {
+        return Stream.of(
+                Arguments.of("{2023-12-25 14:30:00+00:00,2023-12-25 23:59:59.999999+05:30}",
+                        Arrays.asList(
+                                getEpochMillis(2023, 12, 25, 14, 30, 0, 0),
+                                getEpochMillis(2023, 12, 25, 18, 29, 59, 999999000)
+                        )),
+                Arguments.of("{-infinity,infinity}",
+                        Arrays.asList(
+                                getEpochMillis(1970, 1, 1, 0, 0, 0, 0),
+                                getEpochMillis(9999, 12, 31, 23, 59, 59, 0)
+                        ))
+        );
+    }
+
+    private static Stream<Arguments> provideIntervalArrayTestCases() {
+        return Stream.of(
+                Arguments.of("{\"1 year 2 mons 3 days 04:05:06\",\"3 days 04:05:06\"}",
+                        Arrays.asList("P1Y2M3DT4H5M6S", "P3DT4H5M6S"))
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler = new TemporalTypeHandler();
+    }
+
+    @Test
+    void handle_whenValueIsNull_returnsNull() {
+        assertNull(handler.process(PostgresDataType.DATE, "test_column", null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDateTestCases")
+    void handle_withDateType_returnsCorrectEpochMillis(String input, Long expected) {
+        Object result = handler.process(PostgresDataType.DATE, "date_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimeWithoutTimeZoneTestCases")
+    void handle_withTimeWithoutTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
+        Object result = handler.process(PostgresDataType.TIME, "time_column", input);
+        assertEquals(result, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimeStampWithoutTimeZoneTestCases")
+    void handle_withTimeStampWithoutTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
+        Object result = handler.process(PostgresDataType.TIMESTAMP, "timestamp_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimeWithTimeZoneTestCases")
+    void handle_withTimeWithTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
+        Object result = handler.process(PostgresDataType.TIMETZ, "timetz_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimeStampWithTimeZoneTestCases")
+    void handle_withTimeStampWithTimeZoneType_returnsCorrectEpochMillis(String input, long expected) {
+        Object result = handler.process(PostgresDataType.TIMESTAMPTZ, "timestamptz_column", input);
+        assertEquals(expected, result);
+    }
 
     @ParameterizedTest
     @MethodSource("provideIntervalTestCases")
@@ -142,13 +223,53 @@ class TemporalTypeHandlerTest {
         assertEquals(expected, result);
     }
 
-    private static Stream<Arguments> provideIntervalTestCases() {
-        return Stream.of(
-                Arguments.of("1 year 2 mons 3 days 04:05:06", "P1Y2M3DT4H5M6S"),
-                Arguments.of("3 days 04:05:06", "P3DT4H5M6S" ),
-                Arguments.of("1 year", "P1Y")
-        );
+    @ParameterizedTest
+    @MethodSource("provideDateArrayTestCases")
+    void handle_withDateArrayType_returnsCorrectEpochMillisList(String input, List<Long> expected) {
+        Object result = handler.process(PostgresDataType.DATEARRAY, "date_array_column", input);
+        assertEquals(expected, result);
     }
+
+    @ParameterizedTest
+    @MethodSource("provideTimeArrayTestCases")
+    void handle_withTimeArrayType_returnsCorrectEpochMillisList(String input, List<Long> expected) {
+        Object result = handler.process(PostgresDataType.TIMEARRAY, "time_array_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimeTZArrayTestCases")
+    void handle_withTimeTZArrayType_returnsCorrectEpochMillisList(String input, List<Long> expected) {
+        Object result = handler.process(PostgresDataType.TIMETZARRAY, "timetz_array_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimestampArrayTestCases")
+    void handle_withTimestampArrayType_returnsCorrectEpochMillisList(String input, List<Long> expected) {
+        Object result = handler.process(PostgresDataType.TIMESTAMPARRAY, "timestamp_array_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTimestampTZArrayTestCases")
+    void handle_withTimestampTZArrayType_returnsCorrectEpochMillisList(String input, List<Long> expected) {
+        Object result = handler.process(PostgresDataType.TIMESTAMPTZARRAY, "timestamptz_array_column", input);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIntervalArrayTestCases")
+    void handle_withIntervalArrayType_returnsCorrectISO8601FormatList(String input, List<String> expected) {
+        Object result = handler.process(PostgresDataType.INTERVALARRAY, "interval_array_column", input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void handle_withNullInput_returnsNull() {
+        assertNull(handler.process(PostgresDataType.DATEARRAY, "date_array_column", null));
+    }
+
 
     @Test
     void handle_withInvalidFormat_throwsIllegalArgumentException() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/PgArrayParserTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/PgArrayParserTest.java
@@ -1,0 +1,123 @@
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.plugins.source.rds.datatype.postgres.PostgresDataType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PgArrayParserTest {
+
+    @Test
+    void testParseTypedArray_SimpleIntArray() {
+        String input = "{1,2,3}";
+        List<Integer> expected = Arrays.asList(1, 2, 3);
+        Object result = PgArrayParser.parseTypedArray(input, PostgresDataType.INT4ARRAY,
+                (type, value) -> Integer.parseInt(value));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseTypedArray_NestedIntArray() {
+        String input = "{{1,2},{3,4}}";
+        List<List<Integer>> expected = Arrays.asList(
+                Arrays.asList(1, 2),
+                Arrays.asList(3, 4)
+        );
+        Object result = PgArrayParser.parseTypedArray(input, PostgresDataType.INT4ARRAY,
+                (type, value) -> Integer.parseInt(value));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseTypedArray_StringArrayWithQuotes() {
+        String input = "{\"hello\",\"world\"}";
+        List<String> expected = Arrays.asList("hello", "world");
+        Object result = PgArrayParser.parseTypedArray(input, PostgresDataType.TEXTARRAY,
+                (type, value) -> value);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseTypedArray_EmptyArray() {
+        String input = "{}";
+        List<Object> expected = Collections.emptyList();
+        Object result = PgArrayParser.parseTypedArray(input, PostgresDataType.INT4ARRAY,
+                (type, value) -> Integer.parseInt(value));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseTypedArray_NullElements() {
+        String input = "{1,NULL,3}";
+        List<Integer> expected = Arrays.asList(1, null, 3);
+        Object result = PgArrayParser.parseTypedArray(input, PostgresDataType.INT4ARRAY,
+                (type, value) -> value.equals("NULL") ? null : Integer.parseInt(value));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseTypedArray_BoxArray() {
+        String input = "{(0,0,1,1);(2,2,3,3)}";
+        List<String> expected = Arrays.asList("(0,0,1,1)", "(2,2,3,3)");
+        Object result = PgArrayParser.parseTypedArray(input, PostgresDataType.BOX,
+                (type, value) -> value);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseRawArray_SimpleArray() {
+        String input = "{1,2,3}";
+        List<Object> expected = Arrays.asList("1", "2", "3");
+        List<Object> result = PgArrayParser.parseRawArray(input, ',');
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseRawArray_NestedArray() {
+        String input = "{{1,2},{3,4}}";
+        List<Object> expected = Arrays.asList(
+                Arrays.asList("1", "2"),
+                Arrays.asList("3", "4")
+        );
+        List<Object> result = PgArrayParser.parseRawArray(input, ',');
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseRawArray_WithEscapedCharacters() {
+        String input = "{\"hello,world\",\"escaped\\\"quote\"}";
+        List<Object> expected = Arrays.asList("hello,world", "escaped\"quote");
+        List<Object> result = PgArrayParser.parseRawArray(input, ',');
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testParseRawArray_NullInput() {
+        assertNull(PgArrayParser.parseRawArray(null, ','));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidArrayStrings")
+    void testParseRawArray_InvalidInput(String input) {
+        assertThrows(IllegalArgumentException.class, () -> PgArrayParser.parseRawArray(input, ','));
+    }
+
+    private static Stream<Arguments> provideInvalidArrayStrings() {
+        return Stream.of(
+                Arguments.of("1,2,3"),  // No curly braces
+                Arguments.of("{1,2,3"), // Missing closing brace
+                Arguments.of("1,2,3}")  // Missing opening brace
+        );
+    }
+}
+


### PR DESCRIPTION
### Description

- Added a parser to parse array types using `,` as delimiter for built-in array data types and `;` for box array type which are default delimiters. 
- Added support for all built-in array types
- Utilised the Pg library to get the OIDs of built-in data types. 
- No mapping for multirange array types and custom array types, data is returned as-is which is in text format.
- Returning the value as-is which is in text format for data types which are not supported.

 
### Issues Resolved
Contributes to #5309
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
