### PR TITLE
Implement querying for existing documents to handle duplicates on condition or bulk request/operation failures

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -46,19 +46,23 @@ public class BulkOperationWrapper {
     private final BulkOperation bulkOperation;
     private final SerializedJson jsonNode;
 
+    private final String queryTerm;
+
     public BulkOperationWrapper(final BulkOperation bulkOperation) {
-        this(bulkOperation, null, null);
+        this(bulkOperation, null, null, null);
     }
 
-    public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle, final SerializedJson jsonNode) {
+    public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle, final SerializedJson jsonNode,
+                                final String queryTerm) {
         checkNotNull(bulkOperation);
         this.bulkOperation = bulkOperation;
         this.eventHandle = eventHandle;
         this.jsonNode = jsonNode;
+        this.queryTerm = queryTerm;
     }
 
     public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle) {
-        this(bulkOperation, eventHandle, null);
+        this(bulkOperation, eventHandle, null, null);
     }
 
     public BulkOperation getBulkOperation() {
@@ -78,6 +82,10 @@ public class BulkOperationWrapper {
             return jsonNode;
         }
         return getValueFromConverter(BULK_OPERATION_TO_DOCUMENT_CONVERTERS);
+    }
+
+    public String getTermValue() {
+        return queryTerm;
     }
 
     public String getIndex() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -102,17 +102,13 @@ public final class BulkRetryStrategy {
                     RestStatus.REQUEST_TIMEOUT.getStatus()
             ));
 
-    private static final Set<Integer> POTENTIAL_DUPLICATES_ERRORS = new HashSet<>(
-            Arrays.asList(
-                    RestStatus.INTERNAL_SERVER_ERROR.getStatus(),
-                    RestStatus.GATEWAY_TIMEOUT.getStatus()
-            ));
+    private static final Set<Integer> POTENTIAL_DUPLICATES_ERRORS = Set.of(
+            RestStatus.INTERNAL_SERVER_ERROR.getStatus(),
+            RestStatus.GATEWAY_TIMEOUT.getStatus());
 
-    private static final Set<Class<? extends Exception>> SOCKET_TIMEOUT_EXCEPTIONS = new HashSet<>(
-            Arrays.asList(
-                    SocketTimeoutException.class,
-                    JsonParsingException.class
-            ));
+    private static final Set<Class<? extends Exception>> SOCKET_TIMEOUT_EXCEPTIONS = Set.of(
+            SocketTimeoutException.class,
+            JsonParsingException.class);
 
     private final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction;
     private final BiConsumer<List<FailedBulkOperation>, Throwable> logFailure;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.retry.Backoff;
 import io.micrometer.core.instrument.Counter;
+import jakarta.json.stream.JsonParsingException;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -17,11 +18,13 @@ import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager;
 import org.opensearch.rest.RestStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -99,6 +102,18 @@ public final class BulkRetryStrategy {
                     RestStatus.REQUEST_TIMEOUT.getStatus()
             ));
 
+    private static final Set<Integer> POTENTIAL_DUPLICATES_ERRORS = new HashSet<>(
+            Arrays.asList(
+                    RestStatus.INTERNAL_SERVER_ERROR.getStatus(),
+                    RestStatus.GATEWAY_TIMEOUT.getStatus()
+            ));
+
+    private static final Set<Class<? extends Exception>> SOCKET_TIMEOUT_EXCEPTIONS = new HashSet<>(
+            Arrays.asList(
+                    SocketTimeoutException.class,
+                    JsonParsingException.class
+            ));
+
     private final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction;
     private final BiConsumer<List<FailedBulkOperation>, Throwable> logFailure;
     private final PluginMetrics pluginMetrics;
