### PR TITLE
Fix an NullPointerException in S3 sink

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
@@ -116,7 +116,9 @@ public class ParquetOutputCodec implements OutputCodec, BufferedCodec {
     @Override
     public synchronized void complete(final OutputStream outputStream) throws IOException {
         isClosed = true;
-        writer.close();
+        if (writer != null) {
+            writer.close();
+        }
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecTest.java
@@ -244,6 +244,18 @@ public class ParquetOutputCodecTest {
     }
 
     @Test
+    void exception_in_start_should_not_cause_null_pointer_exception_when_complete() throws IOException {
+        final ParquetOutputCodec objectUnderTest = createObjectUnderTest();
+
+        final File tempFile = new File(tempDirectory, FILE_NAME);
+        LocalFilePositionOutputStream outputStream = LocalFilePositionOutputStream.create(tempFile);
+        assertThrows(RuntimeException.class, () -> objectUnderTest.start(null, createEventRecord(generateRecords(1).get(0)), codecContext));
+
+        // Calling complete now should not throw
+        objectUnderTest.complete(outputStream);
+    }
+
+    @Test
     void getSize_returns_0_after_construction() {
         config.setSchema(createStandardSchema().toString());
 


### PR DESCRIPTION
### Description
While working on a customer issue, noticed that if auto schema generation fails with exception, it will cause NPE and shutdown the pipeline. 

The error was something like this:
```
java.lang.NullPointerException: Cannot invoke "org.apache.parquet.hadoop.ParquetWriter.close()" because "this.writer" is null
	at org.opensearch.dataprepper.plugins.codec.parquet.ParquetOutputCodec.complete(ParquetOutputCodec.java:119)
```

This PR tries to fix the NPE.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
