### PR TITLE
feat(expression): add subList function and standardize argument validation

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
@@ -34,7 +34,7 @@ public interface ExpressionEvaluator {
                 return (Boolean) result;
             }
             throw new ClassCastException("Unexpected expression return value of " + result);
-        } catch (ExpressionParsingException e) {
+        } catch (ExpressionParsingException | IllegalArgumentException e) {
             throw e;
         } catch (ExpressionEvaluationException e) {
             return false;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
@@ -102,6 +102,19 @@ public class ExpressionEvaluatorTest {
         assertThrows(ClassCastException.class, () -> expressionEvaluator.evaluateConditional("/status", event("{\"status\":200}")));
     }
 
+    @Test
+    public void testThrowIllegalArgumentException(){
+        expressionEvaluator = new TestExpressionEvaluator(){
+            @Override
+            public Object evaluate(final String statement, final Event event){
+                throw new IllegalArgumentException("Illegal Argument encountered");
+            }
+        };
+        assertThrows(IllegalArgumentException.class, () ->
+            expressionEvaluator.evaluateConditional("/status", event("{\"status\":200}"))
+        );
+    }
+
     private static Event event(final String data) {
         return JacksonEvent.builder().withEventType("event").withData(data).build();
     }

--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -165,7 +165,8 @@ FunctionArgs
 
 fragment
 FunctionArg
-    : JsonPointer
+    : (SUBTRACT)? Integer
+    | JsonPointer
     | String
     ;
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ContainsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ContainsExpressionFunction.java
@@ -20,13 +20,13 @@ public class ContainsExpressionFunction implements ExpressionFunction {
 
     public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
         if (args.size() != NUMBER_OF_ARGS) {
-            throw new RuntimeException("contains() takes exactly two arguments");
+            throw new IllegalArgumentException("contains() takes exactly two arguments");
         }
         String[] strArgs = new String[NUMBER_OF_ARGS];
         for (int i = 0; i < NUMBER_OF_ARGS; i++) {
             Object arg = args.get(i);
             if (!(arg instanceof String)) {
-                throw new RuntimeException(String.format("containsSubstring() takes only string type arguments. \"%s\" is not of type string", arg));
+                throw new IllegalArgumentException(String.format("containsSubstring() takes only string type arguments. \"%s\" is not of type string", arg));
             }
             String str = (String) arg;
             if (str.charAt(0) == '"') {
@@ -37,11 +37,11 @@ public class ContainsExpressionFunction implements ExpressionFunction {
                     return false;
                 }
                 if (!(obj instanceof String)) {
-                    throw new RuntimeException(String.format("containsSubstring() takes only string type arguments. \"%s\" is not of type string", obj));
+                    throw new IllegalArgumentException(String.format("containsSubstring() takes only string type arguments. \"%s\" is not of type string", obj));
                 }
                 strArgs[i] = (String)obj;
             } else {
-                throw new RuntimeException(String.format("Arguments to contains() must be a literal string or a Json Pointer. \"%s\" is not string literal or json pointer", str));
+                throw new IllegalArgumentException(String.format("Arguments to contains() must be a literal string or a Json Pointer. \"%s\" is not string literal or json pointer", str));
             }
         }
         return strArgs[0].contains(strArgs[1]);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
@@ -44,7 +44,11 @@ class GenericExpressionEvaluator implements ExpressionEvaluator {
         }
         try {
             return evaluator.evaluate(parseTree, context);
-        } catch (final Exception exception) {
+        }
+        catch (IllegalArgumentException iae) {
+            throw iae;
+        }
+        catch (final Exception exception) {
             throw new ExpressionEvaluationException("Unable to evaluate statement \"" + statement + "\"", exception);
         }
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunction.java
@@ -18,19 +18,19 @@ public class GetMetadataExpressionFunction implements ExpressionFunction {
 
     public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
         if (args.size() != 1) {
-            throw new RuntimeException("getMetadata() takes only one argument");
+            throw new IllegalArgumentException("getMetadata() takes only one argument");
         }
         Object arg = args.get(0);
         if (!(arg instanceof String)) {
-            throw new RuntimeException("getMetadata() takes only String type arguments");
+            throw new IllegalArgumentException("getMetadata() takes only String type arguments");
         }
         String argStr = ((String)arg).trim();
         if (argStr.length() == 0) {
             return null;
         }
         if (argStr.charAt(0) != '\"' || argStr.length() < 2) {
-            throw new RuntimeException("Literal string expected as argument to getMetadata()");
-        } 
+            throw new IllegalArgumentException("Literal string expected as argument to getMetadata()");
+        }
         argStr = argStr.substring(1, argStr.length()-1).trim();
         if (argStr.isEmpty()) {
             return null;

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
@@ -19,10 +19,10 @@ public class HasTagsExpressionFunction implements ExpressionFunction {
 
     public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
         if (args.size() == 0) {
-            throw new RuntimeException("hasTags() takes at least one argument");
+            throw new IllegalArgumentException("hasTags() takes at least one argument");
         }
         if(!args.stream().allMatch(a -> ((a instanceof String) && (((String)a).length() > 0) && (((String)a).charAt(0) == '"')))) {
-            throw new RuntimeException("hasTags() takes only non-empty string literal type arguments");
+            throw new IllegalArgumentException("hasTags() takes only non-empty string literal type arguments");
         }
         final List<String> tags = args.stream()
                                     .map(a -> {

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LengthExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LengthExpressionFunction.java
@@ -18,27 +18,27 @@ public class LengthExpressionFunction implements ExpressionFunction {
 
     public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
         if (args.size() != 1) {
-            throw new RuntimeException("length() takes only one argument");
+            throw new IllegalArgumentException("length() takes only one argument");
         }
         Object arg = args.get(0);
         if (!(arg instanceof String)) {
-            throw new RuntimeException("length() takes only String type arguments");
+            throw new IllegalArgumentException("length() takes only String type arguments");
         }
         String argStr = ((String)arg).trim();
         if (argStr.length() == 0) {
             return 0;
         }
         if (argStr.charAt(0) == '\"') {
-            throw new RuntimeException("Literal strings not supported as arguments to length()");
+            throw new IllegalArgumentException("Literal strings not supported as arguments to length()");
         } else {
             // argStr must be JsonPointer
             final Object value = event.get(argStr, Object.class);
             if (value == null) {
                 return null;
-            } 
-            
+            }
+
             if (!(value instanceof String)) {
-                throw new RuntimeException(argStr + " is not String type");
+                throw new IllegalArgumentException(argStr + " is not String type");
             }
             return Integer.valueOf(((String)value).length());
         }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -44,12 +44,12 @@ class ParseTreeCoercionService {
                 final int funcNameIndex = nodeStringValue.indexOf("(");
                 final String functionName = nodeStringValue.substring(0, funcNameIndex);
                 final int argsEndIndex = nodeStringValue.indexOf(")", funcNameIndex);
-                final String argsStr = nodeStringValue.substring(funcNameIndex+1, argsEndIndex);
+                final String argsStr = nodeStringValue.substring(funcNameIndex + 1, argsEndIndex);
                 // Split at commas if there's no backslash before the commas, because commas can be part of a function parameter
                 final String[] args = argsStr.split("(?<!\\\\),");
                 List<Object> argList = new ArrayList<>();
-                for (final String arg: args) {
-                    String trimmedArg = arg.trim();
+                for (final String arg : args) {
+                    final String trimmedArg = arg.trim();
                     if (trimmedArg.charAt(0) == '/') {
                         argList.add(trimmedArg);
                     } else if (trimmedArg.charAt(0) == '"') {
@@ -57,6 +57,13 @@ class ParseTreeCoercionService {
                             throw new RuntimeException("Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
                         }
                         argList.add(trimmedArg);
+                    } else if (Character.isDigit(trimmedArg.charAt(0)) || trimmedArg.charAt(0) == '-') {
+                        final Long longValue = Long.valueOf(trimmedArg);
+                        if (longValue > Integer.MAX_VALUE || longValue < Integer.MIN_VALUE) {
+                            argList.add(longValue);
+                        } else {
+                            argList.add(Integer.valueOf(trimmedArg));
+                        }
                     } else {
                         throw new RuntimeException("Unsupported type passed as function argument");
                     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeEvaluator.java
@@ -36,6 +36,8 @@ class ParseTreeEvaluator implements Evaluator<ParseTree, Event> {
             final ParseTreeEvaluatorListener listener = new ParseTreeEvaluatorListener(operatorProvider, coercionService, event);
             walker.walk(listener, parseTree);
             return listener.getResult();
+        } catch (IllegalArgumentException iae) {
+            throw iae;
         } catch (final Exception e) {
             LOG.error(e.getMessage());
             throw new ExpressionEvaluationException(e.getMessage(), e);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
@@ -23,14 +28,14 @@ public class StartsWithExpressionFunction implements ExpressionFunction {
             final Function<Object, Object> convertLiteralType) {
 
         if (args.size() != NUMBER_OF_ARGS) {
-            throw new RuntimeException("startsWith() takes exactly two arguments");
+            throw new IllegalArgumentException("startsWith() takes exactly two arguments");
         }
 
         String[] strArgs = new String[NUMBER_OF_ARGS];
         for (int i = 0; i < NUMBER_OF_ARGS; i++) {
             Object arg = args.get(i);
             if (!(arg instanceof String)) {
-                throw new RuntimeException(String.format("startsWith() takes only string type arguments. \"%s\" is not of type string", arg));
+                throw new IllegalArgumentException(String.format("startsWith() takes only string type arguments. \"%s\" is not of type string", arg));
             }
             String stringOrKey = (String) arg;
             if (stringOrKey.charAt(0) == '"') {
@@ -41,11 +46,11 @@ public class StartsWithExpressionFunction implements ExpressionFunction {
                     return false;
                 }
                 if (!(obj instanceof String)) {
-                    throw new RuntimeException(String.format("startsWith() only operates on string types. The value at \"%s\" is \"%s\" which is not a string type.", stringOrKey, obj));
+                    throw new IllegalArgumentException(String.format("startsWith() only operates on string types. The value at \"%s\" is \"%s\" which is not a string type.", stringOrKey, obj));
                 }
                 strArgs[i] = (String)obj;
             } else {
-                throw new RuntimeException(String.format("Arguments to startsWith() must be a literal string or a Json Pointer. \"%s\" is not string literal or json pointer", stringOrKey));
+                throw new IllegalArgumentException(String.format("Arguments to startsWith() must be a literal string or a Json Pointer. \"%s\" is not string literal or json pointer", stringOrKey));
             }
         }
         return strArgs[0].startsWith(strArgs[1]);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/SubListExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/SubListExpressionFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import javax.inject.Named;
+import java.util.List;
+import java.util.function.Function;
+
+@Named
+public class SubListExpressionFunction implements ExpressionFunction {
+    private static final int NUMBER_OF_ARGS = 3;
+    static final String SUB_LIST_FUNCTION_NAME = "subList";
+
+    @Override
+    public String getFunctionName() {
+        return SUB_LIST_FUNCTION_NAME;
+    }
+
+    @Override
+    public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
+        if (args.size() != NUMBER_OF_ARGS) {
+            throw new IllegalArgumentException("subList() takes exactly three arguments");
+        }
+
+        // Validate and extract JSON pointer argument
+        Object arg0 = args.get(0);
+        if (!(arg0 instanceof String)) {
+            throw new IllegalArgumentException("subList() first argument must be a JSON pointer String");
+        }
+        String jsonPointer = ((String) arg0).trim();
+        if (jsonPointer.isEmpty()) {
+            throw new IllegalArgumentException("subList() JSON pointer cannot be empty");
+        }
+        if (jsonPointer.charAt(0) != '/') {
+            throw new IllegalArgumentException("subList() expects the first argument to be a JSON pointer (starting with '/')");
+        }
+
+        // Retrieve the list from the event
+        Object listObject = event.get(jsonPointer, Object.class);
+        if (listObject == null) {
+            return null;
+        }
+        if (!(listObject instanceof List)) {
+            throw new IllegalArgumentException(jsonPointer + " is not a List type");
+        }
+        List<?> list = (List<?>) listObject;
+
+        int startIndex;
+        int endIndex;
+        try {
+            startIndex = Integer.parseInt(args.get(1).toString());
+            endIndex = Integer.parseInt(args.get(2).toString());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("subList() start and end index arguments must be integers", e);
+        }
+
+        if (startIndex < 0 || startIndex > list.size()) {
+            throw new IllegalArgumentException("subList() start index out of bounds");
+        }
+        if (endIndex == -1) {
+            endIndex = list.size();
+        }
+        if (endIndex < startIndex || endIndex > list.size()) {
+            throw new IllegalArgumentException("subList() end index out of bounds");
+        }
+
+        return list.subList(startIndex, endIndex);
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ContainsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ContainsExpressionFunctionTest.java
@@ -77,10 +77,10 @@ class ContainsExpressionFunctionTest {
     @Test
     void testInvalidContains() {
         containsExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("abcd"), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("\"abcd\"", 1234), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("\"abcd\"", "/"+testKey3), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("abcd", "/"+testKey3), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> containsExpressionFunction.evaluate(List.of("abcd"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> containsExpressionFunction.evaluate(List.of("\"abcd\"", 1234), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> containsExpressionFunction.evaluate(List.of("\"abcd\"", "/"+testKey3), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> containsExpressionFunction.evaluate(List.of("abcd", "/"+testKey3), testEvent, testFunction));
     }
 
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -272,13 +272,10 @@ class GenericExpressionEvaluator_ConditionalIT {
         return Stream.of(
                 arguments("not 5", event("{}")),
                 arguments("not null", event("{}")),
-                arguments("contains(\""+testTag2+"\")", tagEvent),
-                arguments("contains(/intField, /strField)", event("{\"intField\":1234,\"strField\":\"string\"}")),
                 arguments("/status_code >= 300", event("{\"status_code_not_present\": 200}")),
                 arguments("/status_code != null and /status_code >= 300", event("{\"status_code_not_present\": 200}")),
                 arguments("(/status_code >= 300) and (/value == 15)", event("{\"status_code2\": 200, \"value\" : 10}")),
                 arguments("/color in {\"blue\", 222.0, \"yellow\", \"green\"}", event("{\"color\": \"yellow\"}")),
-                arguments("length(\""+testString+"\") == "+testStringLength, event("{\"response\": \""+testString+"\"}")),
                 arguments("/success < /status_code", event("{\"success\": true, \"status_code\": 200}")),
                 arguments("/status_code > 3", event("{\"success\": true, \"status_code_not_present\": 200}")),
                 arguments("/success <= /status_code", event("{\"success\": true, \"status_code\": 200}")),
@@ -289,7 +286,6 @@ class GenericExpressionEvaluator_ConditionalIT {
                 arguments("/status_code < null", event("{\"success\": true, \"status_code\": 200}")),
                 arguments("/status_code <= null", event("{\"success\": true, \"status_code\": 200}")),
                 arguments("not /status_code", event("{\"status_code\": 200}")),
-                arguments("cidrContains(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
                 arguments("/status_code >= 200 and 3", event("{\"status_code\": 200}"))
         );
     }
@@ -319,6 +315,7 @@ class GenericExpressionEvaluator_ConditionalIT {
                 arguments("not/status_code", event("{\"status_code\": 200}")),
                 arguments("trueand/status_code", event("{\"status_code\": 200}")),
                 arguments("trueor/status_code", event("{\"status_code\": 200}")),
+                arguments("length(\""+testString+"\") == "+testStringLength, event("{\"response\": \""+testString+"\"}")),
                 arguments("length(\""+testString+") == "+testStringLength, event("{\"response\": \""+testString+"\"}")),
                 arguments("hasTags(10)", tagEvent),
                 arguments("hasTags("+ testTag1+")", tagEvent),
@@ -326,10 +323,12 @@ class GenericExpressionEvaluator_ConditionalIT {
                 arguments("hasTags(\""+ testTag1+"\","+testTag2+"\")", tagEvent),
                 arguments("hasTags(,\""+testTag2+"\")", tagEvent),
                 arguments("hasTags(\""+testTag2+"\",)", tagEvent),
+                arguments("contains(\""+testTag2+"\")", tagEvent),
                 arguments("contains(\""+testTag2+"\",)", tagEvent),
                 arguments("contains(1234, /strField)", event("{\"intField\":1234,\"strField\":\"string\"}")),
                 arguments("contains(str, /strField)", event("{\"intField\":1234,\"strField\":\"string\"}")),
                 arguments("contains(/strField, 1234)", event("{\"intField\":1234,\"strField\":\"string\"}")),
+                arguments("contains(/intField, /strField)", event("{\"intField\":1234,\"strField\":\"string\"}")),
                 arguments("/color in {\"blue, \"yellow\", \"green\"}", event("{\"color\": \"yellow\"}")),
                 arguments("/color in {\"blue\", yellow\", \"green\"}", event("{\"color\": \"yellow\"}")),
                 arguments("/color in {\", \"yellow\", \"green\"}", event("{\"color\": \"yellow\"}")),
@@ -344,6 +343,7 @@ class GenericExpressionEvaluator_ConditionalIT {
                 arguments("getMetadata(10)", tagEvent),
                 arguments("getMetadata("+ testMetadataKey+ ")", tagEvent),
                 arguments("getMetadata(\""+ testMetadataKey+")", tagEvent),
+                arguments("cidrContains(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
                 arguments("cidrContains(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
         );
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunctionTest.java
@@ -61,29 +61,29 @@ class GetMetadataExpressionFunctionTest {
     void testGetMetadataWithMoreArguments() {
         getMetadataExpressionFunction = createObjectUnderTest();
         String testString = RandomStringUtils.randomAlphabetic(5);
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("arg1", "arg2"), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("\"arg1\"", "\"arg2\""), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("arg1", "arg2", "arg3/arg4"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of("arg1", "arg2"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of("\"arg1\"", "\"arg2\""), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of("arg1", "arg2", "arg3/arg4"), testEvent, testFunction));
     }
 
     @Test
     void testGetMetadataWithNonStringArguments() {
         getMetadataExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of(10), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of(10), testEvent, testFunction));
     }
 
     @Test
     void testGetMetadataWithNonLiteralStringArguments() {
         getMetadataExpressionFunction = createObjectUnderTest();
         String testString = RandomStringUtils.randomAlphabetic(5);
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("testString"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of("testString"), testEvent, testFunction));
     }
 
     @Test
     void testGetMetadataWithInvalidArguments() {
         getMetadataExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of(), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("\""), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of(), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> getMetadataExpressionFunction.evaluate(List.of("\""), testEvent, testFunction));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
@@ -79,13 +79,13 @@ class HasTagsExpressionFunctionTest {
     @Test
     void testHasTagsWithZeroTags() {
         hasTagsExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> hasTagsExpressionFunction.evaluate(List.of(), testEvent, testFunction));
     }
 
     @Test
     void testHasTagsWithMissingTag() {
         hasTagsExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(""), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> hasTagsExpressionFunction.evaluate(List.of(""), testEvent, testFunction));
     }
 
     @Test
@@ -97,13 +97,13 @@ class HasTagsExpressionFunctionTest {
     @Test
     void testHasTagsWithNonStringTags() {
         hasTagsExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(30), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> hasTagsExpressionFunction.evaluate(List.of(30), testEvent, testFunction));
     }
 
     @Test
     void testHasTagsWithStringTagsWithOutQuotes() {
         hasTagsExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of("tag"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> hasTagsExpressionFunction.evaluate(List.of("tag"), testEvent, testFunction));
     }
 
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LengthExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LengthExpressionFunctionTest.java
@@ -47,26 +47,26 @@ class LengthExpressionFunctionTest {
     void testWithOneStringArgumentWithQuotes() {
         lengthExpressionFunction = createObjectUnderTest();
         String testString = RandomStringUtils.randomAlphabetic(5);
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("\"" + testString + "\""), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> lengthExpressionFunction.evaluate(List.of("\"" + testString + "\""), testEvent, testFunction));
     }
 
     @Test
     void testWithTwoArgs() {
         lengthExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("arg1", "arg2"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> lengthExpressionFunction.evaluate(List.of("arg1", "arg2"), testEvent, testFunction));
     }
-    
+
     @Test
     void testWithNonStringArgument() {
         lengthExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of(10), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> lengthExpressionFunction.evaluate(List.of(10), testEvent, testFunction));
     }
-    
+
     @Test
     void testWithInvalidArgument() {
         lengthExpressionFunction = createObjectUnderTest();
         testEvent = createTestEvent(Map.of("key", 10));
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("/key"), testEvent, testFunction));
+        assertThrows(IllegalArgumentException.class, () -> lengthExpressionFunction.evaluate(List.of("/key"), testEvent, testFunction));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunctionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.expression;
 
 import org.junit.jupiter.api.Test;
@@ -76,18 +81,18 @@ public class StartsWithExpressionFunctionTest {
     }
 
     @Test
-    void startsWith_without_2_arguments_throws_RuntimeException() {
+    void startsWith_without_2_arguments_throws_IllegalArgumentException() {
         final ExpressionFunction startsWithExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of("abcd"), testEvent, mock(Function.class)));
+        assertThrows(IllegalArgumentException.class, () -> startsWithExpressionFunction.evaluate(List.of("abcd"), testEvent, mock(Function.class)));
     }
 
     @ParameterizedTest
     @MethodSource("invalidStartsWithProvider")
-    void invalid_startsWith_arguments_throws_RuntimeException(final String firstArg, final Object secondArg, final Object value) {
+    void invalid_startsWith_arguments_throws_IllegalArgumentException(final String firstArg, final Object secondArg, final Object value) {
         final ExpressionFunction startsWithExpressionFunction = createObjectUnderTest();
         final String testKey = "test_key";
 
-        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of(firstArg, secondArg), createTestEvent(Map.of(testKey, value)), mock(Function.class)));
+        assertThrows(IllegalArgumentException.class, () -> startsWithExpressionFunction.evaluate(List.of(firstArg, secondArg), createTestEvent(Map.of(testKey, value)), mock(Function.class)));
     }
 
     private static Stream<Arguments> validStartsWithProvider() {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/SubListExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/SubListExpressionFunctionTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class SubListExpressionFunctionTest {
+    private ExpressionFunction subListExpressionFunction;
+    private Event testEvent;
+    private Function<Object, Object> testFunction;
+
+    private Event createTestEvent(final Object data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+
+    private ExpressionFunction createObjectUnderTest() {
+        return new SubListExpressionFunction();
+    }
+
+    @BeforeEach
+    void setUp() {
+        subListExpressionFunction = createObjectUnderTest();
+        testFunction = mock(Function.class);
+    }
+
+    @Test
+    void getFunctionName_returns_expected_function_name() {
+        assertThat(subListExpressionFunction.getFunctionName(), equalTo(SubListExpressionFunction.SUB_LIST_FUNCTION_NAME));
+    }
+
+    @Test
+    void testSubListValidExtraction() {
+        List<String> sampleList = List.of("one", "two", "three", "four", "five");
+        testEvent = createTestEvent(Map.of("myList", sampleList));
+        Object result = subListExpressionFunction.evaluate(List.of("/myList", 1, 5), testEvent, testFunction);
+        assertThat(result, equalTo(sampleList.subList(1, 5)));
+    }
+
+    @Test
+    void testSubListReturnsNullWhenKeyNotFound() {
+        // If the event does not contain the pointer, event.get returns null
+        testEvent = createTestEvent(Map.of("otherKey", List.of("A", "B")));
+        Object result = subListExpressionFunction.evaluate(List.of("/myList", 0, 1), testEvent, testFunction);
+        assertThat(result, equalTo(null));
+    }
+
+    @Test
+    void testSubListEndIndexAsMinusOne() {
+        List<String> sampleList = List.of("a", "b", "c", "d");
+        testEvent = createTestEvent(Map.of("listKey", sampleList));
+        Object result = subListExpressionFunction.evaluate(List.of("/listKey", 2, -1), testEvent, testFunction);
+        assertThat(result, equalTo(sampleList.subList(2, sampleList.size())));
+    }
+
+    @Test
+    void testSubListWithNonStringJsonPointerThrowsException() {
+        testEvent = createTestEvent(Map.of("myList", List.of(1, 2, 3)));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of(123, 0, 1), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() first argument must be a JSON pointer String"));
+    }
+
+    @Test
+    void testSubListWithEmptyJsonPointerThrowsException() {
+        testEvent = createTestEvent(Map.of("myList", List.of("a", "b", "c")));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("", 0, 1), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() JSON pointer cannot be empty"));
+    }
+
+    @Test
+    void testSubListWithInvalidJsonPointerFormatThrowsException() {
+        testEvent = createTestEvent(Map.of("myList", List.of("a", "b", "c")));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("myList", 0, 1), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() expects the first argument to be a JSON pointer (starting with '/')"));
+    }
+
+    @Test
+    void testSubListWithNonListEventValueThrowsException() {
+        testEvent = createTestEvent(Map.of("myList", "not a list"));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/myList", 0, 1), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("/myList is not a List type"));
+    }
+
+    @Test
+    void testSubListWithInvalidNumberOfArgumentsThrowsException() {
+        testEvent = createTestEvent(Map.of("myList", List.of(1, 2, 3)));
+        assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/myList", 0), testEvent, testFunction));
+    }
+
+    @Test
+    void testSubListWithInvalidIndexParsingThrowsException() {
+        List<Integer> sampleList = List.of(10, 20, 30);
+        testEvent = createTestEvent(Map.of("intList", sampleList));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/intList", "a", "1"), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() start and end index arguments must be integers"));
+    }
+
+    @Test
+    void testSubListWithNegativeStartIndexThrowsException() {
+        List<String> sampleList = List.of("x", "y", "z");
+        testEvent = createTestEvent(Map.of("letters", sampleList));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/letters", -1, 2), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() start index out of bounds"));
+    }
+
+    @Test
+    void testSubListWithStartIndexGreaterThanListSizeThrowsException() {
+        List<String> sampleList = List.of("x", "y", "z");
+        testEvent = createTestEvent(Map.of("letters", sampleList));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/letters", 4, 4), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() start index out of bounds"));
+    }
+
+    @Test
+    void testSubListWithEndIndexLessThanStartIndexThrowsException() {
+        List<String> sampleList = List.of("a", "b", "c", "d");
+        testEvent = createTestEvent(Map.of("myList", sampleList));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/myList", 3, 1), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() end index out of bounds"));
+    }
+
+    @Test
+    void testSubListWithEndIndexOutOfBoundsThrowsException() {
+        List<String> sampleList = List.of("a", "b", "c");
+        testEvent = createTestEvent(Map.of("myList", sampleList));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> subListExpressionFunction.evaluate(List.of("/myList", 1, 5), testEvent, testFunction));
+        assertThat(exception.getMessage(), equalTo("subList() end index out of bounds"));
+    }
+}

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -726,6 +726,29 @@ public class AddEntryProcessorTests {
         assertThat(editedRecords.get(0).getData().toMap().size(), is(1));
     }
 
+
+    @Test
+    public void testValueExpressionWithSubListFunction() {
+        String valueExpression = "subList(/list-field, 1, 3)";
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(
+                createEntry("sublist-result", null, null, null, valueExpression, false, false, null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("list-field", Arrays.asList("item0", "item1", "item2", "item3", "item4"));
+        final Record<Event> record = buildRecordWithEvent(testData);
+
+        List<String> expectedSublist = Arrays.asList("item1", "item2");
+        when(expressionEvaluator.evaluate(valueExpression, record.getData())).thenReturn(expectedSublist);
+
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.containsKey("sublist-result"), is(true));
+        assertThat(event.get("sublist-result", Object.class), equalTo(expectedSublist));
+    }
+
     private AddEntryProcessor createObjectUnderTest() {
         return new AddEntryProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }


### PR DESCRIPTION
### Description

- Introduced `SubListExpressionFunction` to support extracting a sublist from an event field.
- Modified function argument handling to accept integer types directly.
- Updated all expression functions to throw `IllegalArgumentException` for invalid arguments.
- Moved granular type-checking and argument validation responsibilities to individual functions, simplifying the parser and evaluator logic.

### Issues Resolved
Resolves #5529 
 
### Check List
- [x] New functionality includes testing.
- [] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
