### PR TITLE
Fix shutdown and failover handling in RDS source plugin

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/MySqlSchemaManager.java
@@ -156,6 +156,7 @@ public class MySqlSchemaManager implements SchemaManager {
         while (retry <= NUM_OF_RETRIES) {
             try (final Connection connection = connectionManager.getConnection()) {
                 final String mySqlVersion = connection.getMetaData().getDatabaseProductVersion();
+                LOG.info("MySQL version: {}", mySqlVersion);
                 final Statement statement = connection.createStatement();
                 final ResultSet rs = VersionUtil.compareVersions(mySqlVersion, MYSQL_VERSION_8_4) >= 0 ?
                         statement.executeQuery(NEW_BINLOG_STATUS_QUERY) :

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientLifecycleListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientLifecycleListener.java
@@ -35,6 +35,5 @@ public class BinlogClientLifecycleListener implements BinaryLogClient.LifecycleL
     @Override
     public void onDisconnect(BinaryLogClient binaryLogClient) {
         LOG.info("Binlog client disconnected.");
-
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientLifecycleListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientLifecycleListener.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.stream;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BinlogClientLifecycleListener implements BinaryLogClient.LifecycleListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BinlogClientLifecycleListener.class);
+
+    @Override
+    public void onConnect(BinaryLogClient binaryLogClient) {
+        LOG.info("Binlog client connected.");
+    }
+
+    @Override
+    public void onCommunicationFailure(BinaryLogClient binaryLogClient, Exception e) {
+        LOG.error("Binlog client communication failure.", e);
+    }
+
+    @Override
+    public void onEventDeserializationFailure(BinaryLogClient binaryLogClient, Exception e) {
+        LOG.error("Binlog client event deserialization failure.", e);
+    }
+
+    @Override
+    public void onDisconnect(BinaryLogClient binaryLogClient) {
+        LOG.info("Binlog client disconnected.");
+
+    }
+}

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientWrapper.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientWrapper.java
@@ -33,8 +33,6 @@ public class BinlogClientWrapper implements ReplicationLogClient {
 
     @Override
     public void disconnect() throws IOException {
-        binlogClient.disconnect();
-
         List<BinaryLogClient.EventListener> eventListenerList = binlogClient.getEventListeners();
         if (!eventListenerList.isEmpty()) {
             for (BinaryLogClient.EventListener eventListener : eventListenerList) {
@@ -49,6 +47,8 @@ public class BinlogClientWrapper implements ReplicationLogClient {
 
         LOG.debug("Unregistering binlog client lifecycle listeners.");
         binlogClient.getLifecycleListeners().forEach(binlogClient::unregisterLifecycleListener);
+
+        binlogClient.disconnect();
     }
 
     public BinaryLogClient getBinlogClient() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientWrapper.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogClientWrapper.java
@@ -11,11 +11,15 @@
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 
 public class BinlogClientWrapper implements ReplicationLogClient {
 
+    private static final Logger LOG = LoggerFactory.getLogger(BinlogClientWrapper.class);
     private final BinaryLogClient binlogClient;
 
     public BinlogClientWrapper(final BinaryLogClient binlogClient) {
@@ -30,6 +34,21 @@ public class BinlogClientWrapper implements ReplicationLogClient {
     @Override
     public void disconnect() throws IOException {
         binlogClient.disconnect();
+
+        List<BinaryLogClient.EventListener> eventListenerList = binlogClient.getEventListeners();
+        if (!eventListenerList.isEmpty()) {
+            for (BinaryLogClient.EventListener eventListener : eventListenerList) {
+                if (eventListener instanceof BinlogEventListener) {
+                    LOG.debug("Stopping checkpoint manager.");
+                    ((BinlogEventListener) eventListener).stopCheckpointManager();
+                }
+                LOG.debug("Unregistering binlog event listeners.");
+                binlogClient.unregisterEventListener(eventListener);
+            }
+        }
+
+        LOG.debug("Unregistering binlog client lifecycle listeners.");
+        binlogClient.getLifecycleListeners().forEach(binlogClient::unregisterLifecycleListener);
     }
 
     public BinaryLogClient getBinlogClient() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -201,6 +201,10 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         }
     }
 
+    public void stopCheckpointManager() {
+        streamCheckpointManager.stop();
+    }
+
     void handleRotateEvent(com.github.shyiko.mysql.binlog.event.Event event) {
         final RotateEventData data = event.getData();
         currentBinlogCoordinate = new BinlogCoordinate(data.getBinlogFilename(), data.getBinlogPosition());

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationClient.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationClient.java
@@ -84,7 +84,7 @@ public class LogicalReplicationClient implements ReplicationLogClient {
                         stream.setFlushedLSN(lsn);
                         stream.setAppliedLSN(lsn);
                     } catch (Exception e) {
-                        LOG.error("Exception while processing Postgres replication stream. ", e);
+                        LOG.error("Exception while processing Postgres replication stream. ");
                         closeStream();
                         throw e;
                     }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 
 public class StreamWorker {
     private static final Logger LOG = LoggerFactory.getLogger(StreamWorker.class);
@@ -64,12 +63,14 @@ public class StreamWorker {
             LOG.info("Connect to database to read change events.");
             replicationLogClient.connect();
         } catch (Exception e) {
-            LOG.warn(NOISY, "Error while connecting to replication stream, will retry.", e);
+            LOG.warn("Error while connecting to replication stream, will retry.");
+            LOG.debug("Give up stream partition and shut down stream worker");
             sourceCoordinator.giveUpPartition(streamPartition);
-            throw new RuntimeException(e);
-        } finally {
             shutdown();
+            throw new RuntimeException(e);
         }
+
+        LOG.debug("Exited connect() method in stream worker.");
     }
 
     public void shutdown() {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -114,6 +114,7 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
     }
 
     public void shutdown() {
+        streamWorker.shutdown();
         executorService.shutdownNow();
     }
 
@@ -127,6 +128,7 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
             binaryLogClient.registerEventListener(BinlogEventListener.create(
                     streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
                     streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadeActionDetector));
+            binaryLogClient.registerLifecycleListener(new BinlogClientLifecycleListener());
         } else {
             final LogicalReplicationClient logicalReplicationClient = (LogicalReplicationClient) replicationLogClient;
             logicalReplicationClient.setEventProcessor(LogicalReplicationEventProcessor.create(

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -114,7 +114,10 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
     }
 
     public void shutdown() {
-        streamWorker.shutdown();
+        if (streamWorker != null) {
+            streamWorker.shutdown();
+        }
+        LOG.info("Stream worker stopped.");
         executorService.shutdownNow();
     }
 


### PR DESCRIPTION
### Description
- Fixes source plugin shutdown by adding missed resource cleanup code in a few places
- Fixes Aurora failover handing by not shutting down stream worker on disconnect. Rather, let the client to restore connection by itself (in MySQL case) or let it throw exception and cause stream partition to be re-acquired (in Postgres case)
- Adds more logging for information and for troubleshooting
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
