### PR TITLE
Enh/support default credentials in dynamic transformation

### DIFF
--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -458,7 +458,14 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
     }
 
     public String getAccountIdFromRole(final String roleArn) {
-        return Arn.fromString(roleArn).accountId().orElse(null);
+        if (roleArn == null)
+            return null;
+        try {
+            return Arn.fromString(roleArn).accountId().orElse(null);
+        } catch (Exception e) {
+            LOG.warn("Malformatted role ARN for dynamic transformation: {}", roleArn);
+            return null;
+        }
     }
 
     /**

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
@@ -57,7 +57,6 @@ public class MongoDBSourceConfig {
     private Boolean directConnection;
 
     @JsonProperty("aws")
-    @NotNull
     @Valid
     private AwsConfig awsConfig;
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3Source.java
@@ -76,7 +76,7 @@ public class S3Source implements Source<Record<Event>>, UsesSourceCoordination {
         }
         final AwsAuthenticationAdapter awsAuthenticationAdapter = new AwsAuthenticationAdapter(awsCredentialsSupplier, s3SourceConfig);
         final AwsCredentialsProvider credentialsProvider = awsAuthenticationAdapter.getCredentialsProvider();
-        final ConfigBucketOwnerProviderFactory configBucketOwnerProviderFactory = new ConfigBucketOwnerProviderFactory();
+        final ConfigBucketOwnerProviderFactory configBucketOwnerProviderFactory = new ConfigBucketOwnerProviderFactory(credentialsProvider);
         final BucketOwnerProvider bucketOwnerProvider = configBucketOwnerProviderFactory.createBucketOwnerProvider(s3SourceConfig);
         Optional<S3SelectOptions> s3SelectOptional = Optional.ofNullable(s3SourceConfig.getS3SelectOptions());
         S3ObjectPluginMetrics s3ObjectPluginMetrics = new S3ObjectPluginMetrics(pluginMetrics);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactory.java
@@ -53,13 +53,10 @@ public class ConfigBucketOwnerProviderFactory {
         else if(s3SourceConfig.getAwsAuthenticationOptions() != null && s3SourceConfig.getAwsAuthenticationOptions().getAwsStsRoleArn() != null)
             accountId = extractStsRoleArnAccountId(s3SourceConfig);
         else {
-            final Optional<String> accountIdOptional = defaultAwsCredentialsProvider.resolveCredentials().accountId();
-            if (accountIdOptional.isEmpty()) {
-                throw new InvalidPluginConfigurationException(
-                        "The S3 source is unable to determine a bucket owner. Configure the default_bucket_owner for the account Id that owns the bucket. You may also want to configure bucket_owners if you read from S3 buckets in different accounts.");
-            } else {
-                accountId = accountIdOptional.get();
-            }
+            accountId = defaultAwsCredentialsProvider.resolveCredentials().accountId()
+                    .orElseThrow(() -> new InvalidPluginConfigurationException(
+                            "The S3 source is unable to determine a bucket owner. Configure the default_bucket_owner for the account Id that owns the bucket. You may also want to configure bucket_owners if you read from S3 buckets in different accounts."
+                    ));
         }
 
         return new StaticBucketOwnerProvider(accountId);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactory.java
@@ -9,14 +9,23 @@ import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationExcepti
 import org.opensearch.dataprepper.plugins.source.s3.S3SourceConfig;
 import org.opensearch.dataprepper.plugins.source.s3.SqsQueueUrl;
 import org.opensearch.dataprepper.plugins.source.s3.StsArnRole;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.net.MalformedURLException;
+import java.util.Optional;
 
 /**
  * Produces a {@link BucketOwnerProvider} from the S3 source configuration as
  * provided in a {@link S3SourceConfig}.
  */
 public class ConfigBucketOwnerProviderFactory {
+    private final AwsCredentialsProvider defaultAwsCredentialsProvider;
+
+
+    public ConfigBucketOwnerProviderFactory(final AwsCredentialsProvider defaultAwsCredentialsProvider) {
+        this.defaultAwsCredentialsProvider = defaultAwsCredentialsProvider;
+    }
+
     /**
      * Creates the {@link BucketOwnerProvider}
      * @param s3SourceConfig The input {@link S3SourceConfig}
@@ -43,9 +52,15 @@ public class ConfigBucketOwnerProviderFactory {
             accountId = extractQueueAccountId(s3SourceConfig);
         else if(s3SourceConfig.getAwsAuthenticationOptions() != null && s3SourceConfig.getAwsAuthenticationOptions().getAwsStsRoleArn() != null)
             accountId = extractStsRoleArnAccountId(s3SourceConfig);
-        else
-            throw new InvalidPluginConfigurationException(
-                    "The S3 source is unable to determine a bucket owner. Configure the default_bucket_owner for the account Id that owns the bucket. You may also want to configure bucket_owners if you read from S3 buckets in different accounts.");
+        else {
+            final Optional<String> accountIdOptional = defaultAwsCredentialsProvider.resolveCredentials().accountId();
+            if (accountIdOptional.isEmpty()) {
+                throw new InvalidPluginConfigurationException(
+                        "The S3 source is unable to determine a bucket owner. Configure the default_bucket_owner for the account Id that owns the bucket. You may also want to configure bucket_owners if you read from S3 buckets in different accounts.");
+            } else {
+                accountId = accountIdOptional.get();
+            }
+        }
 
         return new StaticBucketOwnerProvider(accountId);
     }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactory.java
@@ -12,7 +12,6 @@ import org.opensearch.dataprepper.plugins.source.s3.StsArnRole;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.net.MalformedURLException;
-import java.util.Optional;
 
 /**
  * Produces a {@link BucketOwnerProvider} from the S3 source configuration as


### PR DESCRIPTION
### Description
This PR supports default credential supplier from data prepper extension by

* fix the bug in getAccountIdFromRoleArn in DynamicConfigTransformer
* fix S3Source bucketOwnerProvider to support default credential from extension
* remove @NotNull annotation on awsConfig for docdb.

Besides unit test, the following docdb source config is tested upon:
```
documentdb-pipeline:
  source:
    documentdb:
      acknowledgments: true
      host: "localhost"
      port: 27017
      authentication:
        username: ${{aws_secrets:secret:username}}
        password: ${{aws_secrets:secret:password}}
      # No AWS block is required
      s3_bucket: "docdb-qchea-test"
      s3_region: "us-east-1" 
      # optional s3_prefix for Opensearch ingestion to write the records
      # s3_prefix: "<<path_prefix>>"
      ssl_insecure_disable_verification: true
      trust_store_file_path: "/Users/qchea/Downloads/InternalAndExternalAndAWSTrustStore.jks"
      trust_store_password: "amazon"
      collections:
        # collection format: <databaseName>.<collectionName>
        - collection: "docdbdemo.streamdemo"
          export: true
          stream: true
```
with the following extension in data-prepper-config.yaml:
```
extensions:
  aws:
    configurations:
      default:
        region: us-east-1
        sts_role_arn: <...>
  ...
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
