### PR TITLE
FIX: opensearch serverless parameter constraint

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/ServerlessOptions.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/ServerlessOptions.java
@@ -10,11 +10,11 @@ import jakarta.validation.constraints.Size;
 
 public class ServerlessOptions {
 
-    @Size(min = 1, message = "network_policy_name cannot be empty")
+    @Size(min = 3, max = 32, message = "network_policy_name should have minimum length of 3 and maximum length of 32")
     @JsonProperty("network_policy_name")
     private String networkPolicyName;
 
-    @Size(min = 1, message = "collection_name cannot be empty")
+    @Size(min = 3, max = 32, message = "collection_name should have minimum length of 3 and maximum length of 32")
     @JsonProperty("collection_name")
     private String collectionName;
 


### PR DESCRIPTION
### Description
This PR tightens the constraint on network policy name as well as collection name to keep them aligned with AWS documentation: https://docs.aws.amazon.com/opensearch-service/latest/ServerlessAPIReference/API_CreateCollection.html
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
