### PR TITLE
Enabling experimental plugins specifically by plugin type and name

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.model.buffer;
 
 import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.plugin.PluginComponentType;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.time.Duration;
@@ -18,6 +19,7 @@ import java.util.concurrent.TimeoutException;
  * Buffer queues the records between TI components and acts as a layer between source and processor/sink. Buffer can
  * be in-memory, disk based or other a standalone implementation.
  */
+@PluginComponentType("buffer")
 public interface Buffer<T extends Record<?>> {
     /**
      * writes the record to the buffer

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginComponentType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginComponentType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.model.plugin;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for Data Prepper plugin type components.
+ * Intended for processor, sink, source, buffer.
+ *
+ * @since 2.12
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface PluginComponentType {
+    /**
+     * Gets the name of the plugin component type.
+     *
+     * @return The name of the plugin component type.
+     */
+    String value();
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/Processor.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/Processor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.processor;
 
+import org.opensearch.dataprepper.model.plugin.PluginComponentType;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Collection;
@@ -14,6 +15,7 @@ import java.util.Collection;
  * Processor interface. These are intermediary processing units using which users can filter,
  * transform and enrich the records into desired format before publishing to the sink.
  */
+@PluginComponentType("processor")
 public interface Processor<InputRecord extends Record<?>, OutputRecord extends Record<?>> {
 
     /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/Sink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/Sink.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.sink;
 
+import org.opensearch.dataprepper.model.plugin.PluginComponentType;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Collection;
@@ -13,6 +14,7 @@ import java.util.Collection;
  * Data Prepper sink interface. Sink may publish records to a disk, a file,
  * to OpenSearch, other pipelines, or other external systems.
  */
+@PluginComponentType("sink")
 public interface Sink<T extends Record<?>> {
 
     /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.model.source;
 
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.plugin.PluginComponentType;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.codec.HasByteDecoder;
 
@@ -13,6 +14,7 @@ import org.opensearch.dataprepper.model.codec.HasByteDecoder;
  * Data Prepper source interface. Source acts as receiver of the events that flow
  * through the transformation pipeline.
  */
+@PluginComponentType("source")
 public interface Source<T extends Record<?>> extends HasByteDecoder {
 
     /**

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -144,12 +144,14 @@ public class DefaultPluginFactory implements PluginFactory {
                 .orElseThrow(() -> new NoPluginFoundException(
                         "Unable to find a plugin named '" + pluginName + "'. Please ensure that plugin is annotated with appropriate values."));
 
-        handleDefinedPlugins(pluginClass, pluginName);
+        handleDefinedPlugins(pluginClass, baseClass, pluginName);
         return pluginClass;
     }
 
-    private <T> void handleDefinedPlugins(final Class<? extends T> pluginClass, final String pluginName) {
-        final DefinedPlugin<? extends T> definedPlugin = new DefinedPlugin<>(pluginClass, pluginName);
+    private <T> void handleDefinedPlugins(final Class<? extends T> pluginClass,
+                                          final Class<? extends T> pluginTypeClass,
+                                          final String pluginName) {
+        final DefinedPlugin<? extends T> definedPlugin = new DefinedPlugin<>(pluginClass, pluginTypeClass, pluginName);
 
         definedPluginConsumers.forEach(definedPluginConsumer -> definedPluginConsumer.accept(definedPlugin));
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefinedPlugin.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DefinedPlugin.java
@@ -9,14 +9,20 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import org.opensearch.dataprepper.model.plugin.PluginComponentType;
+
 import java.util.Objects;
 
 class DefinedPlugin<T> {
     private final Class<? extends T> pluginClass;
+    private final Class<? extends T> pluginTypeClass;
     private final String pluginName;
 
-    public DefinedPlugin(final Class<? extends T> pluginClass, final String pluginName) {
+    public DefinedPlugin(final Class<? extends T> pluginClass,
+                         final Class<? extends T> pluginTypeClass,
+                         final String pluginName) {
         this.pluginClass = Objects.requireNonNull(pluginClass);
+        this.pluginTypeClass = Objects.requireNonNull(pluginTypeClass);
         this.pluginName = Objects.requireNonNull(pluginName);
     }
 
@@ -26,5 +32,13 @@ class DefinedPlugin<T> {
 
     public String getPluginName() {
         return pluginName;
+    }
+
+    public String getPluginTypeName() {
+        if(pluginTypeClass.isAnnotationPresent(PluginComponentType.class)) {
+            return pluginTypeClass.getAnnotation(PluginComponentType.class).value();
+        }
+
+        return null;
     }
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalConfiguration.java
@@ -24,8 +24,8 @@ public class ExperimentalConfiguration {
     @JsonProperty("enable_all")
     private boolean enableAll = false;
 
-    @JsonProperty("enabled")
-    private Map<String, Set<String>> enabled;
+    @JsonProperty("enabled_plugins")
+    private Map<String, Set<String>> enabledPlugins;
 
     public static ExperimentalConfiguration defaultConfiguration() {
         return new ExperimentalConfiguration();
@@ -46,7 +46,7 @@ public class ExperimentalConfiguration {
      * @return A map of plugin types to list of allowed plugins by name.
      * @since 2.12
      */
-    public Map<String, Set<String>> getEnabled() {
-        return enabled != null ? enabled : Collections.emptyMap();
+    public Map<String, Set<String>> getEnabledPlugins() {
+        return enabledPlugins != null ? enabledPlugins : Collections.emptyMap();
     }
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalConfiguration.java
@@ -11,6 +11,10 @@ package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Data Prepper configurations for experimental features.
  *
@@ -19,6 +23,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ExperimentalConfiguration {
     @JsonProperty("enable_all")
     private boolean enableAll = false;
+
+    @JsonProperty("enabled")
+    private Map<String, Set<String>> enabled;
 
     public static ExperimentalConfiguration defaultConfiguration() {
         return new ExperimentalConfiguration();
@@ -31,5 +38,15 @@ public class ExperimentalConfiguration {
      */
     public boolean isEnableAll() {
         return enableAll;
+    }
+
+    /**
+     * Gets enabled plugins by plugin type.
+     *
+     * @return A map of plugin types to list of allowed plugins by name.
+     * @since 2.12
+     */
+    public Map<String, Set<String>> getEnabled() {
+        return enabled != null ? enabled : Collections.emptyMap();
     }
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidator.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidator.java
@@ -41,7 +41,7 @@ class ExperimentalPluginValidator implements Consumer<DefinedPlugin<?>> {
             return false;
 
         final Set<String> enabledPluginsForType =
-                experimentalConfiguration.getEnabled()
+                experimentalConfiguration.getEnabledPlugins()
                         .getOrDefault(definedPlugin.getPluginTypeName(), Collections.emptySet());
         return !enabledPluginsForType.contains(definedPlugin.getPluginName());
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidator.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidator.java
@@ -13,6 +13,8 @@ import org.opensearch.dataprepper.model.annotations.Experimental;
 import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
 
 import javax.inject.Named;
+import java.util.Collections;
+import java.util.Set;
 import java.util.function.Consumer;
 
 @Named
@@ -25,13 +27,22 @@ class ExperimentalPluginValidator implements Consumer<DefinedPlugin<?>> {
 
     @Override
     public void accept(final DefinedPlugin<?> definedPlugin) {
-        if(isPluginDisallowedAsExperimental(definedPlugin.getPluginClass())) {
+        if(isPluginDisallowedAsExperimental(definedPlugin)) {
             throw new NoPluginFoundException("Unable to create experimental plugin " + definedPlugin.getPluginName() +
                     ". You must enable experimental plugins in data-prepper-config.yaml in order to use them.");
         }
     }
 
-    private boolean isPluginDisallowedAsExperimental(final Class<?> pluginClass) {
-        return pluginClass.isAnnotationPresent(Experimental.class) && !experimentalConfiguration.isEnableAll();
+    private boolean isPluginDisallowedAsExperimental(final DefinedPlugin<?> definedPlugin) {
+        final Class<?> pluginClass = definedPlugin.getPluginClass();
+        if(!pluginClass.isAnnotationPresent(Experimental.class))
+            return false;
+        if(experimentalConfiguration.isEnableAll())
+            return false;
+
+        final Set<String> enabledPluginsForType =
+                experimentalConfiguration.getEnabled()
+                        .getOrDefault(definedPlugin.getPluginTypeName(), Collections.emptySet());
+        return !enabledPluginsForType.contains(definedPlugin.getPluginName());
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -248,6 +248,7 @@ class DefaultPluginFactoryTest {
 
                 final DefinedPlugin<?> actualDefinedPlugin = definedPluginArgumentCaptor.getValue();
                 assertThat(actualDefinedPlugin.getPluginClass(), equalTo(expectedPluginClass));
+                assertThat(actualDefinedPlugin.getPluginTypeName(), equalTo("sink"));
                 assertThat(actualDefinedPlugin.getPluginName(), equalTo(pluginName));
             }
         }
@@ -357,6 +358,7 @@ class DefaultPluginFactoryTest {
 
                 final DefinedPlugin<?> actualDefinedPlugin = definedPluginArgumentCaptor.getValue();
                 assertThat(actualDefinedPlugin.getPluginClass(), equalTo(expectedPluginClass));
+                assertThat(actualDefinedPlugin.getPluginTypeName(), equalTo("sink"));
                 assertThat(actualDefinedPlugin.getPluginName(), equalTo(pluginName));
             }
         }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConfigurationTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConfigurationTest.java
@@ -12,8 +12,10 @@ package org.opensearch.dataprepper.plugin;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 
 class ExperimentalConfigurationTest {
     @Test
@@ -21,5 +23,13 @@ class ExperimentalConfigurationTest {
         final ExperimentalConfiguration objectUnderTest = ExperimentalConfiguration.defaultConfiguration();
         assertThat(objectUnderTest, notNullValue());
         assertThat(objectUnderTest.isEnableAll(), equalTo(false));
+    }
+
+    @Test
+    void defaultConfiguration_should_return_config_with_empty_enabled_mp() {
+        final ExperimentalConfiguration objectUnderTest = ExperimentalConfiguration.defaultConfiguration();
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getEnabled(), notNullValue());
+        assertThat(objectUnderTest.getEnabled(), is(anEmptyMap()));
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConfigurationTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConfigurationTest.java
@@ -26,10 +26,10 @@ class ExperimentalConfigurationTest {
     }
 
     @Test
-    void defaultConfiguration_should_return_config_with_empty_enabled_mp() {
+    void defaultConfiguration_should_return_config_with_empty_enabledPlugins_map() {
         final ExperimentalConfiguration objectUnderTest = ExperimentalConfiguration.defaultConfiguration();
         assertThat(objectUnderTest, notNullValue());
-        assertThat(objectUnderTest.getEnabled(), notNullValue());
-        assertThat(objectUnderTest.getEnabled(), is(anEmptyMap()));
+        assertThat(objectUnderTest.getEnabledPlugins(), notNullValue());
+        assertThat(objectUnderTest.getEnabledPlugins(), is(anEmptyMap()));
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidatorTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidatorTest.java
@@ -18,6 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.annotations.Experimental;
 import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -78,6 +80,50 @@ class ExperimentalPluginValidatorTest {
         @Test
         void accept_with_Experimental_plugin_does_not_throw_if_experimental_is_enabled() {
             when(experimentalConfiguration.isEnableAll()).thenReturn(true);
+
+            createObjectUnderTest().accept(definedPlugin);
+        }
+
+        @Test
+        void accept_with_Experimental_plugin_throws_if_experimental_is_not_enabled_for_pluginType() {
+            final String pluginName = UUID.randomUUID().toString();
+            final String pluginTypeName = UUID.randomUUID().toString();
+            when(definedPlugin.getPluginName()).thenReturn(pluginName);
+            when(definedPlugin.getPluginTypeName()).thenReturn(pluginTypeName);
+
+            final ExperimentalPluginValidator objectUnderTest = createObjectUnderTest();
+
+            final NoPluginFoundException actualException = assertThrows(NoPluginFoundException.class, () -> objectUnderTest.accept(definedPlugin));
+
+            assertThat(actualException.getMessage(), notNullValue());
+            assertThat(actualException.getMessage(), containsString(pluginName));
+            assertThat(actualException.getMessage(), containsString("experimental plugin"));
+        }
+
+        @Test
+        void accept_with_Experimental_plugin_throws_if_experimental_is_enabled_for_pluginType_but_not_for_plugin() {
+            final String pluginName = UUID.randomUUID().toString();
+            final String pluginTypeName = UUID.randomUUID().toString();
+            when(definedPlugin.getPluginName()).thenReturn(pluginName);
+            when(definedPlugin.getPluginTypeName()).thenReturn(pluginTypeName);
+            experimentalConfiguration.getEnabled().put(pluginTypeName, Set.of(UUID.randomUUID().toString()));
+
+            final ExperimentalPluginValidator objectUnderTest = createObjectUnderTest();
+
+            final NoPluginFoundException actualException = assertThrows(NoPluginFoundException.class, () -> objectUnderTest.accept(definedPlugin));
+
+            assertThat(actualException.getMessage(), notNullValue());
+            assertThat(actualException.getMessage(), containsString(pluginName));
+            assertThat(actualException.getMessage(), containsString("experimental plugin"));
+        }
+
+        @Test
+        void accept_with_Experimental_plugin_does_not_throw_if_experimental_is_enabled_for_specific_pluginType() {
+            final String pluginName = UUID.randomUUID().toString();
+            final String pluginTypeName = UUID.randomUUID().toString();
+            when(definedPlugin.getPluginName()).thenReturn(pluginName);
+            when(definedPlugin.getPluginTypeName()).thenReturn(pluginTypeName);
+            when(experimentalConfiguration.getEnabled()).thenReturn(Map.of(pluginTypeName, Set.of(UUID.randomUUID().toString(), pluginName)));
 
             createObjectUnderTest().accept(definedPlugin);
         }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidatorTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalPluginValidatorTest.java
@@ -106,7 +106,7 @@ class ExperimentalPluginValidatorTest {
             final String pluginTypeName = UUID.randomUUID().toString();
             when(definedPlugin.getPluginName()).thenReturn(pluginName);
             when(definedPlugin.getPluginTypeName()).thenReturn(pluginTypeName);
-            experimentalConfiguration.getEnabled().put(pluginTypeName, Set.of(UUID.randomUUID().toString()));
+            experimentalConfiguration.getEnabledPlugins().put(pluginTypeName, Set.of(UUID.randomUUID().toString()));
 
             final ExperimentalPluginValidator objectUnderTest = createObjectUnderTest();
 
@@ -123,7 +123,7 @@ class ExperimentalPluginValidatorTest {
             final String pluginTypeName = UUID.randomUUID().toString();
             when(definedPlugin.getPluginName()).thenReturn(pluginName);
             when(definedPlugin.getPluginTypeName()).thenReturn(pluginTypeName);
-            when(experimentalConfiguration.getEnabled()).thenReturn(Map.of(pluginTypeName, Set.of(UUID.randomUUID().toString(), pluginName)));
+            when(experimentalConfiguration.getEnabledPlugins()).thenReturn(Map.of(pluginTypeName, Set.of(UUID.randomUUID().toString(), pluginName)));
 
             createObjectUnderTest().accept(definedPlugin);
         }


### PR DESCRIPTION
### Description

Support enabling experimental plugins specifically by plugin type and name. 

This also includes a change to the core plugin classes to allow them to define themselves as a plugin component type along with a name that is used to create the mapping in the YAML file.

### Issues Resolved

Resolves #5675

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