@@ -119,6 +134,7 @@ public final class BulkRetryStrategy {
     private final Counter bulkRequestServerErrors;
     private final Counter documentsVersionConflictErrors;
     private final Counter documentsDuplicates;
+    private final ExistingDocumentQueryManager existingDocumentQueryManager;
     private static final Logger LOG = LoggerFactory.getLogger(BulkRetryStrategy.class);
 
     static class BulkOperationRequestResponse {
@@ -136,6 +152,7 @@ public final class BulkRetryStrategy {
         BulkResponse getResponse() {
             return response;
         }
+        Exception getException() { return exception; }
         String getExceptionMessage() {
             return exception != null ? exception.getMessage() : "-";
         }
@@ -147,7 +164,9 @@ public final class BulkRetryStrategy {
                              final int maxRetries,
                              final Supplier<AccumulatingBulkRequest> bulkRequestSupplier,
                              final String pipelineName,
-                             final String pluginName) {
+                             final String pluginName,
+                             final ExistingDocumentQueryManager existingDocumentQueryManager) {
+        this.existingDocumentQueryManager = existingDocumentQueryManager;
         this.requestFunction = requestFunction;
         this.logFailure = logFailure;
         this.pluginMetrics = pluginMetrics;
@@ -193,16 +212,18 @@ public final class BulkRetryStrategy {
         final Backoff backoff = Backoff.exponential(INITIAL_DELAY_MS, MAXIMUM_DELAY_MS).withMaxAttempts(maxRetries);
         BulkOperationRequestResponse operationResponse;
         BulkResponse response = null;
+        Exception exception = null;
         AccumulatingBulkRequest request = bulkRequest;
         int attempt = 1;
         do {
-            operationResponse = handleRetry(request, response, attempt);
+            operationResponse = handleRetry(request, response, attempt, exception);
             if (operationResponse != null) {
                 final long delayMillis = backoff.nextDelayMillis(attempt++);
                 String exceptionMessage = "";
                 request = operationResponse.getBulkRequest();
                 response = operationResponse.getResponse();
                 exceptionMessage = operationResponse.getExceptionMessage();
+                exception = operationResponse.getException();
                 if (delayMillis < 0) {
                     RuntimeException e = new RuntimeException(String.format("Number of retries reached the limit of max retries (configured value %d. Last exception message: %s)", maxRetries, exceptionMessage));
                     handleFailures(request, null, e);
@@ -285,8 +306,11 @@ public final class BulkRetryStrategy {
         bulkRequestFailedCounter.increment();
     }
 
-    private BulkOperationRequestResponse handleRetry(final AccumulatingBulkRequest request, final BulkResponse response, int retryCount) throws InterruptedException {
-        final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response);
+    private BulkOperationRequestResponse handleRetry(final AccumulatingBulkRequest request,
+                                                     final BulkResponse response,
+                                                     int retryCount,
+                                                     final Exception previousException) throws InterruptedException {
+        final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response, previousException);
         if (bulkRequestForRetry.getOperationsCount() == 0) {
             return null;
         }
@@ -317,7 +341,14 @@ public final class BulkRetryStrategy {
     }
 
     private AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> createBulkRequestForRetry(
-            final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> request, final BulkResponse response) {
+            final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> request, final BulkResponse response, final Exception previousException) {
+        if (shouldSendAllForQuerying(previousException)) {
+                for (final BulkOperationWrapper bulkOperationWrapper : request.getOperations()) {
+                    existingDocumentQueryManager.addBulkOperation(bulkOperationWrapper);
+                }
+                return bulkRequestSupplier.get();
+        }
+
         if (response == null) {
             // first attempt or retry due to Exception
             return request;
@@ -329,6 +360,12 @@ public final class BulkRetryStrategy {
                 BulkOperationWrapper bulkOperation =
                     (BulkOperationWrapper)request.getOperationAt(index);
                 if (isItemInError(bulkItemResponse)) {
+                    if (existingDocumentQueryManager != null && POTENTIAL_DUPLICATES_ERRORS.contains(bulkItemResponse.status())) {
+                        existingDocumentQueryManager.addBulkOperation(bulkOperation);
+                        index++;
+                        continue;
+                    }
+
                     if (!NON_RETRY_STATUS.contains(bulkItemResponse.status())) {
                         requestToReissue.addOperation(bulkOperation);
                     } else if (bulkItemResponse.error() != null && VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
@@ -415,5 +452,17 @@ public final class BulkRetryStrategy {
 
     private Counter getDocumentStatusCounter(final int status) {
         return pluginMetrics.counterWithTags(DOCUMENT_STATUSES, "status", Integer.toString(status));
+    }
+
+    private boolean shouldSendAllForQuerying(final Exception exception) {
+        if (exception != null && existingDocumentQueryManager != null) {
+            if (SOCKET_TIMEOUT_EXCEPTIONS.contains(exception.getClass())) {
+                return true;
+            }
+
+            return exception instanceof OpenSearchException && POTENTIAL_DUPLICATES_ERRORS.contains(((OpenSearchException) exception).status());
+        }
+
+        return false;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -23,6 +23,7 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.opensearch.client.transport.TransportOptions;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.expression.ExpressionEvaluationException;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.MetricNames;
@@ -61,6 +62,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperatio
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.ClusterSettingsParser;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.DocumentBuilder;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManagerFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapper;
@@ -78,11 +80,15 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -149,6 +155,12 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private final ConcurrentHashMap<Long, Long> lastFlushTimeMap;
   private final PluginConfigObservable pluginConfigObservable;
 
+  private ExistingDocumentQueryManager existingDocumentQueryManager;
+
+  private final ExecutorService queryExecutorService;
+
+  private final int processWorkerThreads;
+
   @DataPrepperPluginConstructor
   public OpenSearchSink(final PluginSetting pluginSetting,
                         final SinkContext sinkContext,
@@ -158,6 +170,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
                         final PluginConfigObservable pluginConfigObservable,
                         final OpenSearchSinkConfig openSearchSinkConfiguration) {
     super(pluginSetting, Integer.MAX_VALUE, INITIALIZE_RETRY_WAIT_TIME_MS);
+    this.processWorkerThreads = pipelineDescription.getNumberOfProcessWorkers();
     this.awsCredentialsSupplier = awsCredentialsSupplier;
     this.sinkContext = sinkContext != null ? sinkContext : new SinkContext(null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
     this.expressionEvaluator = expressionEvaluator;
@@ -190,6 +203,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     this.lastFlushTimeMap = new ConcurrentHashMap<>();
     this.pluginConfigObservable = pluginConfigObservable;
     this.objectMapper = new ObjectMapper();
+    this.queryExecutorService = openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null ?
+            Executors.newSingleThreadExecutor(BackgroundThreadFactory.defaultExecutorThreadFactory("existing-document-query-manager")) : null;
 
     final Optional<DlqConfiguration> dlqConfig = openSearchSinkConfig.getRetryConfiguration().getDlq();
     if (dlqConfig.isPresent()) {
@@ -233,6 +248,12 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     };
     openSearchClientRefresher = new OpenSearchClientRefresher(
             pluginMetrics, connectionConfiguration, clientFunction);
+
+    if (queryExecutorService != null) {
+      existingDocumentQueryManager = new ExistingDocumentQueryManager(openSearchSinkConfig.getIndexConfiguration(), pluginMetrics, openSearchClient);
+      queryExecutorService.submit(existingDocumentQueryManager);
+    }
+
     pluginConfigObservable.addPluginConfigObserver(
             newOpenSearchSinkConfig -> openSearchClientRefresher.update((OpenSearchSinkConfig) newOpenSearchSinkConfig));
     configuredIndexAlias = openSearchSinkConfig.getIndexConfiguration().getIndexAlias();
@@ -280,7 +301,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             maxRetries,
             bulkRequestSupplier,
             pipeline,
-            PLUGIN_NAME);
+            PLUGIN_NAME,
+            openSearchSinkConfig.getIndexConfiguration().getQueryOnBulkFailures() ? existingDocumentQueryManager : null);
 
     this.initialized = true;
     LOG.info("Initialized OpenSearch sink");
@@ -394,6 +416,22 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest = bulkRequestMap.get(threadId);
     long lastFlushTime = lastFlushTimeMap.get(threadId);
 
+    Set<BulkOperationWrapper> documentsReadyForIndexing = new HashSet<>();
+    if (openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null) {
+      documentsReadyForIndexing = existingDocumentQueryManager.getAndClearBulkOperationsReadyToIndex();
+    }
+
+
+    if (!documentsReadyForIndexing.isEmpty()) {
+      LOG.info("Found {} documents ready for indexing from query manager", documentsReadyForIndexing.size());
+    }
+
+    for (final BulkOperationWrapper bulkOperationWrapper : documentsReadyForIndexing) {
+      bulkRequest = flushBatch(bulkRequest, bulkOperationWrapper, lastFlushTime);
+      bulkRequest.addOperation(bulkOperationWrapper);
+    }
+
+
     for (final Record<Event> record : records) {
       final Event event = record.getData();
       final SerializedJson document = getDocument(event);
@@ -465,13 +503,17 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         continue;
       }
 
-      BulkOperationWrapper bulkOperationWrapper = new BulkOperationWrapper(bulkOperation, event.getEventHandle(), serializedJsonNode);
-      final long estimatedBytesBeforeAdd = bulkRequest.estimateSizeInBytesWithDocument(bulkOperationWrapper);
-      if (bulkSize >= 0 && estimatedBytesBeforeAdd >= bulkSize && bulkRequest.getOperationsCount() > 0) {
-        flushBatch(bulkRequest);
-        lastFlushTime = System.currentTimeMillis();
-        bulkRequest = bulkRequestSupplier.get();
+      final String termValue = openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null ?
+              event.get(openSearchSinkConfig.getIndexConfiguration().getQueryTerm(), String.class) : null;
+      BulkOperationWrapper bulkOperationWrapper = new BulkOperationWrapper(bulkOperation, event.getEventHandle(), serializedJsonNode, termValue);
+
+      if (openSearchSinkConfig.getIndexConfiguration().getQueryWhen() != null &&
+              expressionEvaluator.evaluateConditional(openSearchSinkConfig.getIndexConfiguration().getQueryWhen(), event)) {
+        existingDocumentQueryManager.addBulkOperation(bulkOperationWrapper);
+        continue;
       }
+
+      bulkRequest = flushBatch(bulkRequest, bulkOperationWrapper, lastFlushTime);
       bulkRequest.addOperation(bulkOperationWrapper);
     }
 
@@ -606,6 +648,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     super.shutdown();
     closeFiles();
     openSearchClient.shutdown();
+    if (queryExecutorService != null) {
+      existingDocumentQueryManager.stop();
+      queryExecutorService.shutdown();
+    }
   }
 
   private void maybeUpdateServerlessNetworkPolicy() {
@@ -651,5 +697,19 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             (sinkContext.getIncludeKeys() != null && !sinkContext.getIncludeKeys().isEmpty()) ||
             (sinkContext.getExcludeKeys() != null && !sinkContext.getExcludeKeys().isEmpty()) ||
             sinkContext.getTagsTargetKey() != null;
+  }
+
+  private AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> flushBatch(
+          final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest,
+          final BulkOperationWrapper bulkOperationWrapper,
+          long lastFlushTime
+          ) {
+    final long estimatedBytesBeforeAdd = bulkRequest.estimateSizeInBytesWithDocument(bulkOperationWrapper);
+    if (bulkSize >= 0 && estimatedBytesBeforeAdd >= bulkSize && bulkRequest.getOperationsCount() > 0) {
+      flushBatch(bulkRequest);
+      lastFlushTime = System.currentTimeMillis();
+      return bulkRequestSupplier.get();
+    }
+   return bulkRequest;
   }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -503,8 +503,9 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         continue;
       }
 
-      final String termValue = openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null ?
-              event.get(openSearchSinkConfig.getIndexConfiguration().getQueryTerm(), String.class) : null;
+      final String queryTermKey = openSearchSinkConfig.getIndexConfiguration().getQueryTerm();
+      final String termValue = queryTermKey != null ?
+              event.get(queryTermKey, String.class) : null;
       BulkOperationWrapper bulkOperationWrapper = new BulkOperationWrapper(bulkOperation, event.getEventHandle(), serializedJsonNode, termValue);
 
       if (openSearchSinkConfig.getIndexConfiguration().getQueryWhen() != null &&

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.plugins.sink.opensearch.DistributionVersion;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateType;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.model.QueryForExistingDocumentConfiguration;
 
 import java.util.List;
 import java.util.Map;
@@ -174,6 +175,10 @@ public class OpenSearchSinkConfig {
     @Getter
     @JsonProperty("dlq")
     private DlqConfiguration dlq;
+
+    @Getter
+    @JsonProperty("query_for_existing_document")
+    private QueryForExistingDocumentConfiguration queryExistingConfiguration;
 
     @AssertTrue(message = "dlq_file option cannot be used along with dlq option")
     public boolean isDlqValid() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -177,7 +177,7 @@ public class OpenSearchSinkConfig {
     private DlqConfiguration dlq;
 
     @Getter
-    @JsonProperty("query_for_existing_document")
+    @JsonProperty("query_lookup")
     private QueryForExistingDocumentConfiguration queryExistingConfiguration;
 
     @AssertTrue(message = "dlq_file option cannot be used along with dlq option")

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManager.java
@@ -1,0 +1,242 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
+import org.opensearch.client.opensearch.core.MsearchRequest;
+import org.opensearch.client.opensearch.core.MsearchResponse;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.model.QueryManagerBulkOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class ExistingDocumentQueryManager implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExistingDocumentQueryManager.class);
+
+    private static final Duration QUERY_INTERVAL = Duration.ofSeconds(20);
+
+    static final String EVENTS_DROPPED_AND_RELEASED = "eventsDroppedAndReleasedAfterQuery";
+
+    static final String EVENTS_ADDED_FOR_QUERYING = "eventsAddedForQuerying";
+
+    static final String EVENTS_RETURNED_FOR_INDEXING = "eventsReturnedForIndexingAfterQuery";
+
+    private final Counter eventsDroppedAndReleasedCounter;
+
+    private final Counter eventsAddedForQuerying;
+
+    private final Counter eventsReturnedForIndexing;
+
+    private final IndexConfiguration indexConfiguration;
+
+    private final Map<String, Map<String, QueryManagerBulkOperation>> bulkOperationsWaitingForQuery;
+
+    private Set<BulkOperationWrapper> bulkOperationsReadyToIngest;
+
+    private final PluginMetrics pluginMetrics;
+
+    private final OpenSearchClient openSearchClient;
+
+    private boolean shouldStop = false;
+
+    private Instant lastQueryTime;
+
+    private final Lock lockReadyToIngest;
+
+    private final Lock lockWaitingForQuery;
+
+    private final String queryTerm;
+
+    public ExistingDocumentQueryManager(final IndexConfiguration indexConfiguration,
+                                        final PluginMetrics pluginMetrics,
+                                        final OpenSearchClient openSearchClient) {
+        this.indexConfiguration = indexConfiguration;
+        this.queryTerm = indexConfiguration.getQueryTerm();
+        this.bulkOperationsWaitingForQuery = new ConcurrentHashMap<>();
+        this.bulkOperationsReadyToIngest = ConcurrentHashMap.newKeySet();
+        this.pluginMetrics = pluginMetrics;
+        this.openSearchClient = openSearchClient;
+        this.eventsAddedForQuerying = pluginMetrics.counter(EVENTS_ADDED_FOR_QUERYING);
+        this.eventsDroppedAndReleasedCounter = pluginMetrics.counter(EVENTS_DROPPED_AND_RELEASED);
+        this.eventsReturnedForIndexing = pluginMetrics.counter(EVENTS_RETURNED_FOR_INDEXING);
+        this.lockReadyToIngest = new ReentrantLock();
+        this.lockWaitingForQuery = new ReentrantLock();
+    }
+
+    @Override
+    public void run() {
+        while (!Thread.currentThread().isInterrupted() && !shouldStop) {
+            try {
+                runQueryLoop();
+            } catch (final Exception e) {
+                LOG.error("Exception in primary loop responsible for querying for existing documents, retrying", e);
+            } finally {
+                try {
+                    Thread.sleep(QUERY_INTERVAL.toMillis());
+                } catch (final InterruptedException e) {
+                    LOG.error("Interrupted, exiting");
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    void runQueryLoop() {
+        if (!bulkOperationsWaitingForQuery.isEmpty()) {
+
+            // Query for existing documents
+            final MsearchRequest msearchRequest = buildMultiSearchRequest();
+            final MsearchResponse<ObjectNode> msearchResponse = queryForTermValues(msearchRequest);
+            lastQueryTime = Instant.now();
+
+            // Drop and Release Existing Documents
+            dropAndReleaseFoundEvents(msearchResponse);
+
+            // Move non-existing documents past query_duration to bulkOperationsReadyForIndex
+            moveBulkRequestsThatHaveReachedQueryDuration();
+        }
+    }
+
+    public void stop() {
+        shouldStop = true;
+    }
+
+    public void addBulkOperation(final BulkOperationWrapper bulkOperationWrapper) {
+        lockWaitingForQuery.lock();
+        final String termValue = bulkOperationWrapper.getTermValue();
+        try {
+            bulkOperationsWaitingForQuery.computeIfAbsent(bulkOperationWrapper.getIndex(),
+                    k -> new ConcurrentHashMap<>()).put(termValue, new QueryManagerBulkOperation(bulkOperationWrapper, Instant.now(), termValue));
+        } finally {
+            lockWaitingForQuery.unlock();
+        }
+        eventsAddedForQuerying.increment();
+    }
+
+    public Set<BulkOperationWrapper> getAndClearBulkOperationsReadyToIndex() {
+        lockReadyToIngest.lock();
+        try {
+            final Set<BulkOperationWrapper> copyOfBulkOperations = bulkOperationsReadyToIngest;
+            bulkOperationsReadyToIngest = ConcurrentHashMap.newKeySet();
+            eventsReturnedForIndexing.increment(copyOfBulkOperations.size());
+            return copyOfBulkOperations;
+        } finally {
+            lockReadyToIngest.unlock();
+        }
+    }
+
+    private MsearchRequest buildMultiSearchRequest() {
+        return MsearchRequest.of(m -> {
+            for (final Map.Entry<String, Map<String, QueryManagerBulkOperation>> entry : bulkOperationsWaitingForQuery.entrySet()) {
+                final String index = entry.getKey();
+                final List<FieldValue> values = getTermValues(entry.getValue().values());
+
+                m.searches(s -> s
+                        .header(h -> h.index(index))
+                        .body(b -> b
+                                .source(source -> source.filter(f -> f.includes(queryTerm)))
+                                .query(Query.of(q -> q
+                                        .terms(TermsQuery.of(t -> t
+                                                .field(queryTerm)
+                                                .terms(TermsQueryField.of(tf -> tf.value(values)))
+                                        ))
+                                ))
+                        ));
+            }
+            return m;
+        });
+    }
+
+    private MsearchResponse<ObjectNode> queryForTermValues(final MsearchRequest searchRequest) {
+        try {
+            return openSearchClient.msearch(searchRequest, ObjectNode.class);
+        } catch (final Exception e) {
+            LOG.error("Exception while querying for indexes {}", searchRequest.index());
+            throw new RuntimeException(String.format("Exception while querying for indexes %s: %s",
+                    searchRequest.index(), e.getMessage()));
+        }
+    }
+
+    private List<FieldValue> getTermValues(final Collection<QueryManagerBulkOperation> queryManagerBulkOperations) {
+        final List<FieldValue> termValues = new ArrayList<>();
+        for (final QueryManagerBulkOperation queryManagerBulkOperation : queryManagerBulkOperations) {
+            termValues.add(FieldValue.of(queryManagerBulkOperation.getTermValue()));
+        }
+
+        return termValues;
+    }
+
+    private void moveBulkRequestsThatHaveReachedQueryDuration() {
+        for (final Iterator<Map.Entry<String, Map<String, QueryManagerBulkOperation>>> indexIterator =
+             bulkOperationsWaitingForQuery.entrySet().iterator(); indexIterator.hasNext();) {
+            final Map.Entry<String, Map<String, QueryManagerBulkOperation>> operationsForEachIndex = indexIterator.next();
+            final Iterator<Map.Entry<String, QueryManagerBulkOperation>> bulkOperationIterator = operationsForEachIndex.getValue().entrySet().iterator();
+
+            while (bulkOperationIterator.hasNext()) {
+                final Map.Entry<String, QueryManagerBulkOperation> entry = bulkOperationIterator.next();
+                final QueryManagerBulkOperation bulkOperation = entry.getValue();
+                if (bulkOperation.getStartTime().plus(indexConfiguration.getQueryDuration()).isBefore(lastQueryTime)) {
+                    lockReadyToIngest.lock();
+                    try {
+                        LOG.debug("Moving bulk operation for index {} and term value {} to be ingested after querying and finding no existing document",
+                                bulkOperation.getBulkOperationWrapper().getIndex(),
+                                bulkOperation.getTermValue());
+                        bulkOperationsReadyToIngest.add(bulkOperation.getBulkOperationWrapper());
+                        bulkOperationIterator.remove();
+                    } finally {
+                        lockReadyToIngest.unlock();
+                    }
+                }
+            }
+        }
+    }
+
+    private void dropAndReleaseFoundEvents(final MsearchResponse<ObjectNode> msearchResponse) {
+        msearchResponse.responses().forEach(response -> {
+            if (response.isFailure()) {
+                LOG.error("Search response failed: {}", response.failure().error().reason());
+            } else {
+                response.result().hits().hits().forEach(hit -> {
+                    final String indexForHit = hit.index();
+                    final ObjectNode sourceForHit = hit.source();
+                    final String queryTermValue = sourceForHit.findValue(queryTerm).textValue();
+
+                    lockWaitingForQuery.lock();
+                    try {
+                        final Map<String, QueryManagerBulkOperation> bulkOperationsForIndex = bulkOperationsWaitingForQuery.get(indexForHit);
+                        final QueryManagerBulkOperation bulkOperationToRelease = bulkOperationsForIndex.get(queryTermValue);
+                        if (bulkOperationToRelease == null) {
+                            LOG.error("bulk operation for term value {} is null", queryTermValue);
+                        } else {
+                            LOG.debug("Found document with query term {}, dropping and releasing Event handle", queryTermValue);
+                            bulkOperationToRelease.getBulkOperationWrapper().releaseEventHandle(true);
+                            eventsDroppedAndReleasedCounter.increment();
+                            bulkOperationsForIndex.remove(queryTermValue);
+                        }
+                    } finally {
+                        lockWaitingForQuery.unlock();
+                    }
+                });
+            }
+        });
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -77,18 +77,6 @@ public class IndexConfiguration {
     public static final String DOCUMENT_ROOT_KEY = "document_root_key";
     public static final String DOCUMENT_VERSION_EXPRESSION = "document_version";
 
-    public static final String QUERY_FOR_EXISTING_DOCUMENTS = "query_for_existing_document";
-
-    public static final String QUERY_WHEN = "query_when";
-
-    public static final String QUERY_TERM = "query_term";
-
-    public static final String QUERY_DURATION = "query_duration";
-
-    public static final String QUERY_ACTION_ON_FOUND = "action_on_found";
-
-    public static final String QUERY_ON_BULK_FAILURES = "query_on_bulk_failures";
-
     private IndexType indexType;
     private TemplateType templateType;
     private final String indexAlias;
@@ -124,6 +112,8 @@ public class IndexConfiguration {
     private final String queryActionOnFound;
 
     private final boolean queryOnBulkFailures;
+
+    private final Integer queryAsyncDocumentLimit;
 
     private static final String S3_PREFIX = "s3://";
 
@@ -189,6 +179,7 @@ public class IndexConfiguration {
         this.queryTerm = builder.queryTerm;
         this.queryActionOnFound = builder.actionOnFound;
         this.queryDuration = builder.queryDuration;
+        this.queryAsyncDocumentLimit = builder.queryAsyncLimit;
     }
 
     private void determineIndexType(Builder builder) {
@@ -271,6 +262,7 @@ public class IndexConfiguration {
             builder.withQueryTerm(queryExistingConfiguration.getQueryTerm());
             builder.withQueryDuration(queryExistingConfiguration.getQueryDuration());
             builder.withQueryOnIndexingFailure(queryExistingConfiguration.isQueryOnBulkErrors());
+            builder.withQueryAsyncLimit(queryExistingConfiguration.getAsyncDocumentLimit());
             builder.withActionOnFound(ACTION_ON_FOUND_DROP);
         }
 
@@ -412,8 +404,6 @@ public class IndexConfiguration {
 
     public String getQueryWhen() { return queryWhen; }
 
-    public String getQueryActionOnFound() { return queryActionOnFound; }
-
     public Duration getQueryDuration() { return queryDuration; }
 
     public String getQueryTerm() { return queryTerm; }
@@ -421,6 +411,8 @@ public class IndexConfiguration {
     public boolean getQueryOnBulkFailures() {
         return queryOnBulkFailures;
     }
+
+    public Integer getQueryAsyncDocumentLimit() {return queryAsyncDocumentLimit; }
 
     /**
      * This method is used in the creation of IndexConfiguration object. It takes in the template file path
@@ -517,6 +509,8 @@ public class IndexConfiguration {
         private String actionOnFound;
         private Duration queryDuration;
         private boolean queryOnIndexingFailure;
+
+        private Integer queryAsyncLimit;
 
         public Builder withIndexAlias(final String indexAlias) {
             checkArgument(indexAlias != null, "indexAlias cannot be null.");
@@ -744,6 +738,11 @@ public class IndexConfiguration {
 
         public Builder withQueryOnIndexingFailure(final boolean queryOnIndexingFailure) {
             this.queryOnIndexingFailure = queryOnIndexingFailure;
+            return this;
+        }
+
+        public Builder withQueryAsyncLimit(final Integer queryAsyncLimit) {
+            this.queryAsyncLimit = queryAsyncLimit;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/model/QueryForExistingDocumentConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/model/QueryForExistingDocumentConfiguration.java
@@ -25,4 +25,8 @@ public class QueryForExistingDocumentConfiguration {
     @Getter
     @JsonProperty("query_on_bulk_errors")
     private boolean queryOnBulkErrors;
+
+    @Getter
+    @JsonProperty("async_limit")
+    private Integer asyncDocumentLimit = 5000;
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/model/QueryForExistingDocumentConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/model/QueryForExistingDocumentConfiguration.java
@@ -1,0 +1,28 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.index.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.Duration;
+
+public class QueryForExistingDocumentConfiguration {
+
+    @Getter
+    @JsonProperty("query_when")
+    @NotNull
+    private String queryWhen;
+
+    @Getter
+    @JsonProperty("query_duration")
+    private Duration queryDuration = Duration.ofMinutes(3);
+
+    @Getter
+    @JsonProperty("query_term")
+    @NotNull
+    private String queryTerm;
+
+    @Getter
+    @JsonProperty("query_on_bulk_errors")
+    private boolean queryOnBulkErrors;
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/model/QueryManagerBulkOperation.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/model/QueryManagerBulkOperation.java
@@ -1,0 +1,35 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.index.model;
+
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
+
+import java.time.Instant;
+
+public class QueryManagerBulkOperation {
+
+    private final BulkOperationWrapper bulkOperationWrapper;
+
+    private final Instant startTime;
+
+    private final String termValue;
+
+    public QueryManagerBulkOperation(final BulkOperationWrapper bulkOperationWrapper,
+                                     final Instant startTime,
+                                     final String termValue) {
+        this.bulkOperationWrapper = bulkOperationWrapper;
+        this.startTime = startTime;
+        this.termValue = termValue;
+    }
+
+    public BulkOperationWrapper getBulkOperationWrapper() {
+        return bulkOperationWrapper;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    // Write comparator on term value and bulk operation index
+    public String getTermValue() {
+        return termValue;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManagerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManagerTest.java
@@ -1,0 +1,203 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.MsearchRequest;
+import org.opensearch.client.opensearch.core.MsearchResponse;
+import org.opensearch.client.opensearch.core.msearch.MultiSearchItem;
+import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager.EVENTS_ADDED_FOR_QUERYING;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager.EVENTS_DROPPED_AND_RELEASED;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager.EVENTS_RETURNED_FOR_INDEXING;
+
+@ExtendWith(MockitoExtension.class)
+public class ExistingDocumentQueryManagerTest {
+
+    @Mock
+    private IndexConfiguration indexConfiguration;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private OpenSearchClient openSearchClient;
+
+    @Mock
+    private Counter eventsAddedForQuerying;
+
+    @Mock
+    private Counter eventsDroppedAndReleased;
+
+    @Mock
+    private Counter eventsReturnedForIndexing;
+
+    private String queryTerm;
+
+    @BeforeEach
+    void setup() {
+        when(pluginMetrics.counter(EVENTS_ADDED_FOR_QUERYING)).thenReturn(eventsAddedForQuerying);
+        when(pluginMetrics.counter(EVENTS_DROPPED_AND_RELEASED)).thenReturn(eventsDroppedAndReleased);
+        when(pluginMetrics.counter(EVENTS_RETURNED_FOR_INDEXING)).thenReturn(eventsReturnedForIndexing);
+        queryTerm = UUID.randomUUID().toString();
+        when(indexConfiguration.getQueryTerm()).thenReturn(queryTerm);
+    }
+
+    private ExistingDocumentQueryManager createObjectUnderTest() {
+        return new ExistingDocumentQueryManager(indexConfiguration, pluginMetrics, openSearchClient);
+    }
+
+    @Test
+    void add_bulk_operation_and_found_in_query_drops_and_releases_event() throws IOException {
+        final BulkOperationWrapper bulkOperationWrapper = mock(BulkOperationWrapper.class);
+        final String index = UUID.randomUUID().toString();
+        final String termValue = UUID.randomUUID().toString();
+        when(bulkOperationWrapper.getTermValue()).thenReturn(termValue);
+        when(bulkOperationWrapper.getIndex()).thenReturn(index);
+
+        final MsearchResponse<ObjectNode> msearchResponse = mock(MsearchResponse.class);
+        final MultiSearchResponseItem<ObjectNode> responseItem = mock(MultiSearchResponseItem.class);
+        when(responseItem.isFailure()).thenReturn(false);
+
+        final MultiSearchItem<ObjectNode> multiSearchItem = mock(MultiSearchItem.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final Hit<ObjectNode> hit = mock(Hit.class);
+        when(hit.index()).thenReturn(index);
+
+        final ObjectNode objectNode = mock(ObjectNode.class);
+        final JsonNode jsonNode = mock(JsonNode.class);
+        when(jsonNode.textValue()).thenReturn(termValue);
+        when(objectNode.findValue(queryTerm)).thenReturn(jsonNode);
+        when(hit.source()).thenReturn(objectNode);
+
+        when(multiSearchItem.hits()).thenReturn(hitsMetadata);
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+
+        when(responseItem.result()).thenReturn(multiSearchItem);
+
+        when(msearchResponse.responses()).thenReturn(List.of(responseItem));
+
+        when(openSearchClient.msearch(any(MsearchRequest.class), eq(ObjectNode.class)))
+                .thenReturn(msearchResponse);
+
+        final ExistingDocumentQueryManager objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.addBulkOperation(bulkOperationWrapper);
+
+        objectUnderTest.runQueryLoop();
+
+        verify(eventsDroppedAndReleased).increment();
+        verify(eventsAddedForQuerying).increment();
+        verify(bulkOperationWrapper).releaseEventHandle(true);
+
+        verifyNoMoreInteractions(indexConfiguration);
+    }
+
+    @Test
+    void add_bulk_operation_and_not_found_in_query_returns_as_ready_to_ingest() throws IOException, InterruptedException {
+        when(indexConfiguration.getQueryDuration()).thenReturn(Duration.ofMillis(1));
+
+        final BulkOperationWrapper bulkOperationWrapper = mock(BulkOperationWrapper.class);
+        final String index = UUID.randomUUID().toString();
+        final String termValue = UUID.randomUUID().toString();
+        when(bulkOperationWrapper.getTermValue()).thenReturn(termValue);
+        when(bulkOperationWrapper.getIndex()).thenReturn(index);
+
+        final MsearchResponse<ObjectNode> msearchResponse = mock(MsearchResponse.class);
+        final MultiSearchResponseItem<ObjectNode> responseItem = mock(MultiSearchResponseItem.class);
+        when(responseItem.isFailure()).thenReturn(false);
+
+        final MultiSearchItem<ObjectNode> multiSearchItem = mock(MultiSearchItem.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final Hit<ObjectNode> hit = mock(Hit.class);
+        when(hit.index()).thenReturn(index);
+
+        final ObjectNode objectNode = mock(ObjectNode.class);
+        final JsonNode jsonNode = mock(JsonNode.class);
+        when(jsonNode.textValue()).thenReturn(UUID.randomUUID().toString());
+        when(objectNode.findValue(queryTerm)).thenReturn(jsonNode);
+        when(hit.source()).thenReturn(objectNode);
+
+        when(multiSearchItem.hits()).thenReturn(hitsMetadata);
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+
+        when(responseItem.result()).thenReturn(multiSearchItem);
+
+        when(msearchResponse.responses()).thenReturn(List.of(responseItem));
+
+        when(openSearchClient.msearch(any(MsearchRequest.class), eq(ObjectNode.class)))
+                .thenReturn(msearchResponse);
+
+        final ExistingDocumentQueryManager objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.addBulkOperation(bulkOperationWrapper);
+
+        Thread.sleep(20);
+
+        objectUnderTest.runQueryLoop();
+
+        final Set<BulkOperationWrapper> readyForIndexing = objectUnderTest.getAndClearBulkOperationsReadyToIndex();
+        assertThat(readyForIndexing, notNullValue());
+        assertThat(readyForIndexing.size(), equalTo(1));
+        assertThat(readyForIndexing.contains(bulkOperationWrapper), equalTo(true));
+
+        verifyNoMoreInteractions(eventsDroppedAndReleased);
+        verify(eventsAddedForQuerying).increment();
+        verify(eventsReturnedForIndexing).increment(1);
+
+        final Set<BulkOperationWrapper> nothingReadyForIndexing = objectUnderTest.getAndClearBulkOperationsReadyToIndex();
+        assertThat(nothingReadyForIndexing.isEmpty(), equalTo(true));
+        verify(eventsReturnedForIndexing).increment(0);
+
+        final ArgumentCaptor<MsearchRequest> msearchRequestArgumentCaptor = ArgumentCaptor.forClass(MsearchRequest.class);
+        verify(openSearchClient).msearch(msearchRequestArgumentCaptor.capture(), eq(ObjectNode.class));
+
+        final MsearchRequest msearchRequest = msearchRequestArgumentCaptor.getValue();
+        assertThat(msearchRequest.searches().size(), equalTo(1));
+        assertThat(msearchRequest.searches().get(0), notNullValue());
+        assertThat(msearchRequest.searches().get(0).header(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).header().index(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).header().index().size(), equalTo(1));
+        assertThat(msearchRequest.searches().get(0).header().index().get(0), equalTo(index));
+        assertThat(msearchRequest.searches().get(0).body(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().source(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().source().filter(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().source().filter().includes(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().source().filter().includes().size(), equalTo(1));
+        assertThat(msearchRequest.searches().get(0).body().source().filter().includes().get(0), equalTo(queryTerm));
+        assertThat(msearchRequest.searches().get(0).body().query(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().query().terms(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().query().terms().terms(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().query().terms().terms().value(), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().query().terms().terms().value().size(), equalTo(1));
+        assertThat(msearchRequest.searches().get(0).body().query().terms().terms().value().get(0), notNullValue());
+        assertThat(msearchRequest.searches().get(0).body().query().terms().terms().value().get(0).stringValue(), equalTo(termValue));
+    }
+}


### PR DESCRIPTION
### Description
This change adds the option to deduplicate in the OpenSearch sink by querying before writing based on a condition, or by querying if there are errors sending to OpenSearch that could result in partial success, like SocketTimeoutException or 500 internal server error

```
   query_lookup:
          query_when: 'getMetadata("potential_duplicate") == true' // condition that will qualify a document coming into the sink for querying before indexing
          query_term: 'key' // the unique field of the document that will be queried for
          query_on_bulk_errors: true // whether to send errors like 500 or socket timeout for querying rather than immediate retry
          query_duration: PT5M // duration to query for a given document before indexing it
          async_limit: 5000 // number of documents that will be queried at one time before blocking the processor workers threads in the sink
```

Testing:

Run documents that do not exist with unique key and query_when: true, verify they are queried for a couple minutes and then indexed to OpenSearch

Run the same documents through again, verify they are queried and dropped with event handles released.
 
### Issues Resolved
Resolves #5442 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue: https://github.com/opensearch-project/documentation-website/issues/9448
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
