### PR TITLE
add internal batching of the records for Sagemaker job creator

### DIFF
--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessor.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessor.java
@@ -61,11 +61,16 @@ public class MLProcessor extends AbstractProcessor<Record<Event>, Record<Event>>
 
     @Override
     public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
+        List<Record<Event>> resultRecords = new ArrayList<>();
+        // check and process any existing batch
+        mlBatchJobCreator.checkAndProcessBatch();
+        // Add processed records to results
+        mlBatchJobCreator.addProcessedBatchRecordsToResults(resultRecords);
         // reads from input - S3 input
         if (records.size() == 0)
-            return records;
+            return resultRecords;
 
-        List<Record<Event>> resultRecords = new ArrayList<>();
+        // Process new records
         List<Record<Event>> recordsToMlCommons = records.stream()
             .filter(record -> {
                 try {
@@ -90,9 +95,8 @@ public class MLProcessor extends AbstractProcessor<Record<Event>, Record<Event>>
             })
             .collect(Collectors.toList());
 
-        mlBatchJobCreator.addProcessedBatchRecordsToResults(resultRecords);
         if (recordsToMlCommons.isEmpty()) {
-            return records;
+            return resultRecords;
         }
 
         try {

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessor.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessor.java
@@ -90,6 +90,7 @@ public class MLProcessor extends AbstractProcessor<Record<Event>, Record<Event>>
             })
             .collect(Collectors.toList());
 
+        mlBatchJobCreator.addProcessedBatchRecordsToResults(resultRecords);
         if (recordsToMlCommons.isEmpty()) {
             return records;
         }
