### PR TITLE
Comparing an hour difference range for all the timezones to account for Daylight savings

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/utils/TimezoneHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/utils/TimezoneHelperTest.java
@@ -24,10 +24,10 @@ public class TimezoneHelperTest {
                 // Format: sourceZone, targetZone, expectedDuration
 
                 // Same timezone (should return zero)
-                arguments(ZoneId.of("Europe/Paris"), ZoneId.of("Europe/Paris"), Duration.ofHours(0), Duration.ofHours(0)),
+                arguments(ZoneId.of("Europe/Paris"), ZoneId.of("Europe/Paris"), Duration.ofHours(0), Duration.ofHours(-1)),
 
                 // Sydney to London (Sydney is ahead, so positive offset)
-                arguments(ZoneId.of("Australia/Sydney"), ZoneId.of("Europe/London"), Duration.ofHours(11), Duration.ofHours(11)),
+                arguments(ZoneId.of("Australia/Sydney"), ZoneId.of("Europe/London"), Duration.ofHours(11), Duration.ofHours(10)),
 
                 // New York to Tokyo (New York is behind, so negative offset)
                 arguments(ZoneId.of("America/New_York"), ZoneId.of("Asia/Tokyo"), Duration.ofHours(-13), Duration.ofHours(-14)),
@@ -36,7 +36,7 @@ public class TimezoneHelperTest {
                 arguments(ZoneId.of("America/Los_Angeles"), ZoneId.of("Europe/Berlin"), Duration.ofHours(-8), Duration.ofHours(-9)),
 
                 // Auckland to Hawaii (crossing international date line)
-                arguments(ZoneId.of("Pacific/Auckland"), ZoneId.of("Pacific/Honolulu"), Duration.ofHours(23), Duration.ofHours(23))
+                arguments(ZoneId.of("Pacific/Auckland"), ZoneId.of("Pacific/Honolulu"), Duration.ofHours(23), Duration.ofHours(22))
         );
     }
 


### PR DESCRIPTION
### Description
Hours difference compared with UTC will change every 6 months when timezones start or end their Day Light Savings. To account for that delta, the comparison made as a range comparison instead of a fixed difference. Previously this range was not set for all the timezones thinking that they don't follow DST but it looks like they all do. So adjusting their assertions to be range check as well.
 

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
