### PR TITLE
Enable ZeroBuffer

### DIFF
--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -71,6 +71,10 @@ public class TestDataProvider {
     public static final String VALID_PEER_FORWARDER_WITH_ACM_SSL_CONFIG_FILE = "src/test/resources/valid_peer_forwarder_config_with_acm_ssl.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_WITH_METRIC_FILTER = "src/test/resources/valid_data_prepper_config_with_metric_filter.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_WITH_METRIC_FILTER = "src/test/resources/invalid_data_prepper_config_with_metric_filter.yml";
+    public static final String VALID_ZERO_BUFFER_SINGLE_THREAD_CONFIG_FILE = "src/test/resources/valid_zero_buffer_single_thread.yml";
+    public static final String INVALID_ZERO_BUFFER_MULTIPLE_THREADS_CONFIG_FILE = "src/test/resources/invalid_zero_buffer_multiple_threads.yml";
+    public static final String INVALID_ZERO_BUFFER_WITH_SINGLE_THREAD_PROCESSOR_CONFIG_FILE = "src/test/resources/invalid_zero_buffer_with_single_thread_processor.yml";
+    public static final String INVALID_ZERO_BUFFER_MULTIPLE_THREADS_NO_SINGLE_THREAD_PROCESSORS_CONFIG_FILE = "src/test/resources/invalid_zero_buffer_multiple_threads_no_single_thread_processors.yml";
     public static Set<String> VALID_MULTIPLE_PIPELINE_NAMES = new HashSet<>(Arrays.asList("test-pipeline-1",
             "test-pipeline-2", "test-pipeline-3"));
 }

--- a/data-prepper-core/src/test/resources/invalid_zero_buffer_multiple_threads.yml
+++ b/data-prepper-core/src/test/resources/invalid_zero_buffer_multiple_threads.yml
@@ -1,0 +1,8 @@
+simple-sample-pipeline:
+  workers: 2
+  source:
+    random:
+  buffer:
+    zero:
+  sink:
+    - stdout:

--- a/data-prepper-core/src/test/resources/invalid_zero_buffer_multiple_threads_no_single_thread_processors.yml
+++ b/data-prepper-core/src/test/resources/invalid_zero_buffer_multiple_threads_no_single_thread_processors.yml
@@ -1,0 +1,11 @@
+simple-pipeline:
+  workers: 2
+  source:
+    random:
+  buffer:
+    zero:
+  processor:
+    - string_converter:
+        upper_case: true
+  sink:
+    - stdout:

--- a/data-prepper-core/src/test/resources/invalid_zero_buffer_with_single_thread_processor.yml
+++ b/data-prepper-core/src/test/resources/invalid_zero_buffer_with_single_thread_processor.yml
@@ -1,0 +1,10 @@
+simple-pipeline:
+  workers: 1
+  source:
+    random:
+  buffer:
+    zero:
+  processor:
+    - test_processor:
+  sink:
+    - stdout:

--- a/data-prepper-core/src/test/resources/valid_zero_buffer_single_thread.yml
+++ b/data-prepper-core/src/test/resources/valid_zero_buffer_single_thread.yml
@@ -1,0 +1,8 @@
+simple-pipeline:
+  workers: 1
+  source:
+    random:
+  buffer:
+    zero:
+  sink:
+    - stdout:


### PR DESCRIPTION
### Description
At present zero-buffer is disabled due to the issue https://github.com/opensearch-project/data-prepper/pull/5545. 

Enable Zero Buffer under the following constraints:
1. Number of workers is equal to 1
2. Only allow pipelines which do not use @SingleThread processors.

If a pipeline configuration does not meet the above requirements and still uses zero-buffer, then throw an exception to indicate the constraints.
 
### Related Issues
- https://github.com/opensearch-project/data-prepper/pull/5691
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
- [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
