### PR TITLE
Fix a bug in converting Jira ticket updated time to milliseconds

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/models/IssueBean.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/models/IssueBean.java
@@ -17,7 +17,6 @@ import lombok.Setter;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -31,12 +30,6 @@ import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.UPD
 
 public class IssueBean {
 
-    @JsonIgnore
-    private final Pattern JiraDateTimePattern = Pattern.compile(
-            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[-+]\\d{4}$");
-    @JsonIgnore
-    private final DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-
     /**
      * Expand options that include additional issue details in the response.
      */
@@ -44,7 +37,6 @@ public class IssueBean {
     @Setter
     @JsonProperty("expand")
     private String expand = null;
-
     /**
      * The ID of the issue.
      */
@@ -52,7 +44,6 @@ public class IssueBean {
     @Setter
     @JsonProperty("id")
     private String id = null;
-
     /**
      * The URL of the issue details.
      */
@@ -60,7 +51,6 @@ public class IssueBean {
     @Setter
     @JsonProperty("self")
     private String self = null;
-
     /**
      * The key of the issue.
      */
@@ -68,27 +58,27 @@ public class IssueBean {
     @Setter
     @JsonProperty("key")
     private String key = null;
-
     @Getter
     @Setter
     @JsonProperty("renderedFields")
     private Map<String, Object> renderedFields = null;
-
     @Getter
     @Setter
     @JsonProperty("properties")
     private Map<String, Object> properties = null;
-
     @Getter
     @Setter
     @JsonProperty("names")
     private Map<String, String> names = null;
-
     @Getter
     @Setter
     @JsonProperty("fields")
     private Map<String, Object> fields = null;
-
+    @JsonIgnore
+    private final Pattern JiraDateTimePattern = Pattern.compile(
+            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[-+]\\d{4}$");
+    @JsonIgnore
+    private final DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     @JsonIgnore
     public String getProject() {
@@ -124,8 +114,7 @@ public class IssueBean {
                 .toString()).matches()) {
             String charSequence = fields.get(dateTimeFieldToPull).toString();
             OffsetDateTime offsetDateTime = OffsetDateTime.parse(charSequence, offsetDateTimeFormatter);
-            new Date(offsetDateTime.toInstant().toEpochMilli());
-            dateTimeField = offsetDateTime.toEpochSecond() * 1000;
+            dateTimeField = offsetDateTime.toInstant().toEpochMilli();
         }
         return dateTimeField;
     }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/models/IssueBean.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/models/IssueBean.java
@@ -58,22 +58,27 @@ public class IssueBean {
     @Setter
     @JsonProperty("key")
     private String key = null;
+
     @Getter
     @Setter
     @JsonProperty("renderedFields")
     private Map<String, Object> renderedFields = null;
+
     @Getter
     @Setter
     @JsonProperty("properties")
     private Map<String, Object> properties = null;
+
     @Getter
     @Setter
     @JsonProperty("names")
     private Map<String, String> names = null;
+
     @Getter
     @Setter
     @JsonProperty("fields")
     private Map<String, Object> fields = null;
+    
     @JsonIgnore
     private final Pattern JiraDateTimePattern = Pattern.compile(
             "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[-+]\\d{4}$");

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/models/IssueBeanTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/models/IssueBeanTest.java
@@ -78,8 +78,8 @@ public class IssueBeanTest {
         fieldsTestObject.put("created", "2024-07-06T21:12:23.437-0700");
         fieldsTestObject.put("updated", "2022-07-06T21:12:23.106-0700");
         issueBean.setFields(fieldsTestObject);
-        assertEquals(issueBean.getCreatedTimeMillis(), 1720325543000L);
-        assertEquals(issueBean.getUpdatedTimeMillis(), 1657167143000L);
+        assertEquals(1720325543437L, issueBean.getCreatedTimeMillis());
+        assertEquals(1657167143106L, issueBean.getUpdatedTimeMillis());
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixing the issue while converting a ticket updated datetime to milliseconds.
 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
