### PR TITLE
Fixes an uncommon test failure in TruncateProcessorConfigTests by not using zero

### DIFF
--- a/data-prepper-plugins/truncate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfigTests.java
+++ b/data-prepper-plugins/truncate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfigTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.truncate;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -42,7 +43,7 @@ class TruncateProcessorConfigTests {
         assertThat(entry.getLength(), equalTo(null));
         assertThat(entry.getTruncateWhen(), equalTo(null));
     }
-    
+
     @Test
     void testValidConfiguration_withStartAt() throws NoSuchFieldException, IllegalAccessException {
         TruncateProcessorConfig.Entry entry = new TruncateProcessorConfig.Entry();
@@ -56,7 +57,7 @@ class TruncateProcessorConfigTests {
         setField(TruncateProcessorConfig.class, truncateProcessorConfig, "entries", List.of(entry));
         assertTrue(entry.isValidConfig());
     }
-    
+
     @Test
     void testValidConfiguration_withLength() throws NoSuchFieldException, IllegalAccessException {
         TruncateProcessorConfig.Entry entry = new TruncateProcessorConfig.Entry();
@@ -91,25 +92,38 @@ class TruncateProcessorConfigTests {
         assertTrue(entry.isValidConfig());
     }
 
-    @Test
-    void testInvalidConfiguration_StartAt_Length_BothNull() throws NoSuchFieldException, IllegalAccessException { 
-        TruncateProcessorConfig.Entry entry = new TruncateProcessorConfig.Entry();
-        String source = RandomStringUtils.randomAlphabetic(10);
-        setField(TruncateProcessorConfig.Entry.class, entry, "sourceKeys", List.of(source));
-        assertFalse(entry.isValidConfig());
-    }
+    @Nested
+    class InvalidConfigurationWithValidSourceKeys {
+        private TruncateProcessorConfig.Entry entryUnderTest;
+        private int validLength;
+        private int validStartAt;
 
-    @Test
-    void testInvalidConfiguration_StartAt_Length_Negative() throws NoSuchFieldException, IllegalAccessException { 
-        TruncateProcessorConfig.Entry entry = new TruncateProcessorConfig.Entry();
-        String source = RandomStringUtils.randomAlphabetic(10);
-        int length = random.nextInt(100);
-        int startAt = random.nextInt(100);
-        setField(TruncateProcessorConfig.Entry.class, entry, "sourceKeys", List.of(source));
-        setField(TruncateProcessorConfig.Entry.class, entry, "startAt", -startAt);
-        assertFalse(entry.isValidConfig());
-        setField(TruncateProcessorConfig.Entry.class, entry, "startAt", startAt);
-        setField(TruncateProcessorConfig.Entry.class, entry, "length", -length);
-        assertFalse(entry.isValidConfig());
+        @BeforeEach
+        void setUp() throws NoSuchFieldException, IllegalAccessException {
+            entryUnderTest = new TruncateProcessorConfig.Entry();
+            String source = RandomStringUtils.randomAlphabetic(10);
+            setField(TruncateProcessorConfig.Entry.class, entryUnderTest, "sourceKeys", List.of(source));
+
+            validLength = random.nextInt(100) + 1;
+            validStartAt = random.nextInt(100) + 1;
+        }
+
+        @Test
+        void testInvalidConfiguration_StartAt_Length_BothNull() {
+            assertFalse(entryUnderTest.isValidConfig());
+        }
+
+        @Test
+        void testInvalidConfiguration_StartAt_Negative() throws NoSuchFieldException, IllegalAccessException {
+            setField(TruncateProcessorConfig.Entry.class, entryUnderTest, "startAt", -validStartAt);
+            assertFalse(entryUnderTest.isValidConfig());
+        }
+
+        @Test
+        void testInvalidConfiguration_Length_Negative() throws NoSuchFieldException, IllegalAccessException {
+            setField(TruncateProcessorConfig.Entry.class, entryUnderTest, "startAt", validStartAt);
+            setField(TruncateProcessorConfig.Entry.class, entryUnderTest, "length", -validLength);
+            assertFalse(entryUnderTest.isValidConfig());
+        }
     }
 }


### PR DESCRIPTION
### Description

I noticed a test failure in `TruncateProcessorConfigTests`. I suspect this is because the random value can be zero. Then we make that `-0` which is `0` which is valid.

Additionally, there are really two tests in this one test. So I split these. This way we know what actually fails when failures occur.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
