### PR TITLE
Add iterate_on support for convert_type processors to iterate over array of objects and convert within each element

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -146,7 +146,15 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
 
     private void handleWithIterateOn(final Event recordEvent,
                                      final String key) {
-        final List<Map<String, Object>> iterateOnList = recordEvent.get(iterateOn, List.class);
+
+        final List<Map<String, Object>> iterateOnList;
+        try {
+            iterateOnList = recordEvent.get(iterateOn, List.class);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(
+                    String.format("The value of '%s' must be a List of Map<String, Object>, but was incompatible: %s",
+                            iterateOn, e.getMessage()), e);
+        }
         if (iterateOnList != null) {
             int listIndex = 0;
             for (final Map<String, Object> item : iterateOnList) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,6 +39,8 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
     private final List<String> nullValues;
     private final String type;
     private final List<String> tagsOnFailure;
+
+    private final String iterateOn;
     private int scale = 0;
 
     private final ExpressionEvaluator expressionEvaluator;
@@ -59,7 +62,7 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
                 .orElse(List.of());
         this.expressionEvaluator = expressionEvaluator;
         this.tagsOnFailure = convertEntryTypeProcessorConfig.getTagsOnFailure();
-
+        this.iterateOn = convertEntryTypeProcessorConfig.getIterateOn();
         if (convertWhen != null
                 && !expressionEvaluator.isValidExpressionStatement(convertWhen)) {
             throw new InvalidPluginConfigurationException(
@@ -79,28 +82,21 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
                 }
 
                 for (final String key : convertEntryKeys) {
-                    Object keyVal = recordEvent.get(key, Object.class);
-                    if (keyVal != null) {
-                        if (!nullValues.contains(keyVal.toString())) {
-                            try {
-                                if (keyVal instanceof List || keyVal.getClass().isArray()) {
-                                    Stream<Object> inputStream;
-                                    if (keyVal.getClass().isArray()) {
-                                        inputStream = Arrays.stream((Object[])keyVal);
-                                    } else {
-                                        inputStream = ((List<Object>)keyVal).stream();
-                                    }
-                                    List<?> replacementList = inputStream.map(i -> converter.convert(i, converterArguments)).collect(Collectors.toList());
-                                    recordEvent.put(key, replacementList);
-                                } else {
-                                    recordEvent.put(key, converter.convert(keyVal, converterArguments));
+                    if (iterateOn != null) {
+                        handleWithIterateOn(recordEvent, key);
+                    } else {
+                        Object keyVal = recordEvent.get(key, Object.class);
+                        if (keyVal != null) {
+                            if (!nullValues.contains(keyVal.toString())) {
+                                try {
+                                    handleWithoutIterateOn(keyVal, recordEvent, key);
+                                } catch (final RuntimeException e) {
+                                    LOG.error(EVENT, "Unable to convert key: {} with value: {} to {}", key, keyVal, type, e);
+                                    recordEvent.getMetadata().addTags(tagsOnFailure);
                                 }
-                            } catch (final RuntimeException e) {
-                                LOG.error(EVENT, "Unable to convert key: {} with value: {} to {}", key, keyVal, type, e);
-                                recordEvent.getMetadata().addTags(tagsOnFailure);
+                            } else {
+                                recordEvent.delete(key);
                             }
-                        } else {
-                            recordEvent.delete(key);
                         }
                     }
                 }
@@ -129,6 +125,46 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
 
     @Override
     public void shutdown() {
+    }
+
+    private void handleWithoutIterateOn(final Object keyVal,
+                                        final Event recordEvent,
+                                        final String key) {
+        if (keyVal instanceof List || keyVal.getClass().isArray()) {
+            Stream<Object> inputStream;
+            if (keyVal.getClass().isArray()) {
+                inputStream = Arrays.stream((Object[])keyVal);
+            } else {
+                inputStream = ((List<Object>)keyVal).stream();
+            }
+            List<?> replacementList = inputStream.map(i -> converter.convert(i, converterArguments)).collect(Collectors.toList());
+            recordEvent.put(key, replacementList);
+        } else {
+            recordEvent.put(key, converter.convert(keyVal, converterArguments));
+        }
+    }
+
+    private void handleWithIterateOn(final Event recordEvent,
+                                     final String key) {
+        final List<Map<String, Object>> iterateOnList = recordEvent.get(iterateOn, List.class);
+        if (iterateOnList != null) {
+            int listIndex = 0;
+            for (final Map<String, Object> item : iterateOnList) {
+                Object value = null;
+                try {
+                    value = item.get(key);
+                    if (value != null) {
+                        item.put(key, converter.convert(value, converterArguments));
+                    }
+                } catch (final RuntimeException e) {
+                    LOG.error(EVENT, "Unable to convert element {} with key: {} with value: {} to {}", listIndex, key, value, type, e);
+                }
+
+                listIndex++;
+            }
+
+            recordEvent.put(iterateOn, iterateOnList);
+        }
     }
 
     private List<String> getKeysToConvert(final ConvertEntryTypeProcessorConfig convertEntryTypeProcessorConfig) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -80,6 +80,11 @@ public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     })
     private String convertWhen;
 
+    @JsonProperty("iterate_on")
+    @JsonPropertyDescription(
+            "Specifies the key of a list of objects to iterate over and convert types.")
+    private String iterateOn;
+
     public String getKey() {
         return key;
     }
@@ -100,4 +105,6 @@ public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     public List<String> getTagsOnFailure() {
         return tagsOnFailure;
     }
+
+    public String getIterateOn() { return iterateOn; }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -82,7 +82,7 @@ public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
 
     @JsonProperty("iterate_on")
     @JsonPropertyDescription(
-            "Specifies the key of a list of objects to iterate over and convert types.")
+            "Specifies the key of a list of map objects to iterate over and convert types.")
     private String iterateOn;
 
     public String getKey() {

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -470,4 +470,33 @@ public class ConvertEntryTypeProcessorTests {
         assertThat(processedRecords.size(), equalTo(1));
         assertThat(processedRecords.get(0).getData().toMap(), equalTo(expectedData));
     }
+
+    @Test
+    void iterate_on_with_key_that_is_not_list_of_map_does_not_update() {
+        final String iterateOn = "list-key";
+        final String keyToConvert = "key-to-convert";
+
+        when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("long"));
+        when(mockConfig.getKey()).thenReturn(keyToConvert);
+        when(mockConfig.getIterateOn()).thenReturn(iterateOn);
+
+        typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+
+        final String nonListValue = UUID.randomUUID().toString();
+        final Map<String, Object> eventData = new HashMap<>();
+        eventData.put(iterateOn, nonListValue);
+
+        final Map<String, Object> expectedData = new HashMap<>();
+
+        expectedData.put(iterateOn, nonListValue);
+
+        final Event event = JacksonEvent.builder()
+                .withData(eventData)
+                .withEventType("event")
+                .build();
+
+        final List<Record<Event>> processedRecords = (List<Record<Event>>) typeConversionProcessor.doExecute(Collections.singletonList(new Record<>(event)));
+        assertThat(processedRecords.size(), equalTo(1));
+        assertThat(processedRecords.get(0).getData().toMap(), equalTo(expectedData));
+    }
 }


### PR DESCRIPTION


### Description
Adds iterate_on parameter for convert_type processor.

Given this event

```
{
    "list-key": [{
        "some-key": 2,
        "key-to-convert": 10.0
    }, {
        "some-key": 2,
        "key-to-convert": 20.0
    }]
}
```

and this configuration

```
processor:
  - convert_type:
            iterate_on: "list-key"
            key: "key-to-convert"
            type: "long"
```

The result of the Event will convert the decimals to long 

```
{
    "list-key": [{
        "some-key": 2,
        "key-to-convert": 10
    }, {
        "some-key": 2,
        "key-to-convert": 20
    }]
}
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
