### PR TITLE
ENH: iterate_on in add_entries/delete_entries

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -64,6 +64,10 @@ public class AddEntryProcessorConfig {
 
     @JsonPropertyOrder
     public static class Entry {
+        private String iterateOn;
+
+        private boolean useIterateOnContext;
+
         @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include <code>my_key</code>, " +
                 "<code>myKey</code>, and <code>object/sub_Key</code>. The key can also be a format expression, for example, <code>${/key1}</code> to " +
                 "use the value of field <code>key1</code> as the key. Exactly one of <code>key</code> or <code>metadata_key</code> is required.")
@@ -154,6 +158,14 @@ public class AddEntryProcessorConfig {
                 @Example(value = "/some_key == null", description = "Only runs the add_entries processor if the key some_key is null or does not exist.")
         })
         private String addWhen;
+
+        public String getIterateOn() {
+            return iterateOn;
+        }
+
+        public boolean isUseIterateOnContext() {
+            return useIterateOnContext;
+        }
 
         public String getKey() {
             return key;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -64,8 +64,13 @@ public class AddEntryProcessorConfig {
 
     @JsonPropertyOrder
     public static class Entry {
+        @JsonPropertyDescription(
+                "Specifies the key of the list of object to iterate over and add entry into.")
         private String iterateOn;
 
+        @JsonPropertyDescription("Specifies whether the JSON pointer in the expression" +
+                "(<a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">Expression syntax</a>) statement " +
+                "should be within the context of the iterated object specified by the iterate_on key.")
         private boolean useIterateOnContext;
 
         @JsonPropertyDescription("The key of the new entry to be added. Some examples of keys include <code>my_key</code>, " +
@@ -214,13 +219,18 @@ public class AddEntryProcessorConfig {
                      final String valueExpression,
                      final boolean overwriteIfKeyExists,
                      final boolean appendIfKeyExists,
-                     final String addWhen)
+                     final String addWhen,
+                     final String iterateOn,
+                     final boolean useIterateOnContext)
         {
             if (key != null && metadataKey != null) {
                 throw new IllegalArgumentException("Only one of the two - key and metadatakey - should be specified");
             }
             if (key == null && metadataKey == null) {
                 throw new IllegalArgumentException("At least one of the two - key and metadatakey - must be specified");
+            }
+            if (metadataKey != null && iterateOn != null) {
+                throw new IllegalArgumentException("iterate_on cannot be applied to metadata");
             }
             this.key = key;
             this.metadataKey = metadataKey;
@@ -230,6 +240,8 @@ public class AddEntryProcessorConfig {
             this.overwriteIfKeyExists = overwriteIfKeyExists;
             this.appendIfKeyExists = appendIfKeyExists;
             this.addWhen = addWhen;
+            this.iterateOn = iterateOn;
+            this.useIterateOnContext = useIterateOnContext;
         }
 
         public Entry() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -20,8 +21,10 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @DataPrepperPlugin(name = "delete_entries", pluginType = Processor.class, pluginConfigurationType = DeleteEntryProcessorConfig.class)
@@ -32,10 +35,12 @@ public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Recor
     private final String deleteWhen;
 
     private final ExpressionEvaluator expressionEvaluator;
+    private final DeleteEntryProcessorConfig deleteEntryProcessorConfig;
 
     @DataPrepperPluginConstructor
     public DeleteEntryProcessor(final PluginMetrics pluginMetrics, final DeleteEntryProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
+        this.deleteEntryProcessorConfig = config;
         this.entries = config.getWithKeys();
         this.deleteWhen = config.getDeleteWhen();
         this.expressionEvaluator = expressionEvaluator;
@@ -53,13 +58,45 @@ public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Recor
             final Event recordEvent = record.getData();
 
             try {
-                if (Objects.nonNull(deleteWhen) && !expressionEvaluator.evaluateConditional(deleteWhen, recordEvent)) {
-                    continue;
-                }
+                final String iterateOn = deleteEntryProcessorConfig.getIterateOn();
+                if (Objects.isNull(iterateOn)) {
+                    if (Objects.nonNull(deleteWhen) && !expressionEvaluator.evaluateConditional(deleteWhen, recordEvent)) {
+                        continue;
+                    }
 
 
-                for (final EventKey entry : entries) {
-                    recordEvent.delete(entry);
+                    for (final EventKey entry : entries) {
+                        recordEvent.delete(entry);
+                    }
+                } else {
+                    final boolean applyEventDeleteWhen = !deleteEntryProcessorConfig.isUseIterateOnContext() &&
+                            Objects.nonNull(deleteWhen);
+                    final boolean applyIterateDeleteWhen = deleteEntryProcessorConfig.isUseIterateOnContext() &&
+                            Objects.nonNull(deleteWhen);
+                    if (applyEventDeleteWhen && !expressionEvaluator.evaluateConditional(deleteWhen, recordEvent)) {
+                        continue;
+                    }
+                    final List<Map<String, Object>> iterateOnList = recordEvent.get(iterateOn, List.class);
+                    if (iterateOnList != null) {
+                        final List<Map<String, Object>> result = new ArrayList<>();
+                        for (final Map<String, Object> item : iterateOnList) {
+                            final Event context = JacksonEvent.builder()
+                                    .withEventMetadata(recordEvent.getMetadata())
+                                    .withData(item)
+                                    .build();
+                            if (applyIterateDeleteWhen &&
+                                    !expressionEvaluator.evaluateConditional(deleteWhen, context)) {
+                                result.add(item);
+                                continue;
+                            }
+
+                            for (final EventKey entry : entries) {
+                                context.delete(entry);
+                            }
+                            result.add(context.toMap());
+                        }
+                        recordEvent.put(iterateOn, result);
+                    }
                 }
             } catch (final Exception e) {
                 LOG.atError()

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -39,11 +39,23 @@ public class DeleteEntryProcessorConfig {
     })
     private String deleteWhen;
 
+    private String iterateOn;
+
+    private boolean useIterateOnContext;
+
     public List<EventKey> getWithKeys() {
         return withKeys;
     }
 
     public String getDeleteWhen() {
         return deleteWhen;
+    }
+
+    public String getIterateOn() {
+        return iterateOn;
+    }
+
+    public boolean isUseIterateOnContext() {
+        return useIterateOnContext;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -39,8 +39,12 @@ public class DeleteEntryProcessorConfig {
     })
     private String deleteWhen;
 
+    @JsonPropertyDescription(
+            "Specifies the key of the list of object to iterate over and delete the keys specified in with_keys.")
     private String iterateOn;
 
+    @JsonPropertyDescription("Specifies whether the JSON pointer in the expression statement " +
+            "should be within the context of the iterated object specified by the iterate_on key.")
     private boolean useIterateOnContext;
 
     public List<EventKey> getWithKeys() {

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -30,6 +30,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +53,7 @@ public class AddEntryProcessorTests {
     void invalid_add_when_throws_InvalidPluginConfigurationException() {
         final String addWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,addWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false, addWhen, null, false)));
 
         when(expressionEvaluator.isValidExpressionStatement(addWhen)).thenReturn(false);
 
@@ -60,7 +62,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -73,9 +75,151 @@ public class AddEntryProcessorTests {
     }
 
     @Test
+    public void testSingleEntryIterativeAddValue() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Collections.emptyMap());
+        final Record<Event> record = getEvent(mapList);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("newMessage", 3))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddValue_key_exists() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of("newMessage", 5));
+        final Record<Event> record = getEvent(mapList);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("newMessage", 5))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddValue_overwriteIfKeyExists() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, "message", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of("newMessage", 5));
+        final Record<Event> record = getEvent(mapList);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("newMessage", 3))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddValue_appendIfKeyExists() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, true,null, "message", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of("newMessage", 5));
+        final Record<Event> record = getEvent(mapList);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("newMessage", List.of(5, 3)))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddValueExpression() {
+        String valueExpression = "/testKey";
+        when(expressionEvaluator.evaluate(eq(valueExpression), any(Event.class))).thenAnswer(invocation -> {
+            Event eventArg = invocation.getArgument(1);
+            return eventArg.get("testKey", String.class);
+        });
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, valueExpression, false, false,null, "message", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Collections.emptyMap());
+        final Map<String, Object> data = Map.of(
+                "testKey", "testValue",
+                "message", mapList
+        );
+        final Record<Event> record = buildRecordWithEvent(data);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("newMessage", "testValue"))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddValueExpression_useIterateOnContext() {
+        String valueExpression = "/testKey";
+        when(expressionEvaluator.evaluate(eq(valueExpression), any(Event.class))).thenAnswer(invocation -> {
+            Event eventArg = invocation.getArgument(1);
+            return eventArg.get("testKey", String.class);
+        });
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, valueExpression, false, false,null, "message", true)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of("testKey", "testValue"));
+        final Map<String, Object> data = Map.of("message", mapList);
+        final Record<Event> record = buildRecordWithEvent(data);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of(
+                        "newMessage", "testValue",
+                        "testKey", "testValue"
+                ))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddFormatValue() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, TEST_FORMAT, null, false, false,null, "message", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Collections.emptyMap());
+        final Map<String, Object> data = Map.of(
+                "date", "date-value",
+                "time", "time-value",
+                "message", mapList
+        );
+        final Record<Event> record = buildRecordWithEvent(data);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("newMessage", "date-value time-value"))));
+    }
+
+    @Test
+    public void testSingleEntryIterativeAddFormatValue_useIterateOnContext() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, TEST_FORMAT, null, false, false,null, "message", true)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of(
+                "date", "date-value",
+                "time", "time-value"
+        ));
+        final Map<String, Object> data = Map.of("message", mapList);
+        final Record<Event> record = buildRecordWithEvent(data);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of(
+                        "date", "date-value",
+                        "time", "time-value",
+                        "newMessage", "date-value time-value"))));
+    }
+
+    @Test
     public void testMultiAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null),
