### PR TITLE
FIX: sts headers override in AWS secret extension

### DIFF
--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfiguration.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfiguration.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -41,6 +42,10 @@ public class AwsSecretManagerConfiguration {
     @JsonProperty("sts_role_arn")
     @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
     private String awsStsRoleArn;
+
+    @JsonProperty("sts_header_overrides")
+    @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
+    private Map<String, String> awsStsHeaderOverrides;
 
     @JsonProperty("refresh_interval")
     @NotNull(message = "refresh_interval must not be null")
@@ -100,6 +105,11 @@ public class AwsSecretManagerConfiguration {
             AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
                     .roleSessionName("aws-secret-" + UUID.randomUUID())
                     .roleArn(awsStsRoleArn);
+
+            if (awsStsHeaderOverrides != null && !awsStsHeaderOverrides.isEmpty()) {
+                assumeRoleRequestBuilder = assumeRoleRequestBuilder.overrideConfiguration(
+                        configuration -> awsStsHeaderOverrides.forEach(configuration::putHeader));
+            }
 
             awsCredentialsProvider = StsAssumeRoleCredentialsProvider.builder()
                     .stsClient(stsClient)

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfigurationTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfigurationTest.java
@@ -30,16 +30,19 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRequest;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -49,6 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -205,6 +209,49 @@ class AwsSecretManagerConfigurationTest {
         verify(secretsManagerClientBuilder).credentialsProvider(awsCredentialsProviderArgumentCaptor.capture());
         final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsProviderArgumentCaptor.getValue();
         assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+    }
+
+    @Test
+    void testCreateSecretManagerClientWithStsHeaderOverrides() throws IOException {
+        final InputStream inputStream = AwsSecretPluginConfigTest.class.getResourceAsStream(
+                "/test-aws-secret-manager-configuration-with-sts-headers.yaml");
+        final AwsSecretManagerConfiguration awsSecretManagerConfiguration = objectMapper.readValue(
+                inputStream, AwsSecretManagerConfiguration.class);
+        assertThat(awsSecretManagerConfiguration.getAwsSecretId(), equalTo("test-secret"));
+        final StsAssumeRoleCredentialsProvider.Builder stsAssumeRoleCredentialsProviderBuilder =
+                mock(StsAssumeRoleCredentialsProvider.Builder.class);
+        final StsAssumeRoleCredentialsProvider stsAssumeRoleCredentialsProvider =
+                mock(StsAssumeRoleCredentialsProvider.class);
+        when(stsAssumeRoleCredentialsProviderBuilder.stsClient(any()))
+                .thenReturn(stsAssumeRoleCredentialsProviderBuilder);
+        when(stsAssumeRoleCredentialsProviderBuilder.refreshRequest(any(AssumeRoleRequest.class)))
+                .thenReturn(stsAssumeRoleCredentialsProviderBuilder);
+        when(stsAssumeRoleCredentialsProviderBuilder.build()).thenReturn(stsAssumeRoleCredentialsProvider);
+        when(secretsManagerClientBuilder.region(any(Region.class))).thenReturn(secretsManagerClientBuilder);
+        when(secretsManagerClientBuilder.credentialsProvider(any(AwsCredentialsProvider.class)))
+                .thenReturn(secretsManagerClientBuilder);
+        when(secretsManagerClientBuilder.build()).thenReturn(secretsManagerClient);
+        try (final MockedStatic<SecretsManagerClient> secretsManagerClientMockedStatic = mockStatic(
+                SecretsManagerClient.class);
+             final MockedStatic<StsAssumeRoleCredentialsProvider> stsAssumeRoleCredentialsProviderMockedStatic =
+                     mockStatic(StsAssumeRoleCredentialsProvider.class)) {
+            secretsManagerClientMockedStatic.when(SecretsManagerClient::builder).thenReturn(secretsManagerClientBuilder);
+            stsAssumeRoleCredentialsProviderMockedStatic.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(
+                    stsAssumeRoleCredentialsProviderBuilder);
+            assertThat(awsSecretManagerConfiguration.createSecretManagerClient(), is(secretsManagerClient));
+        }
+        verify(secretsManagerClientBuilder).credentialsProvider(awsCredentialsProviderArgumentCaptor.capture());
+        final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsProviderArgumentCaptor.getValue();
+        assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+        final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor =
+                ArgumentCaptor.forClass(AssumeRoleRequest.class);
+        verify(stsAssumeRoleCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
+        final AssumeRoleRequest assumeRoleRequest = assumeRoleRequestArgumentCaptor.getValue();
+        assertThat(assumeRoleRequest.overrideConfiguration().isPresent(), is(true));
+        final AwsRequestOverrideConfiguration awsRequestOverrideConfiguration = assumeRoleRequest
+                .overrideConfiguration().get();
+        assertThat(awsRequestOverrideConfiguration.headers().size(), equalTo(1));
+        assertThat(awsRequestOverrideConfiguration.headers().get("test-header"), equalTo(List.of("test-value")));
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/aws-plugin/src/test/resources/test-aws-secret-manager-configuration-with-sts-headers.yaml
+++ b/data-prepper-plugins/aws-plugin/src/test/resources/test-aws-secret-manager-configuration-with-sts-headers.yaml
@@ -1,0 +1,5 @@
+secret_id: test-secret
+region: us-east-1
+sts_role_arn: arn:aws:iam::123456789012:role/test-role
+sts_header_overrides:
+  test-header: test-value


### PR DESCRIPTION
### Description
This PR allows sts_header_overrides to be configured in aws secret config
 
### Issues Resolved
Resolves #5475 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
