### PR TITLE
Modify cloudwatch sink to use FixedThreadPool

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -74,7 +74,7 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
             dlqPushHandler = new DlqPushHandler(pluginFactory, pluginSetting, pluginMetrics, cloudWatchLogsSinkConfig.getDlq(), region, role, "cloudWatchLogs");
         }
 
-        Executor executor = Executors.newFixedThreadPool(cloudWatchLogsSinkConfig.getNumThreads());
+        Executor executor = Executors.newFixedThreadPool(cloudWatchLogsSinkConfig.getWorkers());
 
         CloudWatchLogsDispatcher cloudWatchLogsDispatcher = CloudWatchLogsDispatcher.builder()
                 .cloudWatchLogsClient(cloudWatchLogsClient)

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
@@ -17,7 +17,7 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 
 public class CloudWatchLogsSinkConfig {
     public static final int DEFAULT_RETRY_COUNT = 5;
-    public static final int DEFAULT_NUM_THREADS = 10;
+    public static final int DEFAULT_NUM_WORKERS = 10;
 
     @JsonProperty("aws")
     @Valid
@@ -44,10 +44,10 @@ public class CloudWatchLogsSinkConfig {
     @Max(15)
     private int maxRetries = DEFAULT_RETRY_COUNT;
 
-    @JsonProperty(value = "num_threads", defaultValue = "10")
+    @JsonProperty(value = "workers", defaultValue = "10")
     @Min(1)
     @Max(50)
-    private int numThreads = DEFAULT_NUM_THREADS;
+    private int workers = DEFAULT_NUM_WORKERS;
 
     public AwsConfig getAwsConfig() {
         return awsConfig;
@@ -73,8 +73,8 @@ public class CloudWatchLogsSinkConfig {
         return maxRetries;
     }
 
-    public int getNumThreads() {
-        return numThreads;
+    public int getWorkers() {
+        return workers;
     }
 
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -68,7 +68,7 @@ class CloudWatchLogsSinkTest {
         when(mockCloudWatchLogsSinkConfig.getLogGroup()).thenReturn(TEST_LOG_GROUP);
         when(mockCloudWatchLogsSinkConfig.getLogStream()).thenReturn(TEST_LOG_STREAM);
         when(mockCloudWatchLogsSinkConfig.getMaxRetries()).thenReturn(3);
-        when(mockCloudWatchLogsSinkConfig.getNumThreads()).thenReturn(10);
+        when(mockCloudWatchLogsSinkConfig.getWorkers()).thenReturn(10);
 
         when(mockPluginSetting.getName()).thenReturn(TEST_PLUGIN_NAME);
         when(mockPluginSetting.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
@@ -46,7 +46,7 @@ class CloudWatchLogsSinkConfigTest {
 
     @Test
     void GIVEN_new_sink_config_WHEN_get_num_threads_called_SHOULD_return_default_value() {
-        assertThat(new CloudWatchLogsSinkConfig().getNumThreads(), equalTo(CloudWatchLogsSinkConfig.DEFAULT_NUM_THREADS));
+        assertThat(new CloudWatchLogsSinkConfig().getWorkers(), equalTo(CloudWatchLogsSinkConfig.DEFAULT_NUM_WORKERS));
     }
 
     @Test
@@ -57,8 +57,8 @@ class CloudWatchLogsSinkConfigTest {
     @Test
     void GIVEN_num_threads_configured_SHOULD_return_the_configured_value() throws NoSuchFieldException, IllegalAccessException {
         int testValue = (new Random()).nextInt();
-        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "numThreads", testValue);
-        assertThat(cloudWatchLogsSinkConfig.getNumThreads(), equalTo(testValue));
+        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "workers", testValue);
+        assertThat(cloudWatchLogsSinkConfig.getWorkers(), equalTo(testValue));
     }
 
     @Test


### PR DESCRIPTION
### Description
Modify cloudwatch sink to use FixedThreadPool. The existing `newCachedThreadPool()` creates huge amount of threads (leading to out of memory error in some cases) when there is large amount of events created.

Modified the code to use `newFixedThreadPool()`.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
