### PR TITLE
Add DLQ support to CloudWatchLogs sink

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
@@ -7,9 +7,9 @@ package org.opensearch.dataprepper.model.failures;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.opensearch.dataprepper.model.event.EventHandle;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -120,6 +120,16 @@ public class DlqObject {
             ", timestamp='" + timestamp + '\'' +
             ", failedData=" + failedData +
             '}';
+    }
+
+    public static DlqObject createDlqObject(PluginSetting pluginSetting, EventHandle eventHandle, Object failedData) {
+        return DlqObject.builder()
+                .withEventHandle(eventHandle)
+                .withFailedData(failedData)
+                .withPluginName(pluginSetting.getName())
+                .withPipelineName(pluginSetting.getPipelineName())
+                .withPluginId(pluginSetting.getName())
+                .build();
     }
 
     public static Builder builder() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.failures;
 
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +19,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import java.util.HashMap;
+import java.util.Map;
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -31,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 
 public class DlqObjectTest {
@@ -118,6 +122,24 @@ public class DlqObjectTest {
         public void test_invalid_failedData() {
             failedData = null;
             assertThrows(NullPointerException.class, this::createTestObject);
+        }
+
+        @Test
+        public void test_createDlqObject() {
+            final String testName = randomUUID().toString();
+            final String testPipelineName = randomUUID().toString();
+            PluginSetting pluginSetting = mock(PluginSetting.class);
+            when(pluginSetting.getName()).thenReturn(testName);
+            when(pluginSetting.getPipelineName()).thenReturn(testPipelineName);
+            eventHandle = mock(EventHandle.class);
+            Map<String, Object> data = new HashMap<>();
+            DlqObject dlqObject = DlqObject.createDlqObject(pluginSetting, eventHandle, data);
+            assertThat(dlqObject, is(notNullValue()));
+            assertThat(dlqObject.getEventHandle(), is(eventHandle));
+            assertThat(dlqObject.getFailedData(), is(data));
+            assertThat(dlqObject.getPluginName(), is(testName));
+            assertThat(dlqObject.getPipelineName(), is(testPipelineName));
+            
         }
     }
 

--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -26,12 +26,14 @@ configurations {
 dependencies {
     implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation project(path: ':data-prepper-plugins:common')
+    implementation project(path: ':data-prepper-plugins:failures-common')
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'software.amazon.awssdk:cloudwatch'
     implementation 'software.amazon.awssdk:cloudwatchlogs'
+    implementation 'software.amazon.awssdk:s3'
     implementation libs.commons.lang3
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
@@ -66,6 +68,7 @@ task integrationTest(type: Test) {
     systemProperty 'tests.cloudwatch.log_stream', System.getProperty('tests.cloudwatch.log_stream')
     systemProperty 'tests.aws.region', System.getProperty('tests.aws.region')
     systemProperty 'tests.aws.role', System.getProperty('tests.aws.role')
+    systemProperty 'tests.s3.bucket', System.getProperty('tests.s3.bucket')
     filter {
         includeTestsMatching '*IT'
     }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -55,7 +55,13 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
                 thresholdConfig.getMaxEventSizeBytes(),
                 thresholdConfig.getMaxRequestSizeBytes(),thresholdConfig.getLogSendInterval());
 
+        if (awsConfig == null && awsCredentialsSupplier == null) {
+            throw new RuntimeException("Missing awsConfig and awsCredentialsSupplier");
+        }
         CloudWatchLogsClient cloudWatchLogsClient = CloudWatchLogsClientFactory.createCwlClient(awsConfig, awsCredentialsSupplier);
+        if (cloudWatchLogsClient == null) {
+            throw new RuntimeException("cloudWatchLogsClient is null");
+        }
 
         BufferFactory bufferFactory = null;
         if (cloudWatchLogsSinkConfig.getBufferType().equals("in_memory")) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;
 import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.Buffer;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.BufferFactory;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.InMemoryBufferFactory;
@@ -27,6 +28,7 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.ThresholdC
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.exception.InvalidBufferTypeException;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
 
 import java.util.Collection;
 import java.util.concurrent.Executor;
@@ -35,10 +37,12 @@ import java.util.concurrent.Executors;
 @DataPrepperPlugin(name = "cloudwatch_logs", pluginType = Sink.class, pluginConfigurationType = CloudWatchLogsSinkConfig.class)
 public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
     private final CloudWatchLogsService cloudWatchLogsService;
+    private DlqPushHandler dlqPushHandler = null;
     private volatile boolean isInitialized;
     @DataPrepperPluginConstructor
     public CloudWatchLogsSink(final PluginSetting pluginSetting,
                               final PluginMetrics pluginMetrics,
+                              final PluginFactory pluginFactory,
                               final CloudWatchLogsSinkConfig cloudWatchLogsSinkConfig,
                               final AwsCredentialsSupplier awsCredentialsSupplier) {
         super(pluginSetting);
@@ -58,11 +62,18 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
             bufferFactory = new InMemoryBufferFactory();
         }
 
+        if (cloudWatchLogsSinkConfig.getDlq() != null) {
+            String region = awsConfig.getAwsRegion().toString();
+            String role = awsConfig.getAwsStsRoleArn();
+            dlqPushHandler = new DlqPushHandler(pluginFactory, pluginSetting, pluginMetrics, cloudWatchLogsSinkConfig.getDlq(), region, role, "cloudWatchLogs");
+        }
+
         Executor executor = Executors.newCachedThreadPool();
 
         CloudWatchLogsDispatcher cloudWatchLogsDispatcher = CloudWatchLogsDispatcher.builder()
                 .cloudWatchLogsClient(cloudWatchLogsClient)
                 .cloudWatchLogsMetrics(cloudWatchLogsMetrics)
+                .dlqPushHandler(dlqPushHandler)
                 .logGroup(cloudWatchLogsSinkConfig.getLogGroup())
                 .logStream(cloudWatchLogsSinkConfig.getLogStream())
                 .backOffTimeBase(thresholdConfig.getBackOffTime())
@@ -77,7 +88,7 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
             throw new InvalidBufferTypeException("Error loading buffer!");
         }
 
-        cloudWatchLogsService = new CloudWatchLogsService(buffer, cloudWatchLogsLimits, cloudWatchLogsDispatcher);
+        cloudWatchLogsService = new CloudWatchLogsService(buffer, cloudWatchLogsLimits, cloudWatchLogsDispatcher, dlqPushHandler);
     }
 
     @Override

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/buffer/Buffer.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/buffer/Buffer.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer;
 
+import org.opensearch.dataprepper.model.event.EventHandle;
 import java.util.List;
 
 /**
@@ -34,7 +35,9 @@ public interface Buffer {
      */
     int getBufferSize();
 
-    void writeEvent(byte[] event);
+    void writeEvent(EventHandle eventHandle, byte[] event);
+
+    List<EventHandle> getEventHandles();
 
     byte[] popEvent();
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/buffer/InMemoryBuffer.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/buffer/InMemoryBuffer.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer;
 
+import org.opensearch.dataprepper.model.event.EventHandle;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -12,9 +14,11 @@ import java.util.List;
 public class InMemoryBuffer implements Buffer {
     private List<byte[]> eventsBuffered;
     private int bufferSize = 0;
+    private List<EventHandle> eventHandles;
 
     InMemoryBuffer() {
         eventsBuffered = new ArrayList<>();
+        eventHandles = new ArrayList<>();
     }
 
     @Override
@@ -28,7 +32,13 @@ public class InMemoryBuffer implements Buffer {
     }
 
     @Override
-    public void writeEvent(final byte[] event) {
+    public List<EventHandle> getEventHandles() {
+        return Collections.unmodifiableList(eventHandles);
+    }
+
+    @Override
+    public void writeEvent(final EventHandle eventHandle, final byte[] event) {
+        eventHandles.add(eventHandle);
         eventsBuffered.add(event);
         bufferSize += event.length;
     }
@@ -57,5 +67,6 @@ public class InMemoryBuffer implements Buffer {
     public void resetBuffer() {
         bufferSize = 0;
         eventsBuffered = new ArrayList<>();
+        eventHandles = new ArrayList<>();
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.AwsConfig;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 
 /**
@@ -27,11 +28,14 @@ public final class CloudWatchLogsClientFactory {
      * @return CloudWatchLogsClient used to interact with CloudWatch Logs services.
      */
     public static CloudWatchLogsClient createCwlClient(final AwsConfig awsConfig, final AwsCredentialsSupplier awsCredentialsSupplier) {
-        final AwsCredentialsOptions awsCredentialsOptions = convertToCredentialOptions(awsConfig);
-        final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
+        final AwsCredentialsProvider awsCredentialsProvider = awsConfig != null ? awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig)) : awsCredentialsSupplier.getProvider(AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider());
+        Region region = awsConfig != null ? awsConfig.getAwsRegion() : awsCredentialsSupplier.getDefaultRegion().get();
 
+        if (awsCredentialsProvider == null || region == null) {
+            return null;
+        }
         return CloudWatchLogsClient.builder()
-                .region(awsConfig.getAwsRegion())
+                .region(region)
                 .credentialsProvider(awsCredentialsProvider)
                 .overrideConfiguration(createOverrideConfiguration()).build();
     }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
@@ -28,7 +28,7 @@ public final class CloudWatchLogsClientFactory {
      * @return CloudWatchLogsClient used to interact with CloudWatch Logs services.
      */
     public static CloudWatchLogsClient createCwlClient(final AwsConfig awsConfig, final AwsCredentialsSupplier awsCredentialsSupplier) {
-        final AwsCredentialsProvider awsCredentialsProvider = awsConfig != null ? awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig)) : awsCredentialsSupplier.getProvider(AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider());
+        final AwsCredentialsProvider awsCredentialsProvider = awsConfig != null ? awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig)) : awsCredentialsSupplier.getProvider(AwsCredentialsOptions.builder().build());
         Region region = awsConfig != null ? awsConfig.getAwsRegion() : awsCredentialsSupplier.getDefaultRegion().get();
 
         if (awsCredentialsProvider == null || region == null) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
@@ -14,10 +14,10 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
  * may refer to it.
  */
 public class CloudWatchLogsMetrics {
-    protected static final String CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED = "cloudWatchLogsRequestsSucceeded";
-    protected static final String CLOUDWATCH_LOGS_EVENTS_SUCCEEDED = "cloudWatchLogsEventsSucceeded";
-    protected static final String CLOUDWATCH_LOGS_EVENTS_FAILED = "cloudWatchLogsEventsFailed";
-    protected static final String CLOUDWATCH_LOGS_REQUESTS_FAILED = "cloudWatchLogsRequestsFailed";
+    public static final String CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED = "cloudWatchLogsRequestsSucceeded";
+    public static final String CLOUDWATCH_LOGS_EVENTS_SUCCEEDED = "cloudWatchLogsEventsSucceeded";
+    public static final String CLOUDWATCH_LOGS_EVENTS_FAILED = "cloudWatchLogsEventsFailed";
+    public static final String CLOUDWATCH_LOGS_REQUESTS_FAILED = "cloudWatchLogsRequestsFailed";
     private final Counter logEventSuccessCounter;
     private final Counter logEventFailCounter;
     private final Counter requestSuccessCount;

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
@@ -11,9 +11,10 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.Buffer;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.SinkStopWatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsSinkUtils;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
+import org.opensearch.dataprepper.model.failures.DlqObject;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -32,26 +33,28 @@ import java.util.concurrent.locks.ReentrantLock;
  * </ol>
  */
 public class CloudWatchLogsService {
-    private static final Logger LOG = LoggerFactory.getLogger(CloudWatchLogsService.class);
     private final CloudWatchLogsDispatcher cloudWatchLogsDispatcher;
     private final Buffer buffer;
     private final CloudWatchLogsLimits cloudWatchLogsLimits;
-    private List<EventHandle> bufferedEventHandles;
+    //private List<EventHandle> bufferedEventHandles;
     private final SinkStopWatch sinkStopWatch;
     private final ReentrantLock processLock;
+    private final DlqPushHandler dlqPushHandler;
     public CloudWatchLogsService(final Buffer buffer,
                                  final CloudWatchLogsLimits cloudWatchLogsLimits,
-                                 final CloudWatchLogsDispatcher cloudWatchLogsDispatcher) {
+                                 final CloudWatchLogsDispatcher cloudWatchLogsDispatcher,
+                                 final DlqPushHandler dlqPushHandler) {
 
         this.buffer = buffer;
         this.cloudWatchLogsLimits = cloudWatchLogsLimits;
 
-        bufferedEventHandles = new ArrayList<>();
+        //bufferedEventHandles = new ArrayList<>();
 
         processLock = new ReentrantLock();
         sinkStopWatch = new SinkStopWatch();
 
         this.cloudWatchLogsDispatcher = cloudWatchLogsDispatcher;
+        this.dlqPushHandler = dlqPushHandler;
     }
 
     /**
@@ -59,65 +62,65 @@ public class CloudWatchLogsService {
      * @param logs Collection of Record events.
      */
     public void processLogEvents(final Collection<Record<Event>> logs) {
-            sinkStopWatch.startIfNotRunning();
-            if (logs.isEmpty() && buffer.getEventCount() > 0) {
-                processLock.lock();
-                try {
-                    if (cloudWatchLogsLimits.isGreaterThanLimitReached(sinkStopWatch.getElapsedTimeInSeconds(),
-                            buffer.getBufferSize(), buffer.getEventCount())) {
-                        stageLogEvents();
-                    }
-                } finally {
-                    processLock.unlock();
+        sinkStopWatch.startIfNotRunning();
+        if (logs.isEmpty() && buffer.getEventCount() > 0) {
+            processLock.lock();
+            try {
+                if (cloudWatchLogsLimits.isTimeLimitReached(sinkStopWatch.getElapsedTimeInSeconds())) {
+                    stageLogEvents();
                 }
-                return;
+            } finally {
+                processLock.unlock();
+            }
+            return;
+        }
+
+        final List<DlqObject> dlqObjects = new ArrayList<>();
+        for (Record<Event> log : logs) {
+            String logString = log.getData().toJsonString();
+            int logLength = logString.length();
+
+            if (cloudWatchLogsLimits.isGreaterThanMaxEventSize(logLength)) {
+                final String failureMessage = String.format("Event blocked due to Max Size restriction! Event Size : %s", (logLength + CloudWatchLogsLimits.APPROXIMATE_LOG_EVENT_OVERHEAD_SIZE));
+                DlqObject dlqObject = CloudWatchLogsSinkUtils.createDlqObject(0, log.getData().getEventHandle(), logString, failureMessage, dlqPushHandler);
+                if (dlqObject != null) {
+                    dlqObjects.add(dlqObject);
+                }
+                continue;
             }
 
-            for (Record<Event> log : logs) {
-                String logString = log.getData().toJsonString();
-                int logLength = logString.length();
+            long time = sinkStopWatch.getElapsedTimeInSeconds();
 
-                if (cloudWatchLogsLimits.isGreaterThanMaxEventSize(logLength)) {
-                    LOG.warn("Event blocked due to Max Size restriction! {Event Size: {} bytes}", (logLength + CloudWatchLogsLimits.APPROXIMATE_LOG_EVENT_OVERHEAD_SIZE));
-                    continue;
+            processLock.lock();
+            try {
+                int bufferSize = buffer.getBufferSize();
+                int bufferEventCount = buffer.getEventCount();
+                if (cloudWatchLogsLimits.maxRequestSizeLimitExceeds(logLength + bufferSize, bufferEventCount+1)) {
+                    stageLogEvents();
+                }
+                addToBuffer(log.getData().getEventHandle(), logString);
+                bufferEventCount = buffer.getEventCount();
+                if (cloudWatchLogsLimits.isMaxEventCountLimitReached(bufferEventCount)) {
+                    stageLogEvents();
                 }
 
-                long time = sinkStopWatch.getElapsedTimeInSeconds();
-
-                processLock.lock();
-                try {
-                    int bufferSize = buffer.getBufferSize();
-                    int bufferEventCount = buffer.getEventCount();
-                    int newBufferEventCount = bufferEventCount + 1;
-                    int newBufferSizeCount = bufferSize + logLength;
-
-                    if ((cloudWatchLogsLimits.isGreaterThanLimitReached(time, newBufferSizeCount, newBufferEventCount) && (bufferEventCount > 0))) {
-                        stageLogEvents();
-                        addToBuffer(log, logString);
-                    } else if (cloudWatchLogsLimits.isEqualToLimitReached(newBufferSizeCount, newBufferEventCount)) {
-                        addToBuffer(log, logString);
-                        stageLogEvents();
-                    } else {
-                        addToBuffer(log, logString);
-                    }
-                } finally {
-                    processLock.unlock();
-                }
+            } finally {
+                processLock.unlock();
             }
+        }
+        CloudWatchLogsSinkUtils.handleDlqObjects(dlqObjects, dlqPushHandler);
     }
 
     private void stageLogEvents() {
         sinkStopWatch.stopAndReset();
 
         List<InputLogEvent> inputLogEvents = cloudWatchLogsDispatcher.prepareInputLogEvents(buffer.getBufferedData());
-        cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, bufferedEventHandles);
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles());
 
         buffer.resetBuffer();
-        bufferedEventHandles = new ArrayList<>();
     }
 
-    private void addToBuffer(final Record<Event> log, final String logString) {
-        bufferedEventHandles.add(log.getData().getEventHandle());
-        buffer.writeEvent(logString.getBytes(StandardCharsets.UTF_8));
+    private void addToBuffer(final EventHandle logEventHandle, final String logString) {
+        buffer.writeEvent(logEventHandle, logString.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
@@ -36,7 +36,6 @@ public class CloudWatchLogsService {
     private final CloudWatchLogsDispatcher cloudWatchLogsDispatcher;
     private final Buffer buffer;
     private final CloudWatchLogsLimits cloudWatchLogsLimits;
-    //private List<EventHandle> bufferedEventHandles;
     private final SinkStopWatch sinkStopWatch;
     private final ReentrantLock processLock;
     private final DlqPushHandler dlqPushHandler;
@@ -47,8 +46,6 @@ public class CloudWatchLogsService {
 
         this.buffer = buffer;
         this.cloudWatchLogsLimits = cloudWatchLogsLimits;
-
-        //bufferedEventHandles = new ArrayList<>();
 
         processLock = new ReentrantLock();
         sinkStopWatch = new SinkStopWatch();

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
@@ -17,7 +17,6 @@ public class CloudWatchLogsSinkConfig {
     public static final String DEFAULT_BUFFER_TYPE = "in_memory";
 
     @JsonProperty("aws")
-    @NotNull
     @Valid
     private AwsConfig awsConfig;
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
@@ -10,6 +10,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+
+
 public class CloudWatchLogsSinkConfig {
     public static final String DEFAULT_BUFFER_TYPE = "in_memory";
 
@@ -17,6 +20,9 @@ public class CloudWatchLogsSinkConfig {
     @NotNull
     @Valid
     private AwsConfig awsConfig;
+
+    @JsonProperty("dlq")
+    private PluginModel dlq;
 
     @JsonProperty("threshold")
     private ThresholdConfig thresholdConfig = new ThresholdConfig();
@@ -40,6 +46,10 @@ public class CloudWatchLogsSinkConfig {
 
     public ThresholdConfig getThresholdConfig() {
         return thresholdConfig;
+    }
+
+    public PluginModel getDlq() {
+        return dlq;
     }
 
     public String getBufferType() {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/dlq/CloudWatchLogsSinkDlqData.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/dlq/CloudWatchLogsSinkDlqData.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.dlq;
+
+import java.util.Objects;
+
+public class CloudWatchLogsSinkDlqData {
+    private final int status;
+    private final String message;
+    private final Object data;
+
+    private CloudWatchLogsSinkDlqData(final int status, final String message, final Object data) {
+        this.status = status;
+        Objects.requireNonNull(message);
+        this.message = message;
+        Objects.requireNonNull(data);
+        this.data = data;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CloudWatchLogsSinkDlqData that = (CloudWatchLogsSinkDlqData) o;
+        return Objects.equals(status, that.status) &&
+            Objects.equals(message, that.message) &&
+            Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, message, data);
+    }
+
+    @Override
+    public String toString() {
+        return "CloudWatchLogsSinkDlqData{" +
+            "status='" + status + '\'' +
+            ", message='" + message + '\'' +
+            ", data=" + data +
+            '}';
+    }
+
+    public static CloudWatchLogsSinkDlqData createDlqData(final int status, final Object data, final String failureMessage) {
+        return CloudWatchLogsSinkDlqData.builder()
+                .withData(data)
+                .withStatus(status)
+                .withMessage(failureMessage)
+                .build();
+    }
+
+    public static CloudWatchLogsSinkDlqData.Builder builder() {
+        return new CloudWatchLogsSinkDlqData.Builder();
+    }
+
+    public static class Builder {
+
+        private int status = 0;
+        private String message;
+        private Object data;
+
+        public Builder withStatus(final int status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder withMessage(final String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder withData(final Object data) {
+            this.data = data;
+            return this;
+        }
+
+        public CloudWatchLogsSinkDlqData build() {
+            return new CloudWatchLogsSinkDlqData(status, message, data);
+        }
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/utils/CloudWatchLogsLimits.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/utils/CloudWatchLogsLimits.java
@@ -24,6 +24,10 @@ public class CloudWatchLogsLimits {
         this.logSendInterval = logSendInterval;
     }
 
+    public boolean isTimeLimitReached(long elapsedTime) {
+        return isGreaterEqualToLogSendInterval(elapsedTime);
+    }
+
     /**
      * Checks to see if we exceed any of the threshold conditions.
      * @param currentTime (long) denoting the time in seconds.
@@ -35,6 +39,26 @@ public class CloudWatchLogsLimits {
         long bufferSizeWithOverhead = (currentRequestSize + ((long) (batchSize) * APPROXIMATE_LOG_EVENT_OVERHEAD_SIZE));
         return (isGreaterThanBatchSize(batchSize) || isGreaterEqualToLogSendInterval(currentTime)
                 || isGreaterThanMaxRequestSize(bufferSizeWithOverhead));
+    }
+
+    /**
+     * Checks to see if we exceed max request size
+     * @param currentRequestSize size of request in bytes.
+     * @param batchSize size of batch in events.
+     * @return boolean true if we exceed the max request size
+     */
+    public boolean maxRequestSizeLimitExceeds(final long currentRequestSize, final int batchSize) {
+        long bufferSizeWithOverhead = (currentRequestSize + ((long) (batchSize) * APPROXIMATE_LOG_EVENT_OVERHEAD_SIZE));
+        return bufferSizeWithOverhead > maxRequestSizeBytes;
+    }
+
+    /**
+     * Checks to see if we have reached max event count
+     * @param batchSize size of batch in events.
+     * @return boolean true if we exceed the max request size
+     */
+    public boolean isMaxEventCountLimitReached(final int batchSize) {
+        return batchSize >= this.maxBatchSize;
     }
 
     /**

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/utils/CloudWatchLogsSinkUtils.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/utils/CloudWatchLogsSinkUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils;
+
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.dlq.CloudWatchLogsSinkDlqData;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
+import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class CloudWatchLogsSinkUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(CloudWatchLogsSinkUtils.class);
+    public static DlqObject createDlqObject(final int status, final EventHandle eventHandle, final String message, final String failureMessage, final DlqPushHandler dlqPushHandler) {
+        if (dlqPushHandler != null) {
+            CloudWatchLogsSinkDlqData cloudWatchLogsSinkDlqData = CloudWatchLogsSinkDlqData.createDlqData(status, message, failureMessage);
+            return DlqObject.createDlqObject(dlqPushHandler.getPluginSetting(), eventHandle, cloudWatchLogsSinkDlqData);
+        } else {
+            eventHandle.release(false);
+        }
+        return null;
+    }
+
+    public static void handleDlqObjects(List<DlqObject> dlqObjects, final DlqPushHandler dlqPushHandler) {
+        if (dlqObjects.size() == 0) {
+            return;
+        }
+        boolean result = false;
+        if (dlqPushHandler != null) {
+            result = dlqPushHandler.perform(dlqObjects);
+        } 
+        for (final DlqObject dlqObject : dlqObjects) {
+            dlqObject.getEventHandle().release(result);
+        }
+    }
+}
+
+

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.when;
 class CloudWatchLogsSinkTest {
     private PluginSetting mockPluginSetting;
     private PluginMetrics mockPluginMetrics;
+    private PluginFactory mockPluginFactory;
     private CloudWatchLogsSinkConfig mockCloudWatchLogsSinkConfig;
     private AwsCredentialsSupplier mockCredentialSupplier;
     private AwsConfig mockAwsConfig;
@@ -52,6 +54,7 @@ class CloudWatchLogsSinkTest {
     void setUp() {
         mockPluginSetting = mock(PluginSetting.class);
         mockPluginMetrics = mock(PluginMetrics.class);
+        mockPluginFactory = mock(PluginFactory.class);
         mockCloudWatchLogsSinkConfig = mock(CloudWatchLogsSinkConfig.class);
         mockCredentialSupplier = mock(AwsCredentialsSupplier.class);
         mockAwsConfig = mock(AwsConfig.class);
@@ -70,7 +73,7 @@ class CloudWatchLogsSinkTest {
     }
 
     CloudWatchLogsSink getTestCloudWatchSink() {
-        return new CloudWatchLogsSink(mockPluginSetting, mockPluginMetrics, mockCloudWatchLogsSinkConfig,
+        return new CloudWatchLogsSink(mockPluginSetting, mockPluginMetrics, mockPluginFactory, mockCloudWatchLogsSinkConfig,
                 mockCredentialSupplier);
     }
 

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
@@ -97,6 +98,19 @@ class CloudWatchLogsSinkTest {
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();
             testCloudWatchSink.doInitialize();
             assertTrue(testCloudWatchSink.isReady());
+        }
+    }
+
+    @Test
+    void WHEN_awsConfig_and_awsCredentialsSupplier_null_THEN_should_throw() {
+        mockCredentialSupplier = null;
+        when(mockCloudWatchLogsSinkConfig.getAwsConfig()).thenReturn(null);
+        try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
+            mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
+                            any(AwsCredentialsSupplier.class)))
+                    .thenReturn(mockClient);
+
+            assertThrows(RuntimeException.class, ()-> getTestCloudWatchSink());
         }
     }
 

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/buffer/InMemoryBufferTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/buffer/InMemoryBufferTest.java
@@ -8,9 +8,12 @@ package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
 
+import java.time.Instant;
 import java.util.ArrayList;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,10 +24,12 @@ public class InMemoryBufferTest {
     private static InMemoryBuffer inMemoryBuffer;
     public static final String TEST_EVENT_MESSAGE = "testing";
     public static final int TEST_COLLECTION_SIZE = 3;
+    private static EventHandle eventHandle;
 
     @BeforeEach
     void setUp() {
         inMemoryBuffer = new InMemoryBuffer();
+        eventHandle = new DefaultEventHandle(Instant.now());
     }
 
     ArrayList<Record<Event>> getTestCollection() {
@@ -54,7 +59,7 @@ public class InMemoryBufferTest {
     @Test
     void GIVEN_filled_buffer_SHOULD_return_valid_event_count() {
         for (Record<Event> eventToTest: getTestCollection()) {
-            inMemoryBuffer.writeEvent(eventToTest.getData().toJsonString().getBytes());
+            inMemoryBuffer.writeEvent(eventHandle, eventToTest.getData().toJsonString().getBytes());
         }
 
         assertThat(inMemoryBuffer.getEventCount(), equalTo(TEST_COLLECTION_SIZE));
@@ -63,7 +68,7 @@ public class InMemoryBufferTest {
     @Test
     void GIVEN_filled_buffer_WHEN_pop_event_SHOULD_return_valid_event_count() {
         for (Record<Event> eventToTest: getTestCollection()) {
-            inMemoryBuffer.writeEvent(eventToTest.getData().toJsonString().getBytes());
+            inMemoryBuffer.writeEvent(eventHandle, eventToTest.getData().toJsonString().getBytes());
         }
 
         inMemoryBuffer.popEvent();
@@ -74,7 +79,7 @@ public class InMemoryBufferTest {
     @Test
     void GIVEN_filled_buffer_WHEN_pop_event_SHOULD_return_valid_buffer_size() {
         for (Record<Event> eventToTest: getTestCollection()) {
-            inMemoryBuffer.writeEvent(eventToTest.getData().toJsonString().getBytes());
+            inMemoryBuffer.writeEvent(eventHandle, eventToTest.getData().toJsonString().getBytes());
         }
 
         inMemoryBuffer.popEvent();
@@ -85,7 +90,7 @@ public class InMemoryBufferTest {
     @Test
     void GIVEN_filled_buffer_WHEN_get_buffer_size_SHOULD_return_valid_buffer_size() {
         for (Record<Event> eventToTest: getTestCollection()) {
-            inMemoryBuffer.writeEvent(eventToTest.getData().toJsonString().getBytes());
+            inMemoryBuffer.writeEvent(eventHandle, eventToTest.getData().toJsonString().getBytes());
         }
 
         assertThat(inMemoryBuffer.getBufferSize(), equalTo(getStringJsonMessageSize() * TEST_COLLECTION_SIZE));
@@ -94,7 +99,7 @@ public class InMemoryBufferTest {
     @Test
     void GIVEN_filled_buffer_WHEN_pop_event_SHOULD_return_valid_string() {
         for (Record<Event> eventToTest: getTestCollection()) {
-            inMemoryBuffer.writeEvent(eventToTest.getData().toJsonString().getBytes());
+            inMemoryBuffer.writeEvent(eventHandle, eventToTest.getData().toJsonString().getBytes());
         }
 
         int eventCount = inMemoryBuffer.getEventCount();

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactoryTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactoryTest.java
@@ -19,12 +19,16 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClientBuilder;
 
+
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mockStatic;
@@ -34,20 +38,39 @@ class CloudWatchLogsClientFactoryTest {
     private AwsConfig mockAwsConfig;
     private AwsCredentialsSupplier mockAwsCredentialsSupplier;
     private AwsCredentialsOptions mockAwsCredentialsOptions;
+    private AwsCredentialsProvider mockAwsCredentialsProvider;
 
     @BeforeEach
     void setUp() {
         mockAwsConfig = mock(AwsConfig.class);
         mockAwsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
         mockAwsCredentialsOptions = mock(AwsCredentialsOptions.class);
+        mockAwsCredentialsProvider = mock(AwsCredentialsProvider.class);
         when(mockAwsConfig.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        when(mockAwsCredentialsSupplier.getDefaultRegion()).thenReturn(Optional.of(Region.US_EAST_1));
     }
 
     @Test
     void GIVEN_default_credentials_SHOULD_return_non_null_client() {
+        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
         final CloudWatchLogsClient cloudWatchLogsClientToTest = CloudWatchLogsClientFactory.createCwlClient(mockAwsConfig, mockAwsCredentialsSupplier);
 
         assertNotNull(cloudWatchLogsClientToTest);
+    }
+
+    @Test
+    void GIVEN_default_credentials_with_no_provider_SHOULD_return_null_client() {
+        final CloudWatchLogsClient cloudWatchLogsClientToTest = CloudWatchLogsClientFactory.createCwlClient(mockAwsConfig, mockAwsCredentialsSupplier);
+
+        assertNull(cloudWatchLogsClientToTest);
+    }
+
+    @Test
+    void GIVEN_default_credentials_with_no_region_SHOULD_return_null_client() {
+        when(mockAwsConfig.getAwsRegion()).thenReturn(null);
+        final CloudWatchLogsClient cloudWatchLogsClientToTest = CloudWatchLogsClientFactory.createCwlClient(mockAwsConfig, mockAwsCredentialsSupplier);
+
+        assertNull(cloudWatchLogsClientToTest);
     }
 
     @Test

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -48,7 +48,7 @@ class CloudWatchLogsDispatcherTest {
         return returnCollection;
     }
 
-    Collection<EventHandle> getSampleEventHandles() {
+    List<EventHandle> getSampleEventHandles() {
         final ArrayList<EventHandle> eventHandles = new ArrayList<>();
 
         for (int i = 0; i < ThresholdConfig.DEFAULT_BATCH_SIZE; i++) {

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/UploaderTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/UploaderTest.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsExcept
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -29,7 +29,7 @@ class UploaderTest {
         mockCloudWatchLogsMetrics = mock(CloudWatchLogsMetrics.class);
     }
 
-    Collection<EventHandle> getTestEventHandles() {
+    List<EventHandle> getTestEventHandles() {
         final ArrayList<EventHandle> eventHandles = new ArrayList<>();
         for (int i = 0; i < ThresholdConfig.DEFAULT_BATCH_SIZE; i++) {
             final EventHandle mockEventHandle = mock(EventHandle.class);

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/DlqPushHandler.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/DlqPushHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.dlq;
+
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.MetricNames;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+
+/**
+ * * An Handler class which helps log failed data to AWS S3 bucket or file based on configuration.
+ */
+
+public class DlqPushHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(DlqPushHandler.class);
+    public static final String NUM_DLQ_SUCCESS = "NumDlqSuccess";
+    public static final String NUM_DLQ_FAILED = "NumDlqFailed";
+    public static final String STS_ROLE_ARN = "sts_role_arn";
+    public static final String REGION = "region";
+
+    private final DlqProvider dlqProvider;
+    private final PluginSetting dlqPluginSetting;
+    private final DlqWriter dlqWriter;
+    private final Counter dlqSuccessCounter;
+    private final Counter dlqFailedCounter;
+
+    public DlqPushHandler(final PluginFactory pluginFactory, final PluginSetting pluginSetting, final PluginMetrics pluginMetrics,
+                          final PluginModel dlqConfig, final String region, final String role, final String metricsPrefix) {
+        Map<String, Object> dlqSettings = dlqConfig.getPluginSettings();
+        if (!dlqSettings.containsKey(REGION) && region != null) {
+            dlqSettings.put(REGION, region);
+        }
+        if (!dlqSettings.containsKey(STS_ROLE_ARN) && role != null) {
+            dlqSettings.put(STS_ROLE_ARN, role);
+        }
+        dlqPluginSetting = new PluginSetting(dlqConfig.getPluginName(), dlqSettings);
+        dlqPluginSetting.setPipelineName(pluginSetting.getPipelineName());
+        this.dlqProvider = pluginFactory.loadPlugin(DlqProvider.class, dlqPluginSetting);
+        if (this.dlqProvider != null) {
+            Optional<DlqWriter> potentialDlq = this.dlqProvider.getDlqWriter(new StringJoiner(MetricNames.DELIMITER)
+              .add(pluginSetting.getPipelineName())
+              .add(pluginSetting.getName()).toString());
+            this.dlqWriter = potentialDlq.isPresent() ? potentialDlq.get() : null;
+        } else {
+            this.dlqWriter = null;
+        }
+        this.dlqSuccessCounter = pluginMetrics.counter(metricsPrefix+NUM_DLQ_SUCCESS);
+        this.dlqFailedCounter = pluginMetrics.counter(metricsPrefix+NUM_DLQ_FAILED);
+    }
+
+    public PluginSetting getPluginSetting() {
+        return dlqPluginSetting;
+    }
+
+    public double getDlqSuccessCounter() {
+        return dlqSuccessCounter.count();
+    }
+
+    public double getDlqFailedCounter() {
+        return dlqFailedCounter.count();
+    }
+
+    public boolean perform(final List<DlqObject> dlqObjects) {
+        try {
+            if (dlqWriter != null && dlqObjects != null && dlqObjects.size() > 0) {
+                dlqWriter.write(dlqObjects, dlqPluginSetting.getPipelineName(), dlqPluginSetting.getName());
+                dlqSuccessCounter.increment(dlqObjects.size());
+                return true;
+            }
+        } catch (Exception e) {
+            LOG.error(NOISY, "failed to write to DLQ", e);
+            dlqFailedCounter.increment(dlqObjects.size());
+        }
+        return false;
+    }
+}
+

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/DlqPushHandlerTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/DlqPushHandlerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.dlq;
+
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DlqPushHandlerTest {
+    static final String METRICS_PREFIX="prefix";
+    static final String TEST_NAME="name";
+    static final String TEST_PIPELINE_NAME="pipelineName";
+
+    @Mock
+    PluginFactory pluginFactory;
+    @Mock
+    PluginSetting pluginSetting;
+    @Mock
+    PluginMetrics pluginMetrics;
+    @Mock
+    private Counter counter;
+    @Mock
+    private DlqProvider dlqProvider;
+    @Mock
+    private DlqWriter dlqWriter;
+
+    private DlqPushHandler dlqPushHandler;
+    private PluginModel dlqConfig;
+    private AtomicInteger count;
+
+
+    @BeforeEach
+    void setup() {
+        count = new AtomicInteger(0);
+        pluginFactory = mock(PluginFactory.class);
+        pluginSetting = mock(PluginSetting.class);
+        pluginMetrics = mock(PluginMetrics.class);
+        dlqProvider = mock(DlqProvider.class);
+        dlqWriter = mock(DlqWriter.class);
+        counter = mock(Counter.class);
+        when(pluginSetting.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
+        when(pluginSetting.getName()).thenReturn(TEST_NAME);
+        when(pluginMetrics.counter(anyString())).thenReturn(counter);
+        when(dlqProvider.getDlqWriter(any())).thenReturn(Optional.of(dlqWriter));
+        when(pluginFactory.loadPlugin(any(Class.class), any(PluginSetting.class))).thenReturn(dlqProvider);
+        dlqConfig = mock(PluginModel.class);
+        when(dlqConfig.getPluginName()).thenReturn(TEST_NAME);
+        when(dlqConfig.getPluginSettings()).thenReturn(new HashMap<String, Object>());
+    }
+
+    DlqPushHandler createObjectUnderTest(final String region, final String role) {
+        return new DlqPushHandler(pluginFactory, pluginSetting, pluginMetrics, dlqConfig, region, role, METRICS_PREFIX);
+    }
+
+    @Test
+    void testDlqPushHandler_basic() {
+        final String region = UUID.randomUUID().toString();
+        final String role = UUID.randomUUID().toString();
+        dlqPushHandler = createObjectUnderTest(region, role);
+        PluginSetting pSetting = dlqPushHandler.getPluginSetting();
+        assertThat(pSetting.getName(), equalTo(TEST_NAME));
+        assertThat(pSetting.getPipelineName(), equalTo(TEST_PIPELINE_NAME));
+        assertThat(pSetting.getAttributeFromSettings(DlqPushHandler.REGION), equalTo(region));
+        assertThat(pSetting.getAttributeFromSettings(DlqPushHandler.STS_ROLE_ARN), equalTo(role));
+        assertThat(dlqPushHandler.getDlqSuccessCounter(), equalTo(0.0d));
+    }
+
+    @Test
+    void testDlqPushHandler_withPerform() throws Exception {
+        doAnswer((a)-> {
+            int v = (int)(double)(a.getArgument(0));
+            count.addAndGet(v);
+            return null;
+        }).when(counter).increment(any(Double.class));
+        final String region = UUID.randomUUID().toString();
+        final String role = UUID.randomUUID().toString();
+        dlqPushHandler = createObjectUnderTest(region, role);
+        PluginSetting pSetting = dlqPushHandler.getPluginSetting();
+        assertThat(pSetting.getName(), equalTo(TEST_NAME));
+        assertThat(pSetting.getPipelineName(), equalTo(TEST_PIPELINE_NAME));
+        assertThat(pSetting.getAttributeFromSettings(DlqPushHandler.REGION), equalTo(region));
+        assertThat(pSetting.getAttributeFromSettings(DlqPushHandler.STS_ROLE_ARN), equalTo(role));
+        assertThat(dlqPushHandler.getDlqSuccessCounter(), equalTo(0.0d));
+        DlqObject dlqObject = mock(DlqObject.class);
+        List<DlqObject> dlqObjects = List.of(dlqObject);
+        doNothing().when(dlqWriter).write(any(List.class), anyString(), anyString());
+        dlqPushHandler.perform(dlqObjects);
+        when(counter.count()).thenReturn(Double.valueOf(count.get()));
+        assertThat(dlqPushHandler.getDlqSuccessCounter(), equalTo(1.0d));
+    }
+
+    @Test
+    void testDlqPushHandler_withPerform_withDLQFailure() throws Exception {
+        doAnswer((a)-> {
+            int v = (int)(double)(a.getArgument(0));
+            count.addAndGet(v);
+            return null;
+        }).when(counter).increment(any(Double.class));
+        final String region = UUID.randomUUID().toString();
+        final String role = UUID.randomUUID().toString();
+        dlqPushHandler = createObjectUnderTest(region, role);
+        PluginSetting pSetting = dlqPushHandler.getPluginSetting();
+        assertThat(pSetting.getName(), equalTo(TEST_NAME));
+        assertThat(pSetting.getPipelineName(), equalTo(TEST_PIPELINE_NAME));
+        assertThat(pSetting.getAttributeFromSettings(DlqPushHandler.REGION), equalTo(region));
+        assertThat(pSetting.getAttributeFromSettings(DlqPushHandler.STS_ROLE_ARN), equalTo(role));
+        assertThat(dlqPushHandler.getDlqSuccessCounter(), equalTo(0.0d));
+        DlqObject dlqObject = mock(DlqObject.class);
+        List<DlqObject> dlqObjects = List.of(dlqObject);
+        doThrow(new RuntimeException("failed")).when(dlqWriter).write(any(List.class), anyString(), anyString());
+        dlqPushHandler.perform(dlqObjects);
+        when(counter.count()).thenReturn(Double.valueOf(count.get()));
+        assertThat(dlqPushHandler.getDlqFailedCounter(), equalTo(1.0d));
+    }
+}


### PR DESCRIPTION
### Description
Add DLQ support to CloudWatchLogs sink
- Added common DLQ push handler to failure common package
- Added DLQ support to cloudwatch using the common DLQ
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
