### PR TITLE
Feature/xray otlp config

### DIFF
--- a/data-prepper-plugins/xray-otlp-sink/README.md
+++ b/data-prepper-plugins/xray-otlp-sink/README.md
@@ -1,0 +1,20 @@
+# X-Ray OTLP Sink
+
+The `xray_otlp_sink` plugin sends span data to [AWS X-Ray](https://docs.aws.amazon.com/xray/) using the OTLP (OpenTelemetry Protocol) format.
+
+## Usage
+
+For information on usage, see the forthcoming documentation in the [Data Prepper Sink Plugins section](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/).
+
+A sample pipeline configuration will be added once the plugin is ready for testing.
+
+## Developer Guide
+
+See the [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) guide for general information on contributions.
+
+The integration tests for this plugin do not run as part of the main Data Prepper build.
+
+To run unit tests for this plugin locally:
+
+```bash
+./gradlew :data-prepper-plugins:xray-otlp-sink:test

--- a/data-prepper-plugins/xray-otlp-sink/build.gradle
+++ b/data-prepper-plugins/xray-otlp-sink/build.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation project(':data-prepper-api')
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/data-prepper-plugins/xray-otlp-sink/build.gradle
+++ b/data-prepper-plugins/xray-otlp-sink/build.gradle
@@ -8,8 +8,11 @@ plugins {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'software.amazon.awssdk:regions'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSink.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSink.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.Sink;
+
+import java.util.Collection;
+
+/**
+ * A Data Prepper Sink plugin that forwards traces to AWS X-Ray's OTLP endpoint.
+ */
+@DataPrepperPlugin(
+        name = "otlp_xray_sink",
+        pluginType = Sink.class
+)
+public class XRayOTLPSink implements Sink<Record<String>> {
+
+    /**
+     * Constructs the OTLP X-Ray Sink.
+     * Configuration loading will be added in a later iteration.
+     */
+    public XRayOTLPSink() {
+        // TODO: Inject config or plugin setting.
+    }
+
+    /**
+     * Lifecycle hook invoked during pipeline startup.
+     * Initialize AWS clients or other resources here.
+     */
+    @Override
+    public void initialize() {
+        // TODO: Initialize AWS X-Ray client
+    }
+
+    /**
+     * Called each time a batch of records is emitted to the sink.
+     * This method is responsible for handling delivery to AWS X-Ray.
+     *
+     * @param records Collection of OTLP log records to process.
+     */
+    @Override
+    public void output(final Collection<Record<String>> records) {
+        // TODO: Process records
+    }
+
+    /**
+     * Indicates whether this sink is ready to receive data.
+     *
+     * @return true if the sink is ready
+     */
+    @Override
+    public boolean isReady() {
+        // TODO: Implement readiness logic
+        return true;
+    }
+
+    /**
+     * Hook called during pipeline shutdown.
+     */
+    @Override
+    public void shutdown() {
+        // TODO: Clean up resources
+    }
+
+    /**
+     * Updates internal latency metrics using the received records.
+     *
+     * @param events Collection of records used for latency tracking.
+     */
+    @Override
+    public void updateLatencyMetrics(final Collection<Record<String>> events) {
+        // TODO: Implement latency tracking with PluginMetrics
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSink.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSink.java
@@ -7,6 +7,9 @@ package org.opensearch.dataprepper.plugins.sink.xrayotlp;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.trace.Span;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
@@ -14,10 +17,12 @@ import java.util.Collection;
  * A Data Prepper Sink plugin that forwards traces to AWS X-Ray's OTLP endpoint.
  */
 @DataPrepperPlugin(
-        name = "otlp_xray_sink",
+        name = "xray_otlp_sink",
         pluginType = Sink.class
 )
-public class XRayOTLPSink implements Sink<Record<String>> {
+public class XRayOTLPSink implements Sink<Record<Span>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(XRayOTLPSink.class);
 
     /**
      * Constructs the OTLP X-Ray Sink.
@@ -43,8 +48,18 @@ public class XRayOTLPSink implements Sink<Record<String>> {
      * @param records Collection of OTLP log records to process.
      */
     @Override
-    public void output(final Collection<Record<String>> records) {
-        // TODO: Process records
+    public void output(final Collection<Record<Span>> records) {
+        for (Record<Span> record : records) {
+            final Span span = record.getData();
+
+            LOG.info("===> Span name: {}", span.getName());
+            LOG.info("===> Trace ID: {}", span.getTraceId());
+            LOG.info("===> Span ID: {}", span.getSpanId());
+            LOG.info("===> Parent ID: {}", span.getParentSpanId());
+            LOG.info("===> Start time (epoch nanos): {}", span.getStartTime());
+            LOG.info("===> End time (epoch nanos): {}", span.getEndTime());
+            LOG.info("===> Attributes: {}", span.getAttributes());
+        }
     }
 
     /**
@@ -72,7 +87,7 @@ public class XRayOTLPSink implements Sink<Record<String>> {
      * @param events Collection of records used for latency tracking.
      */
     @Override
-    public void updateLatencyMetrics(final Collection<Record<String>> events) {
+    public void updateLatencyMetrics(final Collection<Record<Span>> events) {
         // TODO: Implement latency tracking with PluginMetrics
     }
 }

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfig.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration.AwsAuthenticationConfiguration;
+
+/**
+ * Configuration class for the X-Ray OTLP sink plugin.
+ * This class defines the configuration options available when setting up
+ * the X-Ray OTLP sink in Data Prepper pipelines.
+ *
+ * @since 2.6
+ */
+public class XRayOTLPSinkConfig {
+    public static final String DEFAULT_AWS_REGION = "us-east-1";
+
+    /**
+     * AWS configuration for X-Ray access.
+     * Contains authentication and region settings required for AWS X-Ray service.
+     * This is a required configuration and must be valid.
+     */
+    @Getter
+    @JsonProperty("aws")
+    @NotNull
+    @Valid
+    AwsAuthenticationConfiguration awsAuthenticationConfiguration;
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/AwsAuthenticationConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import software.amazon.awssdk.regions.Region;
+
+import static org.opensearch.dataprepper.plugins.sink.xrayotlp.XRayOTLPSinkConfig.DEFAULT_AWS_REGION;
+
+/**
+ * Configuration class for AWS authentication settings.
+ * Handles region, STS role ARN, and external ID configurations required for AWS service access.
+ *
+ * @since 2.6
+ */
+public class AwsAuthenticationConfiguration {
+    /**
+     * AWS region for X-Ray service.
+     * Must be a valid AWS region identifier (e.g., us-east-1, us-west-2).
+     */
+    @JsonProperty("region")
+    @Size(min = 1, message = "Region cannot be empty string")
+    public String awsRegion = DEFAULT_AWS_REGION;
+
+    /**
+     * AWS STS Role ARN for assuming role-based access.
+     * Format: arn:aws:iam::{account}:role/{role-name}
+     * Length must be between 20 and 2048 characters.
+     */
+    @Getter
+    @JsonProperty("sts_role_arn")
+    @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
+    public String awsStsRoleArn;
+
+    /**
+     * External ID for additional security when assuming an IAM role.
+     * Required only if the trust policy requires an external ID.
+     * Length must be between 2 and 1224 characters.
+     */
+    @Getter
+    @JsonProperty("sts_external_id")
+    @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
+    public String awsStsExternalId;
+
+    /**
+     * Gets the AWS Region object corresponding to the configured region string.
+     *
+     * @return Region object if awsRegion is set, null otherwise
+     */
+    public Region getAwsRegion() {
+        return awsRegion != null ? Region.of(awsRegion) : null;
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/AwsAuthenticationConfigurationTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/AwsAuthenticationConfigurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration.AwsAuthenticationConfiguration;
+import software.amazon.awssdk.regions.Region;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AwsAuthenticationConfigurationTest {
+
+    @Test
+    void testGetRegion() {
+        final AwsAuthenticationConfiguration config = new AwsAuthenticationConfiguration();
+        config.awsRegion = "us-west-2";
+
+        assertThat(config.getAwsRegion(), notNullValue());
+        assertThat(config.getAwsRegion(), equalTo(Region.US_WEST_2));
+    }
+
+    @Test
+    void testGetStsRoleArn() {
+        final AwsAuthenticationConfiguration config = new AwsAuthenticationConfiguration();
+        final String roleArn = "arn:aws:iam::123456789012:role/MyRole";
+        config.awsStsRoleArn = roleArn;
+
+        assertThat(config.awsStsRoleArn, equalTo(roleArn));
+    }
+
+    @Test
+    void testGetStsExternalId() {
+        final AwsAuthenticationConfiguration config = new AwsAuthenticationConfiguration();
+        final String externalId = "myExternalId";
+        config.awsStsExternalId = externalId;
+
+        assertThat(config.awsStsExternalId, equalTo(externalId));
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfigTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration.AwsAuthenticationConfiguration;
+import software.amazon.awssdk.regions.Region;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class XRayOTLPSinkConfigTest {
+
+    @Test
+    void testGetAwsConfiguration() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration, notNullValue());
+        assertThat(config.awsAuthenticationConfiguration, equalTo(awsConfig));
+    }
+
+    @Test
+    void testGetAwsConfiguration_whenNull() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        assertThat(config.awsAuthenticationConfiguration, is(nullValue()));
+    }
+
+    @Test
+    void testAwsConfiguration_withRegion() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        awsConfig.awsRegion = "us-west-2";
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration.getAwsRegion(), equalTo(Region.US_WEST_2));
+    }
+
+    @Test
+    void testAwsConfiguration_withStsRole() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        awsConfig.awsStsRoleArn = "arn:aws:iam::123456789012:role/MyRole";
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration.awsStsRoleArn,
+                equalTo("arn:aws:iam::123456789012:role/MyRole"));
+    }
+
+    @Test
+    void testAwsConfiguration_withCompleteConfig() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        awsConfig.awsRegion = "us-west-2";
+        awsConfig.awsStsRoleArn = "arn:aws:iam::123456789012:role/MyRole";
+        awsConfig.awsStsExternalId = "MyExternalId";
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration.getAwsRegion(), equalTo(Region.US_WEST_2));
+        assertThat(config.awsAuthenticationConfiguration.awsStsRoleArn,
+                equalTo("arn:aws:iam::123456789012:role/MyRole"));
+        assertThat(config.awsAuthenticationConfiguration.awsStsExternalId, equalTo("MyExternalId"));
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkTest.java
@@ -5,14 +5,16 @@
 
 package org.opensearch.dataprepper.plugins.sink.xrayotlp;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.trace.Span;
 
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 class XRayOTLPSinkTest {
     private XRayOTLPSink sink;
@@ -29,7 +31,8 @@ class XRayOTLPSinkTest {
 
     @Test
     void testOutput_printsRecordData() {
-        Record<String> record = new Record<>("mock-otlp-span");
+        final Span mockSpan = mock(Span.class);
+        final Record<Span> record = new Record<>(mockSpan);
         assertDoesNotThrow(() -> sink.output(Collections.singletonList(record)));
     }
 

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class XRayOTLPSinkTest {
+    private XRayOTLPSink sink;
+
+    @BeforeEach
+    void setUp() {
+        sink = new XRayOTLPSink();
+    }
+
+    @Test
+    void testInitialize_doesNotThrow() {
+        assertDoesNotThrow(() -> sink.initialize());
+    }
+
+    @Test
+    void testOutput_printsRecordData() {
+        Record<String> record = new Record<>("mock-otlp-span");
+        assertDoesNotThrow(() -> sink.output(Collections.singletonList(record)));
+    }
+
+    @Test
+    void testIsReady_returnsTrue() {
+        assertTrue(sink.isReady());
+    }
+
+    @Test
+    void testShutdown_doesNotThrow() {
+        assertDoesNotThrow(() -> sink.shutdown());
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/resources/data-prepper-config.yaml
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/resources/data-prepper-config.yaml
@@ -1,0 +1,1 @@
+ssl: false

--- a/data-prepper-plugins/xray-otlp-sink/src/test/resources/pipelines.yaml
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/resources/pipelines.yaml
@@ -1,0 +1,13 @@
+otel_trace_source_to_xray:
+  source:
+    otel_trace_source:
+      ssl: false
+
+  sink:
+    - xray_otlp_sink:
+        region: us-west-2
+
+  buffer:
+    bounded_blocking:
+      buffer_size: 10
+      batch_size: 5

--- a/data-prepper-plugins/xray-otlp-sink/src/test/resources/sample-trace.json
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/resources/sample-trace.json
@@ -1,0 +1,28 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": { "stringValue": "test-service" }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "spanId": "bbbbbbbbbbbbbbbb",
+              "name": "test-span",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1697051838000000000",
+              "endTimeUnixNano": "1697051839000000000"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -193,4 +193,4 @@ include 'data-prepper-plugins:saas-source-plugins:source-crawler'
 include 'data-prepper-plugins:saas-source-plugins:jira-source'
 include 'data-prepper-plugins:saas-source-plugins:confluence-source'
 include 'data-prepper-plugins:saas-source-plugins:atlassian-commons'
-
+include 'data-prepper-plugins:xray-otlp-sink'


### PR DESCRIPTION
### Description
This PR introduces the following changes:

- Add XRayOTLPSinkConfig class for X-Ray OTLP sink configuration
- Add AwsAuthenticationConfiguration class for AWS-specific settings
- Add unit tests for XRayOTLPSinkConfig and AwsAuthenticationConfiguration
- Update build.gradle with necessary dependencies

These changes provide the foundation for configuring the X-Ray OTLP sink
in Data Prepper, allowing users to specify AWS region, STS role ARN,
and external ID for authentication.

The configuration follows Data Prepper's standards and includes proper
validation for required fields.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
