### PR TITLE
Set server id for MySQL binlog client

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorker.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.opensearch.dataprepper.plugins.source.rds.utils.ServerIdGenerator;
 import org.postgresql.replication.LogSequenceNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ public class StreamWorker {
 
         if (replicationLogClient instanceof BinlogClientWrapper) {
             setStartBinlogPosition(streamPartition);
+            setServerId();
         } else {
             setStartLsn(streamPartition);
         }
@@ -108,6 +110,12 @@ public class StreamWorker {
             binaryLogClient.setBinlogFilename(binlogFilename);
             binaryLogClient.setBinlogPosition(binlogPosition);
         }
+    }
+
+    private void setServerId() {
+        final int serverId = ServerIdGenerator.generateServerId();
+        LOG.info("Binary log client server id is {}", serverId);
+        ((BinlogClientWrapper) replicationLogClient).getBinlogClient().setServerId(serverId);
     }
 
     private void setStartLsn(final StreamPartition streamPartition) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/ServerIdGenerator.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/utils/ServerIdGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import java.net.InetAddress;
+import java.util.Random;
+
+public class ServerIdGenerator {
+    static final int MIN_SERVER_ID = 100_000;
+    static final int MAX_SERVER_ID = 999_999;
+
+    public static int generateServerId() {
+        try {
+            // Get local IP address
+            String hostAddress = InetAddress.getLocalHost().getHostAddress();
+
+            // Get process-specific info
+            long processId = ProcessHandle.current().pid();
+            long currentTime = System.currentTimeMillis() % MIN_SERVER_ID;
+
+            int hash = Math.abs((hostAddress + processId + currentTime).hashCode());
+
+            return MIN_SERVER_ID + (hash % (MAX_SERVER_ID - MIN_SERVER_ID + 1));
+
+        } catch (Exception e) {
+            // Fallback to random number
+            return MIN_SERVER_ID + new Random().nextInt(MAX_SERVER_ID - MIN_SERVER_ID + 1);
+        }
+    }
+}

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -15,13 +16,16 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.MySqlStreamState;
+import org.opensearch.dataprepper.plugins.source.rds.coordination.state.PostgresStreamState;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.state.StreamProgressState;
 import org.opensearch.dataprepper.plugins.source.rds.model.BinlogCoordinate;
