### PR TITLE
added delete_source functionality to the dissect processor

### DIFF
--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
@@ -88,6 +88,7 @@ public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Ev
 
     private void dissectField(Event event, String field){
         Dissector dissector = dissectorMap.get(field);
+        boolean isDeleteSourceOnSuccessfulDissect = dissectConfig.isDeleteSourceRequested();
         String text = event.get(field, String.class);
         if (dissector.dissectText(text)) {
             List<Field> dissectedFields = dissector.getDissectedFields();
@@ -95,6 +96,9 @@ public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Ev
                 String dissectFieldName = disectedField.getKey();
                 Object dissectFieldValue = convertTargetType(dissectFieldName,disectedField.getValue());
                 event.put(disectedField.getKey(), dissectFieldValue);
+            }
+            if (isDeleteSourceOnSuccessfulDissect) {
+                event.delete(field);
             }
         }
     }

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -54,6 +54,10 @@ public class DissectProcessorConfig {
             "For example, <code>/some_value == \"log\"</code>.")
     private String dissectWhen;
 
+    @JsonProperty
+    @JsonPropertyDescription("If true, the configured fields in the <code>map</code>  will be deleted if the processor was successful.")
+    private boolean deleteSource;
+
     public String getDissectWhen(){
         return dissectWhen;
     }
@@ -63,6 +67,10 @@ public class DissectProcessorConfig {
     }
 
     public Map<String, TargetType> getTargetTypes() { return targetTypeMap; }
+
+    public boolean isDeleteSourceRequested() {
+        return deleteSource;
+    }
 
     @AssertTrue(message = "target_type must be a Map<String, TargetType>. Valid options include [ 'integer', 'string', 'double', 'boolean', 'long', and 'big_decimal' ]")
     boolean isTargetTypeValid() {


### PR DESCRIPTION
### Description
This change will add a new functionality to the `dissect` processor. Now users can choose a new option `delete_source: true` which will delete the source field  if `dissect` processor was successful in extracting the fields.

Example config:

```
  processor:
    - dissect:
        map:
          message: "%{Date} %{Time} %{Log_Type}: %{Message}"
        delete_source: true
```
 
### Issues Resolved
Resolves #5345
 
### Check List
- [x ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ x] New functionality has javadoc added
- [ x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
