### PR TITLE
Add STS header overrides functionality for default role

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.Optional;
+import java.util.Map;
 
 /**
  * An interface available to plugins via the AWS Plugin Extension which supplies
@@ -28,4 +29,10 @@ public interface AwsCredentialsSupplier {
      * @return Default {@link Region}
      */
     Optional<Region> getDefaultRegion();
+
+    /**
+     * Gets the default       if configured. Otherwise returns empty Optional
+     * @return Optional containing Map of STS header overrides
+     */
+    Optional<Map<String, String>> getDefaultStsHeaderOverrides();
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 import software.amazon.awssdk.regions.Region;
 
+import java.util.Map;
+
 public class AwsStsConfiguration {
 
     @JsonProperty("region")
@@ -19,11 +21,19 @@ public class AwsStsConfiguration {
     @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
     private String awsStsRoleArn;
 
+    @JsonProperty("sts_header_overrides")
+    @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
+    private Map<String, String> stsHeaderOverrides;
+
     public Region getAwsRegion() {
         return awsRegion != null ? Region.of(awsRegion) : null;
     }
 
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
+    }
+
+    public Map<String, String> getStsHeaderOverrides() {
+        return stsHeaderOverrides;
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -47,6 +47,10 @@ class CredentialsProviderFactory {
         return defaultStsConfiguration.getAwsRegion();
     }
 
+    Map<String, String> getDefaultStsHeaderOverrides() {
+        return defaultStsConfiguration.getStsHeaderOverrides();
+    }
+
     AwsCredentialsProvider providerFromOptions(final AwsCredentialsOptions credentialsOptions) {
         Objects.requireNonNull(credentialsOptions);
 

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
+import java.util.Map;
 import java.util.Optional;
 
 class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
@@ -29,5 +30,10 @@ class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     @Override
     public Optional<Region> getDefaultRegion() {
         return Optional.ofNullable(credentialsProviderFactory.getDefaultRegion());
+    }
+
+    @Override
+    public Optional<Map<String, String>> getDefaultStsHeaderOverrides() {
+        return Optional.ofNullable(credentialsProviderFactory.getDefaultStsHeaderOverrides());
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.regions.Region;
@@ -16,6 +17,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class AwsStsConfigurationTest {
 
@@ -32,6 +34,36 @@ public class AwsStsConfigurationTest {
         assertThat(objectUnderTest, notNullValue());
         assertThat(objectUnderTest.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/test-role"));
         assertThat(objectUnderTest.getAwsRegion(), equalTo(region));
+    }
+
+    @Test
+    void testStsConfigurationWithHeaderOverrides() throws JsonProcessingException {
+        final String configWithHeaderOverrides =
+                "{\"region\": \"us-west-2\", " +
+                        "\"sts_role_arn\": \"arn:aws:iam::123456789012:role/test-role\", " +
+                        "\"sts_header_overrides\": {\"header1\": \"value1\", \"header2\": \"value2\"}}";
+
+        final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(configWithHeaderOverrides, AwsStsConfiguration.class);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/test-role"));
+        assertThat(objectUnderTest.getAwsRegion(), equalTo(Region.US_WEST_2));
+        assertThat(objectUnderTest.getStsHeaderOverrides(), notNullValue());
+        assertThat(objectUnderTest.getStsHeaderOverrides().size(), equalTo(2));
+        assertThat(objectUnderTest.getStsHeaderOverrides().get("header1"), equalTo("value1"));
+        assertThat(objectUnderTest.getStsHeaderOverrides().get("header2"), equalTo("value2"));
+    }
+
+    @Test
+    void testStsConfigurationWithoutHeaderOverrides() throws JsonProcessingException {
+        final String configWithoutHeaderOverrides =
+                "{\"region\": \"us-west-2\", " +
+                        "\"sts_role_arn\": \"arn:aws:iam::123456789012:role/test-role\"}";
+
+        final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(configWithoutHeaderOverrides, AwsStsConfiguration.class);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getStsHeaderOverrides(), nullValue());
     }
 
     private static List<Region> getRegions() {

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -116,6 +116,33 @@ class CredentialsProviderFactoryTest {
         assertThat(actualRegion, equalTo(region));
     }
 
+    @Test
+    void getDefaultStsHeaderOverrides_returns_expected_headers() {
+        final Map<String, String> headerOverrides = Map.of(
+                "header1", "value1",
+                "header2", "value2",
+                "custom-header", "custom-value"
+        );
+        when(defaultStsConfiguration.getStsHeaderOverrides()).thenReturn(headerOverrides);
+
+        final CredentialsProviderFactory credentialsProviderFactory = createObjectUnderTest();
+
+        final Map<String, String> actualHeaderOverrides = credentialsProviderFactory.getDefaultStsHeaderOverrides();
+
+        assertThat(actualHeaderOverrides, equalTo(headerOverrides));
+    }
+
+    @Test
+    void getDefaultStsHeaderOverrides_returns_null_when_not_configured() {
+        when(defaultStsConfiguration.getStsHeaderOverrides()).thenReturn(null);
+
+        final CredentialsProviderFactory credentialsProviderFactory = createObjectUnderTest();
+
+        final Map<String, String> actualHeaderOverrides = credentialsProviderFactory.getDefaultStsHeaderOverrides();
+
+        assertThat(actualHeaderOverrides, nullValue());
+    }
+
     private static List<Region> getRegions() {
         return Region.regions();
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -85,7 +86,21 @@ class DefaultAwsCredentialsSupplierTest {
 
         final AwsCredentialsSupplier objectUnderTest = createObjectUnderTest();
         assertThat(objectUnderTest.getDefaultRegion(), equalTo(Optional.empty()));
+    }
 
+    @Test
+    void getDefaultStsHeaderOverrides_returns_default_sts_header_overrides() {
+        final Map<String, String> headerOverrides = Map.of("header1", "value1", "header2", "value2");
+        when(credentialsProviderFactory.getDefaultStsHeaderOverrides()).thenReturn(headerOverrides);
+
+        assertThat(createObjectUnderTest().getDefaultStsHeaderOverrides(), equalTo(Optional.of(headerOverrides)));
+    }
+
+    @Test
+    void no_default_sts_header_overrides_returns_empty_optional() {
+        when(credentialsProviderFactory.getDefaultStsHeaderOverrides()).thenReturn(null);
+
+        assertThat(createObjectUnderTest().getDefaultStsHeaderOverrides(), equalTo(Optional.empty()));
     }
 
     private static List<Region> getRegions() {


### PR DESCRIPTION
### Description
- New sts_header_overrides configuration option in AwsStsConfiguration
- Extended AwsCredentialsSupplier interface to expose configured header overrides
- Implemented the method in DefaultAwsCredentialsSupplier
- Added corresponding method to CredentialsProviderFactory
- Added comprehensive test coverage
 
### Issues Resolved
Resolves #5530
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
