### PR TITLE
Handle delayed sync between GSI and primary table when DDB is used as Source Coordination Store

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -131,6 +131,17 @@ public interface SourceCoordinator<T> {
 
 
     /**
+     * Should be called by the source when it is shutting down to indicate that it will no longer be able to perform work on partitions,
+     * or can be called to give up ownership of its partitions in order to pick up new ones with {@link #getNextPartition(Function)} ()}.
+     * @param partitionKey - Key used as the partition key.
+     * @param priorityTimestamp - A timestamp that will determine the order that UNASSIGNED partitions are acquired after they are given up.
+     * @param maxRetries - The number of times to retry giving up the partition before throwing an exception
+     * @throws org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException if the partition could not be given up due to some failure
+     * @since 2.12
+     */
+    void giveUpPartition(final String partitionKey, final Instant priorityTimestamp,final Integer maxRetries);
+
+    /**
      * Should be called by the source after when acknowledgments are enabled to keep ownership of the partition for acknowledgmentTimeout amount of time
      * before another instance of Data Prepper can pick it up for processing. Allows the source to acquire another partition immediately for processing
      * @param partitionKey - the partition to update for ack timeout


### PR DESCRIPTION

### Description
Adding retries and backoff to handle delayed sync between GSI and primary table when DDB is used as Source Coordination Store 

### Issues Resolved
Resolves #5468 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
