### PR TITLE
Add missing OTEL standard fields

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -37,6 +37,7 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     protected static final String SCHEMA_URL_KEY = "schemaUrl";
     protected static final String EXEMPLARS_KEY = "exemplars";
     protected static final String FLAGS_KEY = "flags";
+    protected static final String METADATA_KEY = "metadata";
     private boolean flattenAttributes;
 
     protected JacksonMetric(Builder builder, boolean flattenAttributes) {
@@ -99,6 +100,11 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     @Override
     public String getKind() {
         return this.get(KIND_KEY, String.class);
+    }
+
+    @Override
+    public Map<String, Object> getMetricMetadata() {
+        return this.get(METADATA_KEY, Map.class);
     }
 
     @Override
@@ -256,7 +262,7 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
         }
 
         /**
-         * Sets the scope of the log event
+         * Sets the scope of the metric event
          *
          * @param scope scope to be set
          * @return the builder
@@ -268,7 +274,19 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
         }
 
         /**
-         * Sets the resource of the log event
+         * Sets the metadata of the metric event
+         *
+         * @param metadata metadata to be set
+         * @return the builder
+         * @since 2.11
+         */
+        public T withMetricMetadata(final Map<String, Object> metadata) {
+            put(METADATA_KEY, metadata);
+            return getThis();
+        }
+
+        /**
+         * Sets the resource of the metric event
          *
          * @param resource resource to be set
          * @return the builder

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Metric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Metric.java
@@ -116,7 +116,7 @@ public interface Metric extends Event {
     Integer getFlags();
 
     /**
-     * Gets the scope of this log event.
+     * Gets the scope of this metric event.
      *
      * @return the scope
      * @since 2.11
@@ -124,7 +124,15 @@ public interface Metric extends Event {
     Map<String, Object> getScope();
 
     /**
-     * Gets the resource of this log event.
+     * Gets the metadata of this metric event.
+     *
+     * @return the metadata
+     * @since 2.11
+     */
+    Map<String, Object> getMetricMetadata();
+
+    /**
+     * Gets the resource of this metric event.
      *
      * @return the resource
      * @since 2.11

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -48,6 +48,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
     protected static final String ATTRIBUTES_KEY = "attributes";
     private static final String DROPPED_ATTRIBUTES_COUNT_KEY = "droppedAttributesCount";
     private static final String EVENTS_KEY = "events";
+    private static final String SCHEMA_URL_KEY = "schemaUrl";
     private static final String DROPPED_EVENTS_COUNT_KEY = "droppedEventsCount";
     private static final String LINKS_KEY = "links";
     private static final String DROPPED_LINKS_COUNT_KEY = "droppedLinksCount";
@@ -89,6 +90,11 @@ public class JacksonSpan extends JacksonEvent implements Span {
         putIfAbsent(DROPPED_LINKS_COUNT_KEY, Integer.class, 0);
         putIfAbsent(EVENTS_KEY, LinkedList.class, new LinkedList<>());
         putIfAbsent(DROPPED_EVENTS_COUNT_KEY, Integer.class, 0);
+    }
+
+    @Override
+    public String getSchemaUrl() {
+        return this.get(SCHEMA_URL_KEY, String.class);
     }
 
     @Override
@@ -406,7 +412,19 @@ public class JacksonSpan extends JacksonEvent implements Span {
         }
 
         /**
-         * Sets the status of the log event
+         * Sets the schema url of span
+         *
+         * @param schemaUrl schema url
+         * @return returns the builder
+         * @since 2.11
+         */
+        public Builder withSchemaUrl(final String schemaUrl) {
+            data.put(SCHEMA_URL_KEY, schemaUrl);
+            return this;
+        }
+
+        /**
+         * Sets the status of the span event
          *
          * @param status status to be set
          * @return the builder
@@ -418,7 +436,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
         }
 
         /**
-         * Sets the scope of the log event
+         * Sets the scope of the span event
          *
          * @param scope scope to be set
          * @return the builder
@@ -430,7 +448,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
         }
 
         /**
-         * Sets the resource of the log event
+         * Sets the resource of the span event
          *
          * @param resource resource to be set
          * @return the builder

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
@@ -168,7 +168,15 @@ public interface Span extends Event {
     void setServiceName(final String serviceName);
 
     /**
-     * Gets the scope of this log event.
+     * Gets the schema url of this span event.
+     *
+     * @return the schema url
+     * @since 2.11
+     */
+    String getSchemaUrl();
+
+    /**
+     * Gets the scope of this span event.
      *
      * @return the scope
      * @since 2.11
@@ -176,7 +184,7 @@ public interface Span extends Event {
     Map<String, Object> getScope();
 
     /**
-     * Gets the resource of this log event.
+     * Gets the resource of this span event.
      *
      * @return the resource
      * @since 2.11
@@ -184,7 +192,7 @@ public interface Span extends Event {
     Map<String, Object> getResource();
 
     /**
-     * Gets the status of this log event.
+     * Gets the status of this span event.
      *
      * @return the status
      * @since 2.11

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
@@ -40,6 +40,7 @@ class JacksonGaugeTest {
             "key2", TEST_KEY2);
     protected static final Map<String, Object> TEST_SCOPE = ImmutableMap.of("name", UUID.randomUUID().toString(), "version", UUID.randomUUID().toString(), "attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
     protected static final Map<String, Object> TEST_RESOURCE = ImmutableMap.of("attributes", List.of(Map.of("key", UUID.randomUUID().toString(), "value", UUID.randomUUID().toString())));
+    protected static final Map<String, Object> TEST_METADATA = ImmutableMap.of("metadataKey1", UUID.randomUUID().toString(), "metadataKey2", UUID.randomUUID().toString(), "metadataKey3", UUID.randomUUID().toString());
     protected static final String TEST_SERVICE_NAME = "service";
     protected static final String TEST_NAME = "name";
     protected static final String TEST_DESCRIPTION = "description";
@@ -72,6 +73,7 @@ class JacksonGaugeTest {
                 .withUnit(TEST_UNIT_NAME)
                 .withScope(TEST_SCOPE)
                 .withResource(TEST_RESOURCE)
+                .withMetricMetadata(TEST_METADATA)
                 .withValue(TEST_VALUE)
                 .withServiceName(TEST_SERVICE_NAME)
                 .withExemplars(TEST_EXEMPLARS)
@@ -158,6 +160,12 @@ class JacksonGaugeTest {
     public void testGetResource() {
         final Map<String, Object> resource = gauge.getResource();
         assertThat(resource, is(equalTo(TEST_RESOURCE)));
+    }
+
+    @Test
+    public void testGetMetricMetadata() {
+        final Map<String, Object> metadata = gauge.getMetricMetadata();
+        assertThat(metadata, is(equalTo(TEST_METADATA)));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -47,6 +47,7 @@ public class JacksonSpanTest {
     protected static final String TEST_PARENT_SPAN_ID =  UUID.randomUUID().toString();
     protected static final String TEST_NAME =  UUID.randomUUID().toString();
     protected static final String TEST_KIND =  UUID.randomUUID().toString();
+    protected static final String TEST_SCHEMA_URL =  UUID.randomUUID().toString();
     protected static final int TEST_FLAGS = 10;
     protected static final String TEST_START_TIME =  UUID.randomUUID().toString();
     protected static final String TEST_END_TIME =  UUID.randomUUID().toString();
@@ -106,6 +107,7 @@ public class JacksonSpanTest {
                 .withResource(TEST_RESOURCE)
                 .withStatus(TEST_STATUS)
                 .withStartTime(TEST_START_TIME)
+                .withSchemaUrl(TEST_SCHEMA_URL)
                 .withEndTime(TEST_END_TIME)
                 .withAttributes(TEST_ATTRIBUTES)
                 .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
@@ -166,6 +168,12 @@ public class JacksonSpanTest {
     public void testGetFlags() {
         final Integer flags = jacksonSpan.getFlags();
         assertThat(flags, is(equalTo(TEST_FLAGS)));
+    }
+
+    @Test
+    public void testGetSchemaUrl() {
+        final String schemaUrl = jacksonSpan.getSchemaUrl();
+        assertThat(schemaUrl, is(equalTo(TEST_SCHEMA_URL)));
     }
 
     @Test

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoOpensearchCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoOpensearchCodecTest.java
@@ -466,7 +466,7 @@ public class OTelProtoOpensearchCodecTest {
             assertThat(logRecord.getObservedTime(), is("2020-05-24T14:00:02Z"));
             assertThat(logRecord.getBody(), is("Log value"));
             assertThat(logRecord.getDroppedAttributesCount(), is(3));
-            assertThat(logRecord.getSchemaUrl(), is("schemaurl"));
+            assertThat(logRecord.getSchemaUrl(), is("resourceSchemaUrl"));
             assertThat(logRecord.getSeverityNumber(), is(5));
             assertThat(logRecord.getSeverityText(), is("Severity value"));
             assertThat(logRecord.getTraceId(), is("ba1a1c23b4093b63"));

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoStandardCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoStandardCodecTest.java
@@ -232,9 +232,11 @@ public class OTelProtoStandardCodecTest {
                 }
                 Map<String, Object> resource = span.getResource();
                 assertThat(resource.containsKey(OTelProtoStandardCodec.ATTRIBUTES_KEY), is(true));
+                assertThat((String)resource.get(OTelProtoStandardCodec.SCHEMA_URL_KEY), equalTo("resourceSchemaUrl"));
                 Map<String, Object> attributes = (Map<String, Object>)resource.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
                 assertThat(attributes.containsKey("service.name"), is(true));
                 Map<String, Object> scope = span.getScope();
+                //assertThat((String)span.get(OTelProtoStandardCodec.SCHEMA_URL_KEY, String.class), equalTo("spansSchemaUrl"));
                 assertThat(scope.containsKey(OTelProtoStandardCodec.NAME_KEY), is(true));
             }
         }
@@ -330,7 +332,7 @@ public class OTelProtoStandardCodecTest {
                     .setStringValue("EaglesService").build()).build();
 
             final Map<String, Object> resourceAttributes = decoderUnderTest.getResourceAttributes(Resource.newBuilder()
-                    .addAllAttributes(Arrays.asList(spanAttribute1, spanAttribute2)).build());
+                    .addAllAttributes(Arrays.asList(spanAttribute1, spanAttribute2)).build(), "resourceSchemaUrl");
             final Map<String, Object> actual = (Map<String, Object>)resourceAttributes.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
             assertThat(actual.get(spanAttribute2.getKey()), equalTo(spanAttribute2.getValue().getStringValue()));
             assertThat(actual.containsKey(spanAttribute1.getKey()), is(true));
@@ -360,7 +362,7 @@ public class OTelProtoStandardCodecTest {
                     .setArrayValue(arrayValue)).build();
 
             final Map<String, Object> resource = decoderUnderTest.getResourceAttributes(Resource.newBuilder()
-                    .addAllAttributes(Collections.singletonList(spanAttribute1)).build());
+                    .addAllAttributes(Collections.singletonList(spanAttribute1)).build(), "resourceSchemaUrl");
             final Map<String, Object> actual = (Map<String, Object>)resource.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
             assertThat(actual.containsKey(spanAttribute1.getKey()), is(true));
             final List<Object> actualValue = (List<Object>)actual.get(spanAttribute1.getKey());
@@ -439,11 +441,12 @@ public class OTelProtoStandardCodecTest {
             assertThat(logRecord.getObservedTime(), is("2020-05-24T14:00:02Z"));
             assertThat(logRecord.getBody(), is("Log value"));
             assertThat(logRecord.getDroppedAttributesCount(), is(3));
-            assertThat(logRecord.getSchemaUrl(), is("schemaurl"));
+            assertThat(logRecord.getSchemaUrl(), is("logsSchemaUrl"));
             assertThat(logRecord.getSeverityNumber(), is(5));
             assertThat(logRecord.getSeverityText(), is("Severity value"));
             assertThat(logRecord.getTraceId(), is("ba1a1c23b4093b63"));
             assertThat(logRecord.getSpanId(), is("2cc83ac90ebc469c"));
+            assertThat((String)logRecord.get(OTelProtoStandardCodec.SCHEMA_URL_KEY, String.class), equalTo("logsSchemaUrl"));
             Map<String, Object> scope = logRecord.getScope();
             Map<String, Object> scopeAttributes = (Map<String, Object>)scope.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
             assertThat(scopeAttributes.get("my.scope.attribute"), is("log scope attribute"));
@@ -454,7 +457,10 @@ public class OTelProtoStandardCodecTest {
             assertThat(attributes.get("statement.params"), is("us-east-1"));
             Map<String, Object> resource = logRecord.getResource();
             Map<String, Object> resourceAttributes = (Map<String, Object>)resource.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
+            assertThat((String)resource.get(OTelProtoStandardCodec.SCHEMA_URL_KEY), equalTo("resourceSchemaUrl"));
             assertThat(resourceAttributes.get("service.name"), is("service"));
+            assertThat(resource.get(OTelProtoStandardCodec.DROPPED_ATTRIBUTES_COUNT_KEY), equalTo(0));
+            assertThat(resource.get(OTelProtoStandardCodec.SCHEMA_URL_KEY), equalTo("resourceSchemaUrl"));
         }
 
         @Test
@@ -498,12 +504,19 @@ public class OTelProtoStandardCodecTest {
             assertThat(metric.getUnit(), equalTo("1"));
             assertThat(metric.getName(), equalTo("counter-int"));
             JacksonGauge gauge = (JacksonGauge)metric;
+            assertThat((String)gauge.get(OTelProtoStandardCodec.SCHEMA_URL_KEY, String.class), equalTo("metricsSchemaUrl"));
+            Map<String, Object> resource = gauge.getResource();
+            assertThat((String)resource.get(OTelProtoStandardCodec.SCHEMA_URL_KEY), equalTo("resourceSchemaUrl"));
             assertThat(gauge.getValue(), equalTo(123.0));
             Map<String, Object> scope = gauge.getScope();
             Map<String, Object> scopeAttributes = (Map<String, Object>)scope.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
             assertThat(scopeAttributes.get("my.scope.attribute"), is("gauge scope attribute"));
             assertThat(scope.get(OTelProtoStandardCodec.NAME_KEY), is("my.library"));
             assertThat(scope.get(OTelProtoStandardCodec.VERSION_KEY), is("1.0.0"));
+            Map<String, Object> metadata = gauge.getMetricMetadata();
+            assertThat(metadata.get("metadataKey1"), equalTo("metadataValue1"));
+            assertThat(metadata.get("metadataKey2"), equalTo(200L));
+            assertThat(metadata.get("metadataKey3"), equalTo("metadataValue3"));
         }
 
         private void validateSumMetricRequest(Collection<Record<? extends Metric>> metrics) {
@@ -514,12 +527,19 @@ public class OTelProtoStandardCodecTest {
             assertThat(metric.getUnit(), equalTo("1"));
             assertThat(metric.getName(), equalTo("sum-int"));
             JacksonSum sum = (JacksonSum)metric;
+            assertThat((String)sum.get(OTelProtoStandardCodec.SCHEMA_URL_KEY, String.class), equalTo("metricsSchemaUrl"));
+            Map<String, Object> resource = sum.getResource();
+            assertThat((String)resource.get(OTelProtoStandardCodec.SCHEMA_URL_KEY), equalTo("resourceSchemaUrl"));
             assertThat(sum.getValue(), equalTo(456.0));
             Map<String, Object> scope = sum.getScope();
             Map<String, Object> scopeAttributes = (Map<String, Object>)scope.get(OTelProtoStandardCodec.ATTRIBUTES_KEY);
             assertThat(scopeAttributes.get("my.scope.attribute"), is("sum scope attribute"));
             assertThat(scope.get(OTelProtoStandardCodec.NAME_KEY), is("my.library"));
             assertThat(scope.get(OTelProtoStandardCodec.VERSION_KEY), is("1.0.0"));
+            Map<String, Object> metadata = sum.getMetricMetadata();
+            assertThat(metadata.get("metadataKey1"), equalTo("metadataValue1"));
+            assertThat(metadata.get("metadataKey2"), equalTo(200L));
+            assertThat(metadata.get("metadataKey3"), equalTo("metadataValue3"));
         }
 
         private void validateHistogramMetricRequest(Collection<Record<? extends Metric>> metrics) {
@@ -530,8 +550,13 @@ public class OTelProtoStandardCodecTest {
             assertThat(metric.getUnit(), equalTo("1"));
             assertThat(metric.getName(), equalTo("histogram-int"));
             JacksonHistogram histogram = (JacksonHistogram)metric;
+            assertThat((String)histogram.get(OTelProtoStandardCodec.SCHEMA_URL_KEY, String.class), equalTo("metricsSchemaUrl"));
+            Map<String, Object> resource = histogram.getResource();
+            assertThat((String)resource.get(OTelProtoStandardCodec.SCHEMA_URL_KEY), equalTo("resourceSchemaUrl"));
             assertThat(histogram.getSum(), equalTo(100.0));
             assertThat(histogram.getCount(), equalTo(30L));
+            assertThat(histogram.getMin(), equalTo(40.0));
+            assertThat(histogram.getMax(), equalTo(60.0));
             assertThat(histogram.getExemplars(), equalTo(Collections.emptyList()));
             assertThat(histogram.getExplicitBoundsList(), equalTo(List.of(1.0, 2.0, 3.0, 4.0)));
             assertThat(histogram.getExplicitBoundsCount(), equalTo(4));
@@ -543,6 +568,10 @@ public class OTelProtoStandardCodecTest {
             assertThat(scopeAttributes.get("my.scope.attribute"), is("histogram scope attribute"));
             assertThat(scope.get(OTelProtoStandardCodec.NAME_KEY), is("my.library"));
             assertThat(scope.get(OTelProtoStandardCodec.VERSION_KEY), is("1.0.0"));
+            Map<String, Object> metadata = histogram.getMetricMetadata();
+            assertThat(metadata.get("metadataKey1"), equalTo("metadataValue1"));
+            assertThat(metadata.get("metadataKey2"), equalTo(200L));
+            assertThat(metadata.get("metadataKey3"), equalTo("metadataValue3"));
         }
 
         private void validateHistogramMetricRequestNoExplicitBounds(Collection<Record<? extends Metric>> metrics) {
@@ -566,6 +595,10 @@ public class OTelProtoStandardCodecTest {
             assertThat(scopeAttributes.get("my.scope.attribute"), is("histogram scope attribute"));
             assertThat(scope.get(OTelProtoStandardCodec.NAME_KEY), is("my.library"));
             assertThat(scope.get(OTelProtoStandardCodec.VERSION_KEY), is("1.0.0"));
+            Map<String, Object> metadata = histogram.getMetricMetadata();
+            assertThat(metadata.get("metadataKey1"), equalTo("metadataValue1"));
+            assertThat(metadata.get("metadataKey2"), equalTo(200L));
+            assertThat(metadata.get("metadataKey3"), equalTo("metadataValue3"));
         }
 
 

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-gauge-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-gauge-metrics.json
@@ -2,6 +2,7 @@
   "resourceMetrics": [
     {
       "resource": {
+        "droppedAttributesCount": 0,
         "attributes": [
           {
             "key": "resource-attr",
@@ -11,8 +12,10 @@
           }
         ]
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeMetrics": [
         {
+          "schemaUrl": "metricsSchemaUrl",
           "scope": {
             "name": "my.library",
             "version": "1.0.0",
@@ -29,6 +32,26 @@
             {
               "name": "counter-int",
               "unit": 1,
+              "metadata": [
+                {
+                    "key": "metadataKey1",
+                    "value": {
+                      "stringValue": "metadataValue1"
+                    }
+                },
+                {
+                    "key": "metadataKey2",
+                    "value": {
+                      "intValue": "200"
+                    }
+                },
+                {
+                    "key": "metadataKey3",
+                    "value": {
+                      "stringValue": "metadataValue3"
+                    }
+                }
+              ],
               "gauge": {
                 "dataPoints": [
                   {

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics-no-explicit-bounds.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics-no-explicit-bounds.json
@@ -2,6 +2,7 @@
   "resourceMetrics": [
     {
       "resource": {
+        "droppedAttributesCount": 0,
         "attributes": [
           {
             "key": "resource-attr",
@@ -11,8 +12,10 @@
           }
         ]
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeMetrics": [
         {
+          "schemaUrl": "metricsSchemaUrl",
           "scope": {
             "name": "my.library",
             "version": "1.0.0",
@@ -29,6 +32,26 @@
             {
               "name": "histogram-int",
               "unit": 1,
+              "metadata": [
+                {
+                    "key": "metadataKey1",
+                    "value": {
+                      "stringValue": "metadataValue1"
+                    }
+                },
+                {
+                    "key": "metadataKey2",
+                    "value": {
+                      "intValue": "200"
+                    }
+                },
+                {
+                    "key": "metadataKey3",
+                    "value": {
+                      "stringValue": "metadataValue3"
+                    }
+                }
+              ],
               "histogram": {
                 "dataPoints": [
                   {

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics.json
@@ -2,6 +2,7 @@
   "resourceMetrics": [
     {
       "resource": {
+        "droppedAttributesCount": 0,
         "attributes": [
           {
             "key": "resource-attr",
@@ -11,8 +12,10 @@
           }
         ]
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeMetrics": [
         {
+          "schemaUrl": "metricsSchemaUrl",
           "scope": {
             "name": "my.library",
             "version": "1.0.0",
@@ -29,6 +32,26 @@
             {
               "name": "histogram-int",
               "unit": 1,
+              "metadata": [
+                {
+                    "key": "metadataKey1",
+                    "value": {
+                      "stringValue": "metadataValue1"
+                    }
+                },
+                {
+                    "key": "metadataKey2",
+                    "value": {
+                      "intValue": "200"
+                    }
+                },
+                {
+                    "key": "metadataKey3",
+                    "value": {
+                      "stringValue": "metadataValue3"
+                    }
+                }
+              ],
               "histogram": {
                 "dataPoints": [
                   {
@@ -44,6 +67,8 @@
                     "timeUnixNano": "1581452773000000789",
                     "count": "30",
                     "sum": "100",
+                    "min": "40",
+                    "max": "60",
                     "bucket_counts": [3, 5, 15, 6, 1],
                     "explicit_bounds": [1.0, 2.0, 3.0, 4.0],
                     "exemplars": []

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-both-span-types.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-both-span-types.json
@@ -69,8 +69,10 @@
         ],
         "droppedAttributesCount": 0
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeSpans": [
         {
+         "schemaUrl": "spansSchemaUrl",
           "scope": {
             "name": "io.opentelemetry.auto.spring-webmvc-3.1",
             "version": ""

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log.json
@@ -1,6 +1,7 @@
 {
   "resourceLogs": [{
     "resource": {
+      "droppedAttributesCount": 0,
       "attributes": [{
         "key": "service.name",
         "value": {
@@ -8,7 +9,9 @@
         }
       }]
     },
+    "schemaUrl": "resourceSchemaUrl",
     "scopeLogs": [{
+      "schemaUrl": "logsSchemaUrl",
       "scope": {
         "name": "my.library",
         "version": "1.0.0",
@@ -40,7 +43,6 @@
         "spanId": "LMg6yQ68Rpw=",
         "observedTimeUnixNano": "1590328802000000000"
       }]
-    }],
-    "schemaUrl": "schemaurl"
+    }]
   }]
 }

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-multiple-traces.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-multiple-traces.json
@@ -69,8 +69,10 @@
         ],
         "droppedAttributesCount": 0
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeSpans": [
         {
+          "schemaUrl": "spansSchemaUrl",
           "scope": {
             "name": "io.opentelemetry.auto.spring-webmvc-3.1",
             "version": ""

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-no-spans.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-no-spans.json
@@ -68,7 +68,8 @@
           }
         ],
         "droppedAttributesCount": 0
-      }
+      },
+      "schemaUrl": "resourceSchemaUrl"
     }
   ]
 }

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request.json
@@ -69,8 +69,10 @@
         ],
         "droppedAttributesCount": 0
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeSpans": [
         {
+          "schemaUrl": "spansSchemaUrl",
           "scope": {
             "name": "io.opentelemetry.auto.spring-webmvc-3.1",
             "version": "",

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-sum-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-sum-metrics.json
@@ -2,6 +2,7 @@
   "resourceMetrics": [
     {
       "resource": {
+        "droppedAttributesCount": 0,
         "attributes": [
           {
             "key": "resource-attr",
@@ -11,8 +12,10 @@
           }
         ]
       },
+      "schemaUrl": "resourceSchemaUrl",
       "scopeMetrics": [
         {
+          "schemaUrl": "metricsSchemaUrl",
           "scope": {
             "name": "my.library",
             "version": "1.0.0",
@@ -29,6 +32,26 @@
             {
               "name": "sum-int",
               "unit": 1,
+              "metadata": [
+                {
+                    "key": "metadataKey1",
+                    "value": {
+                      "stringValue": "metadataValue1"
+                    }
+                },
+                {
+                    "key": "metadataKey2",
+                    "value": {
+                      "intValue": "200"
+                    }
+                },
+                {
+                    "key": "metadataKey3",
+                    "value": {
+                      "stringValue": "metadataValue3"
+                    }
+                }
+              ],
               "sum": {
                 "dataPoints": [
                   {


### PR DESCRIPTION
### Description
Added missing OTEL standard fields
1. Added metadata field to all metrics
2. Added min/max to historgram metrics, added zero threshold to exponential histogram metrics
3. Added resource level schema url to all logs, traces and metrics

 
### Issues Resolved
Resolves #4137 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
