### PR TITLE
Rename OTEL standard template mappings index-types

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -164,7 +164,7 @@ public class IndexConfiguration {
 
         String documentIdField = builder.documentIdField;
         String documentId = builder.documentId;
-        if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW) || indexType.equals(IndexType.TRACE_ANALYTICS_RAW_OTEL)) {
+        if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW) || indexType.equals(IndexType.TRACE_ANALYTICS_RAW_PLAIN)) {
             documentId = "${spanId}";
         } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
             documentId = "${hashId}";
@@ -430,17 +430,17 @@ public class IndexConfiguration {
             InputStream s3TemplateFile = null;
             if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
-            } else if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW_OTEL)) {
+            } else if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW_PLAIN)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.RAW_STANDARD_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.LOG_ANALYTICS)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.LOGS_DEFAULT_TEMPLATE_FILE);
-            } else if (indexType.equals(IndexType.LOG_ANALYTICS_OTEL)) {
+            } else if (indexType.equals(IndexType.LOG_ANALYTICS_PLAIN)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.LOGS_STANDARD_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.METRIC_ANALYTICS)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.METRICS_DEFAULT_TEMPLATE_FILE);
-            } else if (indexType.equals(IndexType.METRIC_ANALYTICS_OTEL)) {
+            } else if (indexType.equals(IndexType.METRIC_ANALYTICS_PLAIN)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.METRICS_STANDARD_TEMPLATE_FILE);
             } else if (templateFile != null) {
                 if (templateFile.toLowerCase().startsWith(S3_PREFIX)) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -164,7 +164,7 @@ public class IndexConfiguration {
 
         String documentIdField = builder.documentIdField;
         String documentId = builder.documentId;
-        if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW) || indexType.equals(IndexType.TRACE_ANALYTICS_RAW_STANDARD)) {
+        if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW) || indexType.equals(IndexType.TRACE_ANALYTICS_RAW_OTEL)) {
             documentId = "${spanId}";
         } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
             documentId = "${hashId}";
@@ -430,17 +430,17 @@ public class IndexConfiguration {
             InputStream s3TemplateFile = null;
             if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
-            } else if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW_STANDARD)) {
+            } else if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW_OTEL)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.RAW_STANDARD_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.LOG_ANALYTICS)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.LOGS_DEFAULT_TEMPLATE_FILE);
-            } else if (indexType.equals(IndexType.LOG_ANALYTICS_STANDARD)) {
+            } else if (indexType.equals(IndexType.LOG_ANALYTICS_OTEL)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.LOGS_STANDARD_TEMPLATE_FILE);
             } else if (indexType.equals(IndexType.METRIC_ANALYTICS)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.METRICS_DEFAULT_TEMPLATE_FILE);
-            } else if (indexType.equals(IndexType.METRIC_ANALYTICS_STANDARD)) {
+            } else if (indexType.equals(IndexType.METRIC_ANALYTICS_OTEL)) {
                 templateURL = loadExistingTemplate(templateType, IndexConstants.METRICS_STANDARD_TEMPLATE_FILE);
             } else if (templateFile != null) {
                 if (templateFile.toLowerCase().startsWith(S3_PREFIX)) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
@@ -42,10 +42,10 @@ public class IndexConstants {
     // TODO: extract out version number into version enum
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_SERVICE_MAP, "otel-v1-apm-service-map");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW, "otel-v1-apm-span");
-    TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW_STANDARD, "otel-v1-apm-span");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW_OTEL, "otel-v1-apm-span");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS, "logs-otel-v1");
-    TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS_STANDARD, "logs-otel-v1");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS_OTEL, "logs-otel-v1");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS, "metrics-otel-v1");
-    TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS_STANDARD, "metrics-otel-v1");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS_OTEL, "metrics-otel-v1");
   }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConstants.java
@@ -42,10 +42,10 @@ public class IndexConstants {
     // TODO: extract out version number into version enum
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_SERVICE_MAP, "otel-v1-apm-service-map");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW, "otel-v1-apm-span");
-    TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW_OTEL, "otel-v1-apm-span");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.TRACE_ANALYTICS_RAW_PLAIN, "otel-v1-apm-span");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS, "logs-otel-v1");
-    TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS_OTEL, "logs-otel-v1");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.LOG_ANALYTICS_PLAIN, "logs-otel-v1");
     TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS, "metrics-otel-v1");
-    TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS_OTEL, "metrics-otel-v1");
+    TYPE_TO_DEFAULT_ALIAS.put(IndexType.METRIC_ANALYTICS_PLAIN, "metrics-otel-v1");
   }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
