### PR TITLE
feat: Add configurable stream read constraints for JSON input codec

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.model.codec;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.opensearch.dataprepper.model.event.Event;
@@ -30,10 +31,13 @@ public class JsonDecoder implements ByteDecoder {
     private Collection<String> includeKeys;
     private Collection<String> includeKeysMetadata;
 
-    public JsonDecoder(String keyName, Collection<String> includeKeys, Collection<String> includeKeysMetadata) {
+    public JsonDecoder(String keyName, Collection<String> includeKeys, Collection<String> includeKeysMetadata, int maxEventLength) {
         this.keyName = keyName;
         this.includeKeys = includeKeys;
         this.includeKeysMetadata = includeKeysMetadata;
+        jsonFactory.setStreamReadConstraints(StreamReadConstraints.builder()
+                .maxStringLength(maxEventLength)
+                .build());
     }
 
     public JsonDecoder() {

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
@@ -25,11 +25,10 @@ public class JsonInputCodec extends JsonDecoder implements InputCodec {
 
     @DataPrepperPluginConstructor
     public JsonInputCodec(final JsonInputCodecConfig config) {
-        super(Objects.requireNonNull(config).getKeyName(), config.getIncludeKeys(), config.getIncludeKeysMetadata());
+        super(Objects.requireNonNull(config).getKeyName(), config.getIncludeKeys(), config.getIncludeKeysMetadata(), config.getMaxEventLength());
     }
 
     public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
         parse(inputStream, null, eventConsumer);
     }
-
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfig.java
@@ -11,11 +11,13 @@
 package org.opensearch.dataprepper.plugins.codec.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public class JsonInputCodecConfig {
+    static final Integer DEFAULT_MAX_EVENT_LENGTH = 20000000;
 
     @JsonProperty("key_name")
     @Size(min = 1, max = 2048)
@@ -37,5 +39,13 @@ public class JsonInputCodecConfig {
 
     public List<String> getIncludeKeysMetadata() {
         return includeKeysMetadata;
+    }
+
+    @JsonProperty("max_event_length")
+    @Min(1)
+    private Integer maxEventLength = DEFAULT_MAX_EVENT_LENGTH;
+
+    public Integer getMaxEventLength(){
+        return maxEventLength;
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.codec.json.JsonInputCodecConfig.DEFAULT_MAX_EVENT_LENGTH;
 
 public class JsonCodecsIT {
 
@@ -51,6 +52,7 @@ public class JsonCodecsIT {
         when(jsonInputCodecConfig.getIncludeKeysMetadata()).thenReturn(Collections.emptyList());
         when(jsonInputCodecConfig.getIncludeKeys()).thenReturn(Collections.emptyList());
         when(jsonInputCodecConfig.getKeyName()).thenReturn(null);
+        when(jsonInputCodecConfig.getMaxEventLength()).thenReturn(DEFAULT_MAX_EVENT_LENGTH);
         eventConsumer = mock(Consumer.class);
     }
 

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecConfigTest.java
@@ -7,7 +7,10 @@ package org.opensearch.dataprepper.plugins.codec.json;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opensearch.dataprepper.plugins.codec.json.JsonInputCodecConfig.DEFAULT_MAX_EVENT_LENGTH;
 
 public class JsonInputCodecConfigTest {
 
@@ -21,5 +24,6 @@ public class JsonInputCodecConfigTest {
         assertNull(jsonInputCodecConfig.getKeyName());
         assertNull(jsonInputCodecConfig.getIncludeKeys());
         assertNull(jsonInputCodecConfig.getIncludeKeysMetadata());
+        assertThat(jsonInputCodecConfig.getMaxEventLength(), equalTo(DEFAULT_MAX_EVENT_LENGTH));
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodecTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.codec.json.JsonInputCodecConfig.DEFAULT_MAX_EVENT_LENGTH;
 
 class JsonInputCodecTest {
 
@@ -68,6 +69,7 @@ class JsonInputCodecTest {
         when(jsonInputCodecConfig.getIncludeKeysMetadata()).thenReturn(null);
         when(jsonInputCodecConfig.getIncludeKeys()).thenReturn(null);
         when(jsonInputCodecConfig.getKeyName()).thenReturn(null);
+        when(jsonInputCodecConfig.getMaxEventLength()).thenReturn(DEFAULT_MAX_EVENT_LENGTH);
         eventConsumer = mock(Consumer.class);
     }
 


### PR DESCRIPTION
- Introduced a configurable option for setting the maximum event length in the JSON input codec.
- Updated `JsonDecoder` to accept `max_event_length` parameter and apply it to `StreamReadConstraints`.
- Added validation to ensure the maximum event length is within acceptable limits. 

### Description
This change introduces a new configurable option that allows users to set the maximum event length for the JSON input codec. By setting this parameter, users can control the maximum size of JSON strings that the codec will process, ensuring that excessively large events are not processed and potentially causing issues. The `JsonDecoder` has been updated to accept the `max_event_length` parameter and apply it to the `StreamReadConstraints`. Additionally, validation has been added to ensure that the maximum event length is within acceptable limits.

### Issues Resolved
fixes #5466 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

The documentation issue link : https://github.com/opensearch-project/documentation-website/issues/9370

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check here.