### PR TITLE
Increase default scroll time per batch from 1m to 10m

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -49,7 +49,7 @@ public class ScrollWorker implements SearchWorker {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScrollWorker.class);
     private static final Duration BACKOFF_ON_SCROLL_LIMIT_REACHED = Duration.ofSeconds(120);
-    static final String SCROLL_TIME_PER_BATCH = "1m";
+    static final String SCROLL_TIME_PER_BATCH = "10m";
 
     private final ObjectMapper objectMapper;
     private final SearchAccessor searchAccessor;


### PR DESCRIPTION
### Description
The default scroll time of 1 minute is too low, and can cause the scroll to expire if it takes longer than a minute to write a batch to the buffer (which can happen in full buffer or circuit breaker situations). To handle this, the default is being increased to 10 minutes.
 
### Issues Resolved
Resolves #5679 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
