### PR TITLE
Change log for 2.10.3

### DIFF
--- a/release/release-notes/data-prepper.change-log-2.10.3.md
+++ b/release/release-notes/data-prepper.change-log-2.10.3.md
@@ -1,0 +1,20 @@
+
+* __Generated THIRD-PARTY file for 1a778d1 (#5611)__
+
+  [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Wed, 16 Apr 2025 11:01:42 -0700
+
+  EAD -&gt; refs/heads/2.10, refs/remotes/upstream/2.10
+  Signed-off-by: GitHub &lt;noreply@github.com&gt; Co-authored-by: dlvenable
+  &lt;dlvenable@users.noreply.github.com&gt;
+
+* __Updates Apache Parquet to 1.15.1 to resolve CVE-2025-30065. (#5597) (#5599)__
+
+  [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Wed, 16 Apr 2025 10:51:54 -0700
+
+
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt;
+    (cherry picked from commit bc9127fbcfaa35eaa318b83e367de66dd1935914)
+    
+    Co-authored-by: David Venable &lt;dlv@amazon.com&gt;
+
+


### PR DESCRIPTION
### Description

Adds the change log for 2.10.3.

```
git fetch upstream
git switch 2.10
git fetch upstream --tags
git pull
git-release-notes 2.10.2..HEAD markdown > release/release-notes/data-prepper.change-log-2.10.3.md
```
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
