### PR TITLE
Added integration tests for validating that events are processed exactly once

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorValidationIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorValidationIT.java
@@ -44,8 +44,6 @@ class ProcessorValidationIT {
     private static final int BATCH_SIZE = 5;
     private static final int TOTAL_EVENTS = 100;
     private static final int WAIT_TIMEOUT_SECONDS = 10;
-    private static BaseEventsTrackingProcessor singleThreadEventsTrackingProcessor;
-    private static BaseEventsTrackingProcessor basicEventsTrackingProcessor;
     private static Map<String, List<BaseEventsTrackingProcessor>> PIPELINE_TO_PROCESSORS_MAP;
 
     private DataPrepperTestRunner testRunner;
@@ -55,8 +53,8 @@ class ProcessorValidationIT {
 
     @BeforeAll
     static void setupProcessors() {
-        singleThreadEventsTrackingProcessor = new SingleThreadEventsTrackingTestProcessor();
-        basicEventsTrackingProcessor = new BasicEventsTrackingTestProcessor();
+        BaseEventsTrackingProcessor singleThreadEventsTrackingProcessor = new SingleThreadEventsTrackingTestProcessor();
+        BaseEventsTrackingProcessor basicEventsTrackingProcessor = new BasicEventsTrackingTestProcessor();
         PIPELINE_TO_PROCESSORS_MAP = Map.of(
             "single-thread-processor-pipeline", List.of(singleThreadEventsTrackingProcessor),
             "basic-processor-pipeline", List.of(basicEventsTrackingProcessor),
@@ -66,8 +64,8 @@ class ProcessorValidationIT {
 
     @BeforeEach
     void setUp() {
-        singleThreadEventsTrackingProcessor.reset();
-        basicEventsTrackingProcessor.reset();
+        PIPELINE_TO_PROCESSORS_MAP.values().forEach(processorsList ->
+                processorsList.forEach(BaseEventsTrackingProcessor::reset));
     }
 
     @AfterEach

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorValidationIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorValidationIT.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.plugins.BasicEventsTrackingTestProcessor;
+import org.opensearch.dataprepper.plugins.SingleThreadEventsTrackingTestProcessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Integration tests for validating processor behavior in pipelines and to verify that
+ * events are processed exactly once even while using multiple workers.
+ */
+class ProcessorValidationIT {
+    private static final String IN_MEMORY_IDENTIFIER = "ProcessorValidationIT";
+    private static final int BATCH_SIZE = 5;
+    private static final int TOTAL_EVENTS = 100;
+    private static final int WAIT_TIMEOUT_SECONDS = 10;
+
+    private static final Map<String, List<Class<?>>> PIPELINE_TO_PROCESSORS_MAP = Map.of(
+            "single-thread-processor-pipeline", List.of(SingleThreadEventsTrackingTestProcessor.class),
+            "basic-processor-pipeline", List.of(BasicEventsTrackingTestProcessor.class),
+            "multi-processor-pipeline", List.of(SingleThreadEventsTrackingTestProcessor.class, BasicEventsTrackingTestProcessor.class)
+    );
+
+    private DataPrepperTestRunner testRunner;
+    private InMemorySourceAccessor sourceAccessor;
+    private InMemorySinkAccessor sinkAccessor;
+    private String pipelineType;
+
+    @BeforeEach
+    void setUp() {
+        SingleThreadEventsTrackingTestProcessor.reset();
+        BasicEventsTrackingTestProcessor.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (testRunner != null) {
+            testRunner.stop();
+        }
+    }
+
+    /**
+     * Parameterized test that validates event processing across different pipeline configurations.
+     *
+     * @param pipelineType The type of pipeline configuration to test
+     * @param testName A descriptive name for the test scenario
+     * @param numberOfBatches Number of batches to send to the pipeline
+     * @param eventsPerBatch Number of events in each batch
+     * @param expectedTotalEvents Total number of events expected to be processed
+     */
+    @ParameterizedTest(name = "{index} - {0} - {1}")
+    @MethodSource("provideTestParameters")
+    void test_events_processed_validation(String pipelineType, String testName, int numberOfBatches, int eventsPerBatch, int expectedTotalEvents) {
+        this.pipelineType = pipelineType;
+        initializeTestRunner();
+        List<List<Record<Event>>> batches = createBatches(numberOfBatches, eventsPerBatch);
+        batches.forEach(batch -> sourceAccessor.submit(IN_MEMORY_IDENTIFIER, batch));
+
+        verifyProcessingResults(pipelineType, expectedTotalEvents, eventsPerBatch);
+    }
+
+    /**
+     * Provides test parameters for the parameterized test.
+     * Creates test scenarios for each pipeline type with both single batch and multiple batch configurations.
+     * @return Stream of test parameters
+     */
+    private static Stream<Arguments> provideTestParameters() {
+        List<Arguments> arguments = new ArrayList<>();
+        for (String pipelineType : PIPELINE_TO_PROCESSORS_MAP.keySet()) {
+            arguments.add(Arguments.of(pipelineType, "SingleBatch", 1, TOTAL_EVENTS, TOTAL_EVENTS));
+            arguments.add(Arguments.of(pipelineType, "MultipleBatches", BATCH_SIZE, TOTAL_EVENTS, BATCH_SIZE * TOTAL_EVENTS));
+        }
+        return arguments.stream();
+    }
+
+    /**
+     * Initializes the DataPrepper test runner with the appropriate pipeline configuration.
+     * Sets up source and sink accessors for test data input and output.
+     */
+    private void initializeTestRunner() {
+        String pipelineFile = pipelineType + ".yaml";
+        testRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(pipelineFile)
+                .build();
+        sourceAccessor = testRunner.getInMemorySourceAccessor();
+        sinkAccessor = testRunner.getInMemorySinkAccessor();
+        testRunner.start();
+    }
+
+    /**
+     * Verifies that events were processed correctly by the pipeline.
+     * @param pipelineType The type of pipeline being tested
+     * @param expectedTotalEvents Total number of events expected to be processed
+     * @param eventsPerBatch Number of events in each batch
+     */
+    private void verifyProcessingResults(String pipelineType, int expectedTotalEvents, int eventsPerBatch) {
+        // Wait for all events to be processed
+        await().atMost(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(
+                        sinkAccessor.get(IN_MEMORY_IDENTIFIER).size(),
+                        equalTo(expectedTotalEvents)));
+
+        List<Record<Event>> outputRecords = sinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(outputRecords.size(), equalTo(expectedTotalEvents));
+
+        // Verify each processor in the pipeline processed events
+        List<Class<?>> processors = PIPELINE_TO_PROCESSORS_MAP.get(pipelineType);
+        for (Class<?> processorClass : processors) {
+            Map<String, AtomicInteger> processedEventsMap;
+            String processorName;
+
+            if (processorClass.equals(SingleThreadEventsTrackingTestProcessor.class)) {
+                processedEventsMap = SingleThreadEventsTrackingTestProcessor.getEventsMap();
+                processorName = SingleThreadEventsTrackingTestProcessor.getName();
+            } else if (processorClass.equals(BasicEventsTrackingTestProcessor.class)) {
+                processedEventsMap = BasicEventsTrackingTestProcessor.getEventsMap();
+                processorName = BasicEventsTrackingTestProcessor.getName();
+            } else {
+                throw new IllegalArgumentException("Unknown processor : " + processorClass.getName());
+            }
+
+            verifyEventProcessing(processedEventsMap, outputRecords, expectedTotalEvents, processorName);
+        }
+
+        verifyWorkerThreads(outputRecords, processors);
+
+        int numberOfBatches = expectedTotalEvents / eventsPerBatch;
+        for (int batch = 0; batch < numberOfBatches; batch++) {
+            int finalBatch = batch;
+            List<Record<Event>> batchRecords = outputRecords.stream()
+                    .filter(record -> record.getData().get("batch", Integer.class) == finalBatch)
+                    .collect(Collectors.toList());
+            assertThat(batchRecords.size(), equalTo(eventsPerBatch));
+        }
+    }
+
+    /**
+     * Verifies that each event was processed exactly once by the specified processor.
+     * Checks both the processor's internal tracking map and the event metadata.
+     *
+     * @param processedEventsMap Map tracking which events were processed by the processor
+     * @param outputRecords List of output records from the pipeline
+     * @param expectedTotalEvents Total number of events expected to be processed
+     * @param processorType Name of the processor being verified
+     */
+    private void verifyEventProcessing(Map<String, AtomicInteger> processedEventsMap,
+                                       List<Record<Event>> outputRecords,
+                                       int expectedTotalEvents,
+                                       String processorType) {
+        String countField = processorType + "_processed_count";
+        for (Record<Event> record : outputRecords) {
+            String id = record.getData().get("id", String.class);
+            AtomicInteger count = processedEventsMap.get(id);
+
+            assertThat("Event with ID " + id + " should be processed exactly once by " + processorType,
+                    count.get(), equalTo(1));
+            assertThat("Event processing count should be 1 for " + processorType,
+                    record.getData().get(countField, Integer.class), equalTo(1));
+        }
+
+        assertThat("All events should be processed by " + processorType,
+                processedEventsMap.size(), equalTo(expectedTotalEvents));
+    }
+
+    /**
+     * Verifies that worker threads were assigned correctly based on processor configuration.
+     * Ensures that at least one worker thread was used for processing.
+     *
+     * @param outputRecords List of output records from the pipeline
+     * @param processors List of processors in the pipeline
+     */
+    private void verifyWorkerThreads(List<Record<Event>> outputRecords, List<Class<?>> processors) {
+        Set<String> threadNames = outputRecords.stream()
+                .map(Record::getData)
+                .flatMap(event -> processors.stream()
+                        .map(processorClass -> {
+                            String processorName;
+                            if (processorClass.equals(SingleThreadEventsTrackingTestProcessor.class)) {
+                                processorName = SingleThreadEventsTrackingTestProcessor.getName();
+                            } else if (processorClass.equals(BasicEventsTrackingTestProcessor.class)) {
+                                processorName = BasicEventsTrackingTestProcessor.getName();
+                            } else {
+                                throw new IllegalArgumentException("Unknown processor class: " + processorClass.getName());
+                            }
+                            return event.get(processorName + "_processed_by_thread", String.class);
+                        })
+                        .filter(threadName -> threadName != null))
+                .collect(Collectors.toSet());
+
+        assertThat("There should be at least one worker thread",
+                threadNames.size(), greaterThanOrEqualTo(1));
+    }
+
+    /**
+     * Creates a list of event records with unique IDs and sequential numbering.
+     *
+     * @param count Number of records to create
+     * @return List of event records
+     */
+    private List<Record<Event>> createRecords(int count) {
+        List<Record<Event>> records = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            records.add(new Record<>(createEvent(i)));
+        }
+        return records;
+    }
+
+    /**
+     * Creates multiple batches of event records.
+     * Each batch is assigned a batch number, and events within each batch
+     * are given sequential numbers across all batches.
+     *
+     * @param batchSize Number of batches to create
+     * @param eventsPerBatch Number of events in each batch
+     * @return List of batches, where each batch is a list of event records
+     */
+    private List<List<Record<Event>>> createBatches(int batchSize, int eventsPerBatch) {
+        List<List<Record<Event>>> batches = new ArrayList<>();
+        for (int batch = 0; batch < batchSize; batch++) {
+            int batchOffset = batch * eventsPerBatch;
+            int currentBatch = batch;
+            List<Record<Event>> batchRecords = createRecords(eventsPerBatch).stream()
+                    .map(record -> {
+                        Event event = record.getData();
+                        event.put("sequence", batchOffset + event.get("sequence", Integer.class));
+                        event.put("batch", currentBatch);
+                        return new Record<>(event);
+                    })
+                    .collect(Collectors.toList());
+            batches.add(batchRecords);
+        }
+        return batches;
+    }
+
+    /**
+     * Creates a single event with a unique ID and sequence number.
+     *
+     * @param sequence Sequence number to assign to the event
+     * @return The created event
+     */
+    private Event createEvent(int sequence) {
+        String eventId = UUID.randomUUID().toString();
+        Event event = JacksonEvent.fromMessage(eventId);
+        event.put("id", eventId);
+        event.put("sequence", sequence);
+        return event;
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BaseEventsTrackingProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BaseEventsTrackingProcessor.java
@@ -20,6 +20,7 @@ public abstract class BaseEventsTrackingProcessor implements Processor<Record<Ev
     private final String countPropertyName;
     private final String threadPropertyName;
     private final Map<String, AtomicInteger> eventsMap;
+    private final String processorName;
 
     /**
      * Constructor for the base events tracking processor.
@@ -30,7 +31,31 @@ public abstract class BaseEventsTrackingProcessor implements Processor<Record<Ev
     protected BaseEventsTrackingProcessor(String processorName, Map<String, AtomicInteger> eventsMap) {
         this.countPropertyName = processorName + "_processed_count";
         this.threadPropertyName = processorName + "_processed_by_thread";
+        this.processorName = processorName;
         this.eventsMap = eventsMap;
+    }
+
+    /**
+     * Gets the map of processed events.
+     * @return Map of event IDs to processing counts
+     */
+    public Map<String, AtomicInteger> getEventsMap() {
+        return eventsMap;
+    }
+
+    /**
+     * Gets the name of processor.
+     * @return The processor name
+     */
+    public String getName() {
+        return processorName;
+    }
+
+    /**
+     * Resets the processor's state by clearing the events map.
+     */
+    public void reset() {
+        eventsMap.clear();
     }
 
     /**

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BaseEventsTrackingProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BaseEventsTrackingProcessor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Abstract base class for test processors that track event processing.
+ * This class provides common functionality for tracking all the events that are processed
+ */
+public abstract class BaseEventsTrackingProcessor implements Processor<Record<Event>, Record<Event>> {
+    private final String countPropertyName;
+    private final String threadPropertyName;
+    private final Map<String, AtomicInteger> eventsMap;
+
+    /**
+     * Constructor for the base events tracking processor.
+     *
+     * @param processorName Name of the processor
+     * @param eventsMap Map for tracking processed events
+     */
+    protected BaseEventsTrackingProcessor(String processorName, Map<String, AtomicInteger> eventsMap) {
+        this.countPropertyName = processorName + "_processed_count";
+        this.threadPropertyName = processorName + "_processed_by_thread";
+        this.eventsMap = eventsMap;
+    }
+
+    /**
+     * Processes a collection of event records.
+     * For each event:
+     * 1. Stores the event which was provided for processing in the events map
+     * 2. Records the processing count in the event metadata
+     * 3. Records which thread processed the event in the event metadata
+     *
+     * @param records Collection of event records to process
+     * @return records with added metadata
+     */
+    @Override
+    public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
+        final String threadName = Thread.currentThread().getName();
+
+        for (Record<Event> record : records) {
+            Event event = record.getData();
+            String eventId = event.get("id", String.class);
+
+            if (eventId != null) {
+                AtomicInteger counter = eventsMap.computeIfAbsent(eventId, id -> new AtomicInteger(0));
+                int count = counter.incrementAndGet();
+
+                event.put(countPropertyName, count);
+                event.put(threadPropertyName, threadName);
+            }
+        }
+        return records;
+    }
+
+    @Override
+    public void prepareForShutdown() {
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.processor.Processor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A basic test processor implementation which tracks the list of all events processed by it
+ */
+@DataPrepperPlugin(name = "basic_events_tracking_test", pluginType = Processor.class)
+public class BasicEventsTrackingTestProcessor extends BaseEventsTrackingProcessor {
+    private static final Map<String, AtomicInteger> PROCESSED_EVENTS_MAP = new ConcurrentHashMap<>();
+    private static final String PLUGIN_NAME = "basic_events_tracking_test";
+
+    public BasicEventsTrackingTestProcessor() {
+        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP);
+    }
+
+    /**
+     * Gets the map of processed events.
+     * @return Map of event IDs to processing counts
+     */
+    public static Map<String, AtomicInteger> getEventsMap() {
+        return PROCESSED_EVENTS_MAP;
+    }
+
+    /**
+     * Gets the name of this processor.
+     * @return The processor name
+     */
+    public static String getName() {
+        return PLUGIN_NAME;
+    }
+
+    /**
+     * Resets the processor's state by clearing the events map.
+     */
+    public static void reset() {
+        PROCESSED_EVENTS_MAP.clear();
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
@@ -22,27 +22,4 @@ public class BasicEventsTrackingTestProcessor extends BaseEventsTrackingProcesso
     public BasicEventsTrackingTestProcessor() {
         super(PLUGIN_NAME, PROCESSED_EVENTS_MAP);
     }
-
-    /**
-     * Gets the map of processed events.
-     * @return Map of event IDs to processing counts
-     */
-    public static Map<String, AtomicInteger> getEventsMap() {
-        return PROCESSED_EVENTS_MAP;
-    }
-
-    /**
-     * Gets the name of this processor.
-     * @return The processor name
-     */
-    public static String getName() {
-        return PLUGIN_NAME;
-    }
-
-    /**
-     * Resets the processor's state by clearing the events map.
-     */
-    public static void reset() {
-        PROCESSED_EVENTS_MAP.clear();
-    }
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SingleThreadEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SingleThreadEventsTrackingTestProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.SingleThread;
+import org.opensearch.dataprepper.model.processor.Processor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A @SingleThread test processor implementation which tracks the list of all events processed by it
+ */
+@SingleThread
+@DataPrepperPlugin(name = "single_thread_events_tracking_test", pluginType = Processor.class)
+public class SingleThreadEventsTrackingTestProcessor extends BaseEventsTrackingProcessor {
+    private static final String PLUGIN_NAME = "single_thread_events_tracking_test";
+    private static final Map<String, AtomicInteger> PROCESSED_EVENTS_MAP = new ConcurrentHashMap<>();
+
+    public SingleThreadEventsTrackingTestProcessor() {
+        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP);
+    }
+
+    /**
+     * Gets the map of processed events.
+     * @return Map of event IDs to processing counts
+     */
+    public static Map<String, AtomicInteger> getEventsMap() {
+        return PROCESSED_EVENTS_MAP;
+    }
+
+    /**
+     * Gets the name of this processor.
+     * @return The processor name
+     */
+    public static String getName() {
+        return PLUGIN_NAME;
+    }
+
+    /**
+     * Resets the processor's state by clearing the events map.
+     */
+    public static void reset() {
+        PROCESSED_EVENTS_MAP.clear();
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SingleThreadEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SingleThreadEventsTrackingTestProcessor.java
@@ -24,27 +24,4 @@ public class SingleThreadEventsTrackingTestProcessor extends BaseEventsTrackingP
     public SingleThreadEventsTrackingTestProcessor() {
         super(PLUGIN_NAME, PROCESSED_EVENTS_MAP);
     }
-
-    /**
-     * Gets the map of processed events.
-     * @return Map of event IDs to processing counts
-     */
-    public static Map<String, AtomicInteger> getEventsMap() {
-        return PROCESSED_EVENTS_MAP;
-    }
-
-    /**
-     * Gets the name of this processor.
-     * @return The processor name
-     */
-    public static String getName() {
-        return PLUGIN_NAME;
-    }
-
-    /**
-     * Resets the processor's state by clearing the events map.
-     */
-    public static void reset() {
-        PROCESSED_EVENTS_MAP.clear();
-    }
 }

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/basic-processor-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/basic-processor-pipeline.yaml
@@ -1,0 +1,14 @@
+basic-processor-pipeline:
+  workers: 4
+  source:
+    in_memory:
+      testing_key: ProcessorValidationIT
+  buffer:
+    bounded_blocking:
+      buffer_size: 1000
+      batch_size: 10
+  processor:
+    - basic_events_tracking_test:
+  sink:
+    - in_memory:
+        testing_key: ProcessorValidationIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/multi-processor-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/multi-processor-pipeline.yaml
@@ -1,0 +1,15 @@
+multi-processor-pipeline:
+  workers: 4
+  source:
+    in_memory:
+      testing_key: ProcessorValidationIT
+  buffer:
+    bounded_blocking:
+      buffer_size: 1000
+      batch_size: 10
+  processor:
+    - single_thread_events_tracking_test:
+    - basic_events_tracking_test:
+  sink:
+    - in_memory:
+        testing_key: ProcessorValidationIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/single-thread-processor-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/single-thread-processor-pipeline.yaml
@@ -1,0 +1,15 @@
+single-thread-processor-pipeline:
+  delay: 10
+  workers: 4
+  source:
+    in_memory:
+      testing_key: ProcessorValidationIT
+  buffer:
+    bounded_blocking:
+      buffer_size: 1000
+      batch_size: 10
+  processor:
+    - single_thread_events_tracking_test:
+  sink:
+    - in_memory:
+        testing_key: ProcessorValidationIT

--- a/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
+++ b/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class EndToEndBasicLogTest {
     private static final int HTTP_SOURCE_PORT = 2021;
@@ -90,7 +91,20 @@ public class EndToEndBasicLogTest {
             for (String key: expectedDocKeys) {
                 assertThat(expectedDoc, hasKey(key));
             }
+
+            verifyVerbFieldNotDuplicated(expectedDoc);
         });
+    }
+
+    /**
+     * Verifies that the verb field does not contain duplicated values.
+     * This is to ensure that grok processor doesn't produce duplicate values.
+     */
+    private void verifyVerbFieldNotDuplicated(Map<String, Object> document) {
+        if (document.containsKey("verb") && document.get("verb") != null) {
+            Object verbValue = document.get("verb");
+            assertFalse(verbValue instanceof List, "Verb field should not contain duplicates: " + verbValue);
+        }
     }
 
     private List<String> createListOfExpectedDocumentKeys() {

--- a/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline.yml
+++ b/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline.yml
@@ -1,4 +1,5 @@
 grok-pipeline:
+  workers: 2
   source:
     http:
       path: "/${pipelineName}/logs"


### PR DESCRIPTION
### Description
Added integration tests to verify that each event is processed only once by a processor in a pipeline. The tests cover pipelines with single and multiple processors, including with more than one worker thread configuration
Added two test processors:
- `BasicEventsTrackingTestProcessor`
- `SingleThreadEventsTrackingTestProcessor` (@SingleThread annotated)

Also added additional validation to the `EndToEndBasicLogTest`
### Issues Resolved
- #5690 

Note to Reviewers :
Performed tests to ensure that all the tests containing the `SingleThreadEventsTrackingTestProcessor` fail without the fix introduced in [#5545](https://github.com/opensearch-project/data-prepper/pull/5545), which resolves the issue of processors executing multiple times for the same event.

Manual Test Run results without the changes in PR :
1. Remove the commit in https://github.com/opensearch-project/data-prepper/pull/5545
```
commit e5916ed7eae86b7313a394b36625975874ec0c1a (HEAD -> processor-validation-tests)
Author: Mohammed Aghil Puthiyottil <57040494+MohammedAghil@users.noreply.github.com>
Date:   Thu May 15 19:46:56 2025 +0000

    Revert "Fixes an issue where @SingleThread-annotated processors are called multiple times. The recent addition of the PipelineRunner was getting the full list of processors from the Pipeline. This includes multiple instances of processors which caused them to be invoked multiple times. The solution is to use the list of Processors provided to any given PipelineRunnerImpl instance. For now, this also disables the support for SupportsPipelineRunner buffers in order to get the fix out now. Additionally, this improves the timing of the Connected_SingleExtraSinkIT test since this appears to be flaky locally for me. (#5545)"
    
    This reverts commit 75e18be0887b099f50964f990aca7add31992c65.

commit ca2a85adf46fba0bd40c9340d0ad13e71fb1fb19 (origin/processor-validation-tests)
Author: Mohammed Aghil Puthiyottil <57040494+MohammedAghil@users.noreply.github.com>
Date:   Thu May 15 19:32:48 2025 +0000

    Addressed comments on PIPELINE_TO_PROCESSORS_MAP
    
    Signed-off-by: Mohammed Aghil Puthiyottil <57040494+MohammedAghil@users.noreply.github.com>
```

2. Run the ProcessorValidationIT 
```
Test results - ProcessorValidationIT

Tests: 6, Failures: 4, Duration: 16.860s

Failures:

1 - multi-processor-pipeline - SingleBatch
java.lang.AssertionError: Event with ID 2e051f52-dadd-4595-a60e-37049ded9f81 should be processed exactly once by single_thread_events_tracking_test
Expected: <1>
     but: was <4>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyEventProcessing(ProcessorValidationIT.java:182)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyProcessingResults(ProcessorValidationIT.java:148)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.test_events_processed_validation(ProcessorValidationIT.java:95)

2 - multi-processor-pipeline - MultipleBatches
java.lang.AssertionError: Event with ID b73e5734-2704-4114-a68c-5d81cd0dc67a should be processed exactly once by single_thread_events_tracking_test
Expected: <1>
     but: was <4>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyEventProcessing(ProcessorValidationIT.java:182)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyProcessingResults(ProcessorValidationIT.java:148)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.test_events_processed_validation(ProcessorValidationIT.java:95)

5 - single-thread-processor-pipeline - SingleBatch
java.lang.AssertionError: Event with ID 0b58ad8c-af7a-4c4c-ad66-49aea503e4a0 should be processed exactly once by single_thread_events_tracking_test
Expected: <1>
     but: was <4>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyEventProcessing(ProcessorValidationIT.java:182)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyProcessingResults(ProcessorValidationIT.java:148)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.test_events_processed_validation(ProcessorValidationIT.java:95)

6 - single-thread-processor-pipeline - MultipleBatches
java.lang.AssertionError: Event with ID 178c14b2-0b74-4fec-9df7-1c6a791119e3 should be processed exactly once by single_thread_events_tracking_test
Expected: <1>
     but: was <4>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyEventProcessing(ProcessorValidationIT.java:182)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.verifyProcessingResults(ProcessorValidationIT.java:148)
        at org.opensearch.dataprepper.integration.ProcessorValidationIT.test_events_processed_validation(ProcessorValidationIT.java:95)
```

 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