@@ -51,7 +51,7 @@ public class IndexManagerFactory {
         IndexManager indexManager;
         switch (indexType) {
             case TRACE_ANALYTICS_RAW:
-            case TRACE_ANALYTICS_RAW_OTEL:
+            case TRACE_ANALYTICS_RAW_PLAIN:
                 indexManager = new TraceAnalyticsRawIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
@@ -60,12 +60,12 @@ public class IndexManagerFactory {
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
             case LOG_ANALYTICS:
-            case LOG_ANALYTICS_OTEL:
+            case LOG_ANALYTICS_PLAIN:
                 indexManager = new LogAnalyticsIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
             case METRIC_ANALYTICS:
-            case METRIC_ANALYTICS_OTEL:
+            case METRIC_ANALYTICS_PLAIN:
                 indexManager = new MetricAnalyticsIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
@@ -51,7 +51,7 @@ public class IndexManagerFactory {
         IndexManager indexManager;
         switch (indexType) {
             case TRACE_ANALYTICS_RAW:
-            case TRACE_ANALYTICS_RAW_STANDARD:
+            case TRACE_ANALYTICS_RAW_OTEL:
                 indexManager = new TraceAnalyticsRawIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
@@ -60,12 +60,12 @@ public class IndexManagerFactory {
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
             case LOG_ANALYTICS:
-            case LOG_ANALYTICS_STANDARD:
+            case LOG_ANALYTICS_OTEL:
                 indexManager = new LogAnalyticsIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;
             case METRIC_ANALYTICS:
-            case METRIC_ANALYTICS_STANDARD:
+            case METRIC_ANALYTICS_OTEL:
                 indexManager = new MetricAnalyticsIndexManager(
                         restHighLevelClient, openSearchClient, openSearchSinkConfiguration, clusterSettingsParser, templateStrategy, indexAlias);
                 break;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -13,12 +13,12 @@ import java.util.stream.Collectors;
 
 public enum IndexType {
     TRACE_ANALYTICS_RAW("trace-analytics-raw"),
-    TRACE_ANALYTICS_RAW_STANDARD("trace-analytics-standard-raw"),
+    TRACE_ANALYTICS_RAW_OTEL("trace-analytics-otel-raw"),
     TRACE_ANALYTICS_SERVICE_MAP("trace-analytics-service-map"),
     LOG_ANALYTICS("log-analytics"),
-    LOG_ANALYTICS_STANDARD("log-analytics-standard"),
+    LOG_ANALYTICS_OTEL("log-analytics-otel"),
     METRIC_ANALYTICS("metric-analytics"),
-    METRIC_ANALYTICS_STANDARD("metric-analytics-standard"),
+    METRIC_ANALYTICS_OTEL("metric-analytics-otel"),
     CUSTOM("custom"),
     MANAGEMENT_DISABLED("management_disabled");
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -13,12 +13,12 @@ import java.util.stream.Collectors;
 
 public enum IndexType {
     TRACE_ANALYTICS_RAW("trace-analytics-raw"),
-    TRACE_ANALYTICS_RAW_OTEL("trace-analytics-otel-raw"),
+    TRACE_ANALYTICS_RAW_PLAIN("trace-analytics-plain-raw"),
     TRACE_ANALYTICS_SERVICE_MAP("trace-analytics-service-map"),
     LOG_ANALYTICS("log-analytics"),
-    LOG_ANALYTICS_OTEL("log-analytics-otel"),
+    LOG_ANALYTICS_PLAIN("log-analytics-plain"),
     METRIC_ANALYTICS("metric-analytics"),
-    METRIC_ANALYTICS_OTEL("metric-analytics-otel"),
+    METRIC_ANALYTICS_PLAIN("metric-analytics-plain"),
     CUSTOM("custom"),
     MANAGEMENT_DISABLED("management_disabled");
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
@@ -26,17 +26,17 @@ public class IndexTypeTests {
         assertEquals(Optional.of(IndexType.CUSTOM), IndexType.getByValue("custom"));
         assertEquals(Optional.of(IndexType.MANAGEMENT_DISABLED), IndexType.getByValue("management_disabled"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW), IndexType.getByValue("trace-analytics-raw"));
-        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW_OTEL), IndexType.getByValue("trace-analytics-otel-raw"));
+        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW_PLAIN), IndexType.getByValue("trace-analytics-plain-raw"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_SERVICE_MAP), IndexType.getByValue("trace-analytics-service-map"));
         assertEquals(Optional.of(IndexType.LOG_ANALYTICS), IndexType.getByValue("log-analytics"));
-        assertEquals(Optional.of(IndexType.LOG_ANALYTICS_OTEL), IndexType.getByValue("log-analytics-otel"));
+        assertEquals(Optional.of(IndexType.LOG_ANALYTICS_PLAIN), IndexType.getByValue("log-analytics-plain"));
         assertEquals(Optional.of(IndexType.METRIC_ANALYTICS), IndexType.getByValue("metric-analytics"));
-        assertEquals(Optional.of(IndexType.METRIC_ANALYTICS_OTEL), IndexType.getByValue("metric-analytics-otel"));
+        assertEquals(Optional.of(IndexType.METRIC_ANALYTICS_PLAIN), IndexType.getByValue("metric-analytics-plain"));
     }
 
     @Test
     public void getIndexTypeValues() {
-        assertEquals("[trace-analytics-raw, trace-analytics-otel-raw, trace-analytics-service-map, log-analytics, log-analytics-otel, metric-analytics, metric-analytics-otel, custom, management_disabled]", IndexType.getIndexTypeValues());
+        assertEquals("[trace-analytics-raw, trace-analytics-plain-raw, trace-analytics-service-map, log-analytics, log-analytics-plain, metric-analytics, metric-analytics-plain, custom, management_disabled]", IndexType.getIndexTypeValues());
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
@@ -26,17 +26,17 @@ public class IndexTypeTests {
         assertEquals(Optional.of(IndexType.CUSTOM), IndexType.getByValue("custom"));
         assertEquals(Optional.of(IndexType.MANAGEMENT_DISABLED), IndexType.getByValue("management_disabled"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW), IndexType.getByValue("trace-analytics-raw"));
-        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW_STANDARD), IndexType.getByValue("trace-analytics-standard-raw"));
+        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW_OTEL), IndexType.getByValue("trace-analytics-otel-raw"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_SERVICE_MAP), IndexType.getByValue("trace-analytics-service-map"));
         assertEquals(Optional.of(IndexType.LOG_ANALYTICS), IndexType.getByValue("log-analytics"));
-        assertEquals(Optional.of(IndexType.LOG_ANALYTICS_STANDARD), IndexType.getByValue("log-analytics-standard"));
+        assertEquals(Optional.of(IndexType.LOG_ANALYTICS_OTEL), IndexType.getByValue("log-analytics-otel"));
         assertEquals(Optional.of(IndexType.METRIC_ANALYTICS), IndexType.getByValue("metric-analytics"));
-        assertEquals(Optional.of(IndexType.METRIC_ANALYTICS_STANDARD), IndexType.getByValue("metric-analytics-standard"));
+        assertEquals(Optional.of(IndexType.METRIC_ANALYTICS_OTEL), IndexType.getByValue("metric-analytics-otel"));
     }
 
     @Test
     public void getIndexTypeValues() {
-        assertEquals("[trace-analytics-raw, trace-analytics-standard-raw, trace-analytics-service-map, log-analytics, log-analytics-standard, metric-analytics, metric-analytics-standard, custom, management_disabled]", IndexType.getIndexTypeValues());
+        assertEquals("[trace-analytics-raw, trace-analytics-otel-raw, trace-analytics-service-map, log-analytics, log-analytics-otel, metric-analytics, metric-analytics-otel, custom, management_disabled]", IndexType.getIndexTypeValues());
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
@@ -277,7 +277,7 @@ public class TraceAnalyticsRawIndexManagerTests {
     @Test
     void checkAndCreateIndex_NeedToCreateNewIndex_withStandardIndexManager() throws IOException {
         traceAnalyticsRawStandardIndexManager = indexManagerFactory.getIndexManager(
-                IndexType.TRACE_ANALYTICS_RAW_OTEL, openSearchClient, restHighLevelClient, openSearchSinkConfiguration, templateStrategy);
+                IndexType.TRACE_ANALYTICS_RAW_PLAIN, openSearchClient, restHighLevelClient, openSearchSinkConfiguration, templateStrategy);
 
         when(openSearchIndicesClient.existsAlias(any(ExistsAliasRequest.class))).thenReturn(new BooleanResponse(false));
         when(openSearchIndicesClient.create(any(CreateIndexRequest.class)))

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
@@ -277,7 +277,7 @@ public class TraceAnalyticsRawIndexManagerTests {
     @Test
     void checkAndCreateIndex_NeedToCreateNewIndex_withStandardIndexManager() throws IOException {
         traceAnalyticsRawStandardIndexManager = indexManagerFactory.getIndexManager(
-                IndexType.TRACE_ANALYTICS_RAW_STANDARD, openSearchClient, restHighLevelClient, openSearchSinkConfiguration, templateStrategy);
+                IndexType.TRACE_ANALYTICS_RAW_OTEL, openSearchClient, restHighLevelClient, openSearchSinkConfiguration, templateStrategy);
 
         when(openSearchIndicesClient.existsAlias(any(ExistsAliasRequest.class))).thenReturn(new BooleanResponse(false));
         when(openSearchIndicesClient.create(any(CreateIndexRequest.class)))


### PR DESCRIPTION
### Description
Rename OTEL standard logs/metrics/traces mapping template index-type
from 
`trace-analytics-standard-raw` to `trace-analytics-plain-raw`
`log-analytics-standard` to `log-analytics-plain`
`metric-analytics-standard` to `metric-analytics-plain`.

### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
