### PR TITLE
Explicit enforcing of order

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceService.java
@@ -181,7 +181,7 @@ public class ConfluenceService {
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))
                     .append(CLOSING_ROUND_BRACKET);
         }
-        cQl.append(" order by " + LAST_MODIFIED);
+        cQl.append(" order by " + LAST_MODIFIED + " asc ");
         log.info("Created content filter criteria ConfluenceQl query: {}", cQl);
         return cQl;
     }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceServiceTest.java
@@ -290,7 +290,7 @@ public class ConfluenceServiceTest {
                 .format(DateTimeFormatter.ofPattern(CQL_LAST_MODIFIED_DATE_FORMAT));
         StringBuilder contentFilterCriteria = confluenceService.createContentFilterCriteria(confluenceSourceConfig, pollingTime);
         assertNotNull(contentFilterCriteria);
-        String cqlToAssert = "lastModified>=\"" + formattedZonedPollingTime + "\" order by lastModified";
+        String cqlToAssert = "lastModified>=\"" + formattedZonedPollingTime + "\" order by lastModified asc ";
         assertEquals(cqlToAssert, contentFilterCriteria.toString());
     }
 

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -167,7 +167,7 @@ public class JiraService {
                             .collect(Collectors.joining(DELIMITER, PREFIX, SUFFIX)))
                     .append(CLOSING_ROUND_BRACKET);
         }
-        jiraQl.append(" order by " + UPDATED);
+        jiraQl.append(" order by " + UPDATED + " asc ");
         log.info("Created issue filter criteria JiraQl query: {}", jiraQl);
         return jiraQl;
     }


### PR DESCRIPTION
### Description
When you specify order by field name in jql, default order is ascending but for larger projects, it looks like the jira is not consistent hence enforcing it with specifying the order in jql.

Similar change on the CQL as well. Fixed the corresponding test.
 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