-                createEntry("message2", null, 4, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, false),
+                createEntry("message2", null, 4, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -91,7 +235,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleNoOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -106,7 +250,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -121,8 +265,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiOverwriteMixedAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null),
-                createEntry("message", null, 4, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, null, false),
+                createEntry("message", null, 4, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -137,7 +281,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendValueToExistingSimpleField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final String currentValue = "old_message";
@@ -150,7 +294,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendValueToExistingListField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Object> listValue = new ArrayList<>();
@@ -165,7 +309,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testIntAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -179,7 +323,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBoolAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, true, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, true, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -193,7 +337,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testStringAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, "string", null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, "string", null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -207,7 +351,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testNullAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -233,7 +377,7 @@ public class AddEntryProcessorTests {
     public void testNestedAddProcessorTests() {
         TestObject obj = new TestObject();
         obj.a = "test";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, obj, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, obj, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -248,7 +392,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testArrayAddProcessorTests() {
         Object[] array = new Object[] { 1, 1.2, "string", true, null };
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, array, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, array, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -263,7 +407,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testFloatAddProcessorTests() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("newMessage", null, 1.2, null, null, false, false,null)));
+                .thenReturn(createListOfEntries(createEntry("newMessage", null, 1.2, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -278,7 +422,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testAddSingleFormatEntry() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null)));
+                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -293,8 +437,8 @@ public class AddEntryProcessorTests {
     @Test
     public void testAddMultipleFormatEntries() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null),
-                        createEntry("date-time2", null, null, ANOTHER_TEST_FORMAT, null, false, false,null)));
+                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null, null, false),
+                        createEntry("date-time2", null, null, ANOTHER_TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -311,7 +455,7 @@ public class AddEntryProcessorTests {
     public void testFormatOverwritesExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, true, false,null)));
