### PR TITLE
ENH: use default credentials for aws glue registry in kafka source

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerIT.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -75,6 +76,9 @@ public class ConfluentKafkaProducerConsumerIT {
 
     @Mock
     private PluginConfigObservable pluginConfigObservable;
+
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
 
     private KafkaSource kafkaSource;
     private TopicConsumerConfig topicConfig;
@@ -164,7 +168,8 @@ public class ConfluentKafkaProducerConsumerIT {
     }
 
     public void consumeRecords(String servers) {
-        kafkaSource = new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, null, pluginConfigObservable);
+        kafkaSource = new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                null, pluginConfigObservable, awsCredentialsSupplier);
         kafkaSource.start(buffer);
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerIT.java
@@ -107,6 +107,7 @@ public class ConfluentKafkaProducerConsumerIT {
         receivedRecords = new ArrayList<>();
         acknowledgementSetManager = mock(AcknowledgementSetManager.class);
         pipelineDescription = mock(PipelineDescription.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         when(authConfig.getSaslAuthConfig()).thenReturn(saslAuthConfig);
         when(saslAuthConfig.getPlainTextAuthConfig()).thenReturn(plainTextAuthConfig);
         when(sourceConfig.getAuthConfig()).thenReturn(authConfig);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerWithSchemaRegistryIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerWithSchemaRegistryIT.java
@@ -171,6 +171,7 @@ public class ConfluentKafkaProducerConsumerWithSchemaRegistryIT {
         receivedRecords = new ArrayList<>();
         acknowledgementSetManager = mock(AcknowledgementSetManager.class);
         pipelineDescription = mock(PipelineDescription.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         when(authConfig.getSaslAuthConfig()).thenReturn(saslAuthConfig);
         when(saslAuthConfig.getPlainTextAuthConfig()).thenReturn(plainTextAuthConfig);
         when(schemaConfig.getType()).thenReturn(SchemaRegistryType.CONFLUENT);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerWithSchemaRegistryIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerWithSchemaRegistryIT.java
@@ -19,6 +19,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -129,6 +130,9 @@ public class ConfluentKafkaProducerConsumerWithSchemaRegistryIT {
 
     @Mock
     private PluginConfigObservable pluginConfigObservable;
+
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
 
     private KafkaSource kafkaSource;
     private TopicConsumerConfig jsonTopicConfig;
@@ -271,7 +275,8 @@ public class ConfluentKafkaProducerConsumerWithSchemaRegistryIT {
 
     public void consumeRecords(String servers, KafkaSourceConfig sourceConfig) {
         kafkaSource = new KafkaSource(
-                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, null, pluginConfigObservable);
+                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                null, pluginConfigObservable, awsCredentialsSupplier);
         kafkaSource.start(buffer);
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -130,6 +130,7 @@ public class KafkaSourceJsonTypeIT {
         counter = mock(Counter.class);
         buffer = mock(Buffer.class);
         encryptionConfig = mock(EncryptionConfig.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         receivedRecords = new ArrayList<>();
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
         acknowledgementSetManager = new DefaultAcknowledgementSetManager(executor);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSetManager;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -95,6 +96,9 @@ public class KafkaSourceJsonTypeIT {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     private KafkaSource kafkaSource;
 
     private Counter counter;
@@ -111,7 +115,8 @@ public class KafkaSourceJsonTypeIT {
     private byte[] headerValue2;
 
     public KafkaSource createObjectUnderTest() {
-        return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, kafkaClusterConfigSupplier, pluginConfigObservable);
+        return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                kafkaClusterConfigSupplier, pluginConfigObservable, awsCredentialsSupplier);
     }
 
     @BeforeEach

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
@@ -124,6 +124,7 @@ public class KafkaSourceMultipleAuthTypeIT {
         receivedRecords = new ArrayList<>();
         acknowledgementSetManager = mock(AcknowledgementSetManager.class);
         pipelineDescription = mock(PipelineDescription.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(pluginMetrics.counter(anyString())).thenReturn(counter);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
@@ -16,6 +16,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -88,6 +89,9 @@ public class KafkaSourceMultipleAuthTypeIT {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     private TopicConfig jsonTopic;
     private TopicConfig avroTopic;
 
@@ -106,7 +110,8 @@ public class KafkaSourceMultipleAuthTypeIT {
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(
-                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, kafkaClusterConfigSupplier, pluginConfigObservable);
+                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                kafkaClusterConfigSupplier, pluginConfigObservable, awsCredentialsSupplier);
     }
 
     @BeforeEach

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslPlainTextIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslPlainTextIT.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSetManager;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -103,6 +104,9 @@ public class KafkaSourceSaslPlainTextIT {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     private KafkaSource kafkaSource;
 
     private Counter counter;
@@ -115,7 +119,8 @@ public class KafkaSourceSaslPlainTextIT {
     private String testGroup;
 
     public KafkaSource createObjectUnderTest() {
-        return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, kafkaClusterConfigSupplier, pluginConfigObservable);
+        return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                kafkaClusterConfigSupplier, pluginConfigObservable, awsCredentialsSupplier);
     }
 
     @BeforeEach

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslPlainTextIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslPlainTextIT.java
@@ -141,6 +141,7 @@ public class KafkaSourceSaslPlainTextIT {
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
         acknowledgementSetManager = new DefaultAcknowledgementSetManager(executor);
         pipelineDescription = mock(PipelineDescription.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(pluginMetrics.counter(anyString())).thenReturn(counter);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslScramIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslScramIT.java
@@ -143,6 +143,7 @@ public class KafkaSourceSaslScramIT {
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
         acknowledgementSetManager = new DefaultAcknowledgementSetManager(executor);
         pipelineDescription = mock(PipelineDescription.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(pluginMetrics.counter(anyString())).thenReturn(counter);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslScramIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceSaslScramIT.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSetManager;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -103,6 +104,9 @@ public class KafkaSourceSaslScramIT {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     private KafkaSource kafkaSource;
 
     private Counter counter;
@@ -115,7 +119,8 @@ public class KafkaSourceSaslScramIT {
     private String testGroup;
 
     public KafkaSource createObjectUnderTest() {
-        return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, kafkaClusterConfigSupplier, pluginConfigObservable);
+        return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                kafkaClusterConfigSupplier, pluginConfigObservable, awsCredentialsSupplier);
     }
 
     @BeforeEach

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/MskGlueRegistryMultiTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/MskGlueRegistryMultiTypeIT.java
@@ -159,6 +159,8 @@ public class MskGlueRegistryMultiTypeIT {
         receivedRecords = new ArrayList<>();
         acknowledgementSetManager = mock(AcknowledgementSetManager.class);
         pipelineDescription = mock(PipelineDescription.class);
+        awsCredentialsOptions = mock(AwsCredentialsOptions.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
         when(sourceConfig.getSchemaConfig()).thenReturn(schemaConfig);
         when(schemaConfig.getType()).thenReturn(SchemaRegistryType.AWS_GLUE);
@@ -412,6 +414,7 @@ public class MskGlueRegistryMultiTypeIT {
         properties.put(AWSSchemaRegistryConstants.AWS_REGION, awsConfig.getRegion());
         properties.put(AWSSchemaRegistryConstants.REGISTRY_NAME, testRegistryName);
         properties.put(AWSSchemaRegistryConstants.SCHEMA_NAME, testAvroSchemaName);
+        properties.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, true);
 
         Schema testSchema = null;
         Schema.Parser parser = new Schema.Parser();

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/MskGlueRegistryMultiTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/MskGlueRegistryMultiTypeIT.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -41,6 +43,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaRegistryType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.extension.KafkaClusterConfigSupplier;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,6 +109,12 @@ public class MskGlueRegistryMultiTypeIT {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
+    @Mock
+    private AwsCredentialsOptions awsCredentialsOptions;
+
     private KafkaSource kafkaSource;
     private SourceTopicConfig jsonTopic;
     private SourceTopicConfig avroTopic;
@@ -132,7 +141,8 @@ public class MskGlueRegistryMultiTypeIT {
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(
-                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, kafkaClusterConfigSupplier, pluginConfigObservable);
+                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                kafkaClusterConfigSupplier, pluginConfigObservable, awsCredentialsSupplier);
     }
 
     @BeforeEach
@@ -197,6 +207,8 @@ public class MskGlueRegistryMultiTypeIT {
         encryptionConfig = mock(EncryptionConfig.class);
         when(sourceConfig.getEncryptionConfig()).thenReturn(encryptionConfig);
         System.setProperty("software.amazon.awssdk.http.service.impl", "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+        when(awsConfig.toCredentialsOptions()).thenReturn(awsCredentialsOptions);
+        when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(DefaultCredentialsProvider.create());
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -98,7 +98,7 @@ public class KafkaCustomConsumerFactory {
                 Deserializer<Object> keyDeserializer = (Deserializer<Object>) serializationFactory.getDeserializer(PlaintextKafkaDataConfig.plaintextDataConfig(dataConfig));
                 Deserializer<Object> valueDeserializer = null;
                 if(schema == MessageFormat.PLAINTEXT) {
-                    valueDeserializer = KafkaSecurityConfigurer.getGlueSerializer(kafkaConsumerConfig);
+                    valueDeserializer = KafkaSecurityConfigurer.getGlueSerializer(kafkaConsumerConfig, awsContext);
                 }
                 if(valueDeserializer == null) {
                     valueDeserializer = (Deserializer<Object>) serializationFactory.getDeserializer(dataConfig);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -88,12 +89,16 @@ class KafkaSourceTest {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     private static final String TEST_GROUP_ID = "testGroupId";
     private static final String TEST_CLIENT_ID = "testClientId";
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(
-                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription, kafkaClusterConfigSupplier, pluginConfigObservable);
+                sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
+                kafkaClusterConfigSupplier, pluginConfigObservable, awsCredentialsSupplier);
     }
 
     @BeforeEach

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -15,7 +15,9 @@ import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicBasicCredentialsProvider;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicSaslClientCallbackHandler;
+import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AwsCredentialsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaConnectionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.source.KafkaSourceConfig;
@@ -24,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.kafka.KafkaClient;
 import software.amazon.awssdk.services.kafka.KafkaClientBuilder;
 import software.amazon.awssdk.services.kafka.model.GetBootstrapBrokersRequest;
@@ -70,6 +71,10 @@ public class KafkaSecurityConfigurerTest {
     private AuthConfig.SaslAuthConfig saslAuthConfig;
     @Mock
     private PlainTextAuthConfig plainTextAuthConfig;
+    @Mock
+    private AwsContext awsContext;
+    @Mock
+    private StsAssumeRoleCredentialsProvider stsAssumeRoleCredentialsProvider;
     @Captor
     private ArgumentCaptor<PluginConfigObserver> pluginConfigObserverArgumentCaptor;
 
@@ -244,9 +249,10 @@ public class KafkaSecurityConfigurerTest {
             "kafka-pipeline-msk-default-glue-sts-assume-role.yaml"
     })
     void testGetGlueSerializerWithStsAssumeRoleCredentialsProvider(final String filename) throws IOException {
+        when(awsContext.getOrDefault(any(AwsCredentialsConfig.class))).thenReturn(stsAssumeRoleCredentialsProvider);
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig(filename);
         final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
-                .getGlueSerializer(kafkaSourceConfig);
+                .getGlueSerializer(kafkaSourceConfig, awsContext);
         assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
         assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
                 instanceOf(StsAssumeRoleCredentialsProvider.class));
@@ -256,50 +262,34 @@ public class KafkaSecurityConfigurerTest {
     void testGetGlueSerializerWithDefaultCredentialsProvider() throws IOException {
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig(
                 "kafka-pipeline-bootstrap-servers-glue-default.yaml");
-        final DefaultAwsRegionProviderChain.Builder defaultAwsRegionProviderChainBuilder = mock(
-                DefaultAwsRegionProviderChain.Builder.class);
-        final DefaultAwsRegionProviderChain defaultAwsRegionProviderChain = mock(DefaultAwsRegionProviderChain.class);
-        when(defaultAwsRegionProviderChainBuilder.build()).thenReturn(defaultAwsRegionProviderChain);
-        when(defaultAwsRegionProviderChain.getRegion()).thenReturn(Region.US_EAST_1);
-        try (MockedStatic<DefaultAwsRegionProviderChain> defaultAwsRegionProviderChainMockedStatic =
-                     mockStatic(DefaultAwsRegionProviderChain.class)) {
-            defaultAwsRegionProviderChainMockedStatic.when(DefaultAwsRegionProviderChain::builder)
-                    .thenReturn(defaultAwsRegionProviderChainBuilder);
-            final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
-                    .getGlueSerializer(kafkaSourceConfig);
-            assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
-            assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
-                    instanceOf(DefaultCredentialsProvider.class));
-            assertThat(glueSchemaRegistryKafkaDeserializer
-                    .getGlueSchemaRegistryDeserializationFacade()
-                    .getGlueSchemaRegistryConfiguration()
-                    .getEndPoint(), is(nullValue()));
-        }
+        final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
+        when(awsContext.getOrDefault(any())).thenReturn(defaultCredentialsProvider);
+        final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
+                .getGlueSerializer(kafkaSourceConfig, awsContext);
+        assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
+        assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
+                instanceOf(DefaultCredentialsProvider.class));
+        assertThat(glueSchemaRegistryKafkaDeserializer
+                .getGlueSchemaRegistryDeserializationFacade()
+                .getGlueSchemaRegistryConfiguration()
+                .getEndPoint(), is(nullValue()));
     }
 
     @Test
     void testGetGlueSerializerWithDefaultCredentialsProviderAndOverrridenRegistryEndpoint() throws IOException {
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig(
                 "kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml");
-        final DefaultAwsRegionProviderChain.Builder defaultAwsRegionProviderChainBuilder = mock(
-                DefaultAwsRegionProviderChain.Builder.class);
-        final DefaultAwsRegionProviderChain defaultAwsRegionProviderChain = mock(DefaultAwsRegionProviderChain.class);
-        when(defaultAwsRegionProviderChainBuilder.build()).thenReturn(defaultAwsRegionProviderChain);
-        when(defaultAwsRegionProviderChain.getRegion()).thenReturn(Region.US_EAST_1);
-        try (MockedStatic<DefaultAwsRegionProviderChain> defaultAwsRegionProviderChainMockedStatic =
-                     mockStatic(DefaultAwsRegionProviderChain.class)) {
-            defaultAwsRegionProviderChainMockedStatic.when(DefaultAwsRegionProviderChain::builder)
-                    .thenReturn(defaultAwsRegionProviderChainBuilder);
-            final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
-                    .getGlueSerializer(kafkaSourceConfig);
-            assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
-            assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
-                    instanceOf(DefaultCredentialsProvider.class));
-            assertThat(glueSchemaRegistryKafkaDeserializer
-                    .getGlueSchemaRegistryDeserializationFacade()
-                    .getGlueSchemaRegistryConfiguration()
-                    .getEndPoint(), is("http://fake-glue-registry"));
-        }
+        final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
+        when(awsContext.getOrDefault(any())).thenReturn(defaultCredentialsProvider);
+        final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
+                .getGlueSerializer(kafkaSourceConfig, awsContext);
+        assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
+        assertThat(glueSchemaRegistryKafkaDeserializer.getCredentialProvider(),
+                instanceOf(DefaultCredentialsProvider.class));
+        assertThat(glueSchemaRegistryKafkaDeserializer
+                .getGlueSchemaRegistryDeserializationFacade()
+                .getGlueSchemaRegistryConfiguration()
+                .getEndPoint(), is("http://fake-glue-registry"));
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -250,6 +250,7 @@ public class KafkaSecurityConfigurerTest {
     })
     void testGetGlueSerializerWithStsAssumeRoleCredentialsProvider(final String filename) throws IOException {
         when(awsContext.getOrDefault(any(AwsCredentialsConfig.class))).thenReturn(stsAssumeRoleCredentialsProvider);
+        when(awsContext.getRegionOrDefault(any(AwsCredentialsConfig.class))).thenReturn(Region.US_EAST_1);
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig(filename);
         final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
                 .getGlueSerializer(kafkaSourceConfig, awsContext);
@@ -264,6 +265,7 @@ public class KafkaSecurityConfigurerTest {
                 "kafka-pipeline-bootstrap-servers-glue-default.yaml");
         final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
         when(awsContext.getOrDefault(any())).thenReturn(defaultCredentialsProvider);
+        when(awsContext.getRegionOrDefault(any())).thenReturn(null);
         final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
                 .getGlueSerializer(kafkaSourceConfig, awsContext);
         assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
@@ -281,6 +283,7 @@ public class KafkaSecurityConfigurerTest {
                 "kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml");
         final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
         when(awsContext.getOrDefault(any())).thenReturn(defaultCredentialsProvider);
+        when(awsContext.getRegionOrDefault(any())).thenReturn(null);
         final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
                 .getGlueSerializer(kafkaSourceConfig, awsContext);
         assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -265,7 +265,7 @@ public class KafkaSecurityConfigurerTest {
                 "kafka-pipeline-bootstrap-servers-glue-default.yaml");
         final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
         when(awsContext.getOrDefault(any())).thenReturn(defaultCredentialsProvider);
-        when(awsContext.getRegionOrDefault(any())).thenReturn(null);
+        when(awsContext.getRegionOrDefault(any())).thenReturn(Region.US_EAST_1);
         final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
                 .getGlueSerializer(kafkaSourceConfig, awsContext);
         assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());
@@ -283,7 +283,7 @@ public class KafkaSecurityConfigurerTest {
                 "kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml");
         final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
         when(awsContext.getOrDefault(any())).thenReturn(defaultCredentialsProvider);
-        when(awsContext.getRegionOrDefault(any())).thenReturn(null);
+        when(awsContext.getRegionOrDefault(any())).thenReturn(Region.US_EAST_1);
         final GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer = KafkaSecurityConfigurer
                 .getGlueSerializer(kafkaSourceConfig, awsContext);
         assertThat(glueSchemaRegistryKafkaDeserializer, notNullValue());


### PR DESCRIPTION
### Description
This PR allows credential provider in extension to be applied to AWS glue registry.

Note: 
* The kafka integration test failure on encryption is due to other root causes
* I have run some smoke test as well as MskGlueRegistryMultiTypeIT locally to make sure the default credential is used for AWS glue registry.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
