### PR TITLE
Add traceId to documentId used for spans

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -121,6 +121,8 @@ public class OpenSearchSinkIT {
     private static final String TEST_INDEX_TEMPLATE_V2_FILE = "test-composable-index-template-v2.json";
     private static final String DEFAULT_RAW_SPAN_FILE_1 = "raw-span-1.json";
     private static final String DEFAULT_RAW_SPAN_FILE_2 = "raw-span-2.json";
+    private static final String ALTERNATE_RAW_SPAN_FILE_2_ID_AS_DEFAULT_SPAN_1 = "raw-span-2-same-id-as-1.json";
+
     private static final String DEFAULT_SERVICE_MAP_FILE = "service-map-1.json";
     private static final String INCLUDE_TYPE_NAME_FALSE_URI = "?include_type_name=false";
     private static final String TRACE_INGESTION_TEST_DISABLED_REASON = "Trace ingestion is not supported for ES 6";
@@ -368,7 +370,7 @@ public class OpenSearchSinkIT {
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(expIndexAlias);
         assertThat(retSources.size(), equalTo(2));
         assertThat(retSources, hasItems(expData1, expData2));
-        assertThat(getDocumentCount(expIndexAlias, "_id", (String) expData1.get("spanId")), equalTo(Integer.valueOf(1)));
+        assertThat(getDocumentCount(expIndexAlias, "_id", (String) expData1.get("traceId") + "/" + (String) expData1.get("spanId")), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // Verify metrics
@@ -411,10 +413,32 @@ public class OpenSearchSinkIT {
                         .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
         assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
         assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
-        final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 792.0 : 2058.0;
+        final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 799.0 : 2058.0;
         assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
         assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
     }
+
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
+    @ParameterizedTest
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    public void testOutputRawSpanWithEqualId(final boolean estimateBulkSizeUsingCompression,
+                                         final boolean isRequestCompressionEnabled) throws IOException, InterruptedException {
+        final String testDoc1 = readDocFromFile(DEFAULT_RAW_SPAN_FILE_1);
+        final String testDoc2 = readDocFromFile(ALTERNATE_RAW_SPAN_FILE_2_ID_AS_DEFAULT_SPAN_1);
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final List<Record<Event>> testRecords = Arrays.asList(jsonStringToRecord(testDoc1), jsonStringToRecord(testDoc2));
+        final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfig(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null,
+                                                                                       estimateBulkSizeUsingCompression, isRequestCompressionEnabled);
+        final OpenSearchSink sink = createObjectUnderTest(openSearchSinkConfig, true);
+        sink.output(testRecords);
+
+        final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
+        final List<Map<String, Object>> retSources = getSearchResponseDocSources(expIndexAlias);
+        assertThat("Spans should not overwrite each other",retSources.size(), equalTo(2));
+        sink.shutdown();
+    }
+
 
     @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     @ParameterizedTest
@@ -473,7 +497,7 @@ public class OpenSearchSinkIT {
                         .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
         assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
         assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
-        final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 1078.0 : 2072.0;
+        final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 1085.0 : 2072.0;
         assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
         assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -165,7 +165,7 @@ public class IndexConfiguration {
         String documentIdField = builder.documentIdField;
         String documentId = builder.documentId;
         if (indexType.equals(IndexType.TRACE_ANALYTICS_RAW) || indexType.equals(IndexType.TRACE_ANALYTICS_RAW_PLAIN)) {
-            documentId = "${spanId}";
+            documentId = "${traceId}/${spanId}";
         } else if (indexType.equals(IndexType.TRACE_ANALYTICS_SERVICE_MAP)) {
             documentId = "${hashId}";
         }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -343,7 +343,7 @@ public class IndexConfigurationTests {
         assertEquals(60_000L, indexConfiguration.getFlushTimeout());
         assertEquals(false, indexConfiguration.isEstimateBulkSizeUsingCompression());
         assertEquals(2, indexConfiguration.getMaxLocalCompressionsForEstimation());
-        assertEquals("${spanId}", indexConfiguration.getDocumentId());
+        assertEquals("${traceId}/${spanId}", indexConfiguration.getDocumentId());
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/resources/raw-span-2-same-id-as-1.json
+++ b/data-prepper-plugins/opensearch/src/test/resources/raw-span-2-same-id-as-1.json
@@ -1,0 +1,29 @@
+{
+  "traceId": "aQ/2NNEmtuwsGAOR5ntCNw==",
+  "spanId":"mnO/qUT5ye4=",
+  "parentSpanId": "null",
+  "name":"io.opentelemetry.auto.servlet-3.0",
+  "kind":"SERVER",
+  "status": {
+    "code": 6,
+    "message": "Already exists"
+  },
+  "serviceName": "analytics-service",
+  "startTime":"2020-08-20T05:40:46.042011600Z",
+  "endTime":"2020-08-20T05:40:46.088556800Z",
+  "durationInNanos": 46545200,
+  "span.attributes.http@status_code":200,
+  "span.attributes.net@peer@port":41168,
+  "span.attributes.servlet@path":"/logs",
+  "span.attributes.http@response_content_length":7,
+  "span.attributes.http@user_agent":"curl/7.54.0",
+  "span.attributes.http@flavor":"HTTP/1.1",
+  "span.attributes.servlet@context":"",
+  "span.attributes.http@url":"http://0.0.0.0:8087/logs",
+  "span.attributes.net@peer@ip":"172.29.0.1",
+  "span.attributes.http@method":"POST",
+  "span.attributes.http@client_ip":"172.29.0.1",
+  "resource.attributes@telemetry@sdk@language":"java",
+  "resource.attributes@telemetry@sdk@name":"opentelemetry",
+  "resource.attributes@telemetry@sdk@version":"0.8.0-SNAPSHOT"
+}


### PR DESCRIPTION
### Description
OpenTelemetry spans are currently indexed using the spanId as documentId. This can lead to collisions where spans are not indexed or overwrite each other.

This change adds the traceId to the documentId. OpenTelemetry assumes the combination of traceId and spanId to be unique. If there is still a collision it is safe to assume, that it occurs because of a resending of a previously indexed span.
 
### Issues Resolved
Resolves #5370 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