+                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, true, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -326,7 +470,7 @@ public class AddEntryProcessorTests {
     public void testFormatNotOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, false, false,null)));
+                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -340,7 +484,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendFormatValueToExistingSimpleField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("time", null, 3, TEST_FORMAT, null, false, true,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("time", null, 3, TEST_FORMAT, null, false, true,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -353,7 +497,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendFormatValueToExistingListField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("date-time", null, 3, TEST_FORMAT, null, false, true,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("date-time", null, 3, TEST_FORMAT, null, false, true,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -371,7 +515,7 @@ public class AddEntryProcessorTests {
     public void testFormatPrecedesValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("date-time", null, "date-time-value", TEST_FORMAT, null, false, false,null)));
+                        createListOfEntries(createEntry("date-time", null, "date-time-value", TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -386,7 +530,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testFormatVariousDataTypes() {
         when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(
-                "newField", null, null, "${number-key}-${boolean-key}-${string-key}", null, false, false, null)));
+                "newField", null, null, "${number-key}-${boolean-key}-${string-key}", null, false, false, null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
@@ -398,7 +542,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBadFormatThenEntryNotAdded() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, null, BAD_TEST_FORMAT, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, null, BAD_TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -412,7 +556,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMetadataKeySetWithBadFormatThenEntryNotAdded() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null,"data-time", null, BAD_TEST_FORMAT, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null,"data-time", null, BAD_TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("date", "date-value", "time", "time-value"));
@@ -428,7 +572,7 @@ public class AddEntryProcessorTests {
     public void testKeyIsNotAdded_when_addWhen_condition_is_false() {
         final String addWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,addWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false, addWhen, null, false)));
         when(expressionEvaluator.isValidExpressionStatement(addWhen)).thenReturn(true);
 
         final AddEntryProcessor processor = createObjectUnderTest();
@@ -446,7 +590,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeyIsNotAdded_when_addWhen_condition_is_false() {
         final String addWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newMessage", 3, null, null, false, false,addWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newMessage", 3, null, null, false, false, addWhen, null, false)));
         when(expressionEvaluator.isValidExpressionStatement(addWhen)).thenReturn(true);
 
         final AddEntryProcessor processor = createObjectUnderTest();
