### PR TITLE
Serialization fix when the expected type is PluginConfigVariable

### DIFF
--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
@@ -63,31 +63,41 @@ public class VariableExpander {
                         // which is not of a secrets expression that we would check (filter check above fails) but
                         // still expects an instance of PluginConfigVariable object returned
                         if (destinationType.equals(PluginConfigVariable.class)) {
-                            return destinationType.cast(new PluginConfigVariable() {
-                                @Override
-                                public Object getValue() {
-                                    return rawValue;
-                                }
-
-                                @Override
-                                public void setValue(Object updatedValue) {
-
-                                }
-
-                                @Override
-                                public void refresh() {
-
-                                }
-
-                                @Override
-                                public boolean isUpdatable() {
-                                    return false;
-                                }
-                            });
+                            return destinationType.cast(new ImmutablePluginConfigVariable(rawValue));
                         }
                         return objectMapper.convertValue(rawValue, destinationType);
                     });
         }
         return objectMapper.readValue(jsonParser, destinationType);
     }
+
+    private static class ImmutablePluginConfigVariable implements PluginConfigVariable {
+        private final Object rawValue;
+
+        private ImmutablePluginConfigVariable(final Object rawValue) {
+            this.rawValue = rawValue;
+        }
+
+        @Override
+        public Object getValue() {
+            return rawValue;
+        }
+
+        @Override
+        public void setValue(Object updatedValue) {
+            throw new UnsupportedOperationException("ImmutablePluginConfigVariable doesn't support this operation");
+        }
+
+        @Override
+        public void refresh() {
+            // No-op as this is immutable
+            throw new UnsupportedOperationException("ImmutablePluginConfigVariable doesn't support this operation");
+        }
+
+        @Override
+        public boolean isUpdatable() {
+            return false;
+        }
+    }
+
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -182,7 +183,7 @@ class VariableExpanderTest {
 
     @Test
     void testTranslateJsonParserWithSPluginConfigVariableValue_when_non_secret_format_is_given() throws IOException {
-        final String testSecretReference = "not-in-aws-secrets-expression-format";
+        final String testSecretReference = UUID.randomUUID().toString();
         final JsonParser jsonParser = JSON_FACTORY.createParser(String.format("\"%s\"", testSecretReference));
         jsonParser.nextToken();
         objectUnderTest = new VariableExpander(OBJECT_MAPPER, Set.of(pluginConfigValueTranslator));

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -32,6 +32,8 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -187,6 +189,9 @@ class VariableExpanderTest {
         final Object actualResult = objectUnderTest.translate(jsonParser, PluginConfigVariable.class);
         assertNotNull(actualResult);
         assertInstanceOf(PluginConfigVariable.class, actualResult);
+        PluginConfigVariable pluginConfigVariableInstance = (PluginConfigVariable) actualResult;
+        assertEquals(testSecretReference, pluginConfigVariableInstance.getValue().toString());
+        assertFalse(pluginConfigVariableInstance.isUpdatable());
     }
 
     @Test

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -175,6 +176,17 @@ class VariableExpanderTest {
         final Object actualResult = objectUnderTest.translate(jsonParser, PluginConfigVariable.class);
         assertNotNull(actualResult);
         assertThat(actualResult, equalTo(mockPluginConfigVariable));
+    }
+
+    @Test
+    void testTranslateJsonParserWithSPluginConfigVariableValue_when_non_secret_format_is_given() throws IOException {
+        final String testSecretReference = "not-in-aws-secrets-expression-format";
+        final JsonParser jsonParser = JSON_FACTORY.createParser(String.format("\"%s\"", testSecretReference));
+        jsonParser.nextToken();
+        objectUnderTest = new VariableExpander(OBJECT_MAPPER, Set.of(pluginConfigValueTranslator));
+        final Object actualResult = objectUnderTest.translate(jsonParser, PluginConfigVariable.class);
+        assertNotNull(actualResult);
+        assertInstanceOf(PluginConfigVariable.class, actualResult);
     }
 
     @Test


### PR DESCRIPTION
### Description
Current logic is expecting the rawSecret value to be of a certain format to be able to convert to PluginConfigVariable type. But then the requested type is PluginConfigVariable but raw value is not passing the expression format check filter criteria, we are currently failing to serialize the value into the object type. This fix is to still return an instance of a requested type without any attached functionality. We will be avoiding the serialization issue with this fix.

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
