### PR TITLE
Allowing disabling metrics

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/config/DisableMetricsFilter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/config/DisableMetricsFilter.java
@@ -1,0 +1,36 @@
+package org.opensearch.dataprepper.core.parser.config;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.AntPathMatcher;
+import static org.opensearch.dataprepper.metrics.MetricNames.DELIMITER;
+
+
+import java.util.Collections;
+import java.util.List;
+
+public class DisableMetricsFilter implements MeterFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(DisableMetricsFilter.class);
+    private final List<String> disabledPatterns;
+    private static final AntPathMatcher matcher = new AntPathMatcher(DELIMITER);
+
+    public DisableMetricsFilter(final List<String> disabledPatterns) {
+        this.disabledPatterns = disabledPatterns != null ? disabledPatterns : Collections.emptyList();
+    }
+
+    @Override
+    public MeterFilterReply accept(final Meter.Id id) {
+        final String metricName = id.getName();
+
+        for (final String pattern : disabledPatterns) {
+            if (matcher.match(pattern, metricName)) {
+                return MeterFilterReply.DENY;
+            }
+        }
+        return MeterFilterReply.NEUTRAL;
+    }
+
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
@@ -54,6 +54,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
     private EventConfiguration eventConfiguration;
     private Map<String, String> metricTags = new HashMap<>();
     private List<MetricTagFilter> metricTagFilters = new LinkedList<>();
+    private List<String> disabledMetrics = new LinkedList<>();
     private PeerForwarderConfiguration peerForwarderConfiguration;
     private Duration processorShutdownTimeout;
     private Duration sinkShutdownTimeout;
@@ -88,6 +89,9 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
             final Map<String, String> metricTags,
             @JsonProperty("metric_tag_filters")
             final List<MetricTagFilter> metricTagFilters,
+            @JsonProperty("disabled_metrics")
+            @JsonAlias("disabledMetrics")
+            final List<String> disabledMetrics,
             @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration,
             @JsonProperty("processor_shutdown_timeout")
             @JsonAlias("processorShutdownTimeout")
@@ -120,6 +124,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
         setMetricTagFilters(metricTagFilters);
         setServerPort(serverPort);
         this.peerForwarderConfiguration = peerForwarderConfiguration;