@@ -465,9 +609,9 @@ public class AddEntryProcessorTests {
     @Test
     public void testMetadataKeySetWithDifferentDataTypes() {
         when(mockConfig.getEntries()).thenReturn(createListOfEntries(
-            createEntry(null, "newField", "newValue", null, null, false, false,null),
-            createEntry(null, "newIntField", 123, null, null, false, false,null),
-            createEntry(null, "newBooleanField", true, null, null, false, false,null)
+            createEntry(null, "newField", "newValue", null, null, false, false,null, null, false),
+            createEntry(null, "newIntField", 123, null, null, false, false,null, null, false),
+            createEntry(null, "newBooleanField", true, null, null, false, false,null, null, false)
             ));
 
         final AddEntryProcessor processor = createObjectUnderTest();
@@ -484,7 +628,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetWithFormatNotOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, false, false,null)));
+                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("date", "date-value", "time", "time-value"));
@@ -500,7 +644,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetWithFormatOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, true, false,null)));
+                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, true, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("date", "date-value", "time", "time-value"));
@@ -516,7 +660,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetAppendToExistingSimpleValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null)));
+                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final String currentValue = "time-value1";
@@ -531,7 +675,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetAppendToExistingListValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null)));
+                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Object> listValue = new ArrayList<>();
@@ -546,38 +690,38 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMetadataKeyAndKeyBothNotSetThrows() {
-        assertThrows(IllegalArgumentException.class, () -> createEntry(null, null, "newValue", null, null, false, false,null));
+        assertThrows(IllegalArgumentException.class, () -> createEntry(null, null, "newValue", null, null, false, false,null, null, false));
     }
 
     @Test
     public void testMetadataKeyAndKeyBothSetThrows() {
-        assertThrows(IllegalArgumentException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", null, null, false, false,null));
+        assertThrows(IllegalArgumentException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", null, null, false, false,null, null, false));
     }
 
     @Test
     public void testOnlyOneTypeOfValueIsSupported() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", "/newFormat", null, false, false,null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", "/newFormat", null, false, false,null, null, false));
     }
 
     @Test
     public void testOnlyOneTypeOfValueIsSupportedWithExpressionAndFormat() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, "/newFormat", "length(/message)", false, false,null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, "/newFormat", "length(/message)", false, false,null, null, false));
     }
 
     @Test
     public void testOnlyOneTypeOfValueIsSupportedWithValueAndExpressionAndFormat() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "value", "/newFormat", "length(/message)", false, false,null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "value", "/newFormat", "length(/message)", false, false,null, null, false));
     }
 
     @Test
     public void testWithAllValuesNull() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, null, null, false, false,null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, null, null, false, false,null, null, false));
     }
 
     @Test
     public void testValueExpressionWithArithmeticExpression() {
         String valueExpression = "/number-key";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, false)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         Random random = new Random();
