### PR TITLE
Making Confluence polling to include the last polling time

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
@@ -42,7 +42,7 @@ import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlCons
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.CONTENT_TYPE_IN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.CONTENT_TYPE_NOT_IN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.DELIMITER;
-import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.GREATER_THAN;
+import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.GREATER_THAN_OR_EQUALS;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.PREFIX;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.SPACE_IN;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.SPACE_NOT_IN;
@@ -160,7 +160,7 @@ public class ConfluenceService {
         }
 
         String formattedTimeStamp = ts.atZone(this.confluenceServerZoneId).format(DateTimeFormatter.ofPattern(CQL_LAST_MODIFIED_DATE_FORMAT));
-        StringBuilder cQl = new StringBuilder(LAST_MODIFIED + GREATER_THAN + "\"" + formattedTimeStamp + "\"");
+        StringBuilder cQl = new StringBuilder(LAST_MODIFIED + GREATER_THAN_OR_EQUALS + "\"" + formattedTimeStamp + "\"");
         if (!CollectionUtils.isEmpty(ConfluenceConfigHelper.getSpacesNameIncludeFilter(configuration))) {
             cQl.append(SPACE_IN).append(ConfluenceConfigHelper.getSpacesNameIncludeFilter(configuration).stream()
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/CqlConstants.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/CqlConstants.java
@@ -11,7 +11,7 @@
 package org.opensearch.dataprepper.plugins.source.confluence.utils;
 
 public class CqlConstants {
-    public static final String GREATER_THAN = ">";
+    public static final String GREATER_THAN_OR_EQUALS = ">=";
     public static final String CLOSING_ROUND_BRACKET = ")";
 
     public static final String SPACE_IN = " AND space in (";

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceServiceTest.java
@@ -54,7 +54,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -291,7 +290,8 @@ public class ConfluenceServiceTest {
                 .format(DateTimeFormatter.ofPattern(CQL_LAST_MODIFIED_DATE_FORMAT));
         StringBuilder contentFilterCriteria = confluenceService.createContentFilterCriteria(confluenceSourceConfig, pollingTime);
         assertNotNull(contentFilterCriteria);
-        assertTrue(contentFilterCriteria.toString().contains(formattedZonedPollingTime));
+        String cqlToAssert = "lastModified>=\"" + formattedZonedPollingTime + "\" order by lastModified";
+        assertEquals(cqlToAssert, contentFilterCriteria.toString());
     }
 
 


### PR DESCRIPTION
### Description
Fixing Confluence polling time to include the last polling time so that we don't miss any content created at the exact same second but was not part of the last polling call. This issue wouldn't have happened (or much less problematic) if this time polling timestamp `lastModified>"2025-03-31 16:20"` also considered milliseconds but unfortunately, confluence polling time is only considering up to seconds. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
