### PR TITLE
Allow disabling metrics with data-prepper-config.yaml

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/config/DisableMetricsFilter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/config/DisableMetricsFilter.java
@@ -1,0 +1,36 @@
+package org.opensearch.dataprepper.core.parser.config;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.AntPathMatcher;
+import static org.opensearch.dataprepper.metrics.MetricNames.DELIMITER;
+
+
+import java.util.Collections;
+import java.util.List;
+
+public class DisableMetricsFilter implements MeterFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(DisableMetricsFilter.class);
+    private final List<String> disabledPatterns;
+    private static final AntPathMatcher matcher = new AntPathMatcher(DELIMITER);
+
+    public DisableMetricsFilter(final List<String> disabledPatterns) {
+        this.disabledPatterns = disabledPatterns != null ? disabledPatterns : Collections.emptyList();
+    }
+
+    @Override
+    public MeterFilterReply accept(final Meter.Id id) {
+        final String metricName = id.getName();
+
+        for (final String pattern : disabledPatterns) {
+            if (matcher.match(pattern, metricName)) {
+                return MeterFilterReply.DENY;
+            }
+        }
+        return MeterFilterReply.NEUTRAL;
+    }
+
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
@@ -90,7 +90,6 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
             @JsonProperty("metric_tag_filters")
             final List<MetricTagFilter> metricTagFilters,
             @JsonProperty("disabled_metrics")
-            @JsonAlias("disabledMetrics")
             final List<String> disabledMetrics,
             @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration,
             @JsonProperty("processor_shutdown_timeout")

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
@@ -54,6 +54,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
     private EventConfiguration eventConfiguration;
     private Map<String, String> metricTags = new HashMap<>();
     private List<MetricTagFilter> metricTagFilters = new LinkedList<>();
+    private List<String> disabledMetrics = new LinkedList<>();
     private PeerForwarderConfiguration peerForwarderConfiguration;
     private Duration processorShutdownTimeout;
     private Duration sinkShutdownTimeout;
@@ -88,6 +89,9 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
             final Map<String, String> metricTags,
             @JsonProperty("metric_tag_filters")
             final List<MetricTagFilter> metricTagFilters,
+            @JsonProperty("disabled_metrics")
+            @JsonAlias("disabledMetrics")
+            final List<String> disabledMetrics,
             @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration,
             @JsonProperty("processor_shutdown_timeout")
             @JsonAlias("processorShutdownTimeout")
@@ -120,6 +124,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
         setMetricTagFilters(metricTagFilters);
         setServerPort(serverPort);
         this.peerForwarderConfiguration = peerForwarderConfiguration;
+        this.disabledMetrics = disabledMetrics;
 
         this.processorShutdownTimeout = processorShutdownTimeout != null ? processorShutdownTimeout : DEFAULT_SHUTDOWN_DURATION;
         if (this.processorShutdownTimeout.isNegative()) {
@@ -166,6 +171,11 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
     public List<MetricTagFilter> getMetricTagFilters() {
         return metricTagFilters;
     }
+
+    public List<String> getDisabledMetrics() {
+        return disabledMetrics != null ? disabledMetrics : Collections.emptyList();
+    }
+
 
     private void setSsl(final Boolean ssl) {
         if (ssl != null) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/config/DisableMetricsFilterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/config/DisableMetricsFilterTest.java
@@ -1,0 +1,32 @@
+package org.opensearch.dataprepper.core.parser.config;
+
+import io.micrometer.core.instrument.Meter.Id;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DisableMetricsFilterTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "jvm.gc.max.data.size, jvm.gc.max.data.size, DENY",
+            "jvm.gc.max.data.size, jvm.gc.**, DENY",
+            "test-pipeline.http.successRequests, **.http.successRequests, DENY",
+            "test-pipeline.http.successRequests, jvm.gc.**, NEUTRAL",
+            "metric.allowed, jvm.gc.max.data.size, NEUTRAL"
+    })
+    void testDisabledMetricsFilter(String metricName, String pattern, MeterFilterReply expectedReply) {
+        final DisableMetricsFilter filter = new DisableMetricsFilter(List.of(pattern));
+
+        final Id id = new Id(metricName, Tags.empty(), null, null, Type.COUNTER);
+        final MeterFilterReply result = filter.accept(id);
+
+        assertEquals(expectedReply, result);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the ability to disable specific metrics via the `data-prepper-config.yaml` configuration file.
To use this feature, add a new section to your configuration:

```
disabled_metrics:
  - "jvm.gc.max.data.size"
  - "jvm.gc.**"
  - "**.http.successRequests"
```

**Known Limitations**
Pattern matching is based on the raw Meter ID name, not what is displayed in CloudWatch (e.g., .sum, .count, .max).

- For example, disabling `jvm.gc.max.data.size.value` **won't work**, because the base ID is only `jvm.gc.max.data.size`.
  Only:
```
disabled_metrics:
  - "jvm.gc.max.data.size"
```
  works.

-  Disabling '**.BlockingBuffer.readLatency.count' won't work, because the base ID is 'your-pipeline-name.BlockingBuffer.readLatency'.
  Only:
```
disabled_metrics:
  - "**.BlockingBuffer.readLatency"
```
works.

### Issues Resolved
Resolves #5431 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
      - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
