### PR TITLE
Rename Atlassian state classes to PaginationCrawler

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceClient.java
@@ -25,7 +25,7 @@ import org.opensearch.dataprepper.plugins.source.confluence.utils.HtmlToTextConv
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerClient;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSourceConfig;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.model.ItemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +49,7 @@ import static org.opensearch.dataprepper.plugins.source.confluence.utils.Constan
  * This class represents a Confluence client.
  */
 @Named
-public class ConfluenceClient implements CrawlerClient<AtlassianWorkerProgressState> {
+public class ConfluenceClient implements CrawlerClient<PaginationCrawlerWorkerProgressState> {
 
     private static final Logger log = LoggerFactory.getLogger(ConfluenceClient.class);
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -81,7 +81,7 @@ public class ConfluenceClient implements CrawlerClient<AtlassianWorkerProgressSt
     }
 
     @Override
-    public void executePartition(AtlassianWorkerProgressState state,
+    public void executePartition(PaginationCrawlerWorkerProgressState state,
                                  Buffer<Record<Event>> buffer,
                                  AcknowledgementSet acknowledgementSet) {
         log.trace("Executing the partition: {} with {} ticket(s)",

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSource.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSource.java
@@ -28,7 +28,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.LeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PaginationCrawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.time.Instant;
@@ -74,7 +74,7 @@ public class ConfluenceSource extends CrawlerSourcePlugin {
 
     @Override
     protected LeaderProgressState createLeaderProgressState() {
-        return new AtlassianLeaderProgressState(Instant.EPOCH);
+        return new PaginationCrawlerLeaderProgressState(Instant.EPOCH);
     }
 
     @Override

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceClientTest.java
@@ -23,7 +23,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,7 +48,7 @@ public class ConfluenceClientTest {
     @Mock
     private Buffer<Record<Event>> buffer;
     @Mock
-    private AtlassianWorkerProgressState saasWorkerProgressState;
+    private PaginationCrawlerWorkerProgressState saasWorkerProgressState;
     @Mock
     private AcknowledgementSet acknowledgementSet;
     @Mock

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraClient.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraClient.java
@@ -23,7 +23,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerClient;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSourceConfig;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.model.ItemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +47,7 @@ import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.PRO
  * This class represents a Jira client.
  */
 @Named
-public class JiraClient implements CrawlerClient<AtlassianWorkerProgressState> {
+public class JiraClient implements CrawlerClient<PaginationCrawlerWorkerProgressState> {
 
     private static final Logger log = LoggerFactory.getLogger(JiraClient.class);
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -79,7 +79,7 @@ public class JiraClient implements CrawlerClient<AtlassianWorkerProgressState> {
     }
 
     @Override
-    public void executePartition(AtlassianWorkerProgressState state,
+    public void executePartition(PaginationCrawlerWorkerProgressState state,
                                  Buffer<Record<Event>> buffer,
                                  AcknowledgementSet acknowledgementSet) {
         log.trace("Executing the partition: {} with {} ticket(s)",

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraSource.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraSource.java
@@ -28,7 +28,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.LeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PaginationCrawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.time.Instant;
@@ -74,7 +74,7 @@ public class JiraSource extends CrawlerSourcePlugin {
 
     @Override
     protected LeaderProgressState createLeaderProgressState() {
-        return new AtlassianLeaderProgressState(Instant.EPOCH);
+        return new PaginationCrawlerLeaderProgressState(Instant.EPOCH);
     }
 
     @Override

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraClientTest.java
@@ -23,7 +23,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.PluginExecutorServiceProvider;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,7 +48,7 @@ public class JiraClientTest {
     @Mock
     private Buffer<Record<Event>> buffer;
     @Mock
-    private AtlassianWorkerProgressState saasWorkerProgressState;
+    private PaginationCrawlerWorkerProgressState saasWorkerProgressState;
     @Mock
     private AcknowledgementSet acknowledgementSet;
     @Mock

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/LeaderProgressState.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/LeaderProgressState.java
@@ -1,14 +1,14 @@
 package org.opensearch.dataprepper.plugins.source.source_crawler.base;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.CrowdStrikeLeaderProgressState;
 
 import java.time.Instant;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = AtlassianLeaderProgressState.class),
+        @JsonSubTypes.Type(value = PaginationCrawlerLeaderProgressState.class),
         @JsonSubTypes.Type(value = CrowdStrikeLeaderProgressState.class)
 })
 public interface LeaderProgressState {

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawler.java
@@ -10,7 +10,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.model.ItemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.dataprepper.plugins.source.source_crawler.coordination.scheduler.LeaderScheduler.DEFAULT_EXTEND_LEASE_MINUTES;
 
 @Named
-public class PaginationCrawler implements Crawler<AtlassianWorkerProgressState> {
+public class PaginationCrawler implements Crawler<PaginationCrawlerWorkerProgressState> {
     private static final Logger log = LoggerFactory.getLogger(PaginationCrawler.class);
     private static final int batchSize = 50;
     private static final String PAGINATION_WORKER_PARTITIONS_CREATED = "paginationWorkerPartitionsCreated";
@@ -89,7 +89,7 @@ public class PaginationCrawler implements Crawler<AtlassianWorkerProgressState> 
         return latestModifiedTime;
     }
 
-    public void executePartition(AtlassianWorkerProgressState state, Buffer<Record<Event>> buffer, AcknowledgementSet acknowledgementSet) {
+    public void executePartition(PaginationCrawlerWorkerProgressState state, Buffer<Record<Event>> buffer, AcknowledgementSet acknowledgementSet) {
         client.executePartition(state, buffer, acknowledgementSet);
     }
 
@@ -107,7 +107,7 @@ public class PaginationCrawler implements Crawler<AtlassianWorkerProgressState> 
         ItemInfo itemInfo = itemInfoList.get(0);
         String partitionKey = itemInfo.getPartitionKey();
         List<String> itemIds = itemInfoList.stream().map(ItemInfo::getId).collect(Collectors.toList());
-        AtlassianWorkerProgressState state = new AtlassianWorkerProgressState();
+        PaginationCrawlerWorkerProgressState state = new PaginationCrawlerWorkerProgressState();
         state.setKeyAttributes(itemInfo.getKeyAttributes());
         state.setItemIds(itemIds);
         state.setExportStartTime(Instant.now());

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/SaasWorkerProgressState.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/SaasWorkerProgressState.java
@@ -3,12 +3,12 @@ package org.opensearch.dataprepper.plugins.source.source_crawler.base;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.CrowdStrikeWorkerProgressState;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = AtlassianWorkerProgressState.class, name = "atlassian"),
+        @JsonSubTypes.Type(value = PaginationCrawlerWorkerProgressState.class, name = "pagination_crawler"),
         @JsonSubTypes.Type(value = CrowdStrikeWorkerProgressState.class,  name = "crowdstrike")
 })
 public interface SaasWorkerProgressState {

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerLeaderProgressState.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerLeaderProgressState.java
@@ -6,7 +6,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.LeaderProgr
 
 import java.time.Instant;
 @Data
-public class AtlassianLeaderProgressState implements LeaderProgressState {
+public class PaginationCrawlerLeaderProgressState implements LeaderProgressState {
 
     @JsonProperty("initialized")
     private boolean initialized = false;
@@ -14,7 +14,7 @@ public class AtlassianLeaderProgressState implements LeaderProgressState {
     @JsonProperty("last_poll_time")
     private Instant lastPollTime;
 
-    public AtlassianLeaderProgressState(@JsonProperty("last_poll_time") final Instant lastPollTime) {
+    public PaginationCrawlerLeaderProgressState(@JsonProperty("last_poll_time") final Instant lastPollTime) {
         this.lastPollTime = lastPollTime;
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerWorkerProgressState.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerWorkerProgressState.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @Data
-public class AtlassianWorkerProgressState implements SaasWorkerProgressState {
+public class PaginationCrawlerWorkerProgressState implements SaasWorkerProgressState {
 
     @JsonProperty("totalItems")
     private int totalItems;

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawlerTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/PaginationCrawlerTest.java
@@ -13,8 +13,8 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.model.ItemInfo;
 import org.opensearch.dataprepper.plugins.source.source_crawler.model.TestItemInfo;
 
@@ -46,7 +46,7 @@ public class PaginationCrawlerTest {
     @Mock
     private CrawlerClient client;
     @Mock
-    private AtlassianWorkerProgressState state;
+    private PaginationCrawlerWorkerProgressState state;
     @Mock
     private LeaderPartition leaderPartition;
     private Crawler crawler;
@@ -56,7 +56,7 @@ public class PaginationCrawlerTest {
     @BeforeEach
     public void setup() {
         crawler = new PaginationCrawler(client, pluginMetrics);
-        when(leaderPartition.getProgressState()).thenReturn(Optional.of(new AtlassianLeaderProgressState(lastPollTime)));
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(new PaginationCrawlerLeaderProgressState(lastPollTime)));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class PaginationCrawlerTest {
     void testCrawlWithEmptyList() {
         Instant lastPollTime = Instant.ofEpochMilli(0);
         when(client.listItems(lastPollTime)).thenReturn(Collections.emptyIterator());
-        when(leaderPartition.getProgressState()).thenReturn(Optional.of(new AtlassianLeaderProgressState(lastPollTime)));
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(new PaginationCrawlerLeaderProgressState(lastPollTime)));
         crawler.crawl(leaderPartition, coordinator);
         verify(coordinator, never()).createPartition(any(SaasSourcePartition.class));
     }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/PartitionFactoryTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/PartitionFactoryTest.java
@@ -14,8 +14,8 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.LeaderProgr
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.SaasWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.CrowdStrikeLeaderProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.CrowdStrikeWorkerProgressState;
 import java.time.Instant;
@@ -68,12 +68,12 @@ public class PartitionFactoryTest {
         return Stream.of(
                 Arguments.of(
                         "{\n" +
-                                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState\",\n" +
+                                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState\",\n" +
                                 "  \"last_poll_time\": \"2024-10-30T20:17:46.332Z\"\n" +
                                 "}",
-                        AtlassianLeaderProgressState.class,
+                        PaginationCrawlerLeaderProgressState.class,
                         Instant.parse("2024-10-30T20:17:46.332Z"),
-                        new AtlassianLeaderProgressState(Instant.ofEpochMilli(12345L))
+                        new PaginationCrawlerLeaderProgressState(Instant.ofEpochMilli(12345L))
                 ),
                 Arguments.of(
                         "{\n" +
@@ -115,8 +115,8 @@ public class PartitionFactoryTest {
     }
 
     private static Stream<Arguments> provideWorkerPartitionInputs() {
-        String atlassianJson = "{\n" +
-                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState\",\n" +
+        String paginationCrawlerJson = "{\n" +
+                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState\",\n" +
                 "  \"keyAttributes\": {\"project\": \"project-1\"},\n" +
                 "  \"totalItems\": 0,\n" +
                 "  \"loadedItems\": 20,\n" +
@@ -132,7 +132,7 @@ public class PartitionFactoryTest {
                 "}";
 
         return Stream.of(
-                Arguments.of(SaasSourcePartition.PARTITION_TYPE, atlassianJson, AtlassianWorkerProgressState.class),
+                Arguments.of(SaasSourcePartition.PARTITION_TYPE, paginationCrawlerJson, PaginationCrawlerWorkerProgressState.class),
                 Arguments.of(SaasSourcePartition.PARTITION_TYPE, crowdStrikeJson, CrowdStrikeWorkerProgressState.class)
         );
     }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/LeaderSchedulerTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.Crawler;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -49,10 +49,10 @@ public class LeaderSchedulerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testAtlassianLeaderPartitionsCreation(boolean initializationState) throws InterruptedException {
+    void testPaginationCrawlerLeaderPartitionsCreation(boolean initializationState) throws InterruptedException {
         LeaderScheduler leaderScheduler = new LeaderScheduler(coordinator, crawler);
-        LeaderPartition leaderPartition = new LeaderPartition(new AtlassianLeaderProgressState(Instant.EPOCH));
-        AtlassianLeaderProgressState state = (AtlassianLeaderProgressState) leaderPartition.getProgressState().get();
+        LeaderPartition leaderPartition = new LeaderPartition(new PaginationCrawlerLeaderProgressState(Instant.EPOCH));
+        PaginationCrawlerLeaderProgressState state = (PaginationCrawlerLeaderProgressState) leaderPartition.getProgressState().get();
         state.setInitialized(initializationState);
         state.setLastPollTime(Instant.ofEpochMilli(0L));
         given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
@@ -74,8 +74,8 @@ public class LeaderSchedulerTest {
     @ValueSource(booleans = {true, false})
     void testExceptionWhileAcquiringLeaderPartition(boolean initializationState) throws InterruptedException {
         LeaderScheduler leaderScheduler = new LeaderScheduler(coordinator, crawler);
-        LeaderPartition leaderPartition = new LeaderPartition(new AtlassianLeaderProgressState(Instant.EPOCH));
-        AtlassianLeaderProgressState state = (AtlassianLeaderProgressState) leaderPartition.getProgressState().get();
+        LeaderPartition leaderPartition = new LeaderPartition(new PaginationCrawlerLeaderProgressState(Instant.EPOCH));
+        PaginationCrawlerLeaderProgressState state = (PaginationCrawlerLeaderProgressState) leaderPartition.getProgressState().get();
         state.setInitialized(initializationState);
         state.setLastPollTime(Instant.ofEpochMilli(0L));
         given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willThrow(RuntimeException.class);
@@ -94,8 +94,8 @@ public class LeaderSchedulerTest {
     void testWhileLoopRunnningAfterTheSleep() throws InterruptedException {
         LeaderScheduler leaderScheduler = new LeaderScheduler(coordinator, crawler);
         leaderScheduler.setLeaseInterval(Duration.ofMillis(10));
-        LeaderPartition leaderPartition = new LeaderPartition(new AtlassianLeaderProgressState(Instant.EPOCH));
-        AtlassianLeaderProgressState state = (AtlassianLeaderProgressState) leaderPartition.getProgressState().get();
+        LeaderPartition leaderPartition = new LeaderPartition(new PaginationCrawlerLeaderProgressState(Instant.EPOCH));
+        PaginationCrawlerLeaderProgressState state = (PaginationCrawlerLeaderProgressState) leaderPartition.getProgressState().get();
         state.setInitialized(false);
         state.setLastPollTime(Instant.ofEpochMilli(0L));
         when(crawler.crawl(any(LeaderPartition.class), any(EnhancedSourceCoordinator.class))).thenReturn(Instant.ofEpochMilli(10));

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/WorkerSchedulerTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/scheduler/WorkerSchedulerTest.java
@@ -20,7 +20,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.SaasWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.PartitionFactory;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
-import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState;
 import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.CrowdStrikeWorkerProgressState;
 import java.util.Optional;
 import java.util.UUID;
@@ -71,9 +71,9 @@ public class WorkerSchedulerTest {
     }
 
     @Test
-    void testDeserializeAtlassianWorkerProgressState() throws Exception {
+    void testDeserializePaginationCrawlerWorkerProgressState() throws Exception {
         String json = "{\n" +
-                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState\",\n" +
+                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState\",\n" +
                 "  \"keyAttributes\": {\"project\": \"project-1\"},\n" +
                 "  \"totalItems\": 10,\n" +
                 "  \"loadedItems\": 5,\n" +
@@ -82,18 +82,18 @@ public class WorkerSchedulerTest {
                 "}";
 
         ObjectMapper mapper = new ObjectMapper();
-        mapper.registerSubtypes(AtlassianWorkerProgressState.class);
+        mapper.registerSubtypes(PaginationCrawlerWorkerProgressState.class);
         mapper.registerModule(new JavaTimeModule());
 
         SaasWorkerProgressState state = mapper.readValue(json, SaasWorkerProgressState.class);
 
-        assertTrue(state instanceof AtlassianWorkerProgressState);
-        AtlassianWorkerProgressState atlassianState = (AtlassianWorkerProgressState) state;
+        assertTrue(state instanceof PaginationCrawlerWorkerProgressState);
+        PaginationCrawlerWorkerProgressState paginationCrawlerState = (PaginationCrawlerWorkerProgressState) state;
 
-        assertEquals(10, atlassianState.getTotalItems());
-        assertEquals(5, atlassianState.getLoadedItems());
-        assertEquals("project-1", atlassianState.getKeyAttributes().get("project"));
-        assertEquals(2, atlassianState.getItemIds().size());
+        assertEquals(10, paginationCrawlerState.getTotalItems());
+        assertEquals(5, paginationCrawlerState.getLoadedItems());
+        assertEquals("project-1", paginationCrawlerState.getKeyAttributes().get("project"));
+        assertEquals(2, paginationCrawlerState.getItemIds().size());
     }
 
     @Test

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerLeaderProgressStateTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerLeaderProgressStateTest.java
@@ -11,12 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-public class AtlassianLeaderProgressStateTest {
+public class PaginationCrawlerLeaderProgressStateTest {
 
     @Test
     void testInitializedValuesWithIsoInstant() throws JsonProcessingException {
         String json = "{\n" +
-                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianLeaderProgressState\",\n" +
+                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerLeaderProgressState\",\n" +
                 "  \"last_poll_time\": \"2024-10-20T02:27:15.717Z\",\n" +
                 "  \"initialized\": true\n" +
                 "}";
@@ -25,7 +25,7 @@ public class AtlassianLeaderProgressStateTest {
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-        AtlassianLeaderProgressState state = mapper.readValue(json, AtlassianLeaderProgressState.class);
+        PaginationCrawlerLeaderProgressState state = mapper.readValue(json, PaginationCrawlerLeaderProgressState.class);
 
         assertTrue(state.isInitialized());
         assertEquals(Instant.parse("2024-10-20T02:27:15.717Z"), state.getLastPollTime());
@@ -34,7 +34,7 @@ public class AtlassianLeaderProgressStateTest {
     @Test
     void testConstructor_setsLastPollTimeCorrectly() {
         Instant now = Instant.now();
-        AtlassianLeaderProgressState state = new AtlassianLeaderProgressState(now);
+        PaginationCrawlerLeaderProgressState state = new PaginationCrawlerLeaderProgressState(now);
         assertEquals(now, state.getLastPollTime());
         assertFalse(state.isInitialized(), "Expected 'initialized' to be false by default");
     }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerWorkerProgressStateTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/PaginationCrawlerWorkerProgressStateTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AtlassianWorkerProgressStateTest {
+public class PaginationCrawlerWorkerProgressStateTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper(new JsonFactory())
             .registerModule(new JavaTimeModule())
@@ -20,9 +20,9 @@ public class AtlassianWorkerProgressStateTest {
 
     @Test
     void testDefaultValues() throws JsonProcessingException {
-        AtlassianWorkerProgressState originalState = new AtlassianWorkerProgressState();
+        PaginationCrawlerWorkerProgressState originalState = new PaginationCrawlerWorkerProgressState();
         String serializedState = objectMapper.writeValueAsString(originalState);
-        AtlassianWorkerProgressState workerProgressState = objectMapper.readValue(serializedState, AtlassianWorkerProgressState.class);
+        PaginationCrawlerWorkerProgressState workerProgressState = objectMapper.readValue(serializedState, PaginationCrawlerWorkerProgressState.class);
         assertEquals(0, workerProgressState.getTotalItems());
         assertEquals(0, workerProgressState.getLoadedItems());
         assertNotNull(workerProgressState.getKeyAttributes());
@@ -34,7 +34,7 @@ public class AtlassianWorkerProgressStateTest {
     @Test
     void testInitializedValuesWithIsoInstant() throws JsonProcessingException {
         String json = "{\n" +
-                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.AtlassianWorkerProgressState\",\n" +
+                "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.PaginationCrawlerWorkerProgressState\",\n" +
                 "  \"keyAttributes\": {\"project\": \"project-1\"},\n" +
                 "  \"totalItems\": 10,\n" +
                 "  \"loadedItems\": 20,\n" +
@@ -42,7 +42,7 @@ public class AtlassianWorkerProgressStateTest {
                 "  \"itemIds\": [\"GTMS-25\", \"GTMS-24\"]\n" +
                 "}";
 
-        AtlassianWorkerProgressState workerProgressState = objectMapper.readValue(json, AtlassianWorkerProgressState.class);
+        PaginationCrawlerWorkerProgressState workerProgressState = objectMapper.readValue(json, PaginationCrawlerWorkerProgressState.class);
         assertEquals(10, workerProgressState.getTotalItems());
         assertEquals(20, workerProgressState.getLoadedItems());
         assertNotNull(workerProgressState.getKeyAttributes());


### PR DESCRIPTION
Signed-off-by: Alekhya Parisha <aparisha@amazon.com>

### Description
This PR only includes renaming the existing state objects to be more generic and reuse the same for Atlassian as well as Office365

Renamed AtlassianLeaderProgressState to PaginationCrawlerLeaderProgressState
Renamed AtlassianWorkerProgressState to PaginationCrawlerWorkerProgressState
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
