### PR TITLE
Fix kafka source with glue registry

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
@@ -29,6 +29,9 @@ public class SchemaConfig {
   @JsonProperty("registry_url")
   private String registryURL;
 
+  @JsonProperty("override_endpoint")
+  private Boolean overrideEndpoint = false;
+
   @JsonProperty("version")
   private Integer version;
 
@@ -93,6 +96,10 @@ public class SchemaConfig {
 
   public int getSessionTimeoutms() {
     return sessionTimeoutms;
+  }
+
+  public boolean getOverrideEndpoint() {
+    return overrideEndpoint;
   }
 
   public String getBasicAuthCredentialsSource() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
@@ -402,9 +402,10 @@ public class KafkaSecurityConfigurer {
         configs.put(AWSSchemaRegistryConstants.CACHE_TIME_TO_LIVE_MILLIS, "86400000");
         configs.put(AWSSchemaRegistryConstants.CACHE_SIZE, "10");
         configs.put(AWSSchemaRegistryConstants.COMPATIBILITY_SETTING, Compatibility.FULL);
-        String endpointOverride = kafkaConsumerConfig.getSchemaConfig().getRegistryURL();
-        if (endpointOverride != null) {
-            configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, endpointOverride);
+        String registryUrl = kafkaConsumerConfig.getSchemaConfig().getRegistryURL();
+        boolean endpointOverride = kafkaConsumerConfig.getSchemaConfig().getOverrideEndpoint();
+        if (endpointOverride) {
+            configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, registryUrl);
         }
         glueDeserializer = new GlueSchemaRegistryKafkaDeserializer(awsGlueCredentialsProvider, configs);
         return glueDeserializer;

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-bootstrap-servers-glue-override-endpoint.yaml
@@ -8,6 +8,7 @@ log-pipeline :
         schema:
           type: aws_glue
           registry_url: http://fake-glue-registry
+          override_endpoint: true
         topics:
         - name: "quickstart-events"
           group_id: "groupdID1"


### PR DESCRIPTION
### Description
Fix kafka source with glue registry.
 
Kafka source with glue registry default behavior is broken with PR #5502. This change keeps the old and new behavior by adding a new flag under `schema:`. To get the behavior specified in the issue #5377, new `override_endpoint:` option must be specified under `schema:`
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
