### PR TITLE
Updates Apache Parquet to 1.15.1 to resolve CVE-2025-30065.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -61,7 +61,7 @@ dependencyResolutionManagement {
             library('commons-io', 'commons-io', 'commons-io').version('2.15.1')
             library('commons-codec', 'commons-codec', 'commons-codec').version('1.16.0')
             library('commons-compress', 'org.apache.commons', 'commons-compress').version('1.24.0')
-            version('parquet', '1.14.1')
+            version('parquet', '1.15.1')
             library('parquet-common', 'org.apache.parquet', 'parquet-common').versionRef('parquet')
             library('parquet-avro', 'org.apache.parquet', 'parquet-avro').versionRef('parquet')
             library('parquet-column', 'org.apache.parquet', 'parquet-column').versionRef('parquet')


### PR DESCRIPTION
### Description

Updates Apache Parquet to 1.15.1.
 
### Issues Resolved

N/A

Fixes CVE-2025-30065.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
