### PR TITLE
Support trace groups in standard otel proto codec

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -41,6 +41,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
     private static final String TRACE_STATE_KEY = "traceState";
     private static final String PARENT_SPAN_ID_KEY = "parentSpanId";
     private static final String NAME_KEY = "name";
+    private static final String FLAGS_KEY = "flags";
     private static final String KIND_KEY = "kind";
     private static final String START_TIME_KEY = "startTime";
     private static final String END_TIME_KEY = "endTime";
@@ -50,7 +51,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
     private static final String DROPPED_EVENTS_COUNT_KEY = "droppedEventsCount";
     private static final String LINKS_KEY = "links";
     private static final String DROPPED_LINKS_COUNT_KEY = "droppedLinksCount";
-    private static final String SERVICE_NAME_KEY = "serviceName";
+    public static final String SERVICE_NAME_KEY = "serviceName";
     public static final String TRACE_GROUP_KEY = "traceGroup";
     private static final String DURATION_IN_NANOS_KEY = "durationInNanos";
     public static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
@@ -121,6 +122,11 @@ public class JacksonSpan extends JacksonEvent implements Span {
     }
 
     @Override
+    public Integer getFlags() {
+        return this.get(FLAGS_KEY, Integer.class);
+    }
+
+    @Override
     public Map<String, Object> getScope() {
         return this.get(SCOPE_KEY, Map.class);
     }
@@ -184,6 +190,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
         return this.get(TRACE_GROUP_KEY, String.class);
     }
 
