### PR TITLE
Increase Sqs sink test coverage. Add more metrics

### DIFF
--- a/data-prepper-plugins/sqs-sink/build.gradle
+++ b/data-prepper-plugins/sqs-sink/build.gradle
@@ -46,7 +46,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.90
+                minimum = 0.99
             }
         }
     }

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntry.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntry.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.plugins.accumulator.Buffer;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,12 +66,12 @@ public class SqsSinkBatchEntry {
         return buffer.getSize();
     }
 
-    public void complete() throws Exception {
+    public void complete() throws IOException {
         if (completed) {
             return;
         }
-        writer.complete();
         completed = true;
+        writer.complete();
     }
 
 

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkMetrics.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkMetrics.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.sqs;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
 public class SqsSinkMetrics {
@@ -13,16 +14,22 @@ public class SqsSinkMetrics {
     public static final String SQS_SINK_EVENTS_SUCCEEDED = "sqsSinkEventsSucceeded";
     public static final String SQS_SINK_EVENTS_FAILED = "sqsSinkEventsFailed";
     public static final String SQS_SINK_REQUESTS_FAILED = "sqsSinkRequestsFailed";
+    public static final String SQS_SINK_REQUEST_LATENCY = "sqsSinkRequestLatency";
+    public static final String SQS_SINK_REQUEST_SIZE = "sqsSinkRequestSize";
     private final Counter sqsSinkRequestsSucceeded;
     private final Counter sqsSinkEventsSucceeded;
     private final Counter sqsSinkRequestsFailed;
     private final Counter sqsSinkEventsFailed;
+    private final DistributionSummary sqsSinkRequestLatency;
+    private final DistributionSummary sqsSinkRequestSize;
 
     public SqsSinkMetrics(final PluginMetrics pluginMetrics) {
         this.sqsSinkRequestsSucceeded = pluginMetrics.counter(SQS_SINK_REQUESTS_SUCCEEDED);
         this.sqsSinkEventsSucceeded = pluginMetrics.counter(SQS_SINK_EVENTS_SUCCEEDED);
         this.sqsSinkRequestsFailed = pluginMetrics.counter(SQS_SINK_REQUESTS_FAILED);
         this.sqsSinkEventsFailed = pluginMetrics.counter(SQS_SINK_EVENTS_FAILED);
+        this.sqsSinkRequestLatency = pluginMetrics.summary(SQS_SINK_REQUEST_LATENCY);
+        this.sqsSinkRequestSize = pluginMetrics.summary(SQS_SINK_REQUEST_SIZE);
     }
 
     public void incrementEventsSuccessCounter(int value) {
@@ -39,5 +46,13 @@ public class SqsSinkMetrics {
 
     public void incrementRequestsFailedCounter(int value) {
         sqsSinkRequestsFailed.increment(value);
+    }
+
+    public void recordRequestLatency(double value) {
+        sqsSinkRequestLatency.record(value);
+    }
+
+    public void recordRequestSize(double value) {
+        sqsSinkRequestSize.record(value);
     }
 }

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntryTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntryTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -122,6 +123,18 @@ public class SqsSinkBatchEntryTest {
         assertThat(sqsSinkBatchEntry.getDedupId(), equalTo(deDupId));
         assertThat(sqsSinkBatchEntry.getSize(), equalTo(expectedSize));
         assertThat(sqsSinkBatchEntry.getEventHandles().size(), equalTo(numRecords));
+    }
+
+    @Test
+    public void TestAddingToCompletedEntry() throws Exception {
+        SqsSinkBatchEntry sqsSinkBatchEntry = createObjectUnderTest();
+        List<Record<Event>> records = getRecordList(1);
+        Event event = records.get(0).getData();
+        sqsSinkBatchEntry.addEvent(event);
+        sqsSinkBatchEntry.complete();
+        List<Record<Event>> newRecords = getRecordList(1);
+        Event newEvent = records.get(0).getData();
+        assertThrows(RuntimeException.class, () -> sqsSinkBatchEntry.addEvent(newEvent));
     }
     
     private List<Record<Event>> getRecordList(int numberOfRecords) {

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkDlqDataTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkDlqDataTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -43,6 +44,12 @@ public class SqsSinkDlqDataTest {
         sqsSinkDlqData = createObjectUnderTest(message, data);
         SqsSinkDlqData sqsSinkDlqData2 = createObjectUnderTest(message, data);
         assertTrue(sqsSinkDlqData.equals(sqsSinkDlqData2));
+        assertTrue(sqsSinkDlqData.equals(sqsSinkDlqData));
+        SqsSinkDlqData sqsSinkDlqData3 = createObjectUnderTest(message, data+data);
+        assertFalse(sqsSinkDlqData.equals(sqsSinkDlqData3));
+        Integer testInteger = 5;
+        assertFalse(sqsSinkDlqData.equals(testInteger));
+        assertFalse(sqsSinkDlqData.equals(null));
     }
 
 }


### PR DESCRIPTION
### Description
Added tests to increase sqs sink test coverage to 0.99.
Added distribution summary metrics to capture request latency and request size
Fixed bugs
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
