### PR TITLE
Fix cloudwatch logs sink config

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation project(path: ':data-prepper-plugins:common')
     implementation project(path: ':data-prepper-plugins:failures-common')
+    implementation libs.armeria.core
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
@@ -202,12 +202,10 @@ public class CloudWatchLogsIT {
         when(cloudWatchLogsSinkConfig.getDlq()).thenReturn(null);
         when(cloudWatchLogsSinkConfig.getLogStream()).thenReturn(logStreamName);
         when(cloudWatchLogsSinkConfig.getAwsConfig()).thenReturn(awsConfig);
-        when(cloudWatchLogsSinkConfig.getBufferType()).thenReturn(CloudWatchLogsSinkConfig.DEFAULT_BUFFER_TYPE);
+        when(cloudWatchLogsSinkConfig.getMaxRetries()).thenReturn(3);
 
         thresholdConfig = mock(ThresholdConfig.class);
-        when(thresholdConfig.getBackOffTime()).thenReturn(500L);
         when(thresholdConfig.getLogSendInterval()).thenReturn(60L);
-        when(thresholdConfig.getRetryCount()).thenReturn(10);
         when(thresholdConfig.getMaxEventSizeBytes()).thenReturn(1000L);
         when(cloudWatchLogsSinkConfig.getThresholdConfig()).thenReturn(thresholdConfig);
     }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -29,11 +29,13 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.exception.Invalid
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
+import org.opensearch.dataprepper.model.annotations.Experimental;
 
 import java.util.Collection;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+@Experimental
 @DataPrepperPlugin(name = "cloudwatch_logs", pluginType = Sink.class, pluginConfigurationType = CloudWatchLogsSinkConfig.class)
 public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
     private final CloudWatchLogsService cloudWatchLogsService;
@@ -64,9 +66,7 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
         }
 
         BufferFactory bufferFactory = null;
