### PR TITLE
Reduces byte array copies in AWS Lambda processor when making the request

### DIFF
--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/Buffer.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/Buffer.java
@@ -7,34 +7,30 @@ package org.opensearch.dataprepper.plugins.lambda.common.accumlator;
 
 import java.time.Duration;
 import java.util.List;
+
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
-import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 
 /**
  * A buffer can hold data before flushing it.
  */
 public interface Buffer {
+    long getSize();
 
-  long getSize();
+    int getEventCount();
 
-  int getEventCount();
+    Duration getDuration();
 
-  Duration getDuration();
+    InvokeRequest getRequestPayload(String functionName, String invocationType);
 
-  InvokeRequest getRequestPayload(String functionName, String invocationType);
+    void addRecord(Record<Event> record);
 
-  SdkBytes getPayload();
+    List<Record<Event>> getRecords();
 
-  void addRecord(Record<Event> record);
+    Duration getFlushLambdaLatencyMetric();
 
-  List<Record<Event>> getRecords();
+    Long getPayloadRequestSize();
 
-  Duration getFlushLambdaLatencyMetric();
-
-  Long getPayloadRequestSize();
-
-  Duration stopLatencyWatch();
-  
+    Duration stopLatencyWatch();
 }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/InMemoryBuffer.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/InMemoryBuffer.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.time.StopWatch;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.Event;
