### PR TITLE
Typo fix to correct the timezone issue

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/utils/TimezoneHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/utils/TimezoneHelperTest.java
@@ -46,8 +46,8 @@ public class TimezoneHelperTest {
         Duration reverseOffset = TimezoneHelper.getTimezoneOffset(sourceZone, targetZone);
         // The Range check is because of the Day light saving time changes. Otherwise, this would have been equals check
         assertAll(
-                () -> assertTrue(reverseOffset.compareTo(maxDuration) >= 0, "Timezone Offset should be at least " + minDuration),
-                () -> assertTrue(reverseOffset.compareTo(maxDuration) <= 0, "Timezone Offset should be at most " + maxDuration)
+                () -> assertTrue(reverseOffset.compareTo(maxDuration) >= 0, "Timezone Offset should be at least " + maxDuration),
+                () -> assertTrue(reverseOffset.compareTo(minDuration) <= 0, "Timezone Offset should be at most " + minDuration)
         );
     }
 


### PR DESCRIPTION
### Description
Timezone offset comparison was already considering DST changes but there is a typo in the comparison variable. Fixing that typo in this pr
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