-        if (cloudWatchLogsSinkConfig.getBufferType().equals("in_memory")) {
-            bufferFactory = new InMemoryBufferFactory();
-        }
+        bufferFactory = new InMemoryBufferFactory();
 
         if (cloudWatchLogsSinkConfig.getDlq() != null) {
             String region = awsConfig.getAwsRegion().toString();
@@ -82,8 +82,7 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
                 .dlqPushHandler(dlqPushHandler)
                 .logGroup(cloudWatchLogsSinkConfig.getLogGroup())
                 .logStream(cloudWatchLogsSinkConfig.getLogStream())
-                .backOffTimeBase(thresholdConfig.getBackOffTime())
-                .retryCount(thresholdConfig.getRetryCount())
+                .retryCount(cloudWatchLogsSinkConfig.getMaxRetries())
                 .executor(executor)
                 .build();
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +15,7 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 
 
 public class CloudWatchLogsSinkConfig {
-    public static final String DEFAULT_BUFFER_TYPE = "in_memory";
+    public static final int DEFAULT_RETRY_COUNT = 5;
 
     @JsonProperty("aws")
     @Valid
@@ -26,9 +27,6 @@ public class CloudWatchLogsSinkConfig {
     @JsonProperty("threshold")
     private ThresholdConfig thresholdConfig = new ThresholdConfig();
 
-    @JsonProperty("buffer_type")
-    private String bufferType = DEFAULT_BUFFER_TYPE;
-
     @JsonProperty("log_group")
     @NotEmpty
     @NotNull
@@ -38,6 +36,10 @@ public class CloudWatchLogsSinkConfig {
     @NotEmpty
     @NotNull
     private String logStream;
+
+    @JsonProperty("max_retries")
+    @Size(min = 1, max = 15, message = "retry_count amount should be between 1 and 15")
+    private int maxRetries = DEFAULT_RETRY_COUNT;
 
     public AwsConfig getAwsConfig() {
         return awsConfig;
@@ -51,10 +53,6 @@ public class CloudWatchLogsSinkConfig {
         return dlq;
     }
 
-    public String getBufferType() {
-        return bufferType;
-    }
-
     public String getLogGroup() {
         return logGroup;
     }
@@ -62,4 +60,9 @@ public class CloudWatchLogsSinkConfig {
     public String getLogStream() {
         return logStream;
     }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ThresholdConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ThresholdConfig.java
@@ -12,7 +12,6 @@ import org.hibernate.validator.constraints.time.DurationMin;
 import org.opensearch.dataprepper.model.types.ByteCount;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 /**
  * The threshold config holds the different configurations for
@@ -23,9 +22,7 @@ public class ThresholdConfig {
     public static final int DEFAULT_BATCH_SIZE = 25;
     public static final String DEFAULT_EVENT_SIZE = "256kb";
     public static  final String DEFAULT_SIZE_OF_REQUEST = "1mb";
-    public static final int DEFAULT_RETRY_COUNT = 5;
     public static final long DEFAULT_LOG_SEND_INTERVAL_TIME = 60;
-    public static final long DEFAULT_BACKOFF_TIME = 500;
 
     @JsonProperty("batch_size")
     @Size(min = 1, max = 10000, message = "batch_size amount should be between 1 to 10000")
@@ -38,19 +35,10 @@ public class ThresholdConfig {
     @JsonProperty("max_request_size")
     private String maxRequestSize = DEFAULT_SIZE_OF_REQUEST;
 
-    @JsonProperty("retry_count")
-    @Size(min = 1, max = 15, message = "retry_count amount should be between 1 and 15")
-    private int retryCount = DEFAULT_RETRY_COUNT;
-
     @JsonProperty("log_send_interval")
     @DurationMin(seconds = 60)
     @DurationMax(seconds = 3600)
     private Duration logSendInterval = Duration.ofSeconds(DEFAULT_LOG_SEND_INTERVAL_TIME);
-
-    @JsonProperty("back_off_time")
-    @DurationMin(millis = 500)
-    @DurationMax(millis = 1000)
-    private Duration backOffTime = Duration.ofMillis(DEFAULT_BACKOFF_TIME);
 
     public int getBatchSize() {
         return batchSize;
@@ -64,15 +52,8 @@ public class ThresholdConfig {
         return ByteCount.parse(maxRequestSize).getBytes();
     }
 
-    public int getRetryCount() {
-        return retryCount;
-    }
-
     public long getLogSendInterval() {
         return logSendInterval.getSeconds();
     }
 
-    public long getBackOffTime() {
-        return (backOffTime.get(ChronoUnit.NANOS) / 1000000) + (backOffTime.getSeconds() * 1000);
-    }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -67,7 +67,6 @@ class CloudWatchLogsSinkTest {
         when(mockCloudWatchLogsSinkConfig.getThresholdConfig()).thenReturn(thresholdConfig);
         when(mockCloudWatchLogsSinkConfig.getLogGroup()).thenReturn(TEST_LOG_GROUP);
         when(mockCloudWatchLogsSinkConfig.getLogStream()).thenReturn(TEST_LOG_STREAM);
-        when(mockCloudWatchLogsSinkConfig.getBufferType()).thenReturn(TEST_BUFFER_TYPE);
 
         when(mockPluginSetting.getName()).thenReturn(TEST_PLUGIN_NAME);
         when(mockPluginSetting.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -27,6 +27,7 @@ class CloudWatchLogsDispatcherTest {
     private  CloudWatchLogsClient mockCloudWatchLogsClient;
     private CloudWatchLogsMetrics mockCloudWatchLogsMetrics;
     private Executor mockExecutor;
+    private static final int RETRY_COUNT = 5;
     private static final String LOG_GROUP = "testGroup";
     private static final String LOG_STREAM = "testStream";
     private static final String TEST_STRING = "testMessage";
@@ -66,8 +67,7 @@ class CloudWatchLogsDispatcherTest {
                 .executor(mockExecutor)
                 .logGroup(LOG_GROUP)
                 .logStream(LOG_STREAM)
-                .retryCount(ThresholdConfig.DEFAULT_RETRY_COUNT)
-                .backOffTimeBase(ThresholdConfig.DEFAULT_BACKOFF_TIME)
+                .retryCount(RETRY_COUNT)
                 .build();
     }
 

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/UploaderTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/UploaderTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class UploaderTest {
+    private static final int RETRY_COUNT = 5;
     private CloudWatchLogsClient mockCloudWatchLogsClient;
     private CloudWatchLogsMetrics mockCloudWatchLogsMetrics;
 
@@ -50,8 +51,7 @@ class UploaderTest {
                 .putLogEventsRequest(getMockPutLogEventsRequest())
                 .eventHandles(getTestEventHandles())
                 .totalEventCount(ThresholdConfig.DEFAULT_BATCH_SIZE)
-                .retryCount(ThresholdConfig.DEFAULT_RETRY_COUNT)
-                .backOffTimeBase(ThresholdConfig.DEFAULT_BACKOFF_TIME)
+                .retryCount(RETRY_COUNT)
                 .build();
     }
 
@@ -78,7 +78,7 @@ class UploaderTest {
         CloudWatchLogsDispatcher.Uploader testUploader = getUploader();
         testUploader.run();
 
-        verify(mockCloudWatchLogsMetrics, times(ThresholdConfig.DEFAULT_RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
         verify(mockCloudWatchLogsMetrics, atLeastOnce()).increaseLogEventFailCounter(ThresholdConfig.DEFAULT_BATCH_SIZE);
     }
 
@@ -88,7 +88,7 @@ class UploaderTest {
         CloudWatchLogsDispatcher.Uploader testUploader = getUploader();
         testUploader.run();
 
-        verify(mockCloudWatchLogsMetrics, times(ThresholdConfig.DEFAULT_RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
         verify(mockCloudWatchLogsMetrics, atLeastOnce()).increaseLogEventFailCounter(ThresholdConfig.DEFAULT_BATCH_SIZE);
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
@@ -38,11 +38,6 @@ class CloudWatchLogsSinkConfigTest {
     }
 
     @Test
-    void GIVEN_new_sink_config_WHEN_get_buffer_type_called_SHOULD_return_default_buffer_type() {
-        assertThat(new CloudWatchLogsSinkConfig().getBufferType(), equalTo(CloudWatchLogsSinkConfig.DEFAULT_BUFFER_TYPE));
-    }
-
-    @Test
     void GIVEN_new_sink_config_WHEN_get_log_group_called_SHOULD_return_null() {
         assertThat(new CloudWatchLogsSinkConfig().getLogGroup(), equalTo(null));
     }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ThresholdConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ThresholdConfigTest.java
@@ -31,8 +31,6 @@ class ThresholdConfigTest {
     void GIVEN_new_threshold_config_SHOULD_return_valid_default_values() {
         final ThresholdConfig thresholdConfig = new ThresholdConfig();
 
-        assertThat(thresholdConfig.getBackOffTime(), equalTo(ThresholdConfig.DEFAULT_BACKOFF_TIME));
-        assertThat(thresholdConfig.getRetryCount(), equalTo(ThresholdConfig.DEFAULT_RETRY_COUNT));
         assertThat(thresholdConfig.getBatchSize(), equalTo(ThresholdConfig.DEFAULT_BATCH_SIZE));
         assertThat(thresholdConfig.getMaxEventSizeBytes(), equalTo(ByteCount.parse(ThresholdConfig.DEFAULT_EVENT_SIZE).getBytes()));
         assertThat(thresholdConfig.getMaxRequestSizeBytes(), equalTo(ByteCount.parse(ThresholdConfig.DEFAULT_SIZE_OF_REQUEST).getBytes()));
@@ -64,14 +62,6 @@ class ThresholdConfigTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 10, 15})
-    void GIVEN_deserialized_threshold_config_SHOULD_return_valid_max_retry_count(final int retry_count) {
-        final Map<String, Integer> jsonMap = Map.of("retry_count", retry_count);
-        final ThresholdConfig thresholdConfigTest = objectMapper.convertValue(jsonMap, ThresholdConfig.class);
-        assertThat(thresholdConfigTest.getRetryCount(), equalTo(retry_count));
-    }
-
-    @ParameterizedTest
     @ValueSource(ints = {5, 10, 300})
     void GIVEN_deserialized_threshold_config_SHOULD_return_valid_max_log_send_interval(final int log_send_interval) throws NoSuchFieldException, IllegalAccessException {
         ThresholdConfig sampleThresholdConfig = new ThresholdConfig();
@@ -79,11 +69,4 @@ class ThresholdConfigTest {
         assertThat(sampleThresholdConfig.getLogSendInterval(), equalTo(Duration.ofSeconds(log_send_interval).getSeconds())) ;
     }
 
-    @ParameterizedTest
-    @ValueSource(longs = {0, 500, 1000})
-    void GIVEN_deserialized_threshold_config_SHOULD_return_valid_back_off_time(final long back_off_time) throws NoSuchFieldException, IllegalAccessException {
-        ThresholdConfig sampleThresholdConfig = new ThresholdConfig();
-        ReflectivelySetField.setField(sampleThresholdConfig.getClass(), sampleThresholdConfig, "backOffTime", Duration.ofMillis(back_off_time));
-        assertThat(sampleThresholdConfig.getBackOffTime(), equalTo(back_off_time));
-    }
 }


### PR DESCRIPTION
### Description
Fix cloudwatch logs sink config
Removed `backoff_time`
Moved `retry_count` to top level and renamed it `max_retries`
Removed `buffer_type`
Added `Experimental` tag
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