+        this.disabledMetrics = disabledMetrics;
 
         this.processorShutdownTimeout = processorShutdownTimeout != null ? processorShutdownTimeout : DEFAULT_SHUTDOWN_DURATION;
         if (this.processorShutdownTimeout.isNegative()) {
@@ -166,6 +171,11 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
     public List<MetricTagFilter> getMetricTagFilters() {
         return metricTagFilters;
     }
+
+    public List<String> getDisabledMetrics() {
+        return disabledMetrics != null ? disabledMetrics : Collections.emptyList();
+    }
+
 
     private void setSsl(final Boolean ssl) {
         if (ssl != null) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/config/MetricsConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/config/MetricsConfigTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -156,6 +157,26 @@ class MetricsConfigTest {
     }
 
     @Test
+    public void testGivenDisabledMetricsThenDisabledMetricsFilterDeniesMatchingMetric() {
+        final DataPrepperConfiguration config = mock(DataPrepperConfiguration.class);
+
+        when(config.getMetricRegistryTypes())
+                .thenReturn(Collections.singletonList(MetricRegistryType.Prometheus));
+        when(config.getMetricTags()).thenReturn(Collections.emptyMap());
+        when(config.getMetricTagFilters()).thenReturn(Collections.emptyList());
+        when(config.getDisabledMetrics()).thenReturn(List.of("test.metric.blocked"));
+
+        final MeterRegistry registry = metricsConfig.prometheusMeterRegistry(config);
+        final Counter blockedCounter = registry.counter("test.metric.blocked");
+        final Counter allowedCounter = registry.counter("test.metric.allowed");
+
+        assertThat(blockedCounter.count(), equalTo(0.0)); // Not incremented
+        allowedCounter.increment();
+        assertThat(allowedCounter.count(), equalTo(1.0)); // Should increment fine
+    }
+
+
+    @Test
     public void testGivenConfigWithCloudWatchMeterRegistryThenNoMeterRegistryCreated() {
         final CloudWatchMeterRegistryProvider provider = mock(CloudWatchMeterRegistryProvider.class);
         final CloudWatchMeterRegistry expected = mock(CloudWatchMeterRegistry.class);
@@ -231,30 +252,44 @@ class MetricsConfigTest {
         final MeterBinder binder = mock(MeterBinder.class);
         final List<MeterBinder> meterBinders = Collections.nCopies(copies, binder);
 
-        final MeterRegistry meterRegistryMock = mock(MeterRegistry.class);
-        final List<MeterRegistry> meterRegistries = Collections.nCopies(1, meterRegistryMock);
+        final MeterRegistry realRegistry = new SimpleMeterRegistry();
+        final List<MeterRegistry> meterRegistries = Collections.singletonList(realRegistry);
+
+        final DataPrepperConfiguration config = mock(DataPrepperConfiguration.class);
+        when(config.getMetricTags()).thenReturn(Collections.emptyMap());
+        when(config.getMetricTagFilters()).thenReturn(Collections.emptyList());
+        when(config.getDisabledMetrics()).thenReturn(Collections.emptyList());
 
         final CompositeMeterRegistry meterRegistry = metricsConfig.systemMeterRegistry(
                 meterBinders,
-                meterRegistries);
+                meterRegistries,
+                config);
 
         assertThat(meterRegistry, isA(CompositeMeterRegistry.class));
         verify(binder, times(copies)).bindTo(any(MeterRegistry.class));
     }
 
+
     @Test
     public void testGivenEmptyListOfMeterBindersWhenSystemMeterRegistryThenNoMeterBindersRegistered() {
         final List<MeterBinder> meterBinders = Collections.emptyList();
 
-        final MeterRegistry meterRegistryMock = mock(MeterRegistry.class);
+        final MeterRegistry meterRegistryMock = new SimpleMeterRegistry();
         final List<MeterRegistry> meterRegistries = Collections.nCopies(1, meterRegistryMock);
+
+        final DataPrepperConfiguration config = mock(DataPrepperConfiguration.class);
+        when(config.getMetricTags()).thenReturn(Collections.emptyMap());
+        when(config.getMetricTagFilters()).thenReturn(Collections.emptyList());
+        when(config.getDisabledMetrics()).thenReturn(Collections.emptyList());
 
         final CompositeMeterRegistry meterRegistry = metricsConfig.systemMeterRegistry(
                 meterBinders,
-                meterRegistries);
+                meterRegistries,
+                config);
 
         assertThat(meterRegistry, isA(CompositeMeterRegistry.class));
     }
+
 
     private static Stream<Arguments> provideMetricRegistryTypesAndCreators() {
         return Stream.of(

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/config/MetricsConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/config/MetricsConfigTest.java
@@ -170,11 +170,10 @@ class MetricsConfigTest {
         final Counter blockedCounter = registry.counter("test.metric.blocked");
         final Counter allowedCounter = registry.counter("test.metric.allowed");
 
-        assertThat(blockedCounter.count(), equalTo(0.0)); // Not incremented
+        assertThat(blockedCounter.count(), equalTo(0.0));
         allowedCounter.increment();
-        assertThat(allowedCounter.count(), equalTo(1.0)); // Should increment fine
+        assertThat(allowedCounter.count(), equalTo(1.0));
     }
-
 
     @Test
     public void testGivenConfigWithCloudWatchMeterRegistryThenNoMeterRegistryCreated() {


### PR DESCRIPTION
### Description
This PR introduces the ability to disable specific metrics via the `data-prepper-config.yaml` configuration file.
To use this feature, add a new section to your configuration:

```
disabled_metrics:
  - "jvm.gc.max.data.size"
  - "jvm.gc.**"
  - "**.http.successRequests"
```

**Known Limitations**
Pattern matching is based on the raw Meter ID name, not what is displayed in CloudWatch (e.g., .sum, .count, .max).

- For example, disabling `jvm.gc.max.data.size.value` **won't work**, because the base ID is only `jvm.gc.max.data.size`.
  Only:
```
disabled_metrics:
  - "jvm.gc.max.data.size"
```
  works.

-  Disabling '**.BlockingBuffer.readLatency.count' won't work, because the base ID is '$your-pipeline-name.BlockingBuffer.readLatency'
```
disabled_metrics:
  - "**.BlockingBuffer.readLatency"
```
works.

### Issues Resolved
Resolves #5431 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
      - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
