### PR TITLE
Add OTel Metrics String Attributes to Index Template

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/metrics-otel-v1-index-template.json
@@ -26,6 +26,16 @@
           }
         },
         {
+          "string_resource_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "resource.attributes.*",
+            "match_mapping_type": "string"
+          }
+        },
+        {
           "long_scope_attributes": {
             "mapping": {
               "type": "long"
@@ -44,6 +54,16 @@
           }
         },
         {
+          "string_scope_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "instrumentationScope.attributes.*",
+            "match_mapping_type": "string"
+          }
+        },
+        {
           "long_attributes": {
             "mapping": {
               "type": "long"
@@ -59,6 +79,16 @@
             },
             "path_match": "attributes.*",
             "match_mapping_type": "double"
+          }
+        },
+        {
+          "string_attributes": {
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "path_match": "attributes.*",
+            "match_mapping_type": "string"
           }
         }
       ],


### PR DESCRIPTION

### Description
Introduces keyword mappings for string fields. This was the default for all fields before the latest change in #5539.
 
### Issues Resolved
Fix for regression introduced by #5539.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
