### PR TITLE
Better error handling and printing exception stack trace

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/AtlassianRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/AtlassianRestClient.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.utils.AddressVal
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -56,7 +57,7 @@ public class AtlassianRestClient {
             } catch (HttpClientErrorException ex) {
                 HttpStatus statusCode = ex.getStatusCode();
                 String statusMessage = ex.getMessage();
-                log.error("An exception has occurred while getting response from search API  {}", ex.getMessage());
+                log.error("HTTP client error while getting response from search API. Status: {}, Message: {}", statusCode, statusMessage);
                 if (statusCode == HttpStatus.FORBIDDEN) {
                     throw new UnauthorizedException(statusMessage);
                 } else if (statusCode == HttpStatus.UNAUTHORIZED) {
@@ -66,6 +67,13 @@ public class AtlassianRestClient {
                 } else if (statusCode == HttpStatus.TOO_MANY_REQUESTS) {
                     log.error(NOISY, "Hitting API rate limit. Backing off with sleep timer.", ex);
                 }
+                try {
+                    Thread.sleep((long) RETRY_ATTEMPT_SLEEP_TIME.get(retryCount) * sleepTimeMultiplier);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("Sleep in the retry attempt got interrupted", e);
+                }
+            } catch (RestClientException ex) {
+                log.error("REST client error while getting response from search API: {}", ex.getMessage());
                 try {
                     Thread.sleep((long) RETRY_ATTEMPT_SLEEP_TIME.get(retryCount) * sleepTimeMultiplier);
                 } catch (InterruptedException e) {

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/rest/ConfluenceRestClient.java
@@ -27,6 +27,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.ConfluenceNextLinkValidator.validateAndSanitizeURL;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.CQL_FIELD;
 import static org.opensearch.dataprepper.plugins.source.confluence.utils.CqlConstants.EXPAND_FIELD;
@@ -114,7 +115,7 @@ public class ConfluenceRestClient extends AtlassianRestClient {
                     try {
                         return invokeRestApi(uri, ConfluenceSearchResults.class).getBody();
                     } catch (Exception e) {
-                        log.error("Error while fetching content with cql {}", cql);
+                        log.error(NOISY, "Error while fetching content with cql {}", cql, e);
                         searchRequestsFailedCounter.increment();
                         throw e;
                     }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
@@ -23,6 +23,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.inject.Named;
 import java.net.URI;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.EXPAND_FIELD;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.EXPAND_VALUE;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.JQL_FIELD;
@@ -86,7 +87,7 @@ public class JiraRestClient extends AtlassianRestClient {
                     try {
                         return invokeRestApi(uri, SearchResults.class).getBody();
                     } catch (Exception e) {
-                        log.error("Error while fetching issues with jql {}", jql);
+                        log.error(NOISY, "Error while fetching issues with jql {}", jql, e);
                         searchRequestsFailedCounter.increment();
                         throw e;
                     }


### PR DESCRIPTION
In the current state, the error message that we are printing on failure doesn't have full stack trace so missing to capture the root cause of the failure. Enhanced the error message logging.

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
