### PR TITLE
Change replication slot naming in RDS source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -9,6 +9,7 @@ import com.github.shyiko.mysql.binlog.network.SSLMode;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
@@ -64,6 +65,7 @@ public class RdsService {
     private final RdsSourceConfig sourceConfig;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigObservable pluginConfigObservable;
+    private final PipelineDescription pipelineDescription;
     private ExecutorService executor;
     private LeaderScheduler leaderScheduler;
     private ExportScheduler exportScheduler;
@@ -77,13 +79,15 @@ public class RdsService {
                       final ClientFactory clientFactory,
                       final PluginMetrics pluginMetrics,
                       final AcknowledgementSetManager acknowledgementSetManager,
-                      final PluginConfigObservable pluginConfigObservable) {
+                      final PluginConfigObservable pluginConfigObservable,
+                      final PipelineDescription pipelineDescription) {
         this.sourceCoordinator = sourceCoordinator;
         this.eventFactory = eventFactory;
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginConfigObservable = pluginConfigObservable;
+        this.pipelineDescription = pipelineDescription;
 
         rdsClient = clientFactory.buildRdsClient();
         s3Client = clientFactory.buildS3Client();
@@ -109,7 +113,7 @@ public class RdsService {
         DbTableMetadata dbTableMetadata = getDbTableMetadata(dbMetadata, schemaManager);
 
         leaderScheduler = new LeaderScheduler(
-                sourceCoordinator, sourceConfig, s3PathPrefix,  schemaManager, dbTableMetadata);
+                sourceCoordinator, sourceConfig, s3PathPrefix, schemaManager, dbTableMetadata, pipelineDescription.getPipelineName());
         runnableList.add(leaderScheduler);
 
         if (sourceConfig.isExportEnabled()) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManag
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
@@ -39,6 +40,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
     private final EventFactory eventFactory;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigObservable pluginConfigObservable;
+    private final PipelineDescription pipelineDescription;
     private EnhancedSourceCoordinator sourceCoordinator;
     private RdsService rdsService;
 
@@ -48,12 +50,14 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
                      final EventFactory eventFactory,
                      final AwsCredentialsSupplier awsCredentialsSupplier,
                      final AcknowledgementSetManager acknowledgementSetManager,
-                     final PluginConfigObservable pluginConfigObservable) {
+                     final PluginConfigObservable pluginConfigObservable,
+                     final PipelineDescription pipelineDescription) {
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
         this.eventFactory = eventFactory;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginConfigObservable = pluginConfigObservable;
+        this.pipelineDescription = pipelineDescription;
 
         clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig);
     }
@@ -64,7 +68,8 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
         Objects.requireNonNull(sourceCoordinator);
         sourceCoordinator.createPartition(new LeaderPartition());
 
-        rdsService = new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
+        rdsService = new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics,
+                acknowledgementSetManager, pluginConfigObservable, pipelineDescription);
 
         LOG.info("Start RDS service");
         rdsService.start(buffer);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/PostgresSchemaManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/schema/PostgresSchemaManager.java
@@ -65,6 +65,7 @@ public class PostgresSchemaManager implements SchemaManager {
             try {
                 PreparedStatement statement = conn.prepareStatement(createPublicationStatement);
                 statement.executeUpdate();
+                LOG.info("Publication {} created successfully. ", publicationName);
             } catch (Exception e) {
                 LOG.error("Failed to create publication: {}", e.getMessage());
                 throw e;

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
@@ -94,6 +95,9 @@ class RdsServiceTest {
 
     @Mock
     private PluginConfigObservable pluginConfigObservable;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
 
     @BeforeEach
     void setUp() {
@@ -206,6 +210,7 @@ class RdsServiceTest {
     }
 
     private RdsService createObjectUnderTest() {
-        return new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
+        return new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics,
+                acknowledgementSetManager, pluginConfigObservable, pipelineDescription);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
@@ -45,6 +46,9 @@ class RdsSourceTest {
     @Mock
     private PluginConfigObservable pluginConfigObservable;
 
+    @Mock
+    private PipelineDescription pipelineDescription;
+
     @BeforeEach
     void setUp() {
         when(sourceConfig.getAwsAuthenticationConfig()).thenReturn(awsAuthenticationConfig);
@@ -58,6 +62,7 @@ class RdsSourceTest {
 
     private RdsSource createObjectUnderTest() {
         return new RdsSource(
-                pluginMetrics, sourceConfig, eventFactory, awsCredentialsSupplier, acknowledgementSetManager, pluginConfigObservable);
+                pluginMetrics, sourceConfig, eventFactory, awsCredentialsSupplier, acknowledgementSetManager,
+                pluginConfigObservable, pipelineDescription);
     }
 }


### PR DESCRIPTION
### Description
Change replication slot naming in RDS source to include pipeline name so it's easier to identify the pipeline it associates with.

The replication slot name used to look like this: `data_prepper_xxxxxx`. 
With this change, it will be: `data_prepper_pipeline_name_xxxxxx`. 
Similar change was done for publication name. 
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
