### PR TITLE
Add `getEventType()` expression function

### DIFF
--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -160,7 +160,7 @@ Function
 
 fragment
 FunctionArgs
-    : (FunctionArg SPACE* COMMA SPACE*)* SPACE* FunctionArg
+    : ((FunctionArg SPACE* COMMA SPACE*)* SPACE* FunctionArg)?
     ;
 
 fragment

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import javax.inject.Named;
+import java.util.function.Function;
+import java.util.List;
+
+@Named
+public class GetEventTypeExpressionFunction implements ExpressionFunction {
+
+    @Override
+    public String getFunctionName() {
+        return "getEventType";
+    }
+
+    @Override
+    public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
+        if (!args.isEmpty()) {
+            throw new RuntimeException("getEventType() does not take any arguments");
+        }
+        return event.getMetadata().getEventType();
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunction.java
@@ -19,7 +19,7 @@ public class GetEventTypeExpressionFunction implements ExpressionFunction {
     }
 
     @Override
-    public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
+    public Object evaluate(final List<Object> args, final Event event, final Function<Object, Object> convertLiteralType) {
         if (!args.isEmpty()) {
             throw new RuntimeException("getEventType() does not take any arguments");
         }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -26,7 +26,7 @@ class ParseTreeCoercionService {
     @Inject
     public ParseTreeCoercionService(
             final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions,
-            ExpressionFunctionProvider expressionFunctionProvider) {
+            final ExpressionFunctionProvider expressionFunctionProvider) {
         this.literalTypeConversions = literalTypeConversions;
         convertLiteralType = (value) -> {
             if (literalTypeConversions.containsKey(value.getClass())) {

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -24,15 +24,17 @@ class ParseTreeCoercionService {
     private Function<Object, Object> convertLiteralType;
 
     @Inject
-    public ParseTreeCoercionService(final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions, ExpressionFunctionProvider expressionFunctionProvider) {
+    public ParseTreeCoercionService(
+            final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions,
+            ExpressionFunctionProvider expressionFunctionProvider) {
         this.literalTypeConversions = literalTypeConversions;
         convertLiteralType = (value) -> {
-                if (literalTypeConversions.containsKey(value.getClass())) {
-                    return literalTypeConversions.get(value.getClass()).apply(value);
-                } else {
-                    throw new ExpressionCoercionException("Unsupported type for value " + value);
-                }
-            };
+            if (literalTypeConversions.containsKey(value.getClass())) {
+                return literalTypeConversions.get(value.getClass()).apply(value);
+            } else {
+                throw new ExpressionCoercionException("Unsupported type for value " + value);
+            }
+        };
         this.expressionFunctionProvider = expressionFunctionProvider;
     }
 
@@ -44,23 +46,31 @@ class ParseTreeCoercionService {
                 final int funcNameIndex = nodeStringValue.indexOf("(");
                 final String functionName = nodeStringValue.substring(0, funcNameIndex);
                 final int argsEndIndex = nodeStringValue.indexOf(")", funcNameIndex);
-                final String argsStr = nodeStringValue.substring(funcNameIndex+1, argsEndIndex);
-                // Split at commas if there's no backslash before the commas, because commas can be part of a function parameter
-                final String[] args = argsStr.split("(?<!\\\\),");
                 List<Object> argList = new ArrayList<>();
-                for (final String arg: args) {
-                    String trimmedArg = arg.trim();
-                    if (trimmedArg.charAt(0) == '/') {
-                        argList.add(trimmedArg);
-                    } else if (trimmedArg.charAt(0) == '"') {
-                        if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length()-1) != '"') {
-                            throw new RuntimeException("Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
+
+                // Check if the function has at least one argument
+                 if(argsEndIndex > funcNameIndex + 1) {
+                    final String argsStr = nodeStringValue.substring(funcNameIndex + 1, argsEndIndex);
+                    // Split at commas if there's no backslash before the commas, because commas can
+                    // be part of a function parameter
+                    final String[] args = argsStr.split("(?<!\\\\),");
+                    
+                    for (final String arg : args) {
+                        String trimmedArg = arg.trim();
+                        if (trimmedArg.charAt(0) == '/') {
+                            argList.add(trimmedArg);
+                        } else if (trimmedArg.charAt(0) == '"') {
+                            if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length() - 1) != '"') {
+                                throw new RuntimeException(
+                                        "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
+                            }
+                            argList.add(trimmedArg);
+                        } else {
+                            throw new RuntimeException("Unsupported type passed as function argument");
                         }
-                        argList.add(trimmedArg);
-                    } else {
-                        throw new RuntimeException("Unsupported type passed as function argument");
                     }
                 }
+             
                 return expressionFunctionProvider.provideFunction(functionName, argList, event, convertLiteralType);
             case DataPrepperExpressionParser.EscapedJsonPointer:
                 final String jsonPointerWithoutQuotes = nodeStringValue.substring(1, nodeStringValue.length() - 1);
@@ -68,7 +78,8 @@ class ParseTreeCoercionService {
             case DataPrepperExpressionParser.JsonPointer:
                 return resolveJsonPointerValue(nodeStringValue, event);
             case DataPrepperExpressionParser.String:
-                final String nodeStringValueWithQuotesStripped = nodeStringValue.substring(1, nodeStringValue.length() - 1);
+                final String nodeStringValueWithQuotesStripped = nodeStringValue.substring(1,
+                        nodeStringValue.length() - 1);
                 return nodeStringValueWithQuotesStripped;
             case DataPrepperExpressionParser.Integer:
                 Long longValue = Long.valueOf(nodeStringValue);
@@ -98,14 +109,15 @@ class ParseTreeCoercionService {
         if (obj.getClass().isAssignableFrom(clazz)) {
             return (T) obj;
         }
-        throw new ExpressionCoercionException("Unable to cast " + obj.getClass().getName() + " into " + clazz.getName());
+        throw new ExpressionCoercionException(
+                "Unable to cast " + obj.getClass().getName() + " into " + clazz.getName());
     }
 
     private Object resolveJsonPointerValue(final String jsonPointer, final Event event) {
         final Object value = event.get(jsonPointer, Object.class);
         if (value == null) {
             return null;
-        } 
+        }
         return convertLiteralType.apply(value);
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -248,8 +248,10 @@ class GenericExpressionEvaluator_ConditionalIT {
                 arguments("/name =~ \".*dataprepper-[0-9]+\"", event("{\"name\": \"dataprepper-abc\"}"), false),
                 arguments("/name =~ \".*dataprepper-[0-9]+\"", event("{\"other\": \"dataprepper-abc\"}"), false),
                 arguments("startsWith(\""+strValue+ UUID.randomUUID() + "\",/status)", event("{\"status\":\""+strValue+"\"}"), true),
-                arguments("startsWith(\""+ UUID.randomUUID() +strValue+ "\",/status)", event("{\"status\":\""+strValue+"\"}"), false)
-                );
+                arguments("startsWith(\""+ UUID.randomUUID() +strValue+ "\",/status)", event("{\"status\":\""+strValue+"\"}"), false),
+                arguments("getEventType() == \"event\"",  longEvent, true),
+                arguments("getEventType() == \"LOG\"",  longEvent, false)
+        );
     }
 
     private static Stream<Arguments> invalidExpressionArguments() {
@@ -344,7 +346,10 @@ class GenericExpressionEvaluator_ConditionalIT {
                 arguments("getMetadata(10)", tagEvent),
                 arguments("getMetadata("+ testMetadataKey+ ")", tagEvent),
                 arguments("getMetadata(\""+ testMetadataKey+")", tagEvent),
-                arguments("cidrContains(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
+                arguments("cidrContains(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}")),
+                arguments("getEventType() == \"test_event", tagEvent),
+                arguments("getEventType() == test_event\"", tagEvent)
+                
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_MultiTypeIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_MultiTypeIT.java
@@ -112,13 +112,6 @@ class GenericExpressionEvaluator_MultiTypeIT {
     }
 
     @ParameterizedTest
-    @MethodSource("exceptionExpressionSyntaxArguments")
-    void testExpressionSyntaxEvaluatorCausesException(final String expression, final Event event) {
-        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
-        assertThrows(ExpressionParsingException.class, () -> evaluator.evaluate(expression, event));
-    }
-
-    @ParameterizedTest
     @MethodSource("exceptionExpressionArguments")
     void testExpressionEvaluatorCausesException(final String expression, final Event event) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
@@ -165,20 +158,15 @@ class GenericExpressionEvaluator_MultiTypeIT {
         );
     }
 
-    private static Stream<Arguments> exceptionExpressionSyntaxArguments() {
-        return Stream.of(
-                Arguments.of("join()", event("{\"list\":[\"string\", 1, true]}")),
-                Arguments.of("contains()", event("{\"list\":[\"string\", 1, true]}")),
-                Arguments.of("startsWith()", event("{\"list\":[\"string\", 1, true]}"))
-        );
-    }
-
     private static Stream<Arguments> exceptionExpressionArguments() {
         return Stream.of(
                 // Can't mix Numbers and Strings when using operators
                 Arguments.of("/status + /message", event("{\"status\": 200, \"message\":\"msg\"}")),
                 // Wrong number of arguments
-                Arguments.of("join(/list, \" \", \"third_arg\")", event("{\"list\":[\"string\", 1, true]}"))
+                Arguments.of("join(/list, \" \", \"third_arg\")", event("{\"list\":[\"string\", 1, true]}")),
+                Arguments.of("join()", event("{\"list\":[\"string\", 1, true]}")),
+                Arguments.of("contains()", event("{\"list\":[\"string\", 1, true]}")),
+                Arguments.of("startsWith()", event("{\"list\":[\"string\", 1, true]}"))
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunctionTest.java
@@ -5,7 +5,10 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -43,12 +46,10 @@ class GetEventTypeExpressionFunctionTest {
     }
 
     @Test
-    void testGetEventTypeReturnsNullForNullEventType() {
-        GetEventTypeExpressionFunction function = createObjectUnderTest();
-        Event testEvent = createTestEvent(null);
-
-        Object result = function.evaluate(List.of(), testEvent, Function.identity());
-
-        assertThat(result, equalTo(null));
+    void testGetEventTypeFunctionRegistered() {
+        Event testEvent = createTestEvent("event");
+        final GenericExpressionEvaluator evaluator = mock(GenericExpressionEvaluator.class);
+        when(evaluator.evaluateConditional("getEventType() == \"event\"", testEvent)).thenReturn(true);
+        assertDoesNotThrow(() -> evaluator.evaluateConditional("getEventType() == \"event\"", testEvent));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunctionTest.java
@@ -3,6 +3,9 @@ package org.opensearch.dataprepper.expression;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -27,14 +30,15 @@ class GetEventTypeExpressionFunctionTest {
                 .build();
     }
 
-    @Test
-    void testGetEventTypeReturnsCorrectType() {
+    @ParameterizedTest
+    @ValueSource(strings = {"LOG", "TRACE", "METRIC"})
+    void testGetEventTypeReturnsCorrectType(String eventType) {
         GetEventTypeExpressionFunction function = createObjectUnderTest();
-        Event testEvent = createTestEvent("LOG");
+        Event testEvent = createTestEvent(eventType);
 
         Object result = function.evaluate(List.of(), testEvent, Function.identity());
 
-        assertThat(result, equalTo("LOG"));
+        assertThat(result, equalTo(eventType));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetEventTypeExpressionFunctionTest.java
@@ -1,0 +1,54 @@
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+class GetEventTypeExpressionFunctionTest {
+
+    private GetEventTypeExpressionFunction createObjectUnderTest() {
+        return new GetEventTypeExpressionFunction();
+    }
+
+    private Event createTestEvent(final String eventType) {
+        return JacksonEvent.builder()
+                .withEventType(eventType)
+                .withData(Map.of())
+                .build();
+    }
+
+    @Test
+    void testGetEventTypeReturnsCorrectType() {
+        GetEventTypeExpressionFunction function = createObjectUnderTest();
+        Event testEvent = createTestEvent("LOG");
+
+        Object result = function.evaluate(List.of(), testEvent, Function.identity());
+
+        assertThat(result, equalTo("LOG"));
+    }
+
+    @Test
+    void testGetEventTypeThrowsExceptionWhenArgumentsProvided() {
+        GetEventTypeExpressionFunction function = createObjectUnderTest();
+        Event testEvent = createTestEvent("LOG");
+
+        assertThrows(RuntimeException.class, () -> function.evaluate(List.of("arg1"), testEvent, Function.identity()));
+    }
+
+    @Test
+    void testGetEventTypeReturnsNullForNullEventType() {
+        GetEventTypeExpressionFunction function = createObjectUnderTest();
+        Event testEvent = createTestEvent(null);
+
+        Object result = function.evaluate(List.of(), testEvent, Function.identity());
+
+        assertThat(result, equalTo(null));
+    }
+}

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -184,6 +184,13 @@ Currently, the following functions are supported
    - takes one String literal as argument. This is the key to lookup in the event's metadata. If the key contains "/", then recursive lookup into the metadata attributes is done.
    - returns the value corresponding to the argument (key) passed. Value can be of any type.
    For example, if metadata contains {"key1": "value2", "key2": 10}, then `getMetadata("key1")` returns "value2", and `getMetadata("key2")` return 10.
+ * `getEventType()`
+   - Takes no arguments.
+   - Returns the event type of the given event as a String.
+   - Throws an error if any arguments are provided.
+   - Event types is useful from routing requests based on type examples: `LOG`, `TRACE` and `METRIC`.
+   For example, if the event has an event type `"LOG"`, `getEventType()` will return `"LOG"`.
+   Example usage in an expression: `getEventType() == "LOG"`.
  * `contains()`
    - takes two String arguments. Both should be either string literals or Json Pointers with String values.
    - returns true if the second argument is a substring of the first argument. Otherwise, return false.


### PR DESCRIPTION
### Description
Today DataPrepper have a great event metadata structure that users can use to route between sub-pipelines. We already have functions supported in the expression language to help users route these events: 

1. `getMetaData`- Function to fetch the value of attribute keys from the event
2. `hasTags` - Function to validate existence of tags in an event
 
This PR adds a third metadata related function to help users route based on event Type. `getEventType`: New function to fetch the event type. 

- [x] Updated Antlr grammar
- [x] Updated Expressions documentation
- [x] Updated GenericExpressionIT tests

Example Usage of the new function, the example will be more helpful in the upcoming `OTLP source`:

```
otel-logs-pipelines:
  source:
    otel_logs_source:
      ssl: false
      proto_reflection_service: true
  route:
    - logs: "getEventType() == \"LOG\""
  sink:
    - pipeline:
        name: "logs-pipeline"
        routes:
          - "logs"

logs-pipeline:
  source:
    pipeline:
      name: "otel-logs-pipelines"
  sink:
    - stdout:
```

### Issues Resolved
Related issue: #5596 
Dependent PR: #5677 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
