### PR TITLE
Add codec to http source

### DIFF
--- a/data-prepper-plugins/http-source/src/jmh/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceMeasure.java
+++ b/data-prepper-plugins/http-source/src/jmh/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceMeasure.java
@@ -51,7 +51,7 @@ public class LogHTTPServiceMeasure {
             when(buffer.getOptimalRequestSize()).thenReturn(Optional.of(256 * 1024));
 
             serviceRequestContext = mock(ServiceRequestContext.class);
-            logHTTPService = new LogHTTPService((int) Duration.ofSeconds(10).toMillis(), buffer, PluginMetrics.fromPrefix("testing"));
+            logHTTPService = new LogHTTPService((int) Duration.ofSeconds(10).toMillis(), buffer, PluginMetrics.fromPrefix("testing"), null);
 
             requestHeaders = RequestHeaders.builder()
                     .method(HttpMethod.POST)

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensearch.dataprepper.http.BaseHttpServerConfig;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
 
 public class HTTPSourceConfig extends BaseHttpServerConfig {
 
@@ -20,5 +22,12 @@ public class HTTPSourceConfig extends BaseHttpServerConfig {
     @Override
     public String getDefaultPath() {
         return DEFAULT_LOG_INGEST_URI;
+    }
+
+    @JsonProperty("codec")
+    private PluginModel codec;
+
+    public PluginModel getCodec() {
+        return codec;
     }
 }


### PR DESCRIPTION
### Description
Add codec to http source so it can use the functionality introduced in #5054 to parse CloudWatch Logs data.
The config would look like this:
```
    http:
      codec:
        json:
          key_name: "logEvents"
          include_keys: [ 'owner', 'logGroup', 'logStream' ]
          include_keys_metadata: [ 'owner', 'logGroup', 'logStream' ]
```
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
