### PR TITLE
feat(sink/opensearch): Retry DELETE operations on 404 status

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -53,6 +53,7 @@ public final class BulkRetryStrategy {
     static final long INITIAL_DELAY_MS = 50;
     static final long MAXIMUM_DELAY_MS = Duration.ofMinutes(10).toMillis();
     static final String VERSION_CONFLICT_EXCEPTION_TYPE = "version_conflict_engine_exception";
+    private static final int DELETE_404_MAX_RETRIES = 3;
 
     private static final Set<Integer> NON_RETRY_STATUS = new HashSet<>(
             Arrays.asList(
@@ -238,14 +239,8 @@ public final class BulkRetryStrategy {
 
     public boolean canRetry(final BulkResponse response) {
         for (final BulkResponseItem bulkItemResponse : response.items()) {
-            if (isItemInError(bulkItemResponse)) {
-                boolean isGenerallyRetryable = !NON_RETRY_STATUS.contains(bulkItemResponse.status());
-                boolean isDeleteNotFound = bulkItemResponse.status() == RestStatus.NOT_FOUND.getStatus() &&
-                        bulkItemResponse.operationType() == OperationType.Delete;
-
-                if (isGenerallyRetryable || isDeleteNotFound) {
-                    return true;
-                }
+            if (isItemInError(bulkItemResponse) && canRetryItem(bulkItemResponse)) {
+                return true;
             }
         }
         return false;
@@ -257,12 +252,42 @@ public final class BulkRetryStrategy {
                         !NON_RETRY_STATUS.contains(((OpenSearchException) e).status())));
     }
 
+    private boolean canRetryItem(final BulkResponseItem bulkItemResponse) {
+        return canRetryItem(bulkItemResponse, 1);
+    }
+
+    private boolean canRetryItem(final BulkResponseItem bulkItemResponse, final int attemptNumber) {
+        if (isDeleteOperationWithNotFoundError(bulkItemResponse)) {
+            return canRetryDeleteNotFoundOperation(bulkItemResponse, attemptNumber);
+        }
+        
+        return isGenerallyRetryableOperation(bulkItemResponse);
+    }
+
+    private boolean isDeleteOperationWithNotFoundError(final BulkResponseItem bulkItemResponse) {
+        return bulkItemResponse.status() == RestStatus.NOT_FOUND.getStatus() &&
+               bulkItemResponse.operationType() == OperationType.Delete;
+    }
+
+    private boolean canRetryDeleteNotFoundOperation(final BulkResponseItem bulkItemResponse, final int attemptNumber) {
+        if (attemptNumber > DELETE_404_MAX_RETRIES) {
+            LOG.info("DELETE operation for index '{}' reached maximum retry limit ({}) for 404 errors, sending to DLQ", 
+                    bulkItemResponse.index(), DELETE_404_MAX_RETRIES);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isGenerallyRetryableOperation(final BulkResponseItem bulkItemResponse) {
+        return !NON_RETRY_STATUS.contains(bulkItemResponse.status());
+    }
+
     private BulkOperationRequestResponse handleRetriesAndFailures(final AccumulatingBulkRequest bulkRequestForRetry,
-                                                                  final int retryCount,
+                                                                  final int attemptNumber,
                                                                   final BulkResponse bulkResponse,
                                                                   final Exception exceptionFromRequest) {
         final boolean doRetry = (Objects.isNull(exceptionFromRequest)) ? canRetry(bulkResponse) : canRetry(exceptionFromRequest);
-        if (!Objects.isNull(bulkResponse) && retryCount == 1) { // first attempt
+        if (!Objects.isNull(bulkResponse) && attemptNumber == 1) { 
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                 if (!isItemInError(bulkItemResponse)) {
                     sentDocumentsOnFirstAttemptCounter.increment();
@@ -270,8 +295,8 @@ public final class BulkRetryStrategy {
             }
         }
         if (doRetry) {
-            if (retryCount % 5 == 0) {
-                LOG.warn("Bulk Operation Failed. Number of retries {}. Retrying... ", retryCount, exceptionFromRequest);
+            if (attemptNumber % 5 == 1) { 
+                LOG.warn("Bulk Operation Failed. Number of retries {}. Retrying... ", attemptNumber - 1, exceptionFromRequest);
                 if (exceptionFromRequest == null) {
                     for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                         if(isItemInError(bulkItemResponse)) {
@@ -311,9 +336,9 @@ public final class BulkRetryStrategy {
 
     private BulkOperationRequestResponse handleRetry(final AccumulatingBulkRequest request,
                                                      final BulkResponse response,
-                                                     int retryCount,
+                                                     int attemptNumber,
                                                      final Exception previousException) throws InterruptedException {
-        final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response, previousException);
+        final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response, previousException, attemptNumber);
         if (bulkRequestForRetry.getOperationsCount() == 0) {
             return null;
         }
@@ -323,13 +348,13 @@ public final class BulkRetryStrategy {
             bulkResponse = requestFunction.apply(bulkRequestForRetry);
         } catch (Exception e) {
             incrementErrorCounters(e);
-            return handleRetriesAndFailures(bulkRequestForRetry, retryCount, null, e);
+            return handleRetriesAndFailures(bulkRequestForRetry, attemptNumber, null, e);
         }
         if (bulkResponse.errors()) {
-            return handleRetriesAndFailures(bulkRequestForRetry, retryCount, bulkResponse, null);
+            return handleRetriesAndFailures(bulkRequestForRetry, attemptNumber, bulkResponse, null);
         } else {
             final int numberOfDocs = bulkRequestForRetry.getOperationsCount();
-            final boolean firstAttempt = (retryCount == 1);
+            final boolean firstAttempt = (attemptNumber == 1);
             if (firstAttempt) {
                 sentDocumentsOnFirstAttemptCounter.increment(numberOfDocs);
             }
@@ -344,7 +369,7 @@ public final class BulkRetryStrategy {
     }
 
     private AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> createBulkRequestForRetry(
-            final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> request, final BulkResponse response, final Exception previousException) {
+            final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> request, final BulkResponse response, final Exception previousException, final int attemptNumber) {
         if (shouldSendAllForQuerying(previousException)) {
             for (final BulkOperationWrapper bulkOperationWrapper : request.getOperations()) {
                 existingDocumentQueryManager.addBulkOperation(bulkOperationWrapper);
@@ -369,11 +394,7 @@ public final class BulkRetryStrategy {
                         continue;
                     }
 
-                    boolean isGenerallyRetryable = !NON_RETRY_STATUS.contains(bulkItemResponse.status());
-                    boolean isDeleteNotFound = bulkItemResponse.status() == RestStatus.NOT_FOUND.getStatus() &&
-                            bulkItemResponse.operationType() == OperationType.Delete;
-
-                    if (isGenerallyRetryable || isDeleteNotFound) {
+                    if (canRetryItem(bulkItemResponse, attemptNumber)) {
                         requestToReissue.addOperation(bulkOperation);
                     } else if (bulkItemResponse.error() != null && VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
                         documentsVersionConflictErrors.increment();


### PR DESCRIPTION
### Description
feat(sink/opensearch): Retry DELETE operations on 404 status

Enhances the `BulkRetryStrategy` to retry DELETE operations that initially fail with a 404 (Not Found) status. This addresses race conditions where a delete might be processed before its corresponding create in the same bulk request due to eventual consistency.

- Modified `canRetry` and `createBulkRequestForRetry` to identify and allow retries specifically for `DELETE + 404`.
- Added unit tests verifying the new retry behavior for `DELETE + 404` and ensuring other 404s are retried.

### Issues Resolved
Resolves #5521
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
