### PR TITLE
Add support for updating JacksonEvent array elements

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -195,8 +195,26 @@ public class JacksonEvent implements Event {
         JsonNode childNode = node.get(key);
         if (childNode == null) {
             childNode = mapper.createObjectNode();
-            ((ObjectNode) node).set(key, childNode);
+            if (node.isArray()) {
+                int index = Integer.parseInt(key);
+                ArrayNode arrayNode = (ArrayNode) node;
+
+                while (arrayNode.size() <= index) {
+                    arrayNode.addNull();
+                }
+
+                JsonNode existing = arrayNode.get(index);
+                if (existing == null || !existing.isObject()) {
+                    childNode = mapper.createObjectNode();
+                    arrayNode.set(index, childNode);
+                } else {
+                    childNode = existing;
+                }
+            } else {
+                ((ObjectNode) node).set(key, childNode);
+            }
         }
+
         return childNode;
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -201,13 +201,12 @@ public class JacksonEvent implements Event {
                 int index = Integer.parseInt(key);
                 ArrayNode arrayNode = (ArrayNode) node;
 
+                int distanceFromArrayEnd = index - arrayNode.size();
+                if (distanceFromArrayEnd >= FILL_OUT_OF_BOUNDS_ELEMENTS_LIMIT + 1) {
+                    throw new IndexOutOfBoundsException(
+                            String.format("Cannot expand array past the limit of size %s to reach index %s", arrayNode.size(), index));
+                }
                 while (arrayNode.size() <= index) {
-                    int distanceFromArrayEnd = index - arrayNode.size();
-                    if (distanceFromArrayEnd >= FILL_OUT_OF_BOUNDS_ELEMENTS_LIMIT + 1) {
-                        throw new IndexOutOfBoundsException(
-                                String.format("Cannot expand array past the limit of size %s to reach index %s", arrayNode.size(), index));
-                    }
-
                     arrayNode.addNull();
                 }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -61,6 +61,8 @@ public class JacksonEvent implements Event {
 
     private static final Logger LOG = LoggerFactory.getLogger(JacksonEvent.class);
 
+    private static final int FILL_OUT_OF_BOUNDS_ELEMENTS_LIMIT = 0;
+
     private static final String SEPARATOR = "/";
 
     private static final ObjectMapper mapper = JsonMapper.builder()
@@ -200,6 +202,12 @@ public class JacksonEvent implements Event {
                 ArrayNode arrayNode = (ArrayNode) node;
 
                 while (arrayNode.size() <= index) {
+                    int distanceFromArrayEnd = index - arrayNode.size();
+                    if (distanceFromArrayEnd >= FILL_OUT_OF_BOUNDS_ELEMENTS_LIMIT + 1) {
+                        throw new IndexOutOfBoundsException(
+                                String.format("Cannot expand array past the limit of size %s to reach index %s", arrayNode.size(), index));
+                    }
+
                     arrayNode.addNull();
                 }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -207,7 +207,7 @@ public class JacksonEventTest {
     }
 
     @Test
-    void testPutAndGet_withArrays_out_of_bounds_creates_new_elements() {
+    void testPutAndGet_withArrays_out_of_bounds_throws_IndexOutOfBoundsException() {
 
         final String key = "list-key/3/foo";
         final String fooValue = UUID.randomUUID().toString();
@@ -220,18 +220,7 @@ public class JacksonEventTest {
         final EventKey eventKey = new JacksonEventKey(listKey);
         event.put(eventKey, listValue);
 
-        event.put(key, fooValue);
-
-        final String resultValue = event.get(key, String.class);
-        assertThat(resultValue, equalTo(fooValue));
-
-        final List<Map<String, Object>> listResult = event.get(listKey, List.class);
-
-        assertThat(listResult.size(), equalTo(4));
-        assertThat(listResult.get(0), notNullValue());
-        assertThat(listResult.get(1), nullValue());
-        assertThat(listResult.get(2), nullValue());
-        assertThat(listResult.get(3), notNullValue());
+        assertThrows(IndexOutOfBoundsException.class, () -> event.put(key, fooValue));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -187,7 +187,7 @@ public class JacksonEventTest {
     }
 
     @Test
-    void testPutAndGet_withArrays_out_of_bounds_creates_new_element() {
+    void testPutAndGet_withArrays_out_of_bounds_on_end_of_list_creates_new_element() {
 
         final String key = "list-key/1/foo";
         final String fooValue = UUID.randomUUID().toString();
@@ -204,6 +204,34 @@ public class JacksonEventTest {
 
         final String resultValue = event.get(key, String.class);
         assertThat(resultValue, equalTo(fooValue));
+    }
+
+    @Test
+    void testPutAndGet_withArrays_out_of_bounds_creates_new_elements() {
+
+        final String key = "list-key/3/foo";
+        final String fooValue = UUID.randomUUID().toString();
+
+        final List<Map<String, Object>> listValue = new ArrayList<>();
+        final Map<String, Object> mapValue = Map.of("foo", "bar", "foo-2", "bar-2");
+        listValue.add(mapValue);
+
+        final String listKey = "list-key";
+        final EventKey eventKey = new JacksonEventKey(listKey);
+        event.put(eventKey, listValue);
+
+        event.put(key, fooValue);
+
+        final String resultValue = event.get(key, String.class);
+        assertThat(resultValue, equalTo(fooValue));
+
+        final List<Map<String, Object>> listResult = event.get(listKey, List.class);
+
+        assertThat(listResult.size(), equalTo(4));
+        assertThat(listResult.get(0), notNullValue());
+        assertThat(listResult.get(1), nullValue());
+        assertThat(listResult.get(2), nullValue());
+        assertThat(listResult.get(3), notNullValue());
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes an issue where updating Jackson Event with json pointer paths to array like

```
/list-key/0/nested-key
```

failed with a ClassCastException to ObjectNode (since it is ArrayNode)

```
2025-06-10T14:51:24,907 [test-pipeline-processor-worker-1-thread-1] ERROR
java.lang.ClassCastException: class com.fasterxml.jackson.databind.node.ArrayNode cannot be cast to class com.fasterxml.jackson.databind.node.ObjectNode (com.fasterxml.jackson.databind.node.ArrayNode and com.fasterxml.jackson.databind.node.ObjectNode are in unnamed module of loader 'app')
    at org.opensearch.dataprepper.model.event.JacksonEvent.getOrCreateNode(JacksonEvent.java:198) ~[data-prepper-api-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.model.event.JacksonEvent.put(JacksonEvent.java:161) ~[data-prepper-api-2.11.0-SNAPSHOT.jar:?]
    at org.opensearch.dataprepper.model.event.JacksonEvent.put(JacksonEvent.java:177) ~[data-prepper-api-2.11.0-SNAPSHOT.jar:?]
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
