### PR TITLE
Set version for 2.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@
 
 # ATTENTION: If you are changing the version, please change the DataPrepperVersion whenever the major or minor version changes.
 # See: https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java#L9
-version=2.11.0-SNAPSHOT
+version=2.11.0
 org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
### Description

Updates the Data Prepper version to 2.11. Removes the SNAPSHOT.
 
Commands:

```
git fetch upstream
git switch 2.11
git pull
git switch --create 2.11-version
(edit file)
git add gradle.properties
git commit -m "Set version for 2.11"
git push origin 2.11-version
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