@@ -109,14 +110,16 @@ public class MLProcessor extends AbstractProcessor<Record<Event>, Record<Event>>
 
     @Override
     public void prepareForShutdown() {
+        mlBatchJobCreator.prepareForShutdown();
     }
 
     @Override
     public boolean isReadyForShutdown() {
-        return true;
+        return mlBatchJobCreator.isReadyForShutdown();
     }
 
     @Override
     public void shutdown() {
+        mlBatchJobCreator.shutdown();
     }
 }

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorConfig.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorConfig.java
@@ -28,6 +28,7 @@ import java.util.List;
 @JsonClassDescription("The <code>ml</code> processor enables invocation of the ml-commons plugin in OpenSearch service within your pipeline in order to process events. " +
         "It supports both synchronous and asynchronous invocations based on your use case.")
 public class MLProcessorConfig {
+    private static final int DEFAULT_MAX_BATCH_SIZE = 100;
 
     @JsonProperty("aws")
     @NotNull
@@ -75,6 +76,9 @@ public class MLProcessorConfig {
                     "or exception occurs. This tag may be used in conditional expressions in " +
                     "other parts of the configuration.")
     private List<String> tagsOnFailure = Collections.emptyList();
+
+    @JsonProperty("max_batch_size")
+    private int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
 
     public ActionType getActionType() {
         return actionType;

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/MLBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/MLBatchJobCreator.java
@@ -46,4 +46,12 @@ public interface MLBatchJobCreator {
      */
     default void addProcessedBatchRecordsToResults(List<Record<Event>> resultRecords) {
     }
+
+    /**
+     * Checks and processes batch if batch processing is supported.
+     * Default implementation does nothing.
+     */
+    default void checkAndProcessBatch() {
+        // Default no-op implementation
+    }
 }

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/MLBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/MLBatchJobCreator.java
@@ -27,4 +27,23 @@ public interface MLBatchJobCreator {
         jobName = JOB_NAME_PATTERN.matcher(jobName).replaceAll("");
         return jobName.substring(0, Math.min(63, jobName.length()));
     }
+
+    default void prepareForShutdown() {
+    }
+
+    default boolean isReadyForShutdown() {
+        return true;
+    }
+
+    default void shutdown() {
+    }
+
+    /**
+     * Adds any processed batch records to the provided result records list and clears the processed batch.
+     * Currently, this is needed for SageMaker batch jobs
+     *
+     * @param resultRecords The list to add processed batch records to
+     */
+    default void addProcessedBatchRecordsToResults(List<Record<Event>> resultRecords) {
+    }
 }

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorTest.java
@@ -102,6 +102,7 @@ public class MLProcessorTest {
 
         Collection<Record<Event>> result = mlProcessor.doExecute(records);
 
+        verify(mlBatchJobCreator, times(1)).addProcessedBatchRecordsToResults(new ArrayList<>());
         verify(mlBatchJobCreator, times(1)).createMLBatchJob(records, new ArrayList<>());
         verify(successCounter, times(1)).increment();
     }
@@ -128,7 +129,8 @@ public class MLProcessorTest {
         Collection<Record<Event>> result = mlProcessor.doExecute(records);
 
         // Verify no interactions with mlBatchJobCreator, successCounter, or failureCounter
-        verifyNoInteractions(mlBatchJobCreator, successCounter, failureCounter);
+        verify(mlBatchJobCreator, times(1)).addProcessedBatchRecordsToResults(records);
+        verifyNoInteractions(successCounter, failureCounter);
 
         // Assert that the input records are returned as output
         assertEquals(records, result);
@@ -149,8 +151,16 @@ public class MLProcessorTest {
 
     @Test
     void testShutdownMethods() {
+        when(mlBatchJobCreator.isReadyForShutdown()).thenReturn(true);
+
         assertTrue(mlProcessor.isReadyForShutdown());
         mlProcessor.prepareForShutdown();
         mlProcessor.shutdown();
+
+        // Verify that these methods were called on the batch job creator
+        verify(mlBatchJobCreator).isReadyForShutdown();
+        verify(mlBatchJobCreator).prepareForShutdown();
+        verify(mlBatchJobCreator).shutdown();
+
     }
 }

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorTest.java
@@ -111,7 +111,7 @@ public class MLProcessorTest {
     void testDoExecute_WithNoRecords() {
         Collection<Record<Event>> result = mlProcessor.doExecute(Collections.emptyList());
 
-        verifyNoInteractions(mlBatchJobCreator, successCounter, failureCounter);
+        verifyNoInteractions(successCounter, failureCounter);
         assertTrue(result.isEmpty());
     }
 
@@ -130,6 +130,7 @@ public class MLProcessorTest {
 
         // Verify no interactions with mlBatchJobCreator, successCounter, or failureCounter
         verify(mlBatchJobCreator, times(1)).addProcessedBatchRecordsToResults(records);
+        verify(mlBatchJobCreator, times(1)).checkAndProcessBatch();
         verifyNoInteractions(successCounter, failureCounter);
 
         // Assert that the input records are returned as output

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
@@ -23,17 +23,22 @@ import org.opensearch.dataprepper.plugins.ml_inference.processor.MLProcessorConf
 import org.opensearch.dataprepper.plugins.ml_inference.processor.client.S3ClientFactory;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.common.utils.RetryUtil;
-import org.opensearch.dataprepper.plugins.ml_inference.processor.exception.MLBatchJobException;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledExecutorService;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -64,11 +69,15 @@ public class SageMakerBatchJobCreatorTest {
     @Mock
     private S3Client s3Client;
 
+    @Mock
+    private ScheduledExecutorService scheduler;
     private SageMakerBatchJobCreator sageMakerBatchJobCreator;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
     private Counter counter;
+    private ConcurrentLinkedQueue<Record<Event>> batch_records;
+    private ConcurrentLinkedQueue<Record<Event>> processedBatchRecords;
 
     @BeforeEach
     void setUp() {
@@ -79,72 +88,293 @@ public class SageMakerBatchJobCreatorTest {
         when(mlProcessorConfig.getInputKey()).thenReturn(sourceKey);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
         when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
-        counter = new Counter() {
-            @Override
-            public void increment(double v) {}
-
-            @Override
-            public double count() {
-                return 0;
-            }
-
-            @Override
-            public Id getId() {
-                return null;
-            }
-        };
+        counter = mock(Counter.class);
         when(pluginMetrics.counter(NUMBER_OF_SUCCESSFUL_BATCH_JOBS_CREATION)).thenReturn(counter);
         when(pluginMetrics.counter(NUMBER_OF_FAILED_BATCH_JOBS_CREATION)).thenReturn(counter);
 
-        // sageMakerBatchJobCreator = spy(new SageMakerBatchJobCreator(mlProcessorConfig, awsCredentialsSupplier, pluginMetrics));
-    }
-
-    @Test
-    void testCreateMLBatchJob_Success() {
-        Event event = mock(Event.class);
-        Record<Event> record = new Record<>(event);
-
-        when(event.getJsonNode()).thenReturn(OBJECT_MAPPER.createObjectNode()
-                .put("bucket", "test-bucket")
-                .put("key", "input.jsonl"));
-
-        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class);
-             MockedStatic<S3ClientFactory> mockedS3ClientFactory = mockStatic(S3ClientFactory.class)) {
-            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(true);
+        try (MockedStatic<S3ClientFactory> mockedS3ClientFactory = mockStatic(S3ClientFactory.class)) {
             mockedS3ClientFactory.when(() -> S3ClientFactory.createS3Client(mlProcessorConfig, awsCredentialsSupplier)).thenReturn(s3Client);
 
+            // Create a spy of the real object
             sageMakerBatchJobCreator = spy(new SageMakerBatchJobCreator(mlProcessorConfig, awsCredentialsSupplier, pluginMetrics));
-            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
 
-            sageMakerBatchJobCreator.createMLBatchJob(Arrays.asList(record), new ArrayList<>());
+            // Get access to the private queues for testing
+            Field batchRecordsField = SageMakerBatchJobCreator.class.getDeclaredField("batch_records");
+            batchRecordsField.setAccessible(true);
+            batch_records = (ConcurrentLinkedQueue<Record<Event>>) batchRecordsField.get(sageMakerBatchJobCreator);
 
-            verify(sageMakerBatchJobCreator, times(1)).incrementSuccessCounter();
-            mockedS3ClientFactory.verify(() -> S3ClientFactory.createS3Client(mlProcessorConfig, awsCredentialsSupplier), times(1));
+            Field processedBatchRecordsField = SageMakerBatchJobCreator.class.getDeclaredField("processedBatchRecords");
+            processedBatchRecordsField.setAccessible(true);
+            processedBatchRecords = (ConcurrentLinkedQueue<Record<Event>>) processedBatchRecordsField.get(sageMakerBatchJobCreator);
+
+            // Replace scheduler with mock
+            Field schedulerField = SageMakerBatchJobCreator.class.getDeclaredField("scheduler");
+            schedulerField.setAccessible(true);
+            schedulerField.set(sageMakerBatchJobCreator, scheduler);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 
     @Test
-    void testCreateMLBatchJob_Failure() {
-        Event event = mock(Event.class);
+    void testCreateMLBatchJob_AddsRecordsToBatch() {
+        // Arrange
+        Event event = createMockEvent("test-bucket", "input.jsonl");
         Record<Event> record = new Record<>(event);
+        List<Record<Event>> records = Collections.singletonList(record);
+        List<Record<Event>> resultRecords = new ArrayList<>();
 
-        when(event.getJsonNode()).thenReturn(OBJECT_MAPPER.createObjectNode()
-                .put("bucket", "test-bucket")
-                .put("key", "input.jsonl"));
+        // Act
+        sageMakerBatchJobCreator.createMLBatchJob(records, resultRecords);
+
+        // Assert
+        assertEquals(1, batch_records.size());
+        assertEquals(record, batch_records.peek());
+        assertEquals(0, resultRecords.size());
+    }
+
+    @Test
+    void testAddProcessedBatchRecordsToResults() {
+        // Arrange
+        Event event = createMockEvent("test-bucket", "input.jsonl");
+        Record<Event> record = new Record<>(event);
+        processedBatchRecords.add(record);
+        List<Record<Event>> resultRecords = new ArrayList<>();
+
+        // Act
+        sageMakerBatchJobCreator.addProcessedBatchRecordsToResults(resultRecords);
+
+        // Assert
+        assertEquals(1, resultRecords.size());
+        assertEquals(record, resultRecords.get(0));
+        assertTrue(processedBatchRecords.isEmpty());
+    }
+
+    @Test
+    void testCheckAndProcessBatch_ProcessesWhenMaxSizeReached() throws Exception {
+        // Arrange - fill batch_records to max size
+        for (int i = 0; i < 100; i++) {
+            Event event = createMockEvent("test-bucket", "input" + i + ".jsonl");
+            // Make sure the event's key is properly accessible
+            batch_records.add(new Record<>(event));
+        }
 
         try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class);
              MockedStatic<S3ClientFactory> mockedS3ClientFactory = mockStatic(S3ClientFactory.class)) {
-            sageMakerBatchJobCreator = spy(new SageMakerBatchJobCreator(mlProcessorConfig, awsCredentialsSupplier, pluginMetrics));
-            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(false);
 
-            MLBatchJobException exception = assertThrows(MLBatchJobException.class, () -> {
-                sageMakerBatchJobCreator.createMLBatchJob(Arrays.asList(record), new ArrayList<>());
-            });
+            // Make RetryUtil actually execute the supplier
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(true);
 
-            verify(sageMakerBatchJobCreator, times(1)).incrementFailureCounter();
-            mockedS3ClientFactory.verify(() -> S3ClientFactory.createS3Client(mlProcessorConfig, awsCredentialsSupplier), times(1));
-            assertTrue(exception.getMessage().contains("Failed to create SageMaker batch job"));
+            mockedS3ClientFactory.when(() -> S3ClientFactory.createS3Client(mlProcessorConfig, awsCredentialsSupplier)).thenReturn(s3Client);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
+
+            // Act - trigger batch processing directly
+            callPrivateCheckAndProcessBatch();
+
+            // Assert
+            verify(sageMakerBatchJobCreator).incrementSuccessCounter();
+            verify(counter, times(1)).increment(); // Success counter
+            assertEquals(100, processedBatchRecords.size());
+            assertTrue(batch_records.isEmpty());
         }
     }
 
+    @Test
+    void testCheckAndProcessBatch_ProcessesWhenTimeoutReached() throws Exception {
+        // Arrange - add a few records and set lastUpdateTimestamp to be old
+        Event event = createMockEvent("test-bucket", "input.jsonl");
+        batch_records.add(new Record<>(event));
+
+        // Set lastUpdateTimestamp to be old
+        Field lastUpdateTimestampField = SageMakerBatchJobCreator.class.getDeclaredField("lastUpdateTimestamp");
+        lastUpdateTimestampField.setAccessible(true);
+        lastUpdateTimestampField.set(sageMakerBatchJobCreator, java.util.concurrent.atomic.AtomicLong.class.getDeclaredConstructor(long.class).newInstance(System.currentTimeMillis() - 70000)); // 70 seconds ago
+
+        // Mock RetryUtil to return success
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(true);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
+
+            // Act
+            callPrivateCheckAndProcessBatch();
+
+            // Assert
+            verify(sageMakerBatchJobCreator).incrementSuccessCounter();
+            verify(counter, times(1)).increment(); // Success counter
+            assertEquals(1, processedBatchRecords.size());
+            assertTrue(batch_records.isEmpty());
+        }
+    }
+
+    @Test
+    void testProcessRemainingBatch() throws Exception {
+        // Arrange
+        Event event = createMockEvent("test-bucket", "input.jsonl");
+        batch_records.add(new Record<>(event));
+
+        // Mock RetryUtil to return success
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(true);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
+
+            // Act
+            callPrivateProcessRemainingBatch();
+
+            // Assert
+            verify(sageMakerBatchJobCreator).incrementSuccessCounter();
+            verify(counter, times(1)).increment(); // Success counter
+            assertEquals(1, processedBatchRecords.size());
+            assertTrue(batch_records.isEmpty());
+        }
+    }
+
+    @Test
+    void testHandleFailure_S3UploadException() throws Exception {
+        // Arrange
+        Event event = createMockEvent("test-bucket", "input.jsonl");
+        Record<Event> record = new Record<>(event);
+        batch_records.add(record);
+
+        try (MockedStatic<S3ClientFactory> mockedS3ClientFactory = mockStatic(S3ClientFactory.class)) {
+            mockedS3ClientFactory.when(() -> S3ClientFactory.createS3Client(mlProcessorConfig, awsCredentialsSupplier))
+                    .thenReturn(s3Client);
+
+            // S3 throws exception during upload
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenThrow(new RuntimeException("S3 upload failed"));
+
+            // Act
+            callPrivateCheckAndProcessBatch();
+
+            // Assert
+            verify(sageMakerBatchJobCreator).incrementFailureCounter();
+            verify(counter).increment();
+            assertEquals(1, processedBatchRecords.size());
+            assertTrue(batch_records.isEmpty());
+        }
+    }
+
+    @Test
+    void testHandleFailure_EmptyInputCollection() throws Exception {
+        // Arrange - create an empty batch
+        List<Record<Event>> emptyBatch = new ArrayList<>();
+
+        // Act - directly call processCurrentBatch with reflection
+        Method processMethod = SageMakerBatchJobCreator.class.getDeclaredMethod("processCurrentBatch", List.class);
+        processMethod.setAccessible(true);
+        processMethod.invoke(sageMakerBatchJobCreator, emptyBatch);
+
+        // Assert
+        verify(sageMakerBatchJobCreator).incrementFailureCounter();
+        verify(counter).increment();
+    }
+
+    @Test
+    void testHandleFailure_RetryFailure() throws Exception {
+        // Arrange
+        Event event = createMockEvent("test-bucket", "input.jsonl");
+        Record<Event> record = new Record<>(event);
+        batch_records.add(record);
+
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            // RetryUtil returns false indicating failure
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(false);
+
+            // Act
+            callPrivateCheckAndProcessBatch();
+
+            // Assert
+            verify(sageMakerBatchJobCreator).incrementFailureCounter();
+            verify(counter).increment();
+            assertEquals(1, processedBatchRecords.size());
+            assertTrue(batch_records.isEmpty());
+        }
+    }
+
+    @Test
+    void testShutdown() {
+        // Act
+        sageMakerBatchJobCreator.shutdown();
+
+        // Assert
+        verify(scheduler).shutdown();
+    }
+
+    @Test
+    void testPrepareForShutdown() {
+        // Act
+        sageMakerBatchJobCreator.prepareForShutdown();
+
+        // Assert
+        verify(scheduler).shutdown();
+    }
+
+    @Test
+    void testIsReadyForShutdown_WhenBatchEmpty() {
+        // Arrange
+        batch_records.clear();
+
+        // Act & Assert
+        assertTrue(sageMakerBatchJobCreator.isReadyForShutdown());
+    }
+
+    @Test
+    void testIsReadyForShutdown_WhenBatchNotEmpty() {
+        // Arrange
+        Event event = createMockEvent("test-bucket", "input.jsonl");
+        batch_records.add(new Record<>(event));
+
+        // Act & Assert
+        assertFalse(sageMakerBatchJobCreator.isReadyForShutdown());
+    }
+
+    @Test
+    void testHandleFailure() throws Exception {
+        // Arrange
+        for (int i = 0; i < 100; i++) {
+            Event event = createMockEvent("test-bucket", "input" + i + ".jsonl");
+            // Make sure the event's key is properly accessible
+            batch_records.add(new Record<>(event));
+        }
+        // Mock RetryUtil to return failure
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoff(any(), any())).thenReturn(false);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
+
+            // Act - trigger batch processing with a batch that will fail
+            callPrivateCheckAndProcessBatch();
+
+            // Assert
+            verify(counter, times(1)).increment(); // Failure counter
+            assertEquals(100, processedBatchRecords.size()); // Record should still be added but with failure tag
+            assertTrue(batch_records.isEmpty());
+        }
+    }
+
+    // Helper methods
+    private Event createMockEvent(String bucket, String key) {
+        Event event = mock(Event.class);
+        when(event.getJsonNode()).thenReturn(OBJECT_MAPPER.createObjectNode()
+                .put("bucket", bucket)
+                .put("key", key));
+        // Mock the event.get method which is used when inputKey is not null
+        when(event.get(mlProcessorConfig.getInputKey(), String.class)).thenReturn(key);
+        return event;
+    }
+
+    private void callPrivateCheckAndProcessBatch() throws Exception {
+        // Use reflection to call private method
+        java.lang.reflect.Method method = SageMakerBatchJobCreator.class.getDeclaredMethod("checkAndProcessBatch");
+        method.setAccessible(true);
+        method.invoke(sageMakerBatchJobCreator);
+    }
+
+    private void callPrivateProcessRemainingBatch() throws Exception {
+        // Use reflection to call private method
+        java.lang.reflect.Method method = SageMakerBatchJobCreator.class.getDeclaredMethod("processRemainingBatch");
+        method.setAccessible(true);
+        method.invoke(sageMakerBatchJobCreator);
+    }
 }


### PR DESCRIPTION
### Description
This PR enhances batch job creation by implementing thread-safe record collection across multiple processor worker threads. 

Currently when processing multiple S3 files (e.g., an S3 source with 7 files), records are randomly distributed across worker threads. For example, worker-1 might process files 2,4,6 while worker-2 processes 1,3,5,7, resulting in two separate, potentially undersized batch jobs. Ideally we should only create 1 batch job to process all the files with best efficiency. 

Rather than having each worker thread independently create separate ML batch jobs, all worker threads now contribute records to a shared, thread-safe buffer in the ml processor. The system creates a single consolidated ML batch job when either of these conditions is met:
1. The accumulated records in the buffer reach the maximum batch size threshold (default: 100 records)
2. The buffer remains unchanged (no new records added) for a configurable idle time window (default: 1 minute)

This approach optimizes resource utilization by consolidating what would have been multiple smaller batch jobs into fewer, appropriately-sized batch operations.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
