### PR TITLE
Fix lambda plugin threshold and flaky test

### DIFF
--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/util/ThresholdCheck.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/util/ThresholdCheck.java
@@ -19,15 +19,24 @@ import java.time.Duration;
 public class ThresholdCheck {
 
       public static boolean checkTimeoutExceeded(final Buffer currentBuffer, final Duration maxCollectionDuration) {
+          if (currentBuffer.getEventCount() == 0) {
+              return false;
+          }
         return currentBuffer.getDuration().compareTo(maxCollectionDuration) > 0;
     }
 
      public static boolean checkSizeThresholdExceed(final Buffer currentBuffer, final ByteCount maxBytes, Record<Event> nextRecord) {
+         if (currentBuffer.getEventCount() == 0) {
+             return false;
+         }
         int estimatedRecordSize = estimateRecordSize(nextRecord);
         return (currentBuffer.getSize() + estimatedRecordSize) > maxBytes.getBytes();
     }
 
     public static boolean checkEventCountThresholdExceeded(final Buffer currentBuffer, final int maxEvents) {
+        if (currentBuffer.getEventCount() == 0) {
+            return false;
+        }
         return currentBuffer.getEventCount() >= maxEvents;
     }
 

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessor.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessor.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+import software.amazon.awssdk.services.lambda.model.LambdaException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -201,7 +202,9 @@ public class LambdaProcessor extends AbstractProcessor<Record<Event>, Record<Eve
 
             } catch (Exception e) {
                 LOG.error(NOISY, e.getMessage(), e);
-                if(e.getMessage().contains(EXCEEDING_PAYLOAD_LIMIT_EXCEPTION)){
+                if (e instanceof LambdaException &&
+                        e.getMessage() != null &&
+                        e.getMessage().contains(EXCEEDING_PAYLOAD_LIMIT_EXCEPTION)) {
                     batchExceedingThresholdCounter.increment();
                 }
                 /* fall through */

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/common/ThresholdCheckTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/common/ThresholdCheckTest.java
@@ -55,6 +55,7 @@ class ThresholdCheckTest {
     void testTimeoutExceededTrue() {
         // Simulate a buffer that has been open for 6 minutes (exceeding the 5-minute limit)
         when(buffer.getDuration()).thenReturn(Duration.ofMinutes(6));
+        when(buffer.getEventCount()).thenReturn(1);
         assertTrue(ThresholdCheck.checkTimeoutExceeded(buffer, maxCollectionDuration),
                 "Expected timeout threshold to be exceeded.");
     }
@@ -63,6 +64,7 @@ class ThresholdCheckTest {
     void testTimeoutExceededFalse() {
         // Simulate a buffer that has been open for 4 minutes (within the limit)
         when(buffer.getDuration()).thenReturn(Duration.ofMinutes(4));
+        when(buffer.getEventCount()).thenReturn(1);
         assertFalse(ThresholdCheck.checkTimeoutExceeded(buffer, maxCollectionDuration),
                 "Expected timeout threshold to NOT be exceeded.");
     }
@@ -71,6 +73,7 @@ class ThresholdCheckTest {
     @Test
     void testSizeThresholdExceedTrue() {
         long maxBytesValue = maxBytes.getBytes();
+        when(buffer.getEventCount()).thenReturn(1);
         when(buffer.getSize()).thenReturn(maxBytesValue - 1);
         // The record's estimated size is 2 bytes (from "{}").
         // So, adding the record yields: (maxBytes - 1) + 2 = maxBytes + 1 (exceeds limit).


### PR DESCRIPTION
### Description
Fix lambda plugin threshold to avoid empty buffer and fix flaky test
 
### Issues Resolved
Resolves #5522 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
