### PR TITLE
Fixes an issue where processors are executing multiple times for an event

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Connected_SingleExtraSinkIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Connected_SingleExtraSinkIT.java
@@ -23,9 +23,7 @@ import java.util.stream.IntStream;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 
 public class Connected_SingleExtraSinkIT {
     private static final String IN_MEMORY_IDENTIFIER = "Connected_SingleExtraSinkIT";
@@ -65,8 +63,8 @@ public class Connected_SingleExtraSinkIT {
 
         await().atMost(800, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
-                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK), not(empty()));
-                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK), not(empty()));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreate));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK).size(), equalTo(recordsToCreate));
                 });
 
         assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreate));
@@ -86,8 +84,8 @@ public class Connected_SingleExtraSinkIT {
 
         await().atMost(800, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
-                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK), not(empty()));
-                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK), not(empty()));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreateBatch1));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK).size(), equalTo(recordsToCreateBatch1));
                 });
 
         assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreateBatch1));
@@ -104,8 +102,8 @@ public class Connected_SingleExtraSinkIT {
 
         await().atMost(400, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
-                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK), not(empty()));
-                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK), not(empty()));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreateBatch2));
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_EXIT_SINK).size(), equalTo(recordsToCreateBatch2));
                 });
 
         assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER_ENTRY_SINK).size(), equalTo(recordsToCreateBatch2));

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
@@ -12,8 +12,6 @@ import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.core.peerforwarder.PeerForwardingProcessorDecorator;
 import org.opensearch.dataprepper.core.pipeline.Pipeline;
 import org.opensearch.dataprepper.core.pipeline.PipelineConnector;
-import org.opensearch.dataprepper.core.pipeline.PipelineRunnerImpl;
-import org.opensearch.dataprepper.core.pipeline.SupportsPipelineRunner;
 import org.opensearch.dataprepper.core.pipeline.router.Router;
 import org.opensearch.dataprepper.core.pipeline.router.RouterFactory;
 import org.opensearch.dataprepper.core.sourcecoordination.SourceCoordinatorFactory;
@@ -230,9 +228,10 @@ public class PipelineTransformer {
                     dataPrepperConfiguration.getProcessorShutdownTimeout(), dataPrepperConfiguration.getSinkShutdownTimeout(),
                     getPeerForwarderDrainTimeout(dataPrepperConfiguration));
 
-            if (pipelineDefinedBuffer instanceof SupportsPipelineRunner) {
-                ((SupportsPipelineRunner) pipelineDefinedBuffer).setPipelineRunner(new PipelineRunnerImpl(pipeline));
-            }
+            // TODO: Re-enable zero-buffer
+            //if (pipelineDefinedBuffer instanceof SupportsPipelineRunner) {
+            //    ((SupportsPipelineRunner) pipelineDefinedBuffer).setPipelineRunner(new PipelineRunnerImpl(pipeline, processors));
+            //}
 
             pipelineMap.put(pipelineName, pipeline);
         } catch (Exception ex) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
@@ -30,14 +30,7 @@ public class ProcessWorker implements Runnable {
         this.readBuffer = readBuffer;
         this.processors = processors;
         this.pipeline = pipeline;
-        this.pipelineRunner = new PipelineRunnerImpl(pipeline);
-    }
-
-    public ProcessWorker(PipelineRunner pipelineRunner) {
-        this.pipelineRunner = pipelineRunner;
-        this.readBuffer = pipelineRunner.getPipeline().getBuffer();
-        this.processors = pipelineRunner.getPipeline().getProcessors();
-        this.pipeline = pipelineRunner.getPipeline();
+        this.pipelineRunner = new PipelineRunnerImpl(pipeline, processors);
     }
 
     @Override

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
@@ -85,13 +85,19 @@ class PipelineRunnerTest {
     EventHandle eventHandle;
     @Mock
     DefaultEventHandle defaultEventHandle;
+    private List<Processor> processors;
 
     private void setupPipeline(boolean shouldEnableAcknowledgements) {
         lenient().when(pipeline.areAcknowledgementsEnabled()).thenReturn(shouldEnableAcknowledgements);
     }
 
     private PipelineRunnerImpl createObjectUnderTest() {
-        return new PipelineRunnerImpl(pipeline);
+        return new PipelineRunnerImpl(pipeline, processors);
+    }
+
+    @BeforeEach
+    void setUp() {
+        processors = List.of(processor);
     }
 
     @Nested
@@ -268,7 +274,7 @@ class PipelineRunnerTest {
 
             when(processor.holdsEvents()).thenReturn(false);
             when(processor.execute(records)).thenReturn(List.of());
-            List<Processor> processors = List.of(processor);
+
 
             final PipelineRunnerImpl pipelineRunner = createObjectUnderTest();
             pipelineRunner.runProcessorsAndProcessAcknowledgements(processors, records);
@@ -370,7 +376,6 @@ class PipelineRunnerTest {
             setupPipeline(true);
             // Set up additional pipeline behavior
             when(pipeline.getBuffer()).thenReturn(buffer);
-            when(pipeline.getProcessors()).thenReturn(List.of(processor));
             when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(BUFFER_READ_TIMEOUT_MILLIS);
             when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
             when(pipeline.publishToSinks(anyCollection())).thenReturn(
@@ -397,7 +402,6 @@ class PipelineRunnerTest {
             when(pipeline.getBuffer()).thenReturn(buffer);
             when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(BUFFER_READ_TIMEOUT_MILLIS);
             when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
-            when(pipeline.getProcessors()).thenReturn(List.of(processor));
             when(pipeline.publishToSinks(anyCollection())).thenReturn(
                     Collections.singletonList(CompletableFuture.completedFuture(null)));
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate;
 
-import org.opensearch.dataprepper.core.pipeline.PipelineRunner;
-import org.opensearch.dataprepper.core.pipeline.PipelineRunnerImpl;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
@@ -206,8 +204,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
 
             processWorker.run();
         }
@@ -238,8 +235,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
 
             processWorker.run();
         }
@@ -271,8 +267,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
 
             processWorker.run();
         }
@@ -304,8 +299,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
 
 
             processWorker.run();
@@ -333,8 +327,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -364,8 +357,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
 
             processWorker.run();
         }
@@ -422,8 +414,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -477,8 +468,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -508,8 +498,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -542,8 +531,7 @@ public class AggregateProcessorITWithAcks {
                     .thenReturn(futureHelperResult);
 
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -577,8 +565,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -605,8 +592,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            PipelineRunner pipelineRunner = new PipelineRunnerImpl(pipeline);
-            final ProcessWorker processWorker = new ProcessWorker(pipelineRunner);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)


### PR DESCRIPTION
### Description

Fixes an issue where `@SingleThread`-annotated processors are called multiple times. The recent addition of the `PipelineRunner` was getting the full list of processors from the `Pipeline` class. This includes multiple instances of processors, which caused them to be invoked multiple times. The solution is to use the list of `Processor`s provided to any given `PipelineRunnerImpl` instance. For now, this also disables the support for `SupportsPipelineRunner` buffers in order to get the fix out now. 

Additionally, this improves the timing of the `Connected_SingleExtraSinkIT` test since this appears to be flaky locally for me.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
