### PR TITLE
Add multi-line csv support

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
@@ -100,6 +101,7 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                             Event clonedEvent = JacksonEvent.fromEvent(event);
                             final List<String> row = messageIterator.nextValue();
                             putDataInEvent(clonedEvent, header, row);
+                            addToAcknowledgementSetFromOriginEvent(clonedEvent, event);
                             recordsOut.add(new Record<Event>(clonedEvent));
                         }
                     }
@@ -138,6 +140,13 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
             }
         }
         return (config.isMultiLine()) ? recordsOut : records;
+    }
+
+    protected void addToAcknowledgementSetFromOriginEvent(Event recordEvent, Event originRecordEvent) {
+        DefaultEventHandle eventHandle = (DefaultEventHandle) originRecordEvent.getEventHandle();
+        if (eventHandle != null) {
+            eventHandle.addEventHandle(recordEvent.getEventHandle());
+        }
     }
 
     @Override

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -70,6 +72,7 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
 
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
+        List<Record<Event>> recordsOut = new ArrayList<>();
         for (final Record<Event> record : records) {
 
             final Event event = record.getData();
@@ -85,6 +88,24 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                 if (Objects.isNull(message)) {
                     continue;
                 }
+                if (config.isMultiLine()) {
+                    String[] lines = message.split("[\r\n]+");
+                    if (lines.length <= 1) {
+                        continue;
+                    }
+                    final List<String> header = Arrays.asList(lines[0].split(config.getDelimiter().substring(0,1)));
+                    for (int i = 1; i < lines.length; i++) {
+                        final MappingIterator<List<String>> messageIterator = mapper.readerFor(List.class).with(schema).readValues(lines[i]);
+                        if (messageIterator.hasNextValue()) {
+                            Event clonedEvent = JacksonEvent.fromEvent(event);
+                            final List<String> row = messageIterator.nextValue();
+                            putDataInEvent(clonedEvent, header, row);
+                            recordsOut.add(new Record<Event>(clonedEvent));
+                        }
+                    }
+                    continue;
+                }
+    
 
                 final boolean userDidSpecifyHeaderEventKey = Objects.nonNull(config.getColumnNamesSourceKey());
                 final boolean thisEventHasHeaderSource = userDidSpecifyHeaderEventKey && event.containsKey(config.getColumnNamesSourceKey());
@@ -116,7 +137,7 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                         .log();
             }
         }
-        return records;
+        return (config.isMultiLine()) ? recordsOut : records;
     }
 
     @Override

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -42,7 +42,7 @@ public class CsvProcessorConfig {
             "is parsed. If there is no event header, no action is taken. Default value is true.")
     private Boolean deleteHeader = DEFAULT_DELETE_HEADERS;
 
-    @JsonProperty(value = "multi_line", defaultValue = "false")
+    @JsonProperty(value = "multiline", defaultValue = "false")
     @JsonPropertyDescription("If specified, the source key has multiple lines, including header line")
     private Boolean multiLine = false;
 

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -42,6 +42,10 @@ public class CsvProcessorConfig {
             "is parsed. If there is no event header, no action is taken. Default value is true.")
     private Boolean deleteHeader = DEFAULT_DELETE_HEADERS;
 
+    @JsonProperty(value = "multi_line", defaultValue = "false")
+    @JsonPropertyDescription("If specified, the source key has multiple lines, including header line")
+    private Boolean multiLine = false;
+
     @JsonProperty(value = "quote_character", defaultValue = DEFAULT_QUOTE_CHARACTER)
     @JsonPropertyDescription("The character used as a text qualifier for a single column of data. " +
             "Default value is <code>\"</code>.")
@@ -139,6 +143,8 @@ public class CsvProcessorConfig {
     public String getCsvWhen() { return csvWhen; }
 
     public Boolean isDeleteSource() { return deleteSource; }
+
+    public Boolean isMultiLine() { return multiLine; }
 
     @AssertTrue(message = "delimiter must be exactly one character.")
     boolean isValidDelimiter() {

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfigTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfigTest.java
@@ -33,6 +33,7 @@ public class CsvProcessorConfigTest {
         assertThat(objectUnderTest.isDeleteHeader(), equalTo(DEFAULT_DELETE_HEADERS));
         assertThat(objectUnderTest.getColumnNamesSourceKey(), equalTo(null));
         assertThat(objectUnderTest.getColumnNames(), equalTo(null));
+        assertThat(objectUnderTest.isMultiLine(), equalTo(false));
     }
 
     @Nested
@@ -68,6 +69,14 @@ public class CsvProcessorConfigTest {
             reflectivelySetField(csvProcessorConfig, "quoteCharacter", "\"");
 
             assertThat(csvProcessorConfig.isValidQuoteCharacter(), equalTo(true));
+        }
+
+        @Test
+        void isMultiLine_should_return_true_if_multi_line_is_set()
+                throws NoSuchFieldException, IllegalAccessException {
+            reflectivelySetField(csvProcessorConfig, "multiLine", true);
+
+            assertThat(csvProcessorConfig.isMultiLine(), equalTo(true));
         }
     }
 

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
@@ -128,6 +128,20 @@ class CsvProcessorTest {
     }
 
     @Test
+    void test_when_multLine_then_parsedCorrectly() {
+        when(processorConfig.isMultiLine()).thenReturn(true);
+        when(processorConfig.getDelimiter()).thenReturn(",");
+        csvProcessor = createObjectUnderTest();
+
+        Record<Event> eventUnderTest = createMessageEvent("key1,key2,key3\n1,2,3");
+        final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
+        final Event parsedEvent = getSingleEvent(editedEvents);
+        assertThatKeyEquals(parsedEvent, "key1", "1");
+        assertThatKeyEquals(parsedEvent, "key2", "2");
+        assertThatKeyEquals(parsedEvent, "key3", "3");
+    }
+
+    @Test
     void test_when_deleteHeaderAndHeaderSourceDefined_then_headerIsDeleted() {
         when(processorConfig.isDeleteHeader()).thenReturn(true);
         when(processorConfig.getColumnNamesSourceKey()).thenReturn("header");


### PR DESCRIPTION
### Description
Add multi-line csv support. When the `multi_line` config option is used, the input in the source key is expected to contain multiple lines of CSV format with first line containing column names.
 
### Issues Resolved
Resolves #5783
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