@@ -591,7 +735,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithStringExpression() {
         String valueExpression = "/string-key";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, false)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         String randomString = UUID.randomUUID().toString();
@@ -604,7 +748,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithBooleanExpression() {
         String valueExpression = "/number-key > 5";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, false)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         when(expressionEvaluator.evaluate(valueExpression, record.getData())).thenReturn(false);
@@ -616,7 +760,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithIntegerFunctions() {
         String valueExpression = "length(/string-key)";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("length_key", null, null, null, valueExpression, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("length_key", null, null, null, valueExpression, false, false,null, null, false)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         String randomString = UUID.randomUUID().toString();
@@ -629,7 +773,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithIntegerFunctionsAndMetadataKey() {
         String valueExpression = "length(/date)";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "length_key", null, null, valueExpression, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "length_key", null, null, valueExpression, false, false,null, null, false)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("key", "value"));
         String randomString = UUID.randomUUID().toString();
@@ -642,7 +786,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithStringExpressionWithMetadataKey() {
         String valueExpression = "/date";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newkey", null, null, valueExpression, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newkey", null, null, valueExpression, false, false,null, null, false)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("key", "value"));
         String randomString = UUID.randomUUID().toString();
@@ -654,7 +798,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddSingleFieldWithDynamicKey() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("value_as_name");
@@ -668,7 +812,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddSingleFieldWithDynamicExpression() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}_${getMetadata(\"id\")}", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}_${getMetadata(\"id\")}", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("value_as_name", Map.of("id", 1));
@@ -684,8 +828,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddMultipleFieldsWithDynamicKeys() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null),
-                createEntry("${message}_2", null, 4, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, false),
+                createEntry("${message}_2", null, 4, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("value_as_name");
@@ -701,7 +845,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddFieldWithInvalidInputKeyThenNoChangeToEvent() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("value_as_name");
@@ -715,7 +859,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddFieldWithInvalidDynamicKeyThenNoChangeToEvent() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("name_with_invalid_chars|[$");
@@ -731,8 +875,19 @@ public class AddEntryProcessorTests {
     }
 
     private AddEntryProcessorConfig.Entry createEntry(
-            final String key, final String metadataKey, final Object value, final String format, final String valueExpression, final boolean overwriteIfKeyExists, final boolean appendIfKeyExists, final String addWhen) {
-        return new AddEntryProcessorConfig.Entry(key, metadataKey, value, format, valueExpression, overwriteIfKeyExists, appendIfKeyExists, addWhen);
+            final String key,
+            final String metadataKey,
+            final Object value,
+            final String format,
+            final String valueExpression,
+            final boolean overwriteIfKeyExists,
+            final boolean appendIfKeyExists,
+            final String addWhen,
+            final String iterateOn,
+            final boolean useIterateOnContext) {
+        return new AddEntryProcessorConfig.Entry(
+                key, metadataKey, value, format, valueExpression, overwriteIfKeyExists, appendIfKeyExists, addWhen,
+                iterateOn, useIterateOnContext);
     }
 
     private List<AddEntryProcessorConfig.Entry> createListOfEntries(final AddEntryProcessorConfig.Entry... entries) {


### PR DESCRIPTION
### Description
This PR adds the settings that allow iterate over list of object to add entries and delete entries as feature of mutate event processors.
 
### Issues Resolved
Resolves #2853 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
