### PR TITLE
Allow plugins to access default pipeline role via AwsCredentialsSupplier

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
@@ -28,4 +28,10 @@ public interface AwsCredentialsSupplier {
      * @return Default {@link Region}
      */
     Optional<Region> getDefaultRegion();
+
+    /**
+     * Gets the default STS role ARN if it is configured. Otherwise returns empty Optional
+     * @return Default STS role ARN as String
+     */
+    Optional<String> getDefaultStsRoleArn();
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -47,6 +47,10 @@ class CredentialsProviderFactory {
         return defaultStsConfiguration.getAwsRegion();
     }
 
+    String getDefaultStsRoleArn() {
+        return defaultStsConfiguration.getAwsStsRoleArn();
+    }
+
     AwsCredentialsProvider providerFromOptions(final AwsCredentialsOptions credentialsOptions) {
         Objects.requireNonNull(credentialsOptions);
 

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
@@ -16,7 +16,8 @@ class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     private final CredentialsProviderFactory credentialsProviderFactory;
     private final CredentialsCache credentialsCache;
 
-    DefaultAwsCredentialsSupplier(final CredentialsProviderFactory credentialsProviderFactory, final CredentialsCache credentialsCache) {
+    DefaultAwsCredentialsSupplier(final CredentialsProviderFactory credentialsProviderFactory,
+                                  final CredentialsCache credentialsCache) {
         this.credentialsProviderFactory = credentialsProviderFactory;
         this.credentialsCache = credentialsCache;
     }
@@ -29,5 +30,10 @@ class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     @Override
     public Optional<Region> getDefaultRegion() {
         return Optional.ofNullable(credentialsProviderFactory.getDefaultRegion());
+    }
+
+    @Override
+    public Optional<String> getDefaultStsRoleArn() {
+        return Optional.ofNullable(credentialsProviderFactory.getDefaultStsRoleArn());
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -116,6 +116,14 @@ class CredentialsProviderFactoryTest {
         assertThat(actualRegion, equalTo(region));
     }
 
+    @Test
+    void getDefaultStsRoleArn_returns_from_default_configuration() {
+        final String roleArn = "arn:aws:iam::123456789012:role/test-role";
+        when(defaultStsConfiguration.getAwsStsRoleArn()).thenReturn(roleArn);
+
+        assertThat(createObjectUnderTest().getDefaultStsRoleArn(), equalTo(roleArn));
+    }
+
     private static List<Region> getRegions() {
         return Region.regions();
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
@@ -88,6 +88,21 @@ class DefaultAwsCredentialsSupplierTest {
 
     }
 
+    @Test
+    void getDefaultStsRoleArn_returns_default_sts_role_arn() {
+        final String roleArn = "arn:aws:iam::123456789012:role/test-role";
+        when(credentialsProviderFactory.getDefaultStsRoleArn()).thenReturn(roleArn);
+
+        assertThat(createObjectUnderTest().getDefaultStsRoleArn(), equalTo(Optional.of(roleArn)));
+    }
+
+    @Test
+    void no_default_sts_role_arn_returns_empty_optional() {
+        when(credentialsProviderFactory.getDefaultStsRoleArn()).thenReturn(null);
+
+        assertThat(createObjectUnderTest().getDefaultStsRoleArn(), equalTo(Optional.empty()));
+    }
+
     private static List<Region> getRegions() {
         return Region.regions();
     }


### PR DESCRIPTION
### Description
This change enables plugins to access the default STS role ARN configured in
`data-prepper-config.yaml` via the `AwsCredentialsSupplier` interface.

Changes:
- Added `getDefaultStsRoleArn()` method to `AwsCredentialsSupplier` interface
- Implemented the method in `DefaultAwsCredentialsSupplier`
- Added corresponding method to `CredentialsProviderFactory`
- Added unit tests for the new functionality

This maintains a consistet pattern with how the default region is already
accessible to plugins through the same interface. 

### Issues Resolved
Resolves #4958
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