+
     @Override
     public Long getDurationInNanos() {
         return this.get(DURATION_IN_NANOS_KEY, Long.class);
@@ -200,7 +207,16 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public String getServiceName() {
+        EventMetadata metadata = getMetadata();
+        Object serviceName = metadata.getAttribute(SERVICE_NAME_KEY);
+        if (serviceName != null)
+            return (String)serviceName;
         return this.get(SERVICE_NAME_KEY, String.class);
+    }
+
+    @Override
+    public void setServiceName(final String serviceName) {
+        this.put(SERVICE_NAME_KEY, serviceName);
     }
 
     @Override
@@ -374,6 +390,18 @@ public class JacksonSpan extends JacksonEvent implements Span {
          */
         public Builder withKind(final String kind) {
             data.put(KIND_KEY, kind);
+            return this;
+        }
+
+        /**
+         * Sets the flags of span
+         *
+         * @param flags flags
+         * @return returns the builder
+         * @since 2.11
+         */
+        public Builder withFlags(final Integer flags) {
+            data.put(FLAGS_KEY, flags);
             return this;
         }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -51,9 +51,9 @@ public class JacksonSpan extends JacksonEvent implements Span {
     private static final String LINKS_KEY = "links";
     private static final String DROPPED_LINKS_COUNT_KEY = "droppedLinksCount";
     private static final String SERVICE_NAME_KEY = "serviceName";
-    private static final String TRACE_GROUP_KEY = "traceGroup";
+    public static final String TRACE_GROUP_KEY = "traceGroup";
     private static final String DURATION_IN_NANOS_KEY = "durationInNanos";
-    private static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
+    public static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
 
     private static final List<String> REQUIRED_KEYS = Arrays.asList(TRACE_GROUP_KEY);
     protected static final List<String>
@@ -177,6 +177,10 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public String getTraceGroup() {
+        EventMetadata metadata = getMetadata();
+        Object traceGroup = metadata.getAttribute(TRACE_GROUP_KEY);
+        if (traceGroup != null)
+            return (String)traceGroup;
         return this.get(TRACE_GROUP_KEY, String.class);
     }
 
@@ -187,6 +191,10 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public TraceGroupFields getTraceGroupFields() {
+        EventMetadata metadata = getMetadata();
+        Object traceGroupFields = metadata.getAttribute(TRACE_GROUP_FIELDS_KEY);
+        if (traceGroupFields != null)
+            return (TraceGroupFields)traceGroupFields;
         return this.get(TRACE_GROUP_FIELDS_KEY, DefaultTraceGroupFields.class);
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
@@ -58,6 +58,12 @@ public interface Span extends Event {
     String getKind();
 
     /**
+     * Gets the span's flags
+     * @return the flags
+     */
+    Integer getFlags();
+
+    /**
      * Gets ISO8601 representation of the start time.
      * @return the start time
      * @since 1.2
@@ -153,6 +159,13 @@ public interface Span extends Event {
      * @since 1.3
      */
     void setTraceGroupFields(TraceGroupFields traceGroupFields);
+
+    /**
+     * Sets the service name for this span.
+     * @param serviceName service name
+     * @since 2.11
+     */
+    void setServiceName(final String serviceName);
 
     /**
      * Gets the scope of this log event.

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -47,6 +47,7 @@ public class JacksonSpanTest {
     protected static final String TEST_PARENT_SPAN_ID =  UUID.randomUUID().toString();
     protected static final String TEST_NAME =  UUID.randomUUID().toString();
     protected static final String TEST_KIND =  UUID.randomUUID().toString();
+    protected static final int TEST_FLAGS = 10;
     protected static final String TEST_START_TIME =  UUID.randomUUID().toString();
     protected static final String TEST_END_TIME =  UUID.randomUUID().toString();
     private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", new Date().getTime(), "key2", UUID.randomUUID().toString());
@@ -100,6 +101,7 @@ public class JacksonSpanTest {
                 .withName(TEST_NAME)
                 .withServiceName(TEST_SERVICE_NAME)
                 .withKind(TEST_KIND)
+                .withFlags(TEST_FLAGS)
                 .withScope(TEST_SCOPE)
                 .withResource(TEST_RESOURCE)
                 .withStatus(TEST_STATUS)
@@ -158,6 +160,12 @@ public class JacksonSpanTest {
     public void testGetKind() {
         final String kind = jacksonSpan.getKind();
         assertThat(kind, is(equalTo(TEST_KIND)));
+    }
+
+    @Test
+    public void testGetFlags() {
+        final Integer flags = jacksonSpan.getFlags();
+        assertThat(flags, is(equalTo(TEST_FLAGS)));
     }
 
     @Test
@@ -248,6 +256,16 @@ public class JacksonSpanTest {
     public void testGetTraceGroupFields() {
         final TraceGroupFields traceGroupFields = jacksonSpan.getTraceGroupFields();
         assertThat(traceGroupFields, is(equalTo(traceGroupFields)));
+    }
+
+    @Test
+    public void testSetAndGetServiceName() {
+        String serviceName = jacksonSpan.getServiceName();
+        assertThat(serviceName, is(equalTo(TEST_SERVICE_NAME)));
+        final String testServiceName = "testServiceName";
+        jacksonSpan.setServiceName(testServiceName);
+        serviceName = jacksonSpan.getServiceName();
+        assertThat(serviceName, is(equalTo(testServiceName)));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpanTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.trace;
 
+import org.opensearch.dataprepper.model.event.EventMetadata;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.micrometer.core.instrument.util.IOUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -19,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.List;
@@ -84,6 +86,33 @@ public class JacksonStandardSpanTest extends JacksonSpanTest {
                 .withDurationInNanos(123456L)
                 .withTraceGroupFields(defaultTraceGroupFields)
                 .build();
+    }
+
+    @Test
+    @Override
+    public void testGetTraceGroup() {
+        jacksonSpan = createObjectUnderTest(TEST_ATTRIBUTES);
+        EventMetadata metadata = jacksonSpan.getMetadata();
+        String testTraceGroup = UUID.randomUUID().toString();
+        metadata.setAttribute(JacksonSpan.TRACE_GROUP_KEY, testTraceGroup);
+        final String traceGroup = jacksonSpan.getTraceGroup();
+        assertThat(traceGroup, is(equalTo(testTraceGroup)));
+    }
+
+    @Test
+    @Override
+    public void testGetTraceGroupFields() {
+        jacksonSpan = createObjectUnderTest(TEST_ATTRIBUTES);
+        DefaultTraceGroupFields testTraceGroupFields =
+                DefaultTraceGroupFields.builder()
+                .withDurationInNanos(10000L)
+                .withEndTime(Instant.now().toString())
+                .withStatusCode(10)
+                .build();
+        EventMetadata metadata = jacksonSpan.getMetadata();
+        metadata.setAttribute(JacksonSpan.TRACE_GROUP_FIELDS_KEY, testTraceGroupFields);
+        final TraceGroupFields traceGroupFields = jacksonSpan.getTraceGroupFields();
+        assertThat(traceGroupFields, is(equalTo(testTraceGroupFields)));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpanTest.java
@@ -101,6 +101,33 @@ public class JacksonStandardSpanTest extends JacksonSpanTest {
 
     @Test
     @Override
+    public void testGetServiceName() {
+        jacksonSpan = createObjectUnderTest(TEST_ATTRIBUTES);
+        EventMetadata metadata = jacksonSpan.getMetadata();
+        String testServiceName = UUID.randomUUID().toString();
+        metadata.setAttribute(JacksonSpan.SERVICE_NAME_KEY, testServiceName);
+        final String serviceName = jacksonSpan.getServiceName();
+        assertThat(serviceName, is(equalTo(testServiceName)));
+    }
+
+    @Test
+    @Override
+    public void testSetAndGetServiceName() {
+        jacksonSpan = createObjectUnderTest(TEST_ATTRIBUTES);
+        String serviceName = jacksonSpan.getServiceName();
+        assertThat(serviceName, is(equalTo("testService")));
+
+        EventMetadata metadata = jacksonSpan.getMetadata();
+        String testServiceName = UUID.randomUUID().toString();
+        metadata.setAttribute(JacksonSpan.SERVICE_NAME_KEY, testServiceName);
+        jacksonSpan.setServiceName(jacksonSpan.getServiceName());
+        serviceName = jacksonSpan.getServiceName();
+        assertThat(serviceName, is(equalTo(testServiceName)));
+    }
+
+
+    @Test
+    @Override
     public void testGetTraceGroupFields() {
         jacksonSpan = createObjectUnderTest(TEST_ATTRIBUTES);
         DefaultTraceGroupFields testTraceGroupFields =

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -164,7 +164,7 @@ public class IndexConfiguration {
 
         String documentIdField = builder.documentIdField;
         String documentId = builder.documentId;
-        if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW)) {
+        if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW) || indexType.equals(IndexType.TRACE_ANALYTICS_RAW_STANDARD)) {
             documentId = "${spanId}";
         } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
             documentId = "${hashId}";

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -430,12 +430,18 @@ public class IndexConfiguration {
             InputStream s3TemplateFile = null;
             if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
+            } else if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW_STANDARD)) {
+                templateURL = loadExistingTemplate(templateType, IndexConstants.RAW_STANDARD_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.LOG_ANALYTICS)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.LOGS_DEFAULT_TEMPLATE_FILE);
+            } else if (indexType.equals(IndexType.LOG_ANALYTICS_STANDARD)) {
+                templateURL = loadExistingTemplate(templateType, IndexConstants.LOGS_STANDARD_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.METRIC_ANALYTICS)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.METRICS_DEFAULT_TEMPLATE_FILE);
+            } else if (indexType.equals(IndexType.METRIC_ANALYTICS_STANDARD)) {
+                templateURL = loadExistingTemplate(templateType, IndexConstants.METRICS_STANDARD_TEMPLATE_FILE);
             } else if (templateFile != null) {
                 if (templateFile.toLowerCase().startsWith(S3_PREFIX)) {
                     FileReader s3FileReader = new S3FileReader(s3Client);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
@@ -15,16 +15,19 @@ public class IndexConstants {
   public static final Map<IndexType, String> TYPE_TO_DEFAULT_ALIAS = new HashMap<>();
   // TODO: extract out version number into version enum
   public static final String RAW_DEFAULT_TEMPLATE_FILE = "otel-v1-apm-span-index-template.json";
+  public static final String RAW_STANDARD_TEMPLATE_FILE = "otel-v1-apm-span-index-standard-template.json";
   public static final String RAW_ISM_POLICY = "raw-span-policy";
   public static final String RAW_ISM_FILE_NO_ISM_TEMPLATE = "raw-span-policy-no-ism-template.json";
   public static final String RAW_ISM_FILE_WITH_ISM_TEMPLATE = "raw-span-policy-with-ism-template.json";
 
   public static final String LOGS_DEFAULT_TEMPLATE_FILE = "logs-otel-v1-index-template.json";
+  public static final String LOGS_STANDARD_TEMPLATE_FILE = "logs-otel-v1-index-standard-template.json";
   public static final String LOGS_ISM_POLICY = "logs-policy";
   public static final String LOGS_ISM_FILE_NO_ISM_TEMPLATE = "logs-policy-no-ism-template.json";
   public static final String LOGS_ISM_FILE_WITH_ISM_TEMPLATE = "logs-policy-with-ism-template.json";
 
   public static final String METRICS_DEFAULT_TEMPLATE_FILE = "metrics-otel-v1-index-template.json";
+  public static final String METRICS_STANDARD_TEMPLATE_FILE = "metrics-otel-v1-index-standard-template.json";
   public static final String METRICS_ISM_POLICY = "metrics-policy";
   public static final String METRICS_ISM_FILE_NO_ISM_TEMPLATE = "metrics-policy-no-ism-template.json";
   public static final String METRICS_ISM_FILE_WITH_ISM_TEMPLATE = "metrics-policy-with-ism-template.json";

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
@@ -42,7 +42,10 @@ public class IndexConstants {
     // TODO: extract out version number into version enum
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_SERVICE_MAP, "otel-v1-apm-service-map");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW, "otel-v1-apm-span");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW_STANDARD, "otel-v1-apm-span");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS, "logs-otel-v1");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS_STANDARD, "logs-otel-v1");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS, "metrics-otel-v1");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS_STANDARD, "metrics-otel-v1");
   }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
@@ -51,6 +51,7 @@ public class IndexManagerFactory {
         IndexManager indexManager;
         switch (indexType) {
             case TRACE_ANALYTICS_RAW:
+            case TRACE_ANALYTICS_RAW_STANDARD:
                 indexManager = new TraceAnalyticsRawIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
@@ -59,10 +60,12 @@ public class IndexManagerFactory {
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
             case LOG_ANALYTICS:
+            case LOG_ANALYTICS_STANDARD:
                 indexManager = new LogAnalyticsIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
             case METRIC_ANALYTICS:
+            case METRIC_ANALYTICS_STANDARD:
                 indexManager = new MetricAnalyticsIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -13,9 +13,12 @@ import java.util.stream.Collectors;
 
 public enum IndexType {
     TRACE_ANALYTICS_RAW("trace-analytics-raw"),
+    TRACE_ANALYTICS_RAW_STANDARD("trace-analytics-standard-raw"),
     TRACE_ANALYTICS_SERVICE_MAP("trace-analytics-service-map"),
     LOG_ANALYTICS("log-analytics"),
+    LOG_ANALYTICS_STANDARD("log-analytics-standard"),
     METRIC_ANALYTICS("metric-analytics"),
+    METRIC_ANALYTICS_STANDARD("metric-analytics-standard"),
     CUSTOM("custom"),
     MANAGEMENT_DISABLED("management_disabled");
 

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
@@ -60,6 +60,16 @@
             "path_match": "attributes.*",
             "match_mapping_type": "double"
           }
+        },
+        {
+          "string_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "string"
+          }
         }
     ],
     "properties": {

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
@@ -6,58 +6,104 @@
       "_source": {
         "enabled": true
       },
-      "properties": {
-        "droppedEventsCount": {
-          "type": "integer"
+      "dynamic_templates": [
+        {
+          "long_resource_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "long"
+          }
         },
-        "attributes": {
-          "type": "object"
+        {
+          "double_resource_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "double"
+          }
         },
-        "instrumentationScope": {
+        {
+          "long_scope_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_scope_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "double"
+          }
+        }
+    ],
+    "properties": {
+      "droppedAttributesCount": {
+        "type": "integer"
+      },
+      "instrumentationScope": {
           "properties": {
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
             "name": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                }
-              }
+              "type": "keyword",
+              "ignore_above": 128
             },
             "version": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
-             "attributes": {
-               "type": "object"
-             },
-             "droppedEventsCount": {
-               "type": "integer"
-             }
+              "type": "keyword",
+              "ignore_above": 64
+            }
           }
         },
         "resource": {
           "properties": {
-             "attributes": {
-               "type": "object"
-             },
-             "droppedEventsCount": {
-               "type": "integer"
-             }
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
           }
         },
         "severity": {
           "properties": {
             "number": {
-              "type": "long"
+              "type": "integer"
             },
             "text": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": "32"
             }
           }
         },
@@ -70,68 +116,19 @@
         "time": {
           "type": "date_nanos"
         },
-        "observedTimestamp": {
-          "type": "date_nanos"
-        },
         "observedTime": {
-          "type": "alias",
-          "path": "observedTimestamp"
+          "path": "date_nanos"
         },
         "traceId": {
-          "ignore_above": 256,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 32
         },
         "spanId": {
-          "ignore_above": 256,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 16
         },
         "flags": {
-          "type": "integer"
-        },
-        "schemaUrl": {
-          "type": "keyword"
-        },
-        "instrumentationScope": {
-          "properties": {
-            "name": {
-              "type": "keyword"
-            },
-            "version": {
-              "type": "keyword"
-            }
-          }
-        },
-        "event": {
-          "properties": {
-            "kind": {
-              "type": "keyword"
-            },
-            "domain": {
-              "type": "keyword"
-            },
-            "category": {
-              "type": "keyword"
-            },
-            "type": {
-              "type": "keyword"
-            },
-            "result": {
-              "type": "keyword"
-            },
-           "exception": {
-              "properties": {
-                "message": {
-                  "type": "text"
-                },
-                "stacktrace": {
-                  "type": "text"
-                },
-                "type": {
-                  "type": "keyword"
-                }
-              }
-            }
-          }
+          "type": "long"
         }
       }
     }

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
@@ -1,0 +1,140 @@
+{
+  "version": 1,
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "_source": {
+        "enabled": true
+      },
+      "properties": {
+        "droppedEventsCount": {
+          "type": "integer"
+        },
+        "attributes": {
+          "type": "object"
+        },
+        "instrumentationScope": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 128
+                }
+              }
+            },
+            "version": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+             "attributes": {
+               "type": "object"
+             },
+             "droppedEventsCount": {
+               "type": "integer"
+             }
+          }
+        },
+        "resource": {
+          "properties": {
+             "attributes": {
+               "type": "object"
+             },
+             "droppedEventsCount": {
+               "type": "integer"
+             }
+          }
+        },
+        "severity": {
+          "properties": {
+            "number": {
+              "type": "long"
+            },
+            "text": {
+              "type": "keyword"
+            }
+          }
+        },
+        "body": {
+          "type": "text"
+        },
+        "@timestamp": {
+          "type": "date_nanos"
+        },
+        "time": {
+          "type": "date_nanos"
+        },
+        "observedTimestamp": {
+          "type": "date_nanos"
+        },
+        "observedTime": {
+          "type": "alias",
+          "path": "observedTimestamp"
+        },
+        "traceId": {
+          "ignore_above": 256,
+          "type": "keyword"
+        },
+        "spanId": {
+          "ignore_above": 256,
+          "type": "keyword"
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "schemaUrl": {
+          "type": "keyword"
+        },
+        "instrumentationScope": {
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "version": {
+              "type": "keyword"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "kind": {
+              "type": "keyword"
+            },
+            "domain": {
+              "type": "keyword"
+            },
+            "category": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "result": {
+              "type": "keyword"
+            },
+           "exception": {
+              "properties": {
+                "message": {
+                  "type": "text"
+                },
+                "stacktrace": {
+                  "type": "text"
+                },
+                "type": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
@@ -26,6 +26,16 @@
           }
         },
         {
+          "string_resource_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "string"
+          }
+        },
+        {
           "long_scope_attributes": {
             "mapping": {
               "type": "long"
@@ -41,6 +51,16 @@
             },
             "path_match": "instrumentationScope.attributes.*",
             "match_mapping_type": "double"
+          }
+        },
+        {
+          "string_scope_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "string"
           }
         },
         {

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-standard-template.json
@@ -6,49 +6,109 @@
       "_source": {
         "enabled": true
       },
-      "properties": {
-        "name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+      "dynamic_templates": [
+        {
+          "long_resource_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "long"
           }
         },
-        "droppedEventsCount": {
+        {
+          "double_resource_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_scope_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_scope_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "string_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "string"
+          }
+        }
+      ],
+      "properties": {
+        "droppedAttributesCount": {
           "type": "integer"
         },
-        "attributes": {
-          "type": "object",
+        "instrumentationScope": {
           "properties": {
-            "data_stream": {
-              "properties": {
-                "dataset": {
-                  "ignore_above": 128,
-                  "type": "keyword"
-                },
-                "namespace": {
-                  "ignore_above": 128,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 56,
-                  "type": "keyword"
-                }
-              }
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "name": {
+              "type": "keyword",
+              "ignore_above": 128
+            },
+            "version": {
+              "type": "keyword",
+              "ignore_above": 64
             }
           }
         },
         "resource": {
           "properties": {
-             "attributes": {
-               "type": "object"
-             },
-             "droppedEventsCount": {
-               "type": "integer"
-             }
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
           }
+        },
+        "name": {
+          "type": "keyword",
+          "ignore_above": 256
         },
         "description": {
           "type": "text",
@@ -60,7 +120,7 @@
           }
         },
         "flags": {
-          "type": "integer"
+          "type": "long"
         },
         "unit": {
           "type": "keyword",
@@ -68,29 +128,26 @@
         },
         "kind": {
           "type": "keyword",
-          "ignore_above": 128
+          "ignore_above": 32
         },
         "aggregationTemporality": {
           "type": "keyword",
-          "ignore_above": 128
+          "ignore_above": 64
         },
         "monotonic": {
           "type": "boolean"
         },
         "startTime": {
-          "type": "date"
+          "type": "date_nanos"
         },
         "@timestamp": {
-          "type": "date"
+          "type": "date_nanos"
         },
         "time": {
           "type": "date_nanos"
         },
-        "observedTimestamp": {
-          "type": "date_nanos"
-        },
         "value@int": {
-          "type": "integer"
+          "type": "long"
         },
         "value@double": {
           "type": "double"
@@ -108,10 +165,10 @@
               "type": "double"
             },
             "max": {
-              "type": "float"
+              "type": "double"
             },
             "min": {
-              "type": "float"
+              "type": "double"
             }
           }
         },
@@ -122,10 +179,10 @@
           "type": "long"
         },
         "explicitBoundsList": {
-          "type": "float"
+          "type": "double"
         },
         "explicitBoundsCount": {
-          "type": "float"
+          "type": "double"
         },
         "quantiles": {
           "properties": {
@@ -147,10 +204,10 @@
               "type": "long"
             },
             "max": {
-              "type": "float"
+              "type": "double"
             },
             "min": {
-              "type": "float"
+              "type": "double"
             }
           }
         },
@@ -161,10 +218,10 @@
               "type": "long"
             },
             "max": {
-              "type": "float"
+              "type": "double"
             },
             "min": {
-              "type": "float"
+              "type": "double"
             }
           }
         },
@@ -181,13 +238,13 @@
           "type": "long"
         },
         "max": {
-          "type": "float"
+          "type": "double"
         },
         "min": {
-          "type": "float"
+          "type": "double"
         },
         "sum": {
-          "type": "float"
+          "type": "double"
         },
         "count": {
           "type": "long"
@@ -204,44 +261,15 @@
             "spanId": {
               "ignore_above": 256,
               "type": "keyword"
-            }
-          }
-        },
-        "instrumentationScope": {
-          "properties": {
-            "name": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                }
-              }
             },
-            "version": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
+            "value@int": {
+              "type": "long"
             },
-            "droppedAttributesCount": {
-              "type": "integer"
+            "value@double": {
+              "type": "double"
             },
-            "attributes": {
-              "type": "object"
-              }
-            }
-          }
-        },
-        "schemaUrl": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
+            "value": {
+              "type": "double"
             }
           }
         }
@@ -249,4 +277,3 @@
     }
   }
 }
-

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-standard-template.json
@@ -1,0 +1,252 @@
+{
+  "version": 1,
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "_source": {
+        "enabled": true
+      },
+      "properties": {
+        "name": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "droppedEventsCount": {
+          "type": "integer"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "data_stream": {
+              "properties": {
+                "dataset": {
+                  "ignore_above": 128,
+                  "type": "keyword"
+                },
+                "namespace": {
+                  "ignore_above": 128,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 56,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "resource": {
+          "properties": {
+             "attributes": {
+               "type": "object"
+             },
+             "droppedEventsCount": {
+               "type": "integer"
+             }
+          }
+        },
+        "description": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "unit": {
+          "type": "keyword",
+          "ignore_above": 128
+        },
+        "kind": {
+          "type": "keyword",
+          "ignore_above": 128
+        },
+        "aggregationTemporality": {
+          "type": "keyword",
+          "ignore_above": 128
+        },
+        "monotonic": {
+          "type": "boolean"
+        },
+        "startTime": {
+          "type": "date"
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "time": {
+          "type": "date_nanos"
+        },
+        "observedTimestamp": {
+          "type": "date_nanos"
+        },
+        "value@int": {
+          "type": "integer"
+        },
+        "value@double": {
+          "type": "double"
+        },
+        "value": {
+          "type": "double"
+        },
+        "buckets": {
+          "type" : "nested",
+          "properties": {
+            "count": {
+              "type": "long"
+            },
+            "sum": {
+              "type": "double"
+            },
+            "max": {
+              "type": "float"
+            },
+            "min": {
+              "type": "float"
+            }
+          }
+        },
+        "bucketCount": {
+          "type": "long"
+        },
+        "bucketCountsList": {
+          "type": "long"
+        },
+        "explicitBoundsList": {
+          "type": "float"
+        },
+        "explicitBoundsCount": {
+          "type": "float"
+        },
+        "quantiles": {
+          "properties": {
+            "quantile": {
+              "type": "double"
+            },
+            "value": {
+              "type": "double"
+            }
+          }
+        },
+        "quantileValuesCount": {
+          "type": "long"
+        },
+        "positiveBuckets": {
+          "type" : "nested",
+          "properties": {
+            "count": {
+              "type": "long"
+            },
+            "max": {
+              "type": "float"
+            },
+            "min": {
+              "type": "float"
+            }
+          }
+        },
+        "negativeBuckets": {
+          "type" : "nested",
+          "properties": {
+            "count": {
+              "type": "long"
+            },
+            "max": {
+              "type": "float"
+            },
+            "min": {
+              "type": "float"
+            }
+          }
+        },
+        "negativeOffset": {
+          "type": "integer"
+        },
+        "positiveOffset": {
+          "type": "integer"
+        },
+        "zeroCount": {
+          "type": "long"
+        },
+        "scale": {
+          "type": "long"
+        },
+        "max": {
+          "type": "float"
+        },
+        "min": {
+          "type": "float"
+        },
+        "sum": {
+          "type": "float"
+        },
+        "count": {
+          "type": "long"
+        },
+        "exemplar": {
+          "properties": {
+            "time": {
+              "type": "date_nanos"
+            },
+            "traceId": {
+              "ignore_above": 256,
+              "type": "keyword"
+            },
+            "spanId": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "instrumentationScope": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 128
+                }
+              }
+            },
+            "version": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "attributes": {
+              "type": "object"
+              }
+            }
+          }
+        },
+        "schemaUrl": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-standard-template.json
@@ -26,6 +26,16 @@
           }
         },
         {
+          "string_resource_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "string"
+          }
+        },
+        {
           "long_scope_attributes": {
             "mapping": {
               "type": "long"
@@ -41,6 +51,16 @@
             },
             "path_match": "instrumentationScope.attributes.*",
             "match_mapping_type": "double"
+          }
+        },
+        {
+          "string_scope_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "string"
           }
         },
         {

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-template.json
@@ -3,49 +3,102 @@
   "template": {
     "mappings": {
       "date_detection": false,
-      "dynamic_templates": [
-        {
-          "resources_map": {
-            "mapping": {
-              "type": "keyword"
-            },
-            "path_match": "resource.*"
-          }
-        }
-        ],
       "_source": {
         "enabled": true
       },
+      "dynamic_templates": [
+        {
+          "long_resource_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_resource_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_scope_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_scope_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "double"
+          }
+        }
+      ],
       "properties": {
-        "name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
+        "droppedAttributesCount": {
+          "type": "integer"
+        },
+        "instrumentationScope": {
+          "properties": {
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "name": {
+              "type": "keyword",
+              "ignore_above": 128
+            },
+            "version": {
+              "type": "keyword",
+              "ignore_above": 64
+            }
+          }
+        },
+        "resource": {
+          "properties": {
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
               "type": "keyword",
               "ignore_above": 256
             }
           }
         },
-        "attributes": {
-          "type": "object",
-          "properties": {
-            "data_stream": {
-              "properties": {
-                "dataset": {
-                  "ignore_above": 128,
-                  "type": "keyword"
-                },
-                "namespace": {
-                  "ignore_above": 128,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 56,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
+        "name": {
+          "type": "keyword",
+          "ignore_above": 256
         },
         "description": {
           "type": "text",
@@ -56,35 +109,35 @@
             }
           }
         },
+        "flags": {
+          "type": "long"
+        },
         "unit": {
           "type": "keyword",
           "ignore_above": 128
         },
         "kind": {
           "type": "keyword",
-          "ignore_above": 128
+          "ignore_above": 32
         },
         "aggregationTemporality": {
           "type": "keyword",
-          "ignore_above": 128
+          "ignore_above": 64
         },
         "monotonic": {
           "type": "boolean"
         },
         "startTime": {
-          "type": "date"
+          "type": "date_nanos"
         },
         "@timestamp": {
-          "type": "date"
+          "type": "date_nanos"
         },
         "time": {
           "type": "date_nanos"
         },
-        "observedTimestamp": {
-          "type": "date_nanos"
-        },
         "value@int": {
-          "type": "integer"
+          "type": "long"
         },
         "value@double": {
           "type": "double"
@@ -102,10 +155,10 @@
               "type": "double"
             },
             "max": {
-              "type": "float"
+              "type": "double"
             },
             "min": {
-              "type": "float"
+              "type": "double"
             }
           }
         },
@@ -116,10 +169,10 @@
           "type": "long"
         },
         "explicitBoundsList": {
-          "type": "float"
+          "type": "double"
         },
         "explicitBoundsCount": {
-          "type": "float"
+          "type": "double"
         },
         "quantiles": {
           "properties": {
@@ -141,10 +194,10 @@
               "type": "long"
             },
             "max": {
-              "type": "float"
+              "type": "double"
             },
             "min": {
-              "type": "float"
+              "type": "double"
             }
           }
         },
@@ -155,10 +208,10 @@
               "type": "long"
             },
             "max": {
-              "type": "float"
+              "type": "double"
             },
             "min": {
-              "type": "float"
+              "type": "double"
             }
           }
         },
@@ -175,13 +228,13 @@
           "type": "long"
         },
         "max": {
-          "type": "float"
+          "type": "double"
         },
         "min": {
-          "type": "float"
+          "type": "double"
         },
         "sum": {
-          "type": "float"
+          "type": "double"
         },
         "count": {
           "type": "long"
@@ -198,49 +251,15 @@
             "spanId": {
               "ignore_above": 256,
               "type": "keyword"
-            }
-          }
-        },
-        "instrumentationScope": {
-          "properties": {
-            "name": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                }
-              }
             },
-            "version": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
+            "value@int": {
+              "type": "long"
             },
-            "droppedAttributesCount": {
-              "type": "integer"
+            "value@double": {
+              "type": "double"
             },
-            "schemaUrl": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            }
-          }
-        },
-        "schemaUrl": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
+            "value": {
+              "type": "double"
             }
           }
         }
@@ -248,3 +267,4 @@
     }
   }
 }
+

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
@@ -60,6 +60,16 @@
             "path_match": "attributes.*",
             "match_mapping_type": "double"
           }
+        },
+        {
+          "string_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "string"
+          }
         }
       ],
       "properties": {

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
@@ -3,39 +3,110 @@
   "template": {
     "mappings": {
       "date_detection": false,
-      "dynamic_templates": [
-        {
-          "resource_attributes_map": {
-            "mapping": {
-              "type": "keyword"
-            },
-            "path_match": "resource.attributes.*"
-          }
-        },
-        {
-          "span_attributes_map": {
-            "mapping": {
-              "type": "keyword"
-            },
-            "path_match": "span.attributes.*"
-          }
-        }
-      ],
       "_source": {
         "enabled": true
       },
+      "dynamic_templates": [
+        {
+          "long_resource_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_resource_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_scope_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_scope_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "long_attributes": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "double_attributes": {
+            "mapping": {
+              "type": "double"
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "double"
+          }
+        }
+      ],
       "properties": {
+        "droppedAttributesCount": {
+          "type": "integer"
+        },
+        "instrumentationScope": {
+          "properties": {
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "name": {
+              "type": "keyword",
+              "ignore_above": 128
+            },
+            "version": {
+              "type": "keyword",
+              "ignore_above": 64
+            }
+          }
+        },
+        "resource": {
+          "properties": {
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
+            "schemaUrl": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
         "traceId": {
-          "ignore_above": 256,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 32
         },
         "spanId": {
-          "ignore_above": 256,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 16
         },
         "parentSpanId": {
-          "ignore_above": 256,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 16
         },
         "name": {
           "ignore_above": 1024,
@@ -63,11 +134,12 @@
           }
         },
         "kind": {
-          "ignore_above": 128,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 32
         },
-        "droppedEventsCount": {
-          "type": "integer"
+        "serviceName": {
+          "type": "keyword",
+          "ignore_above": 256
         },
         "startTime": {
           "type": "date_nanos"
@@ -75,46 +147,11 @@
         "endTime": {
           "type": "date_nanos"
         },
-        "attributes": {
-          "type": "object"
+        "@timestamp": {
+          "type": "date_nanos"
         },
-        "instrumentationScope": {
-          "properties": {
-            "name": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                }
-              }
-            },
-            "version": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
-             "attributes": {
-               "type": "object"
-             },
-             "droppedEventsCount": {
-               "type": "integer"
-             }
-          }
-        },
-        "resource": {
-          "properties": {
-             "attributes": {
-               "type": "object"
-             },
-             "droppedEventsCount": {
-               "type": "integer"
-             }
-          }
+        "time": {
+          "type": "date_nanos"
         },
         "status": {
           "properties": {
@@ -122,12 +159,10 @@
               "type": "integer"
             },
             "message": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 2048
             }
           }
-        },
-        "serviceName": {
-          "type": "keyword"
         },
         "durationInNanos": {
           "type": "long"
@@ -135,13 +170,49 @@
         "events": {
           "type": "nested",
           "properties": {
+            "name": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "attributes": {
+              "type": "object"
+            },
+            "droppedAttributesCount": {
+              "type": "integer"
+            },
             "time": {
               "type": "date_nanos"
             }
           }
         },
+        "droppedEventsCount": {
+          "type": "integer"
+        },
         "links": {
-          "type": "nested"
+          "type": "nested",
+          "properties": {
+            "traceId": {
+              "type": "keyword",
+              "ignore_above": 32
+            },
+            "spanId": {
+              "type": "keyword",
+              "ignore_above": 16
+            },
+            "traceState": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "attributes": {
+              "type": "object"
+            },
+            "droppedAttributesCount": {
+              "type": "integer"
+            }
+          }
+        },
+        "droppedLinksCount": {
+          "type": "integer"
         }
       }
     }

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
@@ -1,0 +1,150 @@
+{
+  "version": 1,
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "dynamic_templates": [
+        {
+          "resource_attributes_map": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "path_match": "resource.attributes.*"
+          }
+        },
+        {
+          "span_attributes_map": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "path_match": "span.attributes.*"
+          }
+        }
+      ],
+      "_source": {
+        "enabled": true
+      },
+      "properties": {
+        "traceId": {
+          "ignore_above": 256,
+          "type": "keyword"
+        },
+        "spanId": {
+          "ignore_above": 256,
+          "type": "keyword"
+        },
+        "parentSpanId": {
+          "ignore_above": 256,
+          "type": "keyword"
+        },
+        "name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "traceState": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "traceGroup": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "traceGroupFields": {
+          "properties": {
+            "endTime": {
+              "type": "date_nanos"
+            },
+            "durationInNanos": {
+              "type": "long"
+            },
+            "statusCode": {
+              "type": "integer"
+            }
+          }
+        },
+        "kind": {
+          "ignore_above": 128,
+          "type": "keyword"
+        },
+        "droppedEventsCount": {
+          "type": "integer"
+        },
+        "startTime": {
+          "type": "date_nanos"
+        },
+        "endTime": {
+          "type": "date_nanos"
+        },
+        "attributes": {
+          "type": "object"
+        },
+        "instrumentationScope": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 128
+                }
+              }
+            },
+            "version": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+             "attributes": {
+               "type": "object"
+             },
+             "droppedEventsCount": {
+               "type": "integer"
+             }
+          }
+        },
+        "resource": {
+          "properties": {
+             "attributes": {
+               "type": "object"
+             },
+             "droppedEventsCount": {
+               "type": "integer"
+             }
+          }
+        },
+        "status": {
+          "properties": {
+            "code": {
+              "type": "integer"
+            },
+            "message": {
+              "type": "keyword"
+            }
+          }
+        },
+        "serviceName": {
+          "type": "keyword"
+        },
+        "durationInNanos": {
+          "type": "long"
+        },
+        "events": {
+          "type": "nested",
+          "properties": {
+            "time": {
+              "type": "date_nanos"
+            }
+          }
+        },
+        "links": {
+          "type": "nested"
+        }
+      }
+    }
+  }
+}
+

--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
@@ -26,6 +26,16 @@
           }
         },
         {
+          "string_resource_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "string"
+          }
+        },
+        {
           "long_scope_attributes": {
             "mapping": {
               "type": "long"
@@ -41,6 +51,16 @@
             },
             "path_match": "instrumentationScope.attributes.*",
             "match_mapping_type": "double"
+          }
+        },
+        {
+          "string_scope_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "string"
           }
         },
         {

--- a/data-prepper-plugins/opensearch/src/main/resources/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/logs-otel-v1-index-standard-template.json
@@ -59,6 +59,16 @@
           "path_match": "attributes.*",
           "match_mapping_type": "double"
         }
+      },
+      {
+        "string_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "string"
+        }
       }
   ],
   "properties": {

--- a/data-prepper-plugins/opensearch/src/main/resources/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/logs-otel-v1-index-standard-template.json
@@ -25,6 +25,16 @@
         }
       },
       {
+        "string_resource_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "string"
+        }
+      },
+      {
         "long_scope_attributes": {
           "mapping": {
             "type": "long"
@@ -40,6 +50,16 @@
           },
           "path_match": "instrumentationScope.attributes.*",
           "match_mapping_type": "double"
+        }
+      },
+      {
+        "string_scope_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "string"
         }
       },
       {

--- a/data-prepper-plugins/opensearch/src/main/resources/logs-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/logs-otel-v1-index-standard-template.json
@@ -1,0 +1,135 @@
+{
+  "version": 1,
+  "mappings": {
+    "date_detection": false,
+    "_source": {
+      "enabled": true
+    },
+    "dynamic_templates": [
+      {
+        "long_resource_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_resource_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "double"
+        }
+      },
+      {
+        "long_scope_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_scope_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "double"
+        }
+      },
+      {
+        "long_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "double"
+        }
+      }
+  ],
+  "properties": {
+    "droppedAttributesCount": {
+      "type": "integer"
+    },
+    "instrumentationScope": {
+        "properties": {
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "schemaUrl": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "name": {
+            "type": "keyword",
+            "ignore_above": 128
+          },
+          "version": {
+            "type": "keyword",
+            "ignore_above": 64
+          }
+        }
+      },
+      "resource": {
+        "properties": {
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "schemaUrl": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "severity": {
+        "properties": {
+          "number": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "keyword",
+            "ignore_above": "32"
+          }
+        }
+      },
+      "body": {
+        "type": "text"
+      },
+      "@timestamp": {
+        "type": "date_nanos"
+      },
+      "time": {
+        "type": "date_nanos"
+      },
+      "observedTime": {
+        "path": "date_nanos"
+      },
+      "traceId": {
+        "type": "keyword",
+        "ignore_above": 32
+      },
+      "spanId": {
+        "type": "keyword",
+        "ignore_above": 16
+      },
+      "flags": {
+        "type": "long"
+      }
+    }
+  }
+}
+

--- a/data-prepper-plugins/opensearch/src/main/resources/metrics-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/metrics-otel-v1-index-standard-template.json
@@ -1,0 +1,268 @@
+{
+  "version": 1,
+  "mappings": {
+    "date_detection": false,
+    "_source": {
+      "enabled": true
+    },
+    "dynamic_templates": [
+      {
+        "long_resource_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_resource_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "double"
+        }
+      },
+      {
+        "long_scope_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_scope_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "double"
+        }
+      },
+      {
+        "long_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "double"
+        }
+      }
+    ],
+    "properties": {
+      "droppedAttributesCount": {
+        "type": "integer"
+      },
+      "instrumentationScope": {
+        "properties": {
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "schemaUrl": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "name": {
+            "type": "keyword",
+            "ignore_above": 128
+          },
+          "version": {
+            "type": "keyword",
+            "ignore_above": 64
+          }
+        }
+      },
+      "resource": {
+        "properties": {
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "schemaUrl": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "name": {
+        "type": "keyword",
+        "ignore_above": 256
+      },
+      "description": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "flags": {
+        "type": "long"
+      },
+      "unit": {
+        "type": "keyword",
+        "ignore_above": 128
+      },
+      "kind": {
+        "type": "keyword",
+        "ignore_above": 32
+      },
+      "aggregationTemporality": {
+        "type": "keyword",
+        "ignore_above": 64
+      },
+      "monotonic": {
+        "type": "boolean"
+      },
+      "startTime": {
+        "type": "date_nanos"
+      },
+      "@timestamp": {
+        "type": "date_nanos"
+      },
+      "time": {
+        "type": "date_nanos"
+      },
+      "value@int": {
+        "type": "long"
+      },
+      "value@double": {
+        "type": "double"
+      },
+      "value": {
+        "type": "double"
+      },
+      "buckets": {
+        "type" : "nested",
+        "properties": {
+          "count": {
+            "type": "long"
+          },
+          "sum": {
+            "type": "double"
+          },
+          "max": {
+            "type": "double"
+          },
+          "min": {
+            "type": "double"
+          }
+        }
+      },
+      "bucketCount": {
+        "type": "long"
+      },
+      "bucketCountsList": {
+        "type": "long"
+      },
+      "explicitBoundsList": {
+        "type": "double"
+      },
+      "explicitBoundsCount": {
+        "type": "double"
+      },
+      "quantiles": {
+        "properties": {
+          "quantile": {
+            "type": "double"
+          },
+          "value": {
+            "type": "double"
+          }
+        }
+      },
+      "quantileValuesCount": {
+        "type": "long"
+      },
+      "positiveBuckets": {
+        "type" : "nested",
+        "properties": {
+          "count": {
+            "type": "long"
+          },
+          "max": {
+            "type": "double"
+          },
+          "min": {
+            "type": "double"
+          }
+        }
+      },
+      "negativeBuckets": {
+        "type" : "nested",
+        "properties": {
+          "count": {
+            "type": "long"
+          },
+          "max": {
+            "type": "double"
+          },
+          "min": {
+            "type": "double"
+          }
+        }
+      },
+      "negativeOffset": {
+        "type": "integer"
+      },
+      "positiveOffset": {
+        "type": "integer"
+      },
+      "zeroCount": {
+        "type": "long"
+      },
+      "scale": {
+        "type": "long"
+      },
+      "max": {
+        "type": "double"
+      },
+      "min": {
+        "type": "double"
+      },
+      "sum": {
+        "type": "double"
+      },
+      "count": {
+        "type": "long"
+      },
+      "exemplar": {
+        "properties": {
+          "time": {
+            "type": "date_nanos"
+          },
+          "traceId": {
+            "ignore_above": 256,
+            "type": "keyword"
+          },
+          "spanId": {
+            "ignore_above": 256,
+            "type": "keyword"
+          },
+          "value@int": {
+            "type": "long"
+          },
+          "value@double": {
+            "type": "double"
+          },
+          "value": {
+            "type": "double"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/data-prepper-plugins/opensearch/src/main/resources/metrics-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/metrics-otel-v1-index-standard-template.json
@@ -59,6 +59,16 @@
           "path_match": "attributes.*",
           "match_mapping_type": "double"
         }
+      },
+      {
+        "string_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "string"
+        }
       }
     ],
     "properties": {

--- a/data-prepper-plugins/opensearch/src/main/resources/metrics-otel-v1-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/metrics-otel-v1-index-standard-template.json
@@ -25,6 +25,16 @@
         }
       },
       {
+        "string_resource_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "string"
+        }
+      },
+      {
         "long_scope_attributes": {
           "mapping": {
             "type": "long"
@@ -40,6 +50,16 @@
           },
           "path_match": "instrumentationScope.attributes.*",
           "match_mapping_type": "double"
+        }
+      },
+      {
+        "string_scope_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "string"
         }
       },
       {

--- a/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-standard-template.json
@@ -1,0 +1,218 @@
+{
+  "version": 1,
+  "mappings": {
+    "date_detection": false,
+    "_source": {
+      "enabled": true
+    },
+    "dynamic_templates": [
+      {
+        "long_resource_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_resource_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "double"
+        }
+      },
+      {
+        "long_scope_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_scope_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "double"
+        }
+      },
+      {
+        "long_attributes": {
+          "mapping": {
+            "type": "long"
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "long"
+        }
+      },
+      {
+        "double_attributes": {
+          "mapping": {
+            "type": "double"
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "double"
+        }
+      }
+    ],
+    "properties": {
+      "droppedAttributesCount": {
+        "type": "integer"
+      },
+      "instrumentationScope": {
+        "properties": {
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "schemaUrl": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "name": {
+            "type": "keyword",
+            "ignore_above": 128
+          },
+          "version": {
+            "type": "keyword",
+            "ignore_above": 64
+          }
+        }
+      },
+      "resource": {
+        "properties": {
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "schemaUrl": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "traceId": {
+        "type": "keyword",
+        "ignore_above": 32
+      },
+      "spanId": {
+        "type": "keyword",
+        "ignore_above": 16
+      },
+      "parentSpanId": {
+        "type": "keyword",
+        "ignore_above": 16
+      },
+      "name": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "traceState": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "traceGroup": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "traceGroupFields": {
+        "properties": {
+          "endTime": {
+            "type": "date_nanos"
+          },
+          "durationInNanos": {
+            "type": "long"
+          },
+          "statusCode": {
+            "type": "integer"
+          }
+        }
+      },
+      "kind": {
+        "type": "keyword",
+        "ignore_above": 32
+      },
+      "serviceName": {
+        "type": "keyword",
+        "ignore_above": 256
+      },
+      "startTime": {
+        "type": "date_nanos"
+      },
+      "endTime": {
+        "type": "date_nanos"
+      },
+      "@timestamp": {
+        "type": "date_nanos"
+      },
+      "time": {
+        "type": "date_nanos"
+      },
+      "status": {
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "keyword",
+            "ignore_above": 2048
+          }
+        }
+      },
+      "durationInNanos": {
+        "type": "long"
+      },
+      "events": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "attributes": {
+            "type": "object"
+          },
+          "droppedAttributesCount": {
+            "type": "integer"
+          },
+          "time": {
+            "type": "date_nanos"
+          }
+        }
+      },
+      "droppedEventsCount": {
+        "type": "integer"
+      },
+      "links": {
+        "type": "nested",
+        "properties": {
+          "traceId": {
+            "type": "keyword",
+            "ignore_above": 32
+          },
+          "spanId": {
+            "type": "keyword",
+            "ignore_above": 16
+          },
+          "traceState": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "attributes": {
+            "type": "object"
+          },
+          "droppedAttributesCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "droppedLinksCount": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-standard-template.json
@@ -59,6 +59,16 @@
           "path_match": "attributes.*",
           "match_mapping_type": "double"
         }
+      },
+      {
+        "string_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "attributes.*",
+          "match_mapping_type": "string"
+        }
       }
     ],
     "properties": {

--- a/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-standard-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-standard-template.json
@@ -25,6 +25,16 @@
         }
       },
       {
+        "string_resource_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "resource.attributes.*",
+          "match_mapping_type": "string"
+        }
+      },
+      {
         "long_scope_attributes": {
           "mapping": {
             "type": "long"
@@ -40,6 +50,16 @@
           },
           "path_match": "instrumentationScope.attributes.*",
           "match_mapping_type": "double"
+        }
+      },
+      {
+        "string_scope_attributes": {
+          "mapping": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "path_match": "instrumentationScope.attributes.*",
+          "match_mapping_type": "string"
         }
       },
       {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
@@ -26,14 +26,17 @@ public class IndexTypeTests {
         assertEquals(Optional.of(IndexType.CUSTOM), IndexType.getByValue("custom"));
         assertEquals(Optional.of(IndexType.MANAGEMENT_DISABLED), IndexType.getByValue("management_disabled"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW), IndexType.getByValue("trace-analytics-raw"));
+        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW_STANDARD), IndexType.getByValue("trace-analytics-standard-raw"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_SERVICE_MAP), IndexType.getByValue("trace-analytics-service-map"));
         assertEquals(Optional.of(IndexType.LOG_ANALYTICS), IndexType.getByValue("log-analytics"));
+        assertEquals(Optional.of(IndexType.LOG_ANALYTICS_STANDARD), IndexType.getByValue("log-analytics-standard"));
         assertEquals(Optional.of(IndexType.METRIC_ANALYTICS), IndexType.getByValue("metric-analytics"));
+        assertEquals(Optional.of(IndexType.METRIC_ANALYTICS_STANDARD), IndexType.getByValue("metric-analytics-standard"));
     }
 
     @Test
     public void getIndexTypeValues() {
-        assertEquals("[trace-analytics-raw, trace-analytics-service-map, log-analytics, metric-analytics, custom, management_disabled]", IndexType.getIndexTypeValues());
+        assertEquals("[trace-analytics-raw, trace-analytics-standard-raw, trace-analytics-service-map, log-analytics, log-analytics-standard, metric-analytics, metric-analytics-standard, custom, management_disabled]", IndexType.getIndexTypeValues());
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
@@ -61,6 +61,8 @@ public class TraceAnalyticsRawIndexManagerTests {
 
     private AbstractIndexManager traceAnalyticsRawIndexManager;
 
+    private AbstractIndexManager traceAnalyticsRawStandardIndexManager;
+
     @Mock
     private OpenSearchClient openSearchClient;
 
@@ -124,7 +126,6 @@ public class TraceAnalyticsRawIndexManagerTests {
         when(indexConfiguration.getIndexAlias()).thenReturn(INDEX_ALIAS);
         traceAnalyticsRawIndexManager = indexManagerFactory.getIndexManager(
                 IndexType.TRACE_ANALYTICS_RAW, openSearchClient, restHighLevelClient, openSearchSinkConfiguration, templateStrategy);
-
         when(openSearchClient.cluster()).thenReturn(openSearchClusterClient);
         when(openSearchClusterClient.getSettings(any(GetClusterSettingsRequest.class)))
                 .thenReturn(getClusterSettingsResponse);
@@ -271,6 +272,22 @@ public class TraceAnalyticsRawIndexManagerTests {
         verify(openSearchIndicesClient).create(any(CreateIndexRequest.class));
         verify(openSearchSinkConfiguration).getIndexConfiguration();
         verify(indexConfiguration).getIndexAlias();
+    }
+
+    @Test
+    void checkAndCreateIndex_NeedToCreateNewIndex_withStandardIndexManager() throws IOException {
+        traceAnalyticsRawStandardIndexManager = indexManagerFactory.getIndexManager(
+                IndexType.TRACE_ANALYTICS_RAW_STANDARD, openSearchClient, restHighLevelClient, openSearchSinkConfiguration, templateStrategy);
+
+        when(openSearchIndicesClient.existsAlias(any(ExistsAliasRequest.class))).thenReturn(new BooleanResponse(false));
+        when(openSearchIndicesClient.create(any(CreateIndexRequest.class)))
+                .thenReturn(null);
+        traceAnalyticsRawStandardIndexManager.checkAndCreateIndex();
+        verify(openSearchClient, times(2)).indices();
+        verify(openSearchIndicesClient).existsAlias(any(ExistsAliasRequest.class));
+        verify(openSearchIndicesClient).create(any(CreateIndexRequest.class));
+        verify(openSearchSinkConfiguration, times(2)).getIndexConfiguration();
+        verify(indexConfiguration, times(2)).getIndexAlias();
     }
 
     @Test

--- a/data-prepper-plugins/otel-logs-source/src/test/resources/testjson/test-standard-log.json
+++ b/data-prepper-plugins/otel-logs-source/src/test/resources/testjson/test-standard-log.json
@@ -16,7 +16,6 @@
   },
   "flags": 0,
   "severityNumber": 2,
-  "serviceName": "testServiceName",
   "body": "Test body",
   "schemaUrl": "testSchemaUrl",
   "spanId": "746573745370616e4964",

--- a/data-prepper-plugins/otel-metrics-source/src/test/resources/testjson/test-standard-metrics.json
+++ b/data-prepper-plugins/otel-metrics-source/src/test/resources/testjson/test-standard-metrics.json
@@ -17,7 +17,6 @@
     "kind": "GAUGE",
     "flags": 0,
     "description": "testGaugeDescription",
-    "serviceName": null,
     "schemaUrl": "testSchemaUrl",
     "unit": "1",
     "exemplars": [],
@@ -47,7 +46,6 @@
     "kind": "SUM",
     "flags": 0,
     "description": "testSumDescription",
-    "serviceName": null,
     "schemaUrl": "testSchemaUrl",
     "isMonotonic": false,
     "unit": "1",
@@ -88,7 +86,6 @@
       6
     ],
     "positiveOffset": 2,
-    "serviceName": null,
     "negativeBuckets": [
       {
         "min": 0.9170040432046712,
@@ -195,7 +192,6 @@
     "flags": 1,
     "description": "testHistogramDescription",
     "sum": 100,
-    "serviceName": null,
     "schemaUrl": "testSchemaUrl",
     "unit": "1",
     "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -235,7 +231,6 @@
     "flags": 1,
     "description": "testSummaryDescription",
     "sum": 100,
-    "serviceName": null,
     "schemaUrl": "testSchemaUrl",
     "quantiles": [
       {

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCommonUtils.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCommonUtils.java
@@ -15,7 +15,7 @@ public class OTelProtoCommonUtils {
         return Instant.ofEpochSecond(0L, unixNano).toString();
     }
 
-    public static long timeISO8601ToNanos(final String timeISO08601) {
+    public static long convertISO8601ToNanos(final String timeISO08601) {
         final Instant instant = Instant.parse(timeISO08601);
         return instant.getEpochSecond() * NANO_MULTIPLIER + instant.getNano();
     }
@@ -23,5 +23,6 @@ public class OTelProtoCommonUtils {
     public static String convertByteStringToString(ByteString bs) {
         return Hex.encodeHexString(bs.toByteArray());
     }
+
 }
 

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoStandardCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoStandardCodec.java
@@ -7,6 +7,9 @@ package org.opensearch.dataprepper.plugins.otel.codec;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
+import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils.convertISO8601ToNanos;
+import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils.convertUnixNanosToISO8601;
+import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils.convertByteStringToString;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -28,6 +31,7 @@ import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Status;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.log.JacksonStandardOTelLog;
 import org.opensearch.dataprepper.model.log.OpenTelemetryLog;
 import org.opensearch.dataprepper.model.metric.Bucket;
@@ -51,6 +55,7 @@ import org.opensearch.dataprepper.model.trace.DefaultTraceGroupFields;
 import org.opensearch.dataprepper.model.trace.JacksonStandardSpan;
 import org.opensearch.dataprepper.model.trace.Link;
 import org.opensearch.dataprepper.model.trace.Span;
+import org.opensearch.dataprepper.model.trace.JacksonSpan;
 import org.opensearch.dataprepper.model.trace.SpanEvent;
 import org.opensearch.dataprepper.model.trace.TraceGroupFields;
 import org.slf4j.Logger;
@@ -135,14 +140,6 @@ public class OTelProtoStandardCodec {
             return Objects.hash(scale, sign);
         }
     }
-    public static String convertUnixNanosToISO8601(final long unixNano) {
-        return Instant.ofEpochSecond(0L, unixNano).toString();
-    }
-
-    public static long timeISO8601ToNanos(final String timeISO08601) {
-        final Instant instant = Instant.parse(timeISO08601);
-        return instant.getEpochSecond() * NANO_MULTIPLIER + instant.getNano();
-    }
 
     public static class OTelProtoDecoder implements OTelProtoCodec.OTelProtoDecoder {
 
@@ -176,11 +173,11 @@ public class OTelProtoStandardCodec {
         @Override
         public List<OpenTelemetryLog> parseExportLogsServiceRequest(final ExportLogsServiceRequest exportLogsServiceRequest, final Instant timeReceived) {
             return exportLogsServiceRequest.getResourceLogsList().stream()
-                    .flatMap(rs -> parseResourceLogs(rs, timeReceived).stream()).collect(Collectors.toList());
+                    .flatMap(rs -> parseResourceLogs(rs, timeReceived)).collect(Collectors.toList());
         }
 
-        protected Collection<OpenTelemetryLog> parseResourceLogs(ResourceLogs rs, final Instant timeReceived) {
-            final String serviceName = OTelProtoStandardCodec.getServiceName(rs.getResource()).orElse(null);
+        protected Stream<OpenTelemetryLog> parseResourceLogs(ResourceLogs rs, final Instant timeReceived) {
+            final String serviceName = getServiceName(rs.getResource()).orElse(null);
             final Map<String, Object> resourceAttributes = getResourceAttributes(rs.getResource());
             final String schemaUrl = rs.getSchemaUrl();
 
@@ -189,14 +186,14 @@ public class OTelProtoStandardCodec {
                     .map(sls -> {
                             return processLogsList(sls.getLogRecordsList(),
                                     serviceName,
-                                    OTelProtoStandardCodec.getInstrumentationScopeAttributes(sls.getScope()),
+                                    getInstrumentationScopeAttributes(sls.getScope()),
                                     resourceAttributes,
                                     schemaUrl,
                                     timeReceived);
                     })
                     .flatMap(Collection::stream);
 
-            return mappedScopeListLogs.collect(Collectors.toList());
+            return mappedScopeListLogs;
         }
 
         protected Map<String, ResourceSpans> splitResourceSpansByTraceId(final ResourceSpans resourceSpans) {
@@ -303,20 +300,19 @@ public class OTelProtoStandardCodec {
                                                          final Instant timeReceived) {
             return logsList.stream()
                     .map(log -> JacksonStandardOTelLog.builder()
-                            .withTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(log.getTimeUnixNano()))
-                            .withObservedTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(log.getObservedTimeUnixNano()))
-                            .withServiceName(serviceName)
+                            .withTime(convertUnixNanosToISO8601(log.getTimeUnixNano()))
+                            .withObservedTime(convertUnixNanosToISO8601(log.getObservedTimeUnixNano()))
                             .withAttributes(convertKeyValueToAttributes(log.getAttributesList()))
                             .withScope(ils)
                             .withResource(resourceAttributes)
                             .withSchemaUrl(schemaUrl)
                             .withFlags(log.getFlags())
-                            .withTraceId(OTelProtoStandardCodec.convertByteStringToString(log.getTraceId()))
-                            .withSpanId(OTelProtoStandardCodec.convertByteStringToString(log.getSpanId()))
+                            .withTraceId(convertByteStringToString(log.getTraceId()))
+                            .withSpanId(convertByteStringToString(log.getSpanId()))
                             .withSeverityNumber(log.getSeverityNumberValue())
                             .withSeverityText(log.getSeverityText())
                             .withDroppedAttributesCount(log.getDroppedAttributesCount())
-                            .withBody(OTelProtoStandardCodec.convertAnyValue(log.getBody()))
+                            .withBody(convertAnyValue(log.getBody()))
                             .withTimeReceived(timeReceived)
                             .build())
                     .collect(Collectors.toList());
@@ -328,16 +324,15 @@ public class OTelProtoStandardCodec {
 
         protected Span parseSpan(final io.opentelemetry.proto.trace.v1.Span sp, final Map<String, Object> instrumentationScopeAttributes,
                                     final String serviceName, final Map<String, Object> resourceAttributes, final Instant timeReceived) {
-            return JacksonStandardSpan.builder()
+            Span span = JacksonStandardSpan.builder()
                     .withSpanId(convertByteStringToString(sp.getSpanId()))
                     .withTraceId(convertByteStringToString(sp.getTraceId()))
                     .withTraceState(sp.getTraceState())
                     .withParentSpanId(convertByteStringToString(sp.getParentSpanId()))
                     .withName(sp.getName())
-                    .withServiceName(serviceName)
                     .withKind(sp.getKind().name())
-                    .withStartTime(getStartTimeISO8601(sp))
-                    .withEndTime(getEndTimeISO8601(sp))
+                    .withStartTime(convertUnixNanosToISO8601(sp.getStartTimeUnixNano()))
+                    .withEndTime(convertUnixNanosToISO8601(sp.getEndTimeUnixNano()))
                     .withStatus(getStatus(sp.getStatus()))
                     .withScope(instrumentationScopeAttributes)
                     .withResource(resourceAttributes)
@@ -347,11 +342,13 @@ public class OTelProtoStandardCodec {
                     .withDroppedEventsCount(sp.getDroppedEventsCount())
                     .withLinks(sp.getLinksList().stream().map(this::getLink).collect(Collectors.toList()))
                     .withDroppedLinksCount(sp.getDroppedLinksCount())
-                    .withTraceGroup(getTraceGroup(sp))
                     .withDurationInNanos(sp.getEndTimeUnixNano() - sp.getStartTimeUnixNano())
-                    .withTraceGroupFields(getTraceGroupFields(sp))
                     .withTimeReceived(timeReceived)
                     .build();
+            EventMetadata eventMetadata = span.getMetadata();
+            eventMetadata.setAttribute(JacksonSpan.TRACE_GROUP_KEY, getTraceGroup(sp));
+            eventMetadata.setAttribute(JacksonSpan.TRACE_GROUP_FIELDS_KEY, getTraceGroupFields(sp));
+            return span;
         }
 
         protected Object convertAnyValue(final AnyValue value) {
@@ -485,11 +482,11 @@ public class OTelProtoStandardCodec {
             Collection<Record<? extends Metric>> recordsOut = new ArrayList<>();
             for (ResourceMetrics rs : request.getResourceMetricsList()) {
                 final Map<String, Object> resourceAttributes = getResourceAttributes(rs.getResource());
-                final String serviceName = OTelProtoStandardCodec.getServiceName(rs.getResource()).orElse(null);
+                final String serviceName = getServiceName(rs.getResource()).orElse(null);
 
                 for (ScopeMetrics sm : rs.getScopeMetricsList()) {
                     final String schemaUrl = sm.getSchemaUrl();
-                    final Map<String, Object> ils = OTelProtoStandardCodec.getInstrumentationScopeAttributes(sm.getScope());
+                    final Map<String, Object> ils = getInstrumentationScopeAttributes(sm.getScope());
                     recordsOut.addAll(processMetricsList(sm.getMetricsList(), serviceName, ils, resourceAttributes, schemaUrl, droppedCounter, exponentialHistogramMaxAllowedScale, timeReceived, calculateHistogramBuckets, calculateExponentialHistogramBuckets));
                 }
             }
@@ -541,15 +538,14 @@ public class OTelProtoStandardCodec {
                         .withUnit(metric.getUnit())
                         .withName(metric.getName())
                         .withDescription(metric.getDescription())
-                        .withStartTime(OTelProtoStandardCodec.getStartTimeISO8601(dp))
-                        .withTime(OTelProtoStandardCodec.getTimeISO8601(dp))
-                        .withServiceName(serviceName)
-                        .withValue(OTelProtoStandardCodec.getValueAsDouble(dp))
+                        .withStartTime(convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
+                        .withTime(convertUnixNanosToISO8601(dp.getTimeUnixNano()))
+                        .withValue(getValueAsDouble(dp))
                         .withScope(ils)
                         .withResource(resourceAttributes)
                         .withAttributes(convertKeyValueToAttributes(dp.getAttributesList()))
                         .withSchemaUrl(schemaUrl)
-                        .withExemplars(OTelProtoStandardCodec.convertExemplars(dp.getExemplarsList()))
+                        .withExemplars(convertExemplars(dp.getExemplarsList()))
                         .withFlags(dp.getFlags())
                         .withTimeReceived(timeReceived)
                         .build())
@@ -569,17 +565,16 @@ public class OTelProtoStandardCodec {
                         .withUnit(metric.getUnit())
                         .withName(metric.getName())
                         .withDescription(metric.getDescription())
-                        .withStartTime(OTelProtoStandardCodec.getStartTimeISO8601(dp))
                         .withAttributes(convertKeyValueToAttributes(dp.getAttributesList()))
-                        .withTime(OTelProtoStandardCodec.getTimeISO8601(dp))
-                        .withServiceName(serviceName)
+                        .withStartTime(convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
+                        .withTime(convertUnixNanosToISO8601(dp.getTimeUnixNano()))
                         .withIsMonotonic(metric.getSum().getIsMonotonic())
-                        .withValue(OTelProtoStandardCodec.getValueAsDouble(dp))
+                        .withValue(getValueAsDouble(dp))
                         .withAggregationTemporality(metric.getSum().getAggregationTemporality().toString())
                         .withScope(ils)
                         .withResource(resourceAttributes)
                         .withSchemaUrl(schemaUrl)
-                        .withExemplars(OTelProtoStandardCodec.convertExemplars(dp.getExemplarsList()))
+                        .withExemplars(convertExemplars(dp.getExemplarsList()))
                         .withFlags(dp.getFlags())
                         .withTimeReceived(timeReceived)
                         .build())
@@ -599,12 +594,11 @@ public class OTelProtoStandardCodec {
                         .withUnit(metric.getUnit())
                         .withName(metric.getName())
                         .withDescription(metric.getDescription())
-                        .withStartTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
-                        .withTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(dp.getTimeUnixNano()))
-                        .withServiceName(serviceName)
+                        .withStartTime(convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
+                        .withTime(convertUnixNanosToISO8601(dp.getTimeUnixNano()))
                         .withCount(dp.getCount())
                         .withSum(dp.getSum())
-                        .withQuantiles(OTelProtoStandardCodec.getQuantileValues(dp.getQuantileValuesList()))
+                        .withQuantiles(getQuantileValues(dp.getQuantileValuesList()))
                         .withQuantilesValueCount(dp.getQuantileValuesCount())
                         .withScope(ils)
                         .withResource(resourceAttributes)
@@ -631,9 +625,8 @@ public class OTelProtoStandardCodec {
                             .withUnit(metric.getUnit())
                             .withName(metric.getName())
                             .withDescription(metric.getDescription())
-                            .withStartTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
-                            .withTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(dp.getTimeUnixNano()))
-                            .withServiceName(serviceName)
+                            .withStartTime(convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
+                            .withTime(convertUnixNanosToISO8601(dp.getTimeUnixNano()))
                             .withSum(dp.getSum())
                             .withCount(dp.getCount())
                             .withBucketCount(dp.getBucketCountsCount())
@@ -645,11 +638,11 @@ public class OTelProtoStandardCodec {
                             .withResource(resourceAttributes)
                             .withAttributes(convertKeyValueToAttributes(dp.getAttributesList()))
                             .withSchemaUrl(schemaUrl)
-                            .withExemplars(OTelProtoStandardCodec.convertExemplars(dp.getExemplarsList()))
+                            .withExemplars(convertExemplars(dp.getExemplarsList()))
                             .withTimeReceived(timeReceived)
                             .withFlags(dp.getFlags());
                     if (calculateHistogramBuckets) {
-                        builder.withBuckets(OTelProtoStandardCodec.createBuckets(dp.getBucketCountsList(), dp.getExplicitBoundsList()));
+                        builder.withBuckets(createBuckets(dp.getBucketCountsList(), dp.getExplicitBoundsList()));
                     }
                     JacksonHistogram jh = builder.build();
                     return jh;
@@ -685,9 +678,8 @@ public class OTelProtoStandardCodec {
                             .withUnit(metric.getUnit())
                             .withName(metric.getName())
                             .withDescription(metric.getDescription())
-                            .withStartTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
-                            .withTime(OTelProtoStandardCodec.convertUnixNanosToISO8601(dp.getTimeUnixNano()))
-                            .withServiceName(serviceName)
+                            .withStartTime(convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
+                            .withTime(convertUnixNanosToISO8601(dp.getTimeUnixNano()))
                             .withSum(dp.getSum())
                             .withCount(dp.getCount())
                             .withZeroCount(dp.getZeroCount())
@@ -701,13 +693,13 @@ public class OTelProtoStandardCodec {
                             .withResource(resourceAttributes)
                             .withAttributes(convertKeyValueToAttributes(dp.getAttributesList()))
                             .withSchemaUrl(schemaUrl)
-                            .withExemplars(OTelProtoStandardCodec.convertExemplars(dp.getExemplarsList()))
+                            .withExemplars(convertExemplars(dp.getExemplarsList()))
                             .withTimeReceived(timeReceived)
                             .withFlags(dp.getFlags());
 
                     if (calculateExponentialHistogramBuckets) {
-                        builder.withPositiveBuckets(OTelProtoStandardCodec.createExponentialBuckets(dp.getPositive(), dp.getScale()));
-                        builder.withNegativeBuckets(OTelProtoStandardCodec.createExponentialBuckets(dp.getNegative(), dp.getScale()));
+                        builder.withPositiveBuckets(createExponentialBuckets(dp.getPositive(), dp.getScale()));
+                        builder.withNegativeBuckets(createExponentialBuckets(dp.getNegative(), dp.getScale()));
                     }
 
                     return builder.build();
@@ -814,7 +806,7 @@ public class OTelProtoStandardCodec {
         protected io.opentelemetry.proto.trace.v1.Span.Event convertSpanEvent(final SpanEvent spanEvent) throws UnsupportedEncodingException {
             final io.opentelemetry.proto.trace.v1.Span.Event.Builder builder = io.opentelemetry.proto.trace.v1.Span.Event.newBuilder();
             builder.setName(spanEvent.getName());
-            builder.setTimeUnixNano(timeISO8601ToNanos(spanEvent.getTime()));
+            builder.setTimeUnixNano(convertISO8601ToNanos(spanEvent.getTime()));
             builder.setDroppedAttributesCount(spanEvent.getDroppedAttributesCount());
             final List<KeyValue> attributeKeyValueList = new ArrayList<>();
             for (Map.Entry<String, Object> entry : spanEvent.getAttributes().entrySet()) {
@@ -858,8 +850,8 @@ public class OTelProtoStandardCodec {
                     .setTraceState(span.getTraceState())
                     .setName(span.getName())
                     .setKind(io.opentelemetry.proto.trace.v1.Span.SpanKind.valueOf(span.getKind()))
-                    .setStartTimeUnixNano(timeISO8601ToNanos(span.getStartTime()))
-                    .setEndTimeUnixNano(timeISO8601ToNanos(span.getEndTime()))
+                    .setStartTimeUnixNano(convertISO8601ToNanos(span.getStartTime()))
+                    .setEndTimeUnixNano(convertISO8601ToNanos(span.getEndTime()))
                     .setDroppedAttributesCount(span.getDroppedAttributesCount())
                     .setDroppedEventsCount(span.getDroppedEventsCount())
                     .setDroppedLinksCount(span.getDroppedLinksCount());
@@ -1171,9 +1163,5 @@ public class OTelProtoStandardCodec {
             }
         }
         return mappedBuckets;
-    }
-
-    public static String convertByteStringToString(ByteString bs) {
-        return Hex.encodeHexString(bs.toByteArray());
     }
 }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoStandardCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoStandardCodec.java
@@ -334,6 +334,7 @@ public class OTelProtoStandardCodec {
                     .withStartTime(convertUnixNanosToISO8601(sp.getStartTimeUnixNano()))
                     .withEndTime(convertUnixNanosToISO8601(sp.getEndTimeUnixNano()))
                     .withStatus(getStatus(sp.getStatus()))
+                    .withFlags(sp.getFlags())
                     .withScope(instrumentationScopeAttributes)
                     .withResource(resourceAttributes)
                     .withAttributes(convertKeyValueToAttributes(sp.getAttributesList()))
@@ -346,6 +347,7 @@ public class OTelProtoStandardCodec {
                     .withTimeReceived(timeReceived)
                     .build();
             EventMetadata eventMetadata = span.getMetadata();
+            eventMetadata.setAttribute(JacksonSpan.SERVICE_NAME_KEY, serviceName);
             eventMetadata.setAttribute(JacksonSpan.TRACE_GROUP_KEY, getTraceGroup(sp));
             eventMetadata.setAttribute(JacksonSpan.TRACE_GROUP_FIELDS_KEY, getTraceGroupFields(sp));
             return span;

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCommonUtilsTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCommonUtilsTest.java
@@ -24,9 +24,9 @@ public class OTelProtoCommonUtilsTest {
     }
 
     @Test
-    public void test_timeISO8601ToNanos() {
+    public void test_convertISO8601ToNanos() {
         Instant curTime = Instant.now();
-        assertThat(curTime.getEpochSecond() * OTelProtoCommonUtils.NANO_MULTIPLIER + curTime.getNano(), equalTo(OTelProtoCommonUtils.timeISO8601ToNanos(curTime.toString())));
+        assertThat(curTime.getEpochSecond() * OTelProtoCommonUtils.NANO_MULTIPLIER + curTime.getNano(), equalTo(OTelProtoCommonUtils.convertISO8601ToNanos(curTime.toString())));
     }
 
     @Test

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoOpensearchCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoOpensearchCodecTest.java
@@ -48,6 +48,7 @@ import org.opensearch.dataprepper.model.trace.Link;
 import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.model.trace.SpanEvent;
 import org.opensearch.dataprepper.model.trace.TraceGroupFields;
+import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils.convertUnixNanosToISO8601;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -406,11 +407,11 @@ public class OTelProtoOpensearchCodecTest {
                     .setEndTimeUnixNano(1598013600000000321L).build();
             final io.opentelemetry.proto.trace.v1.Span emptyTimeSpan = io.opentelemetry.proto.trace.v1.Span.newBuilder().build();
 
-            final String startTime = decoderUnderTest.getStartTimeISO8601(startTimeUnixNano);
+            final String startTime = convertUnixNanosToISO8601(startTimeUnixNano.getStartTimeUnixNano());
             assertThat(Instant.parse(startTime).getEpochSecond() * NANO_MULTIPLIER + Instant.parse(startTime).getNano(), equalTo(startTimeUnixNano.getStartTimeUnixNano()));
-            final String endTime = decoderUnderTest.getEndTimeISO8601(endTimeUnixNano);
+            final String endTime = convertUnixNanosToISO8601(endTimeUnixNano.getEndTimeUnixNano());
             assertThat(Instant.parse(endTime).getEpochSecond() * NANO_MULTIPLIER + Instant.parse(endTime).getNano(), equalTo(endTimeUnixNano.getEndTimeUnixNano()));
-            final String emptyTime = decoderUnderTest.getStartTimeISO8601(endTimeUnixNano);
+            final String emptyTime = convertUnixNanosToISO8601(endTimeUnixNano.getStartTimeUnixNano());
             assertThat(Instant.parse(emptyTime).getEpochSecond() * NANO_MULTIPLIER + Instant.parse(emptyTime).getNano(), equalTo(emptyTimeSpan.getStartTimeUnixNano()));
 
         }
@@ -444,7 +445,7 @@ public class OTelProtoOpensearchCodecTest {
                     .build();
             final TraceGroupFields expectedTraceGroupFields = DefaultTraceGroupFields.builder()
                     .withStatusCode(testStatusCode)
-                    .withEndTime(decoderUnderTest.getEndTimeISO8601(span2))
+                    .withEndTime(convertUnixNanosToISO8601(span2.getStartTimeUnixNano()))
                     .withDurationInNanos(testEndTimeUnixNano - testStartTimeUnixNano)
                     .build();
             assertThat(decoderUnderTest.getTraceGroupFields(span2), equalTo(expectedTraceGroupFields));
@@ -899,9 +900,9 @@ public class OTelProtoOpensearchCodecTest {
     public void testTimeCodec() {
         final long testNanos = System.nanoTime();
         final String timeISO8601 = OTelProtoCommonUtils.convertUnixNanosToISO8601(testNanos);
-        final long nanoCodecResult = OTelProtoCommonUtils.timeISO8601ToNanos(OTelProtoCommonUtils.convertUnixNanosToISO8601(testNanos));
+        final long nanoCodecResult = OTelProtoCommonUtils.convertISO8601ToNanos(OTelProtoCommonUtils.convertUnixNanosToISO8601(testNanos));
         assertThat(nanoCodecResult, equalTo(testNanos));
-        final String stringCodecResult = OTelProtoCommonUtils.convertUnixNanosToISO8601(OTelProtoCommonUtils.timeISO8601ToNanos(timeISO8601));
+        final String stringCodecResult = OTelProtoCommonUtils.convertUnixNanosToISO8601(OTelProtoCommonUtils.convertISO8601ToNanos(timeISO8601));
         assertThat(stringCodecResult, equalTo(timeISO8601));
     }
 

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
@@ -88,6 +88,7 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
         for (Record<Span> record : records) {
             final Span span = record.getData();
             processSpan(span, processedSpans);
+            fillInServiceName(span);
         }
 
         processedSpans.addAll(getTracesToFlushByGarbageCollection());
@@ -197,6 +198,7 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
                             if (traceGroup != null) {
                                 spans.forEach(span -> {
                                     fillInTraceGroupInfo(span, traceGroup);
+                                    fillInServiceName(span);
                                     recordsToFlush.add(span);
                                 });
                             } else {
@@ -224,6 +226,11 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
     private void fillInTraceGroupInfo(final Span span, final TraceGroup traceGroup) {
         span.setTraceGroup(traceGroup.getTraceGroup());
         span.setTraceGroupFields(traceGroup.getTraceGroupFields());
+    }
+
+    private void fillInServiceName(final Span span) {
+        // For standard OTEL getServiceName() returns service name from metadata
+        span.setServiceName(span.getServiceName());
     }
 
     private boolean shouldGarbageCollect() {

--- a/data-prepper-plugins/otel-trace-source/src/test/resources/testjson/test-standard-trace.json
+++ b/data-prepper-plugins/otel-trace-source/src/test/resources/testjson/test-standard-trace.json
@@ -16,7 +16,6 @@
     }
   },
   "kind": "SPAN_KIND_INTERNAL",
-  "serviceName": "TestTraceServiceName",
   "parentSpanId": "",
   "spanId": "746573745370616e4944",
   "traceState": "",


### PR DESCRIPTION
### Description
1. Support OTEL trace groups and trace group fields in standaed OTEL proto codec
2. Cleanup and address comments from https://github.com/opensearch-project/data-prepper/pull/5524
3. Add template mappings for using standard OTEL log/trace/metrics in opensearch sink
 
### Issues Resolved
Resolves #5259 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
