### PR TITLE
Fix validation for default route

### DIFF
--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/route/three-route-with-default-route.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/route/three-route-with-default-route.yaml
@@ -13,7 +13,6 @@ routing-pipeline:
     - alpha: '/value == "a"'
     - beta: '/value == "b"'
     - gamma: '/value == "g"'
-    - _default: '/_default == "z"'
   sink:
     - in_memory:
         testing_key: ConditionalRoutingIT_alpha

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/PipelineConfigurationValidator.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/PipelineConfigurationValidator.java
@@ -30,6 +30,8 @@ public class PipelineConfigurationValidator {
     private static final String PIPELINE_TYPE = "pipeline";
     private static final Set<String> INVALID_PIPELINE_NAMES = new HashSet<>(List.of("data-prepper", "dataPrepper", "core"));
 
+    private static final String DEFAULT_ROUTE = "_default";
+
     /**
      * Sorts the pipelines in topological order while also validating for
      * i. cycles in pipeline configuration
@@ -199,6 +201,7 @@ public class PipelineConfigurationValidator {
                 }
                 List<String> invalidRoutes = sinkRoutes.stream()
                         .filter(route -> !validRoutes.contains(route))
+                        .filter(route -> !route.equals(DEFAULT_ROUTE))
                         .collect(Collectors.toList());
 
                 if (!invalidRoutes.isEmpty()) {


### PR DESCRIPTION
### Description
This change (https://github.com/opensearch-project/data-prepper/pull/5501) broke the _default route supported from this PR (https://github.com/opensearch-project/data-prepper/pull/4662). This PR fixes the validation on _default route
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