@@ -27,126 +28,123 @@ import software.amazon.awssdk.services.lambda.model.InvokeRequest;
  */
 public class InMemoryBuffer implements Buffer {
 
-  private final ByteArrayOutputStream byteArrayOutputStream;
+    private final ByteArrayOutputStream byteArrayOutputStream;
 
-  protected List<Record<Event>> records;
-  private final StopWatch bufferWatch;
-  private final StopWatch lambdaLatencyWatch;
-  private final OutputCodec requestCodec;
-  private final OutputCodecContext outputCodecContext;
-  private final long payloadResponseSize;
-  private int eventCount;
-  private long payloadRequestSize;
+    protected List<Record<Event>> records;
+    private final StopWatch bufferWatch;
+    private final StopWatch lambdaLatencyWatch;
+    private final OutputCodec requestCodec;
+    private final OutputCodecContext outputCodecContext;
+    private final long payloadResponseSize;
+    private int eventCount;
+    private long payloadRequestSize;
 
 
-  public InMemoryBuffer(String batchOptionKeyName) {
-    this(batchOptionKeyName, new OutputCodecContext());
-  }
-
-  public InMemoryBuffer(String batchOptionKeyName, OutputCodecContext outputCodecContext) {
-    byteArrayOutputStream = new ByteArrayOutputStream();
-    records = new ArrayList<>();
-    bufferWatch = new StopWatch();
-    bufferWatch.start();
-    lambdaLatencyWatch = new StopWatch();
-    eventCount = 0;
-    payloadRequestSize = 0;
-    payloadResponseSize = 0;
-    // Setup request codec
-    JsonOutputCodecConfig jsonOutputCodecConfig = new JsonOutputCodecConfig();
-    jsonOutputCodecConfig.setKeyName(batchOptionKeyName);
-    requestCodec = new JsonOutputCodec(jsonOutputCodecConfig);
-    this.outputCodecContext = outputCodecContext;
-  }
-
-  @Override
-  public void addRecord(Record<Event> record) {
-    records.add(record);
-    Event event = record.getData();
-    try {
-      if (eventCount == 0) {
-        requestCodec.start(this.byteArrayOutputStream, event, this.outputCodecContext);
-      }
-      requestCodec.writeEvent(event, this.byteArrayOutputStream);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    eventCount++;
-  }
-
-  @Override
-  public List<Record<Event>> getRecords() {
-    return records;
-  }
-
-  @Override
-  public long getSize() {
-    return byteArrayOutputStream.size();
-  }
-
-  @Override
-  public int getEventCount() {
-    return eventCount;
-  }
-
-  public Duration getDuration() {
-    return Duration.ofMillis(bufferWatch.getTime(TimeUnit.MILLISECONDS));
-  }
-
-  @Override
-  public InvokeRequest getRequestPayload(String functionName, String invocationType) {
-
-    if (eventCount == 0) {
-      //We never added any events so there is no payload
-      return null;
+    public InMemoryBuffer(String batchOptionKeyName) {
+        this(batchOptionKeyName, new OutputCodecContext());
     }
 
-    try {
-      requestCodec.complete(this.byteArrayOutputStream);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    public InMemoryBuffer(String batchOptionKeyName, OutputCodecContext outputCodecContext) {
+        byteArrayOutputStream = new ByteArrayOutputStream(32 * 1024);
+        records = new ArrayList<>();
+        bufferWatch = new StopWatch();
+        bufferWatch.start();
+        lambdaLatencyWatch = new StopWatch();
+        eventCount = 0;
+        payloadRequestSize = 0;
+        payloadResponseSize = 0;
+        // Setup request codec
+        JsonOutputCodecConfig jsonOutputCodecConfig = new JsonOutputCodecConfig();
+        jsonOutputCodecConfig.setKeyName(batchOptionKeyName);
+        requestCodec = new JsonOutputCodec(jsonOutputCodecConfig);
+        this.outputCodecContext = outputCodecContext;
     }
 
-    SdkBytes payload = getPayload();
-    payloadRequestSize = payload.asByteArray().length;
-
-    // Setup an InvokeRequest.
-    InvokeRequest request = InvokeRequest.builder()
-        .functionName(functionName)
-        .payload(payload)
-        .invocationType(invocationType)
-        .build();
-
-    synchronized (this) {
-      if (lambdaLatencyWatch.isStarted()) {
-        lambdaLatencyWatch.reset();
-      }
-      lambdaLatencyWatch.start();
+    @Override
+    public void addRecord(Record<Event> record) {
+        records.add(record);
+        Event event = record.getData();
+        try {
+            if (eventCount == 0) {
+                requestCodec.start(this.byteArrayOutputStream, event, this.outputCodecContext);
+            }
+            requestCodec.writeEvent(event, this.byteArrayOutputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        eventCount++;
     }
-    return request;
-  }
 
-  public synchronized Duration stopLatencyWatch() {
-    if (lambdaLatencyWatch.isStarted()) {
-      lambdaLatencyWatch.stop();
+    @Override
+    public List<Record<Event>> getRecords() {
+        return records;
     }
-    long timeInMillis = lambdaLatencyWatch.getTime();
-    return Duration.ofMillis(timeInMillis);
-  }
 
-  @Override
-  public SdkBytes getPayload() {
-    byte[] bytes = byteArrayOutputStream.toByteArray();
-    return SdkBytes.fromByteArray(bytes);
-  }
+    @Override
+    public long getSize() {
+        return byteArrayOutputStream.size();
+    }
 
-  public Duration getFlushLambdaLatencyMetric() {
-    return Duration.ofMillis(lambdaLatencyWatch.getTime(TimeUnit.MILLISECONDS));
-  }
+    @Override
+    public int getEventCount() {
+        return eventCount;
+    }
 
-  public Long getPayloadRequestSize() {
-    return payloadRequestSize;
-  }
+    public Duration getDuration() {
+        return Duration.ofMillis(bufferWatch.getTime(TimeUnit.MILLISECONDS));
+    }
 
+    @Override
+    public InvokeRequest getRequestPayload(String functionName, String invocationType) {
+
+        if (eventCount == 0) {
+            //We never added any events so there is no payload
+            return null;
+        }
+
+        try {
+            requestCodec.complete(this.byteArrayOutputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        SdkBytes payload = getPayload();
+        payloadRequestSize = payload.asByteArrayUnsafe().length;
+
+        // Setup an InvokeRequest.
+        InvokeRequest request = InvokeRequest.builder()
+                .functionName(functionName)
+                .payload(payload)
+                .invocationType(invocationType)
+                .build();
+
+        synchronized (this) {
+            if (lambdaLatencyWatch.isStarted()) {
+                lambdaLatencyWatch.reset();
+            }
+            lambdaLatencyWatch.start();
+        }
+        return request;
+    }
+
+    public synchronized Duration stopLatencyWatch() {
+        if (lambdaLatencyWatch.isStarted()) {
+            lambdaLatencyWatch.stop();
+        }
+        long timeInMillis = lambdaLatencyWatch.getTime();
+        return Duration.ofMillis(timeInMillis);
+    }
+
+    private SdkBytes getPayload() {
+        return SdkBytes.fromByteArrayUnsafe(byteArrayOutputStream.toByteArray());
+    }
+
+    public Duration getFlushLambdaLatencyMetric() {
+        return Duration.ofMillis(lambdaLatencyWatch.getTime(TimeUnit.MILLISECONDS));
+    }
+
+    public Long getPayloadRequestSize() {
+        return payloadRequestSize;
+    }
 }
 

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/common/accumulator/InMemoryBufferTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/common/accumulator/InMemoryBufferTest.java
@@ -9,7 +9,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -17,12 +20,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.event.Event;
@@ -39,110 +52,178 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 @ExtendWith(MockitoExtension.class)
 class InMemoryBufferTest {
 
-  public static final int MAX_EVENTS = 55;
-  private final String invocationType = InvocationType.REQUEST_RESPONSE.getAwsLambdaValue();
-  private final String functionName = "testFunction";
-  private final String batchOptionKeyName = "bathOption";
-  @Mock
-  private LambdaAsyncClient lambdaAsyncClient;
+    public static final int MAX_EVENTS = 55;
+    private String invocationType;
+    private String functionName;
+    private final String batchOptionKeyName = "bathOption";
+    @Mock
+    private LambdaAsyncClient lambdaAsyncClient;
 
-  public static Record<Event> getSampleRecord() {
-    Event event = JacksonEvent.fromMessage(String.valueOf(UUID.randomUUID()));
-    return new Record<>(event);
-  }
-
-  @Test
-  void test_with_write_event_into_buffer() {
-    InMemoryBuffer inMemoryBuffer = new InMemoryBuffer(batchOptionKeyName);
-    //UUID based random event created. Each UUID string is of 36 characters long
-    int eachEventSize = 36;
-    long sizeToAssert = eachEventSize * MAX_EVENTS;
-    while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
-      inMemoryBuffer.addRecord(getSampleRecord());
+    public static Record<Event> getSampleRecord() {
+        Event event = JacksonEvent.fromMessage(String.valueOf(UUID.randomUUID()));
+        return new Record<>(event);
     }
-    assertThat(inMemoryBuffer.getSize(), greaterThanOrEqualTo(sizeToAssert));
-    assertThat(inMemoryBuffer.getEventCount(), equalTo(MAX_EVENTS));
-    assertThat(inMemoryBuffer.getDuration(), notNullValue());
-    assertThat(inMemoryBuffer.getDuration(), greaterThanOrEqualTo(Duration.ZERO));
-  }
 
-  @Test
-  void test_with_write_event_into_buffer_and_flush_toLambda() {
-
-    // Mock the response of the invoke method
-    InvokeResponse mockResponse = InvokeResponse.builder()
-        .statusCode(200) // HTTP 200 for successful invocation
-        .payload(
-            SdkBytes.fromString("{\"key\": \"value\"}", java.nio.charset.StandardCharsets.UTF_8))
-        .build();
-    CompletableFuture<InvokeResponse> future = CompletableFuture.completedFuture(mockResponse);
-    when(lambdaAsyncClient.invoke(any(InvokeRequest.class))).thenReturn(future);
-
-    InMemoryBuffer inMemoryBuffer = new InMemoryBuffer(batchOptionKeyName);
-    while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
-      inMemoryBuffer.addRecord(getSampleRecord());
+    @BeforeEach
+    void setUp() {
+        invocationType = InvocationType.REQUEST_RESPONSE.getAwsLambdaValue();
+        functionName = UUID.randomUUID().toString();
     }
-    assertDoesNotThrow(() -> {
-      InvokeRequest requestPayload = inMemoryBuffer.getRequestPayload(
-          functionName, invocationType);
-      CompletableFuture<InvokeResponse> responseFuture = lambdaAsyncClient.invoke(requestPayload);
-      InvokeResponse response = responseFuture.join();
-      assertThat(response.statusCode(), equalTo(200));
-    });
-  }
 
-  @Test
-  void test_uploadedToLambda_success() {
-    // Mock the response of the invoke method
-    InvokeResponse mockResponse = InvokeResponse.builder()
-        .statusCode(200) // HTTP 200 for successful invocation
-        .payload(
-            SdkBytes.fromString("{\"key\": \"value\"}", java.nio.charset.StandardCharsets.UTF_8))
-        .build();
+    private InMemoryBuffer createObjectUnderTest() {
+        return new InMemoryBuffer(batchOptionKeyName);
+    }
 
-    CompletableFuture<InvokeResponse> future = CompletableFuture.completedFuture(mockResponse);
-    when(lambdaAsyncClient.invoke(any(InvokeRequest.class))).thenReturn(future);
+    @Test
+    void test_with_write_event_into_buffer() {
+        InMemoryBuffer inMemoryBuffer = createObjectUnderTest();
+        //UUID based random event created. Each UUID string is of 36 characters long
+        int eachEventSize = 36;
+        long sizeToAssert = eachEventSize * MAX_EVENTS;
+        while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
+            inMemoryBuffer.addRecord(getSampleRecord());
+        }
+        assertThat(inMemoryBuffer.getSize(), greaterThanOrEqualTo(sizeToAssert));
+        assertThat(inMemoryBuffer.getEventCount(), equalTo(MAX_EVENTS));
+        assertThat(inMemoryBuffer.getDuration(), notNullValue());
+        assertThat(inMemoryBuffer.getDuration(), greaterThanOrEqualTo(Duration.ZERO));
+    }
 
-    InMemoryBuffer inMemoryBuffer = new InMemoryBuffer(batchOptionKeyName);
-    assertNotNull(inMemoryBuffer);
-    inMemoryBuffer.addRecord(getSampleRecord());
+    @Test
+    void test_with_write_event_into_buffer_and_flush_toLambda() {
 
-    assertDoesNotThrow(() -> {
-      InvokeRequest requestPayload = inMemoryBuffer.getRequestPayload(
-          functionName, invocationType);
-      CompletableFuture<InvokeResponse> responseFuture = lambdaAsyncClient.invoke(requestPayload);
-      InvokeResponse response = responseFuture.join();
-      assertThat(response.statusCode(), equalTo(200));
-    });
-  }
+        // Mock the response of the invoke method
+        InvokeResponse mockResponse = InvokeResponse.builder()
+                .statusCode(200) // HTTP 200 for successful invocation
+                .payload(
+                        SdkBytes.fromString("{\"key\": \"value\"}", java.nio.charset.StandardCharsets.UTF_8))
+                .build();
+        CompletableFuture<InvokeResponse> future = CompletableFuture.completedFuture(mockResponse);
+        when(lambdaAsyncClient.invoke(any(InvokeRequest.class))).thenReturn(future);
 
-  @Test
-  void test_uploadedToLambda_fails() {
-    // Mock an exception when invoking lambda
-    SdkClientException sdkClientException = SdkClientException.create("Mock exception");
+        InMemoryBuffer inMemoryBuffer = createObjectUnderTest();
+        while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
+            inMemoryBuffer.addRecord(getSampleRecord());
+        }
+        assertDoesNotThrow(() -> {
+            InvokeRequest requestPayload = inMemoryBuffer.getRequestPayload(
+                    functionName, invocationType);
+            CompletableFuture<InvokeResponse> responseFuture = lambdaAsyncClient.invoke(requestPayload);
+            InvokeResponse response = responseFuture.join();
+            assertThat(response.statusCode(), equalTo(200));
+        });
+    }
 
-    CompletableFuture<InvokeResponse> future = new CompletableFuture<>();
-    future.completeExceptionally(sdkClientException);
+    @Test
+    void test_uploadedToLambda_success() {
+        // Mock the response of the invoke method
+        InvokeResponse mockResponse = InvokeResponse.builder()
+                .statusCode(200) // HTTP 200 for successful invocation
+                .payload(
+                        SdkBytes.fromString("{\"key\": \"value\"}", java.nio.charset.StandardCharsets.UTF_8))
+                .build();
 
-    when(lambdaAsyncClient.invoke(any(InvokeRequest.class))).thenReturn(future);
+        CompletableFuture<InvokeResponse> future = CompletableFuture.completedFuture(mockResponse);
+        when(lambdaAsyncClient.invoke(any(InvokeRequest.class))).thenReturn(future);
 
-    InMemoryBuffer inMemoryBuffer = new InMemoryBuffer(batchOptionKeyName);
-    assertNotNull(inMemoryBuffer);
+        InMemoryBuffer inMemoryBuffer = createObjectUnderTest();
+        assertNotNull(inMemoryBuffer);
+        inMemoryBuffer.addRecord(getSampleRecord());
 
-    assertNull(inMemoryBuffer.getRequestPayload(functionName, invocationType));
-    inMemoryBuffer.addRecord(getSampleRecord());
-    // Execute and assert exception
-    CompletionException exception = assertThrows(CompletionException.class, () -> {
-      InvokeRequest requestPayload = inMemoryBuffer.getRequestPayload(
-          functionName, invocationType);
-      CompletableFuture<InvokeResponse> responseFuture = lambdaAsyncClient.invoke(requestPayload);
-      responseFuture.join();// This will throw CompletionException
-    });
+        assertDoesNotThrow(() -> {
+            InvokeRequest requestPayload = inMemoryBuffer.getRequestPayload(
+                    functionName, invocationType);
+            CompletableFuture<InvokeResponse> responseFuture = lambdaAsyncClient.invoke(requestPayload);
+            InvokeResponse response = responseFuture.join();
+            assertThat(response.statusCode(), equalTo(200));
+        });
+    }
 
-    // Verify that the cause of the CompletionException is the SdkClientException we threw
-    assertThat(exception.getCause(), instanceOf(SdkClientException.class));
-    assertThat(exception.getCause().getMessage(), equalTo("Mock exception"));
+    @Test
+    void test_uploadedToLambda_fails() {
+        // Mock an exception when invoking lambda
+        SdkClientException sdkClientException = SdkClientException.create("Mock exception");
 
-  }
+        CompletableFuture<InvokeResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(sdkClientException);
 
+        when(lambdaAsyncClient.invoke(any(InvokeRequest.class))).thenReturn(future);
+
+        InMemoryBuffer inMemoryBuffer = createObjectUnderTest();
+        assertNotNull(inMemoryBuffer);
+
+        assertNull(inMemoryBuffer.getRequestPayload(functionName, invocationType));
+        inMemoryBuffer.addRecord(getSampleRecord());
+        // Execute and assert exception
+        CompletionException exception = assertThrows(CompletionException.class, () -> {
+            InvokeRequest requestPayload = inMemoryBuffer.getRequestPayload(
+                    functionName, invocationType);
+            CompletableFuture<InvokeResponse> responseFuture = lambdaAsyncClient.invoke(requestPayload);
+            responseFuture.join();// This will throw CompletionException
+        });
+
+        // Verify that the cause of the CompletionException is the SdkClientException we threw
+        assertThat(exception.getCause(), instanceOf(SdkClientException.class));
+        assertThat(exception.getCause().getMessage(), equalTo("Mock exception"));
+    }
+
+    @Test
+    void getPayloadRequestSize_returns_0_before_complete() {
+        assertThat(createObjectUnderTest().getPayloadRequestSize(), equalTo(0L));
+    }
+
+    @Test
+    void getPayloadRequestSize_returns_size_of_bytes_after_getRequestPayload() {
+        final InMemoryBuffer objectUnderTest = createObjectUnderTest();
+        IntStream.range(0, MAX_EVENTS)
+                .forEach(i -> objectUnderTest.addRecord(getSampleRecord()));
+
+        objectUnderTest.getRequestPayload(functionName, invocationType);
+        assertAll(
+                () -> assertThat(objectUnderTest.getPayloadRequestSize(), greaterThanOrEqualTo(2800L)),
+                () -> assertThat(objectUnderTest.getPayloadRequestSize(), lessThanOrEqualTo(2900L))
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(InvocationType.class)
+    void getRequestPayload_returns_correct_InvokeRequest(final InvocationType invocationTypeEnum) throws IOException {
+        invocationType = invocationTypeEnum.getAwsLambdaValue();
+        final InMemoryBuffer objectUnderTest = createObjectUnderTest();
+
+        final List<Record<Event>> sampleRecords = IntStream.range(0, MAX_EVENTS)
+                .mapToObj(i -> getSampleRecord())
+                .collect(Collectors.toList());
+
+        sampleRecords.stream()
+                .forEach(objectUnderTest::addRecord);
+
+        final InvokeRequest invokeRequest = objectUnderTest.getRequestPayload(functionName, invocationType);
+
+        assertAll(
+                () -> assertThat(invokeRequest.functionName(), equalTo(functionName)),
+                () -> assertThat(invokeRequest.invocationTypeAsString(), equalTo(invocationType))
+        );
+
+        final SdkBytes payload = invokeRequest.payload();
+        assertThat(payload, notNullValue());
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> actualMap = objectMapper.readValue(payload.asInputStream(), Map.class);
+        assertThat(actualMap, notNullValue());
+        assertThat(actualMap, hasKey(batchOptionKeyName));
+        assertThat(actualMap.get(batchOptionKeyName), instanceOf(List.class));
+        final List<Map<String, Object>> actualList = (List<Map<String, Object>>) actualMap.get(batchOptionKeyName);
+        assertThat(actualList.size(), equalTo(MAX_EVENTS));
+        for (int i = 0; i < MAX_EVENTS; i++) {
+            final Map<String, Object> eventObject = actualList.get(i);
+            assertThat(eventObject, notNullValue());
+            assertThat(eventObject, instanceOf(Map.class));
+            assertThat(eventObject, hasKey("message"));
+            assertThat(eventObject.get("message"), instanceOf(String.class));
+
+            final Record<Event> eventRecord = sampleRecords.get(i);
+            assertThat(eventObject, equalTo(eventRecord.getData().toMap()));
+        }
+    }
 }


### PR DESCRIPTION
### Description

Improves the AWS Lambda processor's memory usage by creating fewer byte arrays when creating the request for the Lambda function. This uses the "unsafe" methods on SdkBytes. However, these are fine here because the byte[] is not accessible anywhere else for modification. This additionally adds some new unit tests to verify the actual behavior of the InMemoryBuffer as well.

Additionally, I removed the `getPayload()` method from the buffer because it was not used.

I also increased the initial byte buffer size to 32kb since this is probably going to be at least this large.

I also ran the code formatter to clean it up some to match existing files.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