+import org.postgresql.replication.LogSequenceNumber;
 
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -34,12 +38,6 @@ class StreamWorkerTest {
     private EnhancedSourceCoordinator sourceCoordinator;
 
     @Mock
-    private BinlogClientWrapper binlogClientWrapper;
-
-    @Mock
-    private BinaryLogClient binaryLogClient;
-
-    @Mock
     private PluginMetrics pluginMetrics;
 
     @Mock
@@ -47,55 +45,119 @@ class StreamWorkerTest {
 
     private StreamWorker streamWorker;
 
-    @BeforeEach
-    void setUp() {
-        streamWorker = createObjectUnderTest();
+    @Nested
+    class TestForMySql {
+        @Mock
+        private BinlogClientWrapper binlogClientWrapper;
+
+        @Mock
+        private BinaryLogClient binaryLogClient;
+
+        @BeforeEach
+        void setUp() {
+            streamWorker = createObjectUnderTest();
+        }
+
+        @Test
+        void test_processStream_with_given_binlog_coordinates() throws IOException {
+            final StreamProgressState streamProgressState = mock(StreamProgressState.class);
+            final MySqlStreamState mySqlStreamState = mock(MySqlStreamState.class);
+            final String binlogFilename = UUID.randomUUID().toString();
+            final long binlogPosition = 100L;
+            when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+            when(streamProgressState.getMySqlStreamState()).thenReturn(mySqlStreamState);
+            when(mySqlStreamState.getCurrentPosition()).thenReturn(new BinlogCoordinate(binlogFilename, binlogPosition));
+            when(streamProgressState.shouldWaitForExport()).thenReturn(false);
+            when(binlogClientWrapper.getBinlogClient()).thenReturn(binaryLogClient);
+
+            streamWorker.processStream(streamPartition);
+
+            verify(binaryLogClient).setBinlogFilename(binlogFilename);
+            verify(binaryLogClient).setBinlogPosition(binlogPosition);
+            verify(binlogClientWrapper).connect();
+        }
+
+        @Test
+        void test_processStream_without_current_binlog_coordinates() throws IOException {
+            final StreamProgressState streamProgressState = mock(StreamProgressState.class);
+            final MySqlStreamState mySqlStreamState = mock(MySqlStreamState.class);
+            when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+            final String binlogFilename = "binlog-001";
+            final long binlogPosition = 100L;
+            when(streamProgressState.getMySqlStreamState()).thenReturn(mySqlStreamState);
+            when(mySqlStreamState.getCurrentPosition()).thenReturn(null);
+            when(streamProgressState.shouldWaitForExport()).thenReturn(false);
+            when(binlogClientWrapper.getBinlogClient()).thenReturn(binaryLogClient);
+
+            streamWorker.processStream(streamPartition);
+
+            verify(binaryLogClient, never()).setBinlogFilename(binlogFilename);
+            verify(binaryLogClient, never()).setBinlogPosition(binlogPosition);
+            verify(binlogClientWrapper).connect();
+        }
+
+        @Test
+        void test_shutdown() throws IOException {
+            streamWorker.shutdown();
+            verify(binlogClientWrapper).disconnect();
+        }
+
+        private StreamWorker createObjectUnderTest() {
+            return new StreamWorker(sourceCoordinator, binlogClientWrapper, pluginMetrics);
+        }
+
     }
 
-    @Test
-    void test_processStream_with_given_binlog_coordinates() throws IOException {
-        final StreamProgressState streamProgressState = mock(StreamProgressState.class);
-        final MySqlStreamState mySqlStreamState = mock(MySqlStreamState.class);
-        final String binlogFilename = UUID.randomUUID().toString();
-        final long binlogPosition = 100L;
-        when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
-        when(streamProgressState.getMySqlStreamState()).thenReturn(mySqlStreamState);
-        when(mySqlStreamState.getCurrentPosition()).thenReturn(new BinlogCoordinate(binlogFilename, binlogPosition));
-        when(streamProgressState.shouldWaitForExport()).thenReturn(false);
-        when(binlogClientWrapper.getBinlogClient()).thenReturn(binaryLogClient);
+    @Nested
+    class TestForPostgres {
+        @Mock
+        private LogicalReplicationClient logicalReplicationClient;
 
-        streamWorker.processStream(streamPartition);
+        @BeforeEach
+        void setUp() {
+            streamWorker = createObjectUnderTest();
+        }
 
-        verify(binaryLogClient).setBinlogFilename(binlogFilename);
-        verify(binaryLogClient).setBinlogPosition(binlogPosition);
-        verify(binlogClientWrapper).connect();
-    }
+        @Test
+        void test_processStream_with_given_currentLsn() {
+            final StreamProgressState streamProgressState = mock(StreamProgressState.class);
+            final PostgresStreamState postgresStreamState = mock(PostgresStreamState.class);
+            final String currentLsn = UUID.randomUUID().toString();
+            when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+            when(streamProgressState.getPostgresStreamState()).thenReturn(postgresStreamState);
+            when(postgresStreamState.getCurrentLsn()).thenReturn(currentLsn);
+            when(streamProgressState.shouldWaitForExport()).thenReturn(false);
 
-    @Test
-    void test_processStream_without_current_binlog_coordinates() throws IOException {
-        final StreamProgressState streamProgressState = mock(StreamProgressState.class);
-        final MySqlStreamState mySqlStreamState = mock(MySqlStreamState.class);
-        when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
-        final String binlogFilename = "binlog-001";
-        final long binlogPosition = 100L;
-        when(streamProgressState.getMySqlStreamState()).thenReturn(mySqlStreamState);
-        when(mySqlStreamState.getCurrentPosition()).thenReturn(null);
-        when(streamProgressState.shouldWaitForExport()).thenReturn(false);
+            streamWorker.processStream(streamPartition);
 
-        streamWorker.processStream(streamPartition);
+            verify(logicalReplicationClient).setStartLsn(LogSequenceNumber.valueOf(currentLsn));
+            verify(logicalReplicationClient).connect();
+        }
 
-        verify(binaryLogClient, never()).setBinlogFilename(binlogFilename);
-        verify(binaryLogClient, never()).setBinlogPosition(binlogPosition);
-        verify(binlogClientWrapper).connect();
-    }
+        @Test
+        void test_processStream_without_currentLsn() {
+            final StreamProgressState streamProgressState = mock(StreamProgressState.class);
+            final PostgresStreamState postgresStreamState = mock(PostgresStreamState.class);
+            when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+            when(streamProgressState.getPostgresStreamState()).thenReturn(postgresStreamState);
+            when(postgresStreamState.getCurrentLsn()).thenReturn(null);
+            when(streamProgressState.shouldWaitForExport()).thenReturn(false);
 
-    @Test
-    void test_shutdown() throws IOException {
-        streamWorker.shutdown();
-        verify(binlogClientWrapper).disconnect();
-    }
+            streamWorker.processStream(streamPartition);
 
-    private StreamWorker createObjectUnderTest() {
-        return new StreamWorker(sourceCoordinator, binlogClientWrapper, pluginMetrics);
+            verify(logicalReplicationClient, never()).setStartLsn(any());
+            verify(logicalReplicationClient).connect();
+        }
+
+        @Test
+        void test_shutdown() throws IOException {
+            streamWorker.shutdown();
+            verify(logicalReplicationClient).disconnect();
+        }
+
+        private StreamWorker createObjectUnderTest() {
+            return new StreamWorker(sourceCoordinator, logicalReplicationClient, pluginMetrics);
+        }
+
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/ServerIdGeneratorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/utils/ServerIdGeneratorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.source.rds.utils;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.apache.parquet.filter.ColumnPredicates.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.rds.utils.ServerIdGenerator.MAX_SERVER_ID;
+import static org.opensearch.dataprepper.plugins.source.rds.utils.ServerIdGenerator.MIN_SERVER_ID;
+
+class ServerIdGeneratorTest {
+    @Test
+    public void generateServerId_shouldReturnValueWithinValidRange() {
+        // When
+        int serverId = ServerIdGenerator.generateServerId();
+
+        // Then
+        assertThat("Server ID should be within valid range",
+                serverId, allOf(
+                        greaterThanOrEqualTo(MIN_SERVER_ID),
+                        lessThanOrEqualTo(MAX_SERVER_ID)
+                ));
+    }
+
+    @Test
+    public void generateServerId_shouldFallbackToRandomWhenInetAddressFails() {
+        // Given - Mock InetAddress to throw exception
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+            mockedInetAddress.when(InetAddress::getLocalHost)
+                    .thenThrow(new UnknownHostException("Mocked exception"));
+
+            // When
+            int serverId = ServerIdGenerator.generateServerId();
+
+            // Then
+            assertThat("Fallback should generate valid server ID",
+                    serverId, allOf(
+                            greaterThanOrEqualTo(MIN_SERVER_ID),
+                            lessThanOrEqualTo(MAX_SERVER_ID)
+                    ));
+
+            // Verify the exception path was taken
+            mockedInetAddress.verify(InetAddress::getLocalHost);
+        }
+    }
+
+    @Test
+    public void generateServerId_shouldHandleProcessHandleFailure() {
+        // Given - Mock ProcessHandle to throw exception
+        try (MockedStatic<ProcessHandle> mockedProcessHandle = mockStatic(ProcessHandle.class)) {
+            mockedProcessHandle.when(ProcessHandle::current)
+                    .thenThrow(new RuntimeException("Mocked process failure"));
+
+            // When
+            int serverId = ServerIdGenerator.generateServerId();
+
+            // Then
+            assertThat("Should fallback gracefully on ProcessHandle failure",
+                    serverId, allOf(
+                            greaterThanOrEqualTo(MIN_SERVER_ID),
+                            lessThanOrEqualTo(MAX_SERVER_ID)
+                    ));
+        }
+    }
+
+    @Test
+    public void generateServerId_shouldProduceDifferentValuesForDifferentHosts() {
+        // Given - Mock different IP addresses
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+
+            // Mock first host
+            InetAddress mockAddress1 = mock(InetAddress.class);
+            when(mockAddress1.getHostAddress()).thenReturn("192.168.1.100");
+            mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(mockAddress1);
+
+            int serverId1 = ServerIdGenerator.generateServerId();
+
+            // Mock second host
+            InetAddress mockAddress2 = mock(InetAddress.class);
+            when(mockAddress2.getHostAddress()).thenReturn("192.168.1.200");
+            mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(mockAddress2);
+
+            int serverId2 = ServerIdGenerator.generateServerId();
+
+            // Then
+            assertThat("Both IDs should be in valid range",
+                    serverId1, allOf(
+                            greaterThanOrEqualTo(MIN_SERVER_ID),
+                            lessThanOrEqualTo(MAX_SERVER_ID)
+                    ));
+
+            assertThat("Both IDs should be in valid range",
+                    serverId2, allOf(
+                            greaterThanOrEqualTo(MIN_SERVER_ID),
+                            lessThanOrEqualTo(MAX_SERVER_ID)
+                    ));
+
+            assertThat("Different hosts should likely generate different server IDs",
+                    serverId1, is(not(equalTo(serverId2))));
+        }
+    }
+}


### PR DESCRIPTION
### Description
Set a custom server id for MySQL binlog client before making connection to the MySQL database. 

Before this CR, server id is always 65535 by default and can result in server id conflict when two Data Prepper pipelines try to connect to the same MySQL database's binary log stream.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
