### PR TITLE
FIX: data type of type in actions

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/ActionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/ActionConfiguration.java
@@ -6,24 +6,16 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
-import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 
 public class ActionConfiguration {
+    @NotEmpty
     @JsonProperty("type")
-    private OpenSearchBulkActions type;
-
-    @AssertTrue(message = "action must be one of index, create, update, upsert, delete")
-    boolean isActionValid() {
-        if (type == null) {         //type will be null if the string doesn't match one of the enums
-            return false;
-        }
-        return true;
-    }
+    private String type;
 
     public String getType() {
-        return type.toString();
+        return type;
     }
 
     @Getter

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -50,7 +50,7 @@ public class OpenSearchSinkConfigurationTests {
         OpenSearchSinkConfiguration.readOSConfig(generateOpenSearchSinkConfig(INVALID_ACTION_CONFIG));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidActions() throws IOException {
         OpenSearchSinkConfiguration.readOSConfig(generateOpenSearchSinkConfig(INVALID_ACTIONS_CONFIG));
 
@@ -63,7 +63,7 @@ public class OpenSearchSinkConfigurationTests {
         OpenSearchSinkConfiguration.readOSConfig(generateOpenSearchSinkConfig(INVALID_ACTION_WITH_EXPRESSION_CONFIG), expressionEvaluator);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidActionsWithExpression() throws IOException {
         expressionEvaluator = mock(ExpressionEvaluator.class);
         when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(false);


### PR DESCRIPTION
### Description
This PR fixes the data type of type in ActionConfiguration to allow data prepper expression. It also adds jakarta annotation.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
