### PR TITLE
Add bucket_owner option to S3 DLQ

### DIFF
--- a/data-prepper-plugins/failures-common/build.gradle
+++ b/data-prepper-plugins/failures-common/build.gradle
@@ -10,6 +10,7 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -55,6 +55,8 @@ public class S3DlqWriter implements DlqWriter {
     private final S3Client s3Client;
     private final String bucket;
     private final String keyPathPrefix;
+
+    private final String bucketOwner;
     private final ObjectMapper objectMapper;
 
     private final Counter dlqS3RecordsSuccessCounter;
@@ -80,6 +82,7 @@ public class S3DlqWriter implements DlqWriter {
             enforceDefaultDelimiterOnKeyPathPrefix(s3DlqWriterConfig.getKeyPathPrefix());
         this.objectMapper = objectMapper;
         this.keyPathGenerator = new KeyPathGenerator(keyPathPrefix);
+        this.bucketOwner = s3DlqWriterConfig.getBucketOwner();
     }
 
     @Override
@@ -102,6 +105,7 @@ public class S3DlqWriter implements DlqWriter {
     private void doWrite(final List<DlqObject> dlqObjects, final String pipelineName, final String pluginId) throws IOException {
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
             .bucket(bucket)
+            .expectedBucketOwner(bucketOwner)
             .key(buildKey(pipelineName, pluginId))
             .build();
 

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.dlq.s3;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensearch.dataprepper.aws.validator.AwsAccountId;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import software.amazon.awssdk.arns.Arn;
@@ -60,6 +61,10 @@ public class S3DlqWriterConfig {
     @JsonProperty("sts_header_overrides")
     private Map<String, String> stsHeaderOverrides;
 
+    @JsonProperty("bucket_owner")
+    @AwsAccountId
+    private String bucketOwner;
+
     public String getBucket() {
         if (bucket.startsWith(S3_PREFIX)) {
             return bucket.substring(S3_PREFIX.length());
@@ -74,6 +79,8 @@ public class S3DlqWriterConfig {
     public Region getRegion() {
         return Region.of(region);
     }
+
+    public String getBucketOwner() { return bucketOwner; }
 
     private AwsCredentialsProvider getAwsCredentialsProvider() {
 

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
@@ -140,6 +140,7 @@ public class S3DlqWriterTest {
         when(config.getKeyPathPrefix()).thenReturn(keyPathPrefix);
         when(config.getS3Client()).thenReturn(s3Client);
         when(config.getBucket()).thenReturn(bucket);
+        when(config.getBucketOwner()).thenReturn(UUID.randomUUID().toString());
         when(dlqS3RequestTimer.recordCallable(any(Callable.class))).thenAnswer(a -> {
             try {
                 return a.getArgument(0, Callable.class).call();
@@ -161,6 +162,7 @@ public class S3DlqWriterTest {
         assertThat(putObjectRequest.bucket(), is(equalTo(bucket)));
         assertThat(putObjectRequest.key(), startsWith(String.format("%s-%s-%s", expectedKeyPrefix, pipelineName, pluginId)));
         assertThat(putObjectRequest.key(), endsWith(".json"));
+        assertThat(putObjectRequest.expectedBucketOwner(), equalTo(config.getBucketOwner()));
         verify(dlqS3RequestSuccessCounter).increment();
         verify(dlqS3RecordsSuccessCounter).increment(dlqObjects.size());
     }


### PR DESCRIPTION
### Description
This adds a `bucket_owner` configuration option to the S3 DLQ and passes this bucket owner to `expectedBucketOwner` in the PutObject request.

```
dlq:
  s3:
    bucket_owner: "123456789012"
```
 
### Issues Resolved
Resolves #5498 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
