### PR TITLE
Give up partition when there is no Ack

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
@@ -42,7 +42,7 @@ public class StreamAcknowledgementManager {
     public static final String NEGATIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME = "negativeAcknowledgementSets";
     public static final String RECORDS_CHECKPOINTED = "recordsCheckpointed";
     public static final String NO_DATA_EXTEND_LEASE_COUNT = "noDataExtendLeaseCount";
-    public static final String GIVE_UP_PARTITION_COUNT = "giveupPartitionCount";
+    public static final String GIVE_UP_PARTITION_COUNT = "giveUpPartitionCount";
 
 
     public StreamAcknowledgementManager(final AcknowledgementSetManager acknowledgementSetManager,
@@ -85,8 +85,10 @@ public class StreamAcknowledgementManager {
                                 checkpointStatus = checkpoints.peek();
                                 ackCount++;
                                 // at high TPS each ack contains 100 records. This should checkpoint every 100*50 = 5000 records.
-                                if (ackCount % CHECKPOINT_RECORD_INTERVAL == 0) {
+                                if ((ackCount % CHECKPOINT_RECORD_INTERVAL == 0) ||
+                                        (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)){
                                     checkpoint(lastCheckpointStatus.getResumeToken(), lastCheckpointStatus.getRecordCount());
+                                    lastCheckpointTime = System.currentTimeMillis();
                                 }
                             } while (checkpointStatus != null && checkpointStatus.isPositiveAcknowledgement());
                             checkpoint(lastCheckpointStatus.getResumeToken(), lastCheckpointStatus.getRecordCount());
@@ -95,19 +97,23 @@ public class StreamAcknowledgementManager {
                     } else {
                         LOG.debug("Checkpoint not complete for resume token {}", checkpointStatus.getResumeToken());
                         final Duration ackWaitDuration = Duration.between(Instant.ofEpochMilli(checkpointStatus.getCreateTimestamp()), Instant.now());
+                        // negative ack
                         if (checkpointStatus.isNegativeAcknowledgement()) {
-                            // Give up partition and should interrupt parent thread to stop processing stream
-                            if (lastCheckpointStatus != null && lastCheckpointStatus.isPositiveAcknowledgement()) {
-                                checkpoint(lastCheckpointStatus.getResumeToken(), lastCheckpointStatus.getRecordCount());
-                            }
-                            LOG.warn("Acknowledgement not received for the checkpoint {} past wait time. Giving up partition.", checkpointStatus.getResumeToken());
-                            partitionCheckpoint.giveUpPartition();
-                            this.giveupPartitionCount.increment();
+                            LOG.warn("Negative Acknowledgement received for the checkpoint {}. Giving up partition.", checkpointStatus.getResumeToken());
+                            giveUpPartition(lastCheckpointStatus);
                             break;
+                        } else {
+                            // no ack received within timeout period (15 secs + 60 secs)
+                            if (!ackWaitDuration.minus(partitionAcknowledgmentTimeout)
+                                    .minusMillis(checkPointIntervalInMs).isNegative()) {
+                                LOG.warn("Acknowledgement not received for the checkpoint {} past wait time. Giving up partition.", checkpointStatus.getResumeToken());
+                                giveUpPartition(lastCheckpointStatus);
+                                break;
+                            }
                         }
                     }
                 } else {
-                    if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
+                    if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) { // 1 min
                         partitionCheckpoint.extendLease();
                         this.noDataExtendLeaseCount.increment();
                         lastCheckpointTime = System.currentTimeMillis();
@@ -128,10 +134,19 @@ public class StreamAcknowledgementManager {
         executorService.shutdown();
     }
 
+    private void giveUpPartition(final CheckpointStatus lastCheckpointStatus) {
+        // Give up partition and should interrupt parent thread to stop processing stream
+        if (lastCheckpointStatus != null && lastCheckpointStatus.isPositiveAcknowledgement()) {
+            checkpoint(lastCheckpointStatus.getResumeToken(), lastCheckpointStatus.getRecordCount());
+        }
+        partitionCheckpoint.giveUpPartition();
+        this.giveupPartitionCount.increment();
+    }
+
     private void checkpoint(final String resumeToken, final long recordCount) {
         LOG.debug("Perform regular checkpointing for resume token {} at record count {}", resumeToken, recordCount);
         partitionCheckpoint.checkpoint(resumeToken, recordCount);
-        this.recordsCheckpointed.increment(recordCount);
+        this.recordsCheckpointed.increment();
     }
 
     Optional<AcknowledgementSet> createAcknowledgementSet(final String resumeToken, final long recordNumber) {

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManagerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManagerTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
@@ -107,11 +106,11 @@ public class StreamAcknowledgementManagerTest {
         assertThat(ackCheckpointStatus.isPositiveAcknowledgement(), is(true));
         await()
            .atMost(Duration.ofSeconds(10)).untilAsserted(() ->
-                verify(partitionCheckpoint).checkpoint(resumeToken, recordCount));
+                verify(partitionCheckpoint, times(2)).checkpoint(resumeToken, recordCount));
         assertThat(streamAckManager.getCheckpoints().peek(), is(nullValue()));
         verify(positiveAcknowledgementSets).increment();
         verifyNoInteractions(negativeAcknowledgementSets);
-        verify(recordsCheckpointed, atLeastOnce()).increment(anyDouble());
+        verify(recordsCheckpointed, atLeastOnce()).increment();
     }
 
     @Test
@@ -146,12 +145,12 @@ public class StreamAcknowledgementManagerTest {
         assertThat(ackCheckpointStatus.isPositiveAcknowledgement(), is(true));
         await()
             .atMost(Duration.ofSeconds(10)).untilAsserted(() ->
-                verify(partitionCheckpoint).checkpoint(resumeToken2, recordCount2));
+                verify(partitionCheckpoint, times(2)).checkpoint(resumeToken2, recordCount2));
         assertThat(streamAckManager.getCheckpoints().peek(), is(nullValue()));
 
         verify(positiveAcknowledgementSets, atLeastOnce()).increment();
         verifyNoInteractions(negativeAcknowledgementSets);
-        verify(recordsCheckpointed, atLeastOnce()).increment(anyDouble());
+        verify(recordsCheckpointed, atLeastOnce()).increment();
     }
 
     @Test


### PR DESCRIPTION
### Description
Give up partition when there is no Ack to avoid partition expiring. When there is no ACK, there is a code flow where partition checkpoint is not updated.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
