### PR TITLE
FIX: NPE in JsonCodec with keyName

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -72,7 +72,7 @@ public class JsonDecoder implements ByteDecoder {
             }
 
             if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
-                if (keyName != null && !nodeName.equals(keyName)) {
+                if (keyName != null && !keyName.equals(nodeName)) {
                     continue;
                 }
                 parseRecordsArray(jsonParser, timeReceived, eventConsumer, includeKeysMap, includeMetadataKeysMap);

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
@@ -172,6 +172,20 @@ public class JsonDecoderTest {
         }
 
         @Test
+        void test_JsonDecoder_withKeyName_when_parsing_json_array_should_skip() throws IOException {
+            final Instant now = Instant.now();
+            String inputString = "[]";
+            List<Record<Event>> records = new ArrayList<>();
+            jsonDecoder = new JsonDecoder(key_name, null, null, maxEventLength);
+            jsonDecoder.parse(new ByteArrayInputStream(inputString.getBytes()), now, (record) -> {
+                records.add(record);
+                receivedTime = record.getData().getEventHandle().getInternalOriginationTime();
+            });
+
+            assertTrue(records.isEmpty());
+        }
+
+        @Test
         void test_basicJsonDecoder_withInputConfig_withoutEvents_empty_metadata_keys() throws IOException {
             final Instant now = Instant.now();
             List<Record<Event>> records = new ArrayList<>();


### PR DESCRIPTION
### Description
This PR fixes the NPE on parsing json array when key_name is specified
 
### Issues Resolved
Resolves #5658 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
