### PR TITLE
Fix for Issue 5531

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerIT.java
@@ -448,7 +448,7 @@ public class S3ScanObjectWorkerIT {
     }
 
     @Test
-    public void processS3Object_test_multiple_dataselections_on_multiple_buckets() throws Exception {
+    public void processS3Object_test_multiple_dataselections_on_same_bucket() throws Exception {
         String keyPrefix = "s3source/s3-scan/dataMetadataTest/" + Instant.now().toEpochMilli();
         final String bucketOptionYaml = "name: " + bucket + "\n" +
                 "filter:\n" +


### PR DESCRIPTION
### Description
Fixes issue 5531.
Root causes for the bug -
1. The newly added metadata_only option only maps S3DataSelection to a bucket, which means there can only one data selection for a given bucket
2. The existing s3 scan code does not handle if the same bucket is specified twice because the scan time for the bucket is updated first time, making the second scan not possible
This change fixes both issues.
 
### Issues Resolved
Resolves #5531 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
