### PR TITLE
Improvements to artifacts to support Maven artifacts for plugins.

### DIFF
--- a/data-prepper-plugin-schema/build.gradle
+++ b/data-prepper-plugin-schema/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'data-prepper.publish'
 }
 
+group = 'org.opensearch.dataprepper.core'
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugin-framework')

--- a/data-prepper-plugins/build.gradle
+++ b/data-prepper-plugins/build.gradle
@@ -10,6 +10,10 @@ plugins {
 subprojects {
     apply plugin: 'data-prepper.publish'
     group = 'org.opensearch.dataprepper.plugins'
+
+    jar {
+        archiveBaseName.set("data-prepper-${project.name}")
+    }
 }
 
 dependencies {

--- a/data-prepper-plugins/saas-source-plugins/build.gradle
+++ b/data-prepper-plugins/saas-source-plugins/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 subprojects {
     apply plugin: 'data-prepper.publish'
-    group = 'org.opensearch.dataprepper.plugins.source'
 }
 
 dependencies {


### PR DESCRIPTION
### Description

This PR helps improve our Maven artifacts to prepare to publish Data Prepper plugins to Maven Central:

* Prepend the `data-prepper-` prefix to jar names, though they aren't used in the Maven coordinates. 
* Move some projects into `.plugins` or `.core` groupIds

### Issues Resolved

Resolves #4931

Contributes toward: #5710 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
