### PR TITLE
Stand-alone uber-jar for performance-test

### DIFF
--- a/performance-test/README.md
+++ b/performance-test/README.md
@@ -59,6 +59,23 @@ Setup your AWS credentials to meet your needs. Then run a command similar to the
 ./gradlew :performance-test:compileGatlingJava
 ```
 
+### Deploying
+
+You can also create an uber-jar that has everything needed to run the Gatling performance tests so that you can
+deploy them easily.
+
+```shell
+./gradlew :performance-test:assemble
+```
+
+This will create an uber jar in `performance-test/build/libs` with the name `opensearch-data-prepper-performance-test-${VERSION}.jar`
+
+You can run this using a command similar to the following.
+
+```shell
+java -jar performance-test/build/libs/opensearch-data-prepper-performance-test-2.11.0-SNAPSHOT.jar -s org.opensearch.dataprepper.test.performance.StaticRequestSimulation
+```
+
 # Gatling Documentation
 [Gatling Quickstart](https://gatling.io/docs/gatling/tutorials/quickstart/)
 [Gatling Advanced Simulations](https://gatling.io/docs/gatling/tutorials/advanced/)

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -6,6 +6,7 @@
 plugins {
     id 'java'
     id 'io.gatling.gradle' version '3.10.4'
+    id 'com.gradleup.shadow' version '8.3.6'
 }
 
 configurations.all {
@@ -45,6 +46,28 @@ dependencies {
             because 'CVE-2023-50572'
         }
     }
+}
+
+jar {
+    from(sourceSets.gatling.output)
+}
+
+tasks.shadowJar {
+    archiveBaseName = "${project.rootProject.name}-${project.name}"
+    archiveClassifier = ''
+    archiveVersion = "${project.rootProject.version}"
+    configurations = [project.configurations.gatlingRuntimeClasspath]
+    manifest {
+        attributes 'Main-Class': 'io.gatling.app.Gatling'
+    }
+}
+
+tasks.named('shadowJar').configure {
+    dependsOn 'jar'
+}
+
+tasks.named('assemble').configure {
+    dependsOn('shadowJar')
 }
 
 test {


### PR DESCRIPTION
### Description

Build an uber-jar for the Data Prepper performance-test project that can be deployed with all the necessary Gatling dependencies and run stand-alone.

See the updates in the `README.md` for what this produces and how I ran it to verify that it works.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
