### PR TITLE
Removing batch_size attribute and made the Crawler extensible

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/AtlassianSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/AtlassianSourceConfig.java
@@ -21,8 +21,6 @@ import java.util.List;
 @Getter
 public abstract class AtlassianSourceConfig implements CrawlerSourceConfig {
 
-    private static final int DEFAULT_BATCH_SIZE = 50;
-
     /**
      * Jira account url
      */
@@ -35,12 +33,6 @@ public abstract class AtlassianSourceConfig implements CrawlerSourceConfig {
     @JsonProperty("authentication")
     @Valid
     protected AuthenticationConfig authenticationConfig;
-
-    /**
-     * Batch size for fetching tickets
-     */
-    @JsonProperty("batch_size")
-    protected int batchSize = DEFAULT_BATCH_SIZE;
 
 
     /**

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSource.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSource.java
@@ -24,8 +24,8 @@ import org.opensearch.dataprepper.plugins.source.atlassian.AtlassianSourceConfig
 import org.opensearch.dataprepper.plugins.source.atlassian.rest.auth.AtlassianAuthConfig;
 import org.opensearch.dataprepper.plugins.source.confluence.utils.ConfluenceConfigHelper;
 import org.opensearch.dataprepper.plugins.source.source_crawler.CrawlerApplicationContextMarker;
-import org.opensearch.dataprepper.plugins.source.source_crawler.base.Crawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSourcePlugin;
+import org.opensearch.dataprepper.plugins.source.source_crawler.base.PaginationCrawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class ConfluenceSource extends CrawlerSourcePlugin {
                             final AtlassianAuthConfig jiraOauthConfig,
                             final PluginFactory pluginFactory,
                             final AcknowledgementSetManager acknowledgementSetManager,
-                            Crawler crawler,
+                            final PaginationCrawler crawler,
                             PluginExecutorServiceProvider executorServiceProvider) {
         super(PLUGIN_NAME, pluginMetrics, confluenceSourceConfig, pluginFactory, acknowledgementSetManager, crawler, executorServiceProvider);
         log.info("Creating Confluence Source Plugin");

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
@@ -19,8 +19,6 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 @Getter
 public class ConfluenceSourceConfig extends AtlassianSourceConfig implements CrawlerSourceConfig {
 
-    private static final int DEFAULT_BATCH_SIZE = 50;
-
     /**
      * Filter Config to filter what tickets get ingested
      */

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/PageTypeConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/PageTypeConfig.java
@@ -33,8 +33,7 @@ public class PageTypeConfig {
     @AssertTrue(message = "Confluence PageType should be one of [page, blogpost, comment, attachment]")
     boolean isValidPageType() {
         return checkGivenListForValidPageTypes(include)
-                && checkGivenListForValidPageTypes(exclude)
-                && noOverlapBetweenIncludeAndExclude();
+                && checkGivenListForValidPageTypes(exclude);
     }
 
     @AssertTrue(message = "There should be no overlap between include and exclude values under PageType filter")

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceTest.java
@@ -24,7 +24,7 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.AuthenticationConfig;
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.BasicConfig;
 import org.opensearch.dataprepper.plugins.source.atlassian.rest.auth.AtlassianAuthConfig;
-import org.opensearch.dataprepper.plugins.source.source_crawler.base.Crawler;
+import org.opensearch.dataprepper.plugins.source.source_crawler.base.PaginationCrawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
 
 import java.util.concurrent.ExecutorService;
@@ -58,7 +58,7 @@ public class ConfluenceSourceTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
     @Mock
-    private Crawler crawler;
+    private PaginationCrawler crawler;
     @Mock
     private EnhancedSourceCoordinator sourceCooridinator;
     @Mock

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/PageTypeConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/configuration/PageTypeConfigTest.java
@@ -35,7 +35,7 @@ class PageTypeConfigTest {
         pageTypeConfig.exclude.add("page");
         pageTypeConfig.exclude.add("blogpost");
 
-        assertFalse(pageTypeConfig.isValidPageType());
+        assertFalse(pageTypeConfig.noOverlapBetweenIncludeAndExclude());
     }
 
     @Test

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraSource.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraSource.java
@@ -24,8 +24,8 @@ import org.opensearch.dataprepper.plugins.source.atlassian.AtlassianSourceConfig
 import org.opensearch.dataprepper.plugins.source.atlassian.rest.auth.AtlassianAuthConfig;
 import org.opensearch.dataprepper.plugins.source.jira.utils.JiraConfigHelper;
 import org.opensearch.dataprepper.plugins.source.source_crawler.CrawlerApplicationContextMarker;
-import org.opensearch.dataprepper.plugins.source.source_crawler.base.Crawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSourcePlugin;
+import org.opensearch.dataprepper.plugins.source.source_crawler.base.PaginationCrawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class JiraSource extends CrawlerSourcePlugin {
                       final AtlassianAuthConfig jiraOauthConfig,
                       final PluginFactory pluginFactory,
                       final AcknowledgementSetManager acknowledgementSetManager,
-                      Crawler crawler,
+                      final PaginationCrawler crawler,
                       PluginExecutorServiceProvider executorServiceProvider) {
         super(PLUGIN_NAME, pluginMetrics, jiraSourceConfig, pluginFactory, acknowledgementSetManager, crawler, executorServiceProvider);
         log.info("Creating Jira Source Plugin");

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraSourceConfig.java
@@ -20,8 +20,6 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 @Getter
 public class JiraSourceConfig extends AtlassianSourceConfig implements CrawlerSourceConfig {
 
-    private static final int DEFAULT_BATCH_SIZE = 50;
-
     /**
      * Filter Config to filter what tickets get ingested
      */

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraSourceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraSourceTest.java
@@ -24,7 +24,7 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.AuthenticationConfig;
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.BasicConfig;
 import org.opensearch.dataprepper.plugins.source.atlassian.rest.auth.AtlassianAuthConfig;
-import org.opensearch.dataprepper.plugins.source.source_crawler.base.Crawler;
+import org.opensearch.dataprepper.plugins.source.source_crawler.base.PaginationCrawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
 
 import java.util.concurrent.ExecutorService;
@@ -58,7 +58,7 @@ public class JiraSourceTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
     @Mock
-    private Crawler crawler;
+    private PaginationCrawler crawler;
     @Mock
     private EnhancedSourceCoordinator sourceCooridinator;
     @Mock

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/Crawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/Crawler.java
@@ -1,110 +1,22 @@
 package org.opensearch.dataprepper.plugins.source.source_crawler.base;
 
-import io.micrometer.core.instrument.Timer;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.LeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.SaasWorkerProgressState;
-import org.opensearch.dataprepper.plugins.source.source_crawler.model.ItemInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.inject.Named;
-import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
-import static org.opensearch.dataprepper.plugins.source.source_crawler.coordination.scheduler.LeaderScheduler.DEFAULT_EXTEND_LEASE_MINUTES;
+public interface Crawler {
 
-@Named
-public class Crawler {
-    private static final Logger log = LoggerFactory.getLogger(Crawler.class);
-    private final Timer crawlingTimer;
+    Instant crawl(LeaderPartition leaderPartition,
+                  EnhancedSourceCoordinator coordinator);
 
-    private final CrawlerClient client;
-
-    public Crawler(CrawlerClient client, PluginMetrics pluginMetrics) {
-        this.client = client;
-        this.crawlingTimer = pluginMetrics.timer("crawlingTime");
-    }
-
-    public Instant crawl(LeaderPartition leaderPartition,
-                         EnhancedSourceCoordinator coordinator, int batchSize) {
-        long startTime = System.currentTimeMillis();
-        Instant lastLeaderSavedInstant = Instant.now();
-        LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
-        // Leader state is always saved in UTC since the timestamps in the api response are always in UTC
-        Instant lastPollTime = leaderProgressState.getLastPollTime();
-        Iterator<ItemInfo> itemInfoIterator = client.listItems(lastPollTime);
-        Instant latestModifiedTime = lastPollTime;
-        log.info("Starting to crawl the source with lastPollTime: {}", lastPollTime);
-        do {
-            final List<ItemInfo> itemInfoList = new ArrayList<>();
-            for (int i = 0; i < batchSize && itemInfoIterator.hasNext(); i++) {
-                ItemInfo nextItem = itemInfoIterator.next();
-                if (nextItem == null) {
-                    //we don't expect null items, but just in case, we'll skip them
-                    log.info("Unexpected encounter of a null item.");
-                    continue;
-                }
-                itemInfoList.add(nextItem);
-                if (nextItem.getLastModifiedAt().isAfter(latestModifiedTime)) {
-                    latestModifiedTime = nextItem.getLastModifiedAt();
-                }
-            }
-            createPartition(itemInfoList, coordinator);
-
-            // Check point leader progress state at every minute interval.
-            Instant currentTimeInstance = Instant.now();
-            if (Duration.between(lastLeaderSavedInstant, currentTimeInstance).toMinutes() >= 1) {
-                // intermediate updates to master partition state
-                updateLeaderProgressState(leaderPartition, latestModifiedTime, coordinator);
-                lastLeaderSavedInstant = currentTimeInstance;
-            }
-
-        } while (itemInfoIterator.hasNext());
-        updateLeaderProgressState(leaderPartition, latestModifiedTime, coordinator);
-        long crawlTimeMillis = System.currentTimeMillis() - startTime;
-        log.debug("Crawling completed in {} ms", crawlTimeMillis);
-        crawlingTimer.record(crawlTimeMillis, TimeUnit.MILLISECONDS);
-        return latestModifiedTime;
-    }
-
-    public void executePartition(SaasWorkerProgressState state, Buffer<Record<Event>> buffer, AcknowledgementSet acknowledgementSet) {
-        client.executePartition(state, buffer, acknowledgementSet);
-    }
-
-    private void updateLeaderProgressState(LeaderPartition leaderPartition, Instant updatedPollTime, EnhancedSourceCoordinator coordinator) {
-        LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
-        leaderProgressState.setLastPollTime(updatedPollTime);
-        leaderPartition.setLeaderProgressState(leaderProgressState);
-        coordinator.saveProgressStateForPartition(leaderPartition, DEFAULT_EXTEND_LEASE_MINUTES);
-    }
-
-    private void createPartition(List<ItemInfo> itemInfoList, EnhancedSourceCoordinator coordinator) {
-        if (itemInfoList.isEmpty()) {
-            return;
-        }
-        ItemInfo itemInfo = itemInfoList.get(0);
-        String partitionKey = itemInfo.getPartitionKey();
-        List<String> itemIds = itemInfoList.stream().map(ItemInfo::getId).collect(Collectors.toList());
-        SaasWorkerProgressState state = new SaasWorkerProgressState();
-        state.setKeyAttributes(itemInfo.getKeyAttributes());
-        state.setItemIds(itemIds);
-        state.setExportStartTime(Instant.now());
-        state.setLoadedItems(itemInfoList.size());
-        SaasSourcePartition sourcePartition = new SaasSourcePartition(state, partitionKey);
-        coordinator.createPartition(sourcePartition);
-    }
+    void executePartition(SaasWorkerProgressState state,
+                          Buffer<Record<Event>> buffer,
+                          AcknowledgementSet acknowledgementSet);
 
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourceConfig.java
@@ -7,8 +7,6 @@ public interface CrawlerSourceConfig {
 
     int DEFAULT_NUMBER_OF_WORKERS = 1;
 
-    int getBatchSize();
-
     /**
      * Boolean to indicate if acknowledgments enabled for this source
      *

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourcePlugin.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourcePlugin.java
@@ -41,7 +41,6 @@ public abstract class CrawlerSourcePlugin implements Source<Record<Event>>, Uses
     private final CrawlerSourceConfig sourceConfig;
     private final Crawler crawler;
     private final String sourcePluginName;
-    private final int batchSize;
 
 
     public CrawlerSourcePlugin(final String sourcePluginName,
@@ -57,7 +56,6 @@ public abstract class CrawlerSourcePlugin implements Source<Record<Event>>, Uses
         this.sourceConfig = sourceConfig;
         this.pluginFactory = pluginFactory;
         this.crawler = crawler;
-        this.batchSize = sourceConfig.getBatchSize();
 
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.executorService = executorServiceProvider.get();
@@ -72,7 +70,7 @@ public abstract class CrawlerSourcePlugin implements Source<Record<Event>>, Uses
         boolean isPartitionCreated = coordinator.createPartition(new LeaderPartition());
         log.debug("Leader partition creation status: {}", isPartitionCreated);
 
-        Runnable leaderScheduler = new LeaderScheduler(coordinator, crawler, batchSize);
+        Runnable leaderScheduler = new LeaderScheduler(coordinator, crawler);
         this.executorService.submit(leaderScheduler);
         //Register worker threaders
         for (int i = 0; i < sourceConfig.DEFAULT_NUMBER_OF_WORKERS; i++) {

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
@@ -1,0 +1,111 @@
+package org.opensearch.dataprepper.plugins.source.source_crawler.base;
+
+import io.micrometer.core.instrument.Timer;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.LeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.SaasWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.model.ItemInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.opensearch.dataprepper.plugins.source.source_crawler.coordination.scheduler.LeaderScheduler.DEFAULT_EXTEND_LEASE_MINUTES;
+
+@Named
+public class PaginationCrawler implements Crawler {
+    private static final Logger log = LoggerFactory.getLogger(PaginationCrawler.class);
+    private static final int batchSize = 50;
+    private final Timer crawlingTimer;
+
+    private final CrawlerClient client;
+
+    public PaginationCrawler(CrawlerClient client, PluginMetrics pluginMetrics) {
+        this.client = client;
+        this.crawlingTimer = pluginMetrics.timer("crawlingTime");
+    }
+
+    public Instant crawl(LeaderPartition leaderPartition,
+                         EnhancedSourceCoordinator coordinator) {
+        long startTime = System.currentTimeMillis();
+        Instant lastLeaderSavedInstant = Instant.now();
+        LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
+        // Leader state is always saved in UTC since the timestamps in the api response are always in UTC
+        Instant lastPollTime = leaderProgressState.getLastPollTime();
+        Iterator<ItemInfo> itemInfoIterator = client.listItems(lastPollTime);
+        Instant latestModifiedTime = lastPollTime;
+        log.info("Starting to crawl the source with lastPollTime: {}", lastPollTime);
+        do {
+            final List<ItemInfo> itemInfoList = new ArrayList<>();
+            for (int i = 0; i < batchSize && itemInfoIterator.hasNext(); i++) {
+                ItemInfo nextItem = itemInfoIterator.next();
+                if (nextItem == null) {
+                    //we don't expect null items, but just in case, we'll skip them
+                    log.info("Unexpected encounter of a null item.");
+                    continue;
+                }
+                itemInfoList.add(nextItem);
+                if (nextItem.getLastModifiedAt().isAfter(latestModifiedTime)) {
+                    latestModifiedTime = nextItem.getLastModifiedAt();
+                }
+            }
+            createPartition(itemInfoList, coordinator);
+
+            // Check point leader progress state at every minute interval.
+            Instant currentTimeInstance = Instant.now();
+            if (Duration.between(lastLeaderSavedInstant, currentTimeInstance).toMinutes() >= 1) {
+                // intermediate updates to master partition state
+                updateLeaderProgressState(leaderPartition, latestModifiedTime, coordinator);
+                lastLeaderSavedInstant = currentTimeInstance;
+            }
+
+        } while (itemInfoIterator.hasNext());
+        updateLeaderProgressState(leaderPartition, latestModifiedTime, coordinator);
+        long crawlTimeMillis = System.currentTimeMillis() - startTime;
+        log.debug("Crawling completed in {} ms", crawlTimeMillis);
+        crawlingTimer.record(crawlTimeMillis, TimeUnit.MILLISECONDS);
+        return latestModifiedTime;
+    }
+
+    public void executePartition(SaasWorkerProgressState state, Buffer<Record<Event>> buffer, AcknowledgementSet acknowledgementSet) {
+        client.executePartition(state, buffer, acknowledgementSet);
+    }
+
+    private void updateLeaderProgressState(LeaderPartition leaderPartition, Instant updatedPollTime, EnhancedSourceCoordinator coordinator) {
+        LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
+        leaderProgressState.setLastPollTime(updatedPollTime);
+        leaderPartition.setLeaderProgressState(leaderProgressState);
+        coordinator.saveProgressStateForPartition(leaderPartition, DEFAULT_EXTEND_LEASE_MINUTES);
+    }
+
+    private void createPartition(List<ItemInfo> itemInfoList, EnhancedSourceCoordinator coordinator) {
+        if (itemInfoList.isEmpty()) {
+            return;
+        }
+        ItemInfo itemInfo = itemInfoList.get(0);
+        String partitionKey = itemInfo.getPartitionKey();
+        List<String> itemIds = itemInfoList.stream().map(ItemInfo::getId).collect(Collectors.toList());
+        SaasWorkerProgressState state = new SaasWorkerProgressState();
+        state.setKeyAttributes(itemInfo.getKeyAttributes());
+        state.setItemIds(itemIds);
+        state.setExportStartTime(Instant.now());
+        state.setLoadedItems(itemInfoList.size());
+        SaasSourcePartition sourcePartition = new SaasSourcePartition(state, partitionKey);
+        coordinator.createPartition(sourcePartition);
+    }
+
+}

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
@@ -32,15 +32,18 @@ public class PaginationCrawler implements Crawler {
     private static final Logger log = LoggerFactory.getLogger(PaginationCrawler.class);
     private static final int batchSize = 50;
     private static final String PAGINATION_WORKER_PARTITIONS_CREATED = "paginationWorkerPartitionsCreated";
+    private static final String INVALID_PAGINATION_ITEMS = "invalidPaginationItems";
     private final Timer crawlingTimer;
     private final CrawlerClient client;
     private final Counter parititionsCreatedCounter;
+    private final Counter invalidPaginationItemsCounter;
 
 
     public PaginationCrawler(CrawlerClient client, PluginMetrics pluginMetrics) {
         this.client = client;
         this.crawlingTimer = pluginMetrics.timer("crawlingTime");
         this.parititionsCreatedCounter = pluginMetrics.counter(PAGINATION_WORKER_PARTITIONS_CREATED);
+        this.invalidPaginationItemsCounter = pluginMetrics.counter(INVALID_PAGINATION_ITEMS);
 
     }
 
@@ -61,6 +64,7 @@ public class PaginationCrawler implements Crawler {
                 if (nextItem == null) {
                     //we don't expect null items, but just in case, we'll skip them
                     log.info("Unexpected encounter of a null item.");
+                    invalidPaginationItemsCounter.increment();
                     continue;
                 }
                 itemInfoList.add(nextItem);

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
@@ -1,5 +1,6 @@
 package org.opensearch.dataprepper.plugins.source.source_crawler.base;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
@@ -30,13 +31,17 @@ import static org.opensearch.dataprepper.plugins.source.source_crawler.coordinat
 public class PaginationCrawler implements Crawler {
     private static final Logger log = LoggerFactory.getLogger(PaginationCrawler.class);
     private static final int batchSize = 50;
+    private static final String PAGINATION_WORKER_PARTITIONS_CREATED = "paginationWorkerPartitionsCreated";
     private final Timer crawlingTimer;
-
     private final CrawlerClient client;
+    private final Counter parititionsCreatedCounter;
+
 
     public PaginationCrawler(CrawlerClient client, PluginMetrics pluginMetrics) {
         this.client = client;
         this.crawlingTimer = pluginMetrics.timer("crawlingTime");
+        this.parititionsCreatedCounter = pluginMetrics.counter(PAGINATION_WORKER_PARTITIONS_CREATED);
+
     }
 
     public Instant crawl(LeaderPartition leaderPartition,
@@ -106,6 +111,7 @@ public class PaginationCrawler implements Crawler {
         state.setLoadedItems(itemInfoList.size());
         SaasSourcePartition sourcePartition = new SaasSourcePartition(state, partitionKey);
         coordinator.createPartition(sourcePartition);
+        parititionsCreatedCounter.increment();
     }
 
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/LeaderScheduler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/LeaderScheduler.java
@@ -27,15 +27,12 @@ public class LeaderScheduler implements Runnable {
     private LeaderPartition leaderPartition;
     private final EnhancedSourceCoordinator coordinator;
     private final Crawler crawler;
-    private final int batchSize;
 
     public LeaderScheduler(EnhancedSourceCoordinator coordinator,
-                           Crawler crawler,
-                           int batchSize) {
+                           Crawler crawler) {
         this.coordinator = coordinator;
         this.leaseInterval = DEFAULT_LEASE_INTERVAL;
         this.crawler = crawler;
-        this.batchSize = batchSize;
     }
 
     @Override
@@ -56,7 +53,7 @@ public class LeaderScheduler implements Runnable {
                 // May want to quit this scheduler if we don't want to monitor future changes
                 if (leaderPartition != null) {
                     //Start crawling, create child partitions and also continue to update leader partition state
-                    crawler.crawl(leaderPartition, coordinator, batchSize);
+                    crawler.crawl(leaderPartition, coordinator);
                 }
 
             } catch (Exception e) {

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawlerTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawlerTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @ExtendWith(MockitoExtension.class)
-public class CrawlerTest {
+public class PaginationCrawlerTest {
     private static final int DEFAULT_BATCH_SIZE = 50;
     @Mock
     private AcknowledgementSet acknowledgementSet;


### PR DESCRIPTION
### Description
- Based on the Gameday feedback, `batch_size` parameter is confusing to expose to the user. Removed this attribute from the config and made it default constant value of 50
- Made the Crawler as an interface to provide an extensibility of implementing different crawlers. CrowdStrike saas source needs a different kind of crawling strategy. This will help them implement their own version of crawling.
 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
