### PR TITLE
Adding Processor Registry to provision Atomic swapping of Processor instances

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -27,6 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @FixMethodOrder()
@@ -52,7 +53,7 @@ class PipelinesWithAcksIT {
                 .withPipelinesDirectoryOrFile(configFile)
                 .build();
 
-	LOG.info("PipelinesWithAcksIT with config file {} started at {}", configFile, Instant.now());
+        LOG.info("PipelinesWithAcksIT with config file {} started at {}", configFile, Instant.now());
         dataPrepperTestRunner.start();
         inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
         inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
@@ -60,7 +61,7 @@ class PipelinesWithAcksIT {
 
     @AfterEach
     void tearDown() {
-	LOG.info("PipelinesWithAcksIT with stopped at {}", Instant.now());
+        LOG.info("PipelinesWithAcksIT with stopped at {}", Instant.now());
         dataPrepperTestRunner.stop();
     }
 
@@ -133,8 +134,8 @@ class PipelinesWithAcksIT {
 
         await().atMost(40000, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
-            assertTrue(inMemorySourceAccessor != null);
-            assertTrue(inMemorySourceAccessor.getAckReceived() != null);
+                    assertNotNull(inMemorySourceAccessor);
+                    assertNotNull(inMemorySourceAccessor.getAckReceived());
         });
         List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
         assertThat(outputRecords.size(), equalTo(0));

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorSwapPipelineIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorSwapPipelineIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.configuration.PipelineModel;
+import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.pipeline.parser.PipelineConfigurationFileReader;
+import org.opensearch.dataprepper.pipeline.parser.PipelinesDataflowModelParser;
+import org.opensearch.dataprepper.pipeline.parser.model.PipelineConfiguration;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.opensearch.dataprepper.test.framework.DataPrepperTestRunner.BASE_PATH;
+
+class ProcessorSwapPipelineIT {
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessorSwapPipelineIT.class);
+    private static final String IN_MEMORY_IDENTIFIER = "ProcessorSwapPipelineIT";
+    private static final String PIPELINE_CONFIGURATION_FOLDER_UNDER_TEST = "processor-swap";
+    private static final String PIPELINE_NAME_IN_YAML = "processor-pipeline";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+    private PluginFactory pluginFactory;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(PIPELINE_CONFIGURATION_FOLDER_UNDER_TEST + "/source")
+                .build();
+
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+        pluginFactory = dataPrepperTestRunner.getPluginFactory();
+        dataPrepperTestRunner.start();
+        LOG.info("Started test runner.");
+    }
+
+    @AfterEach
+    void tearDown() {
+        LOG.info("Test tear down. Stop the test runner.");
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void run_with_single_record() {
+        final String messageValue = UUID.randomUUID().toString();
+        final Event event = JacksonEvent.fromMessage(messageValue);
+        final Record<Event> eventRecord = new Record<>(event);
+
+        LOG.info("Submitting a single record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, Collections.singletonList(eventRecord));
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+                });
+
+        final List<Record<Event>> records = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+
+        assertThat(records.size(), equalTo(1));
+
+        assertThat(records.get(0), notNullValue());
+        assertThat(records.get(0).getData(), notNullValue());
+        assertThat(records.get(0).getData().get("message", String.class), equalTo(messageValue));
+        assertThat(records.get(0).getData().get("test1", String.class), equalTo("knownPrefix10"));
+        assertThat(records.get(0).getData().get("test1_copy_original", String.class), equalTo("knownPrefix10"));
+
+        // Dynamically swap the pipeline processors
+        LOG.info("Swapping the pipeline processors");
+        List<Processor> targetPipelineProcessors = getTargetPipelineProcessors();
+        dataPrepperTestRunner.swapProcessors(PIPELINE_NAME_IN_YAML, targetPipelineProcessors);
+
+        // Send one more event and assert against the updated processor behavior
+        LOG.info("Submitting another single record.");
+        final String updatedMessageValue = UUID.randomUUID().toString();
+        final Event updatedEvent = JacksonEvent.fromMessage(updatedMessageValue);
+        final Record<Event> updatedEventRecord = new Record<>(updatedEvent);
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, Collections.singletonList(updatedEventRecord));
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+                });
+
+        final List<Record<Event>> updatedRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+
+        LOG.info("Asserting the updated processor behavior");
+        assertThat(updatedRecords.size(), equalTo(2));
+        Event processedOutput = updatedRecords.get(1).getData();
+
+        assertThat(processedOutput, notNullValue());
+        assertThat(processedOutput, notNullValue());
+        assertThat(processedOutput.get("message", String.class), equalTo(updatedMessageValue));
+        assertThat(processedOutput.get("test1", String.class), equalTo("knownUpdatedPrefix10"));
+        assertThat(processedOutput.get("test1_copy_updated", String.class), equalTo("knownUpdatedPrefix10"));
+
+    }
+
+
+    private List<Processor> getTargetPipelineProcessors() {
+        // Create the target pipeline
+        String targetPipelineFolderPath = BASE_PATH + "/pipeline/" + PIPELINE_CONFIGURATION_FOLDER_UNDER_TEST + "/target";
+        PipelinesDataFlowModel targetPipelinesDataFlowModel =
+                new PipelinesDataflowModelParser(
+                        new PipelineConfigurationFileReader(targetPipelineFolderPath))
+                        .parseConfiguration();
+
+        PipelineModel pipelineModel = targetPipelinesDataFlowModel.getPipelines().get(PIPELINE_NAME_IN_YAML);
+        PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(pipelineModel);
+        List<Processor> processors = new ArrayList<>();
+        for (PluginSetting pluginSetting : pipelineConfiguration.getProcessorPluginSettings()) {
+            List<Processor> processorsList =
+                    pluginFactory.loadPlugins(Processor.class, pluginSetting, (actualClass -> 1));
+            processors.add(processorsList.get(0));
+        }
+        return processors;
+    }
+
+
+    @Test
+    void pipeline_with_single_batch_of_records() {
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        LOG.info("Submitting a batch of record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecords);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+                });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreate));
+
+        final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+
+        for (int i = 0; i < sinkRecords.size(); i++) {
+            final Record<Event> inputRecord = inputRecords.get(i);
+            final Record<Event> sinkRecord = sinkRecords.get(i);
+            assertThat(sinkRecord, notNullValue());
+            final Event recordData = sinkRecord.getData();
+            assertThat(recordData, notNullValue());
+            assertThat(
+                    recordData.get("message", String.class),
+                    equalTo(inputRecord.getData().get("message", String.class)));
+            assertThat(recordData.get("test1", String.class),
+                    equalTo("knownPrefix1" + i));
+            assertThat(recordData.get("test1_copy", String.class),
+                    equalTo("knownPrefix1" + i));
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.test.framework;
 import org.opensearch.dataprepper.AbstractContextManager;
 import org.opensearch.dataprepper.core.DataPrepper;
 import org.opensearch.dataprepper.core.parser.config.FileStructurePathProvider;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
 import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
 import org.slf4j.Logger;
@@ -15,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Provides the ability to run a Data Prepper test instance. Each of these will run
@@ -25,7 +28,7 @@ import javax.annotation.Nullable;
  */
 public class DataPrepperTestRunner {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperTestRunner.class);
-    private static final String BASE_PATH = "src/integrationTest/resources/org/opensearch/dataprepper";
+    public static final String BASE_PATH = "src/integrationTest/resources/org/opensearch/dataprepper";
     private final String dataPrepperConfigFile;
     private final String pipelinesDirectoryOrFile;
     private final InMemorySourceAccessor inMemorySourceAccessor;
@@ -58,6 +61,21 @@ public class DataPrepperTestRunner {
     public void start() {
         contextManager.getDataPrepperBean()
                 .execute();
+    }
+
+    public PluginFactory getPluginFactory() {
+        return contextManager.getDataPrepperBean()
+                .getPluginFactory();
+    }
+
+    /**
+     * Dynamically Swap processors in a running pipeline
+     */
+    public void swapProcessors(String pipelineName, List<Processor> newProcessors) {
+        contextManager.getDataPrepperBean()
+                .getPipeline(pipelineName)
+                .getProcessorRegistry()
+                .swapProcessors(newProcessors);
     }
 
     /**

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
@@ -74,7 +74,6 @@ public class DataPrepperTestRunner {
     public void swapProcessors(String pipelineName, List<Processor> newProcessors) {
         contextManager.getDataPrepperBean()
                 .getPipeline(pipelineName)
-                .getProcessorRegistry()
                 .swapProcessors(newProcessors);
     }
 

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/processor-swap/source/processor-swap-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/processor-swap/source/processor-swap-pipeline.yaml
@@ -1,0 +1,17 @@
+processor-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: ProcessorSwapPipelineIT
+
+  processor:
+    - simple_test:
+        key1: /test1
+        value_prefix1: knownPrefix1
+    - simple_copy_test:
+        source: /test1
+        target: /test1_copy_original
+
+  sink:
+    - in_memory:
+        testing_key: ProcessorSwapPipelineIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/processor-swap/target/processor-swap-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/processor-swap/target/processor-swap-pipeline.yaml
@@ -1,0 +1,17 @@
+processor-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: ProcessorSwapPipelineIT
+
+  processor:
+    - simple_test:
+        key1: /test1
+        value_prefix1: knownUpdatedPrefix1
+    - simple_copy_test:
+        source: /test1
+        target: /test1_copy_updated
+
+  sink:
+    - in_memory:
+        testing_key: ProcessorSwapPipelineIT

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/DataPrepper.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/DataPrepper.java
@@ -102,6 +102,10 @@ public class DataPrepper implements PipelinesProvider {
         shutdownServers();
     }
 
+    public Pipeline getPipeline(String pipelineName) {
+        return transformationPipelines.get(pipelineName);
+    }
+
     private void shutdownPipelines() {
         shutdownPipelines(DataPrepperShutdownOptions.defaultOptions());
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
@@ -55,10 +55,9 @@ import static java.lang.String.format;
 
 @SuppressWarnings("rawtypes")
 public class PipelineTransformer {
-    private static final Logger LOG = LoggerFactory.getLogger(PipelineTransformer.class);
-
     static final String CONDITIONAL_ROUTE_INVALID_EXPRESSION_FORMAT = "Route %s contains an invalid conditional expression '%s'. " +
             "See https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/ for valid expression syntax.";
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineTransformer.class);
     private static final String PIPELINE_TYPE = "pipeline";
     private static final String ATTRIBUTE_NAME = "name";
     private final PipelinesDataFlowModel pipelinesDataFlowModel;
@@ -207,7 +206,7 @@ public class PipelineTransformer {
                             return PeerForwardingProcessorDecorator.decorateProcessors(
                                     processors, peerForwarderProvider, pipelineName, processorComponentList.get(0).getName(),
                                     dataPrepperConfiguration.getPeerForwarderConfiguration() != null ?
-                                        dataPrepperConfiguration.getPeerForwarderConfiguration().getExcludeIdentificationKeys() : null,
+                                            dataPrepperConfiguration.getPeerForwarderConfiguration().getExcludeIdentificationKeys() : null,
                                     pipelineConfiguration.getWorkers()
                             );
                         }
@@ -233,24 +232,24 @@ public class PipelineTransformer {
             if (pipelineDefinedBuffer instanceof SupportsPipelineRunner) {
                 // Check if there are any processors with @SingleThread annotation
                 boolean hasSingleThreadedProcessors = processorSets.stream()
-                    .flatMap(List::stream)
-                    .map(IdentifiedComponent::getComponent)
-                    .map(Object::getClass)
-                    .anyMatch(processorClass -> processorClass.isAnnotationPresent(SingleThread.class));
+                        .flatMap(List::stream)
+                        .map(IdentifiedComponent::getComponent)
+                        .map(Object::getClass)
+                        .anyMatch(processorClass -> processorClass.isAnnotationPresent(SingleThread.class));
 
                 // Only allow ZeroBuffer for single-threaded pipelines with no @SingleThread processors
                 if (processorThreads == 1 && !hasSingleThreadedProcessors) {
                     ((SupportsPipelineRunner) pipelineDefinedBuffer).setPipelineRunner(
-                        new PipelineRunnerImpl(pipeline, pipeline.getProcessors()));
+                            new PipelineRunnerImpl(pipeline));
                 } else {
                     if (hasSingleThreadedProcessors) {
                         throw new IllegalStateException(
-                            "ZeroBuffer cannot be used with @SingleThread processors. " +
-                            "Pipeline [" + pipelineName + "] contains one or more @SingleThread processors.");
+                                "ZeroBuffer cannot be used with @SingleThread processors. " +
+                                        "Pipeline [" + pipelineName + "] contains one or more @SingleThread processors.");
                     } else {
                         throw new IllegalStateException(
-                            "ZeroBuffer cannot be used with multiple processor threads. " +
-                            "Pipeline [" + pipelineName + "] is configured with " + processorThreads + " threads.");
+                                "ZeroBuffer cannot be used with multiple processor threads. " +
+                                        "Pipeline [" + pipelineName + "] is configured with " + processorThreads + " threads.");
                     }
                 }
             }
@@ -396,24 +395,6 @@ public class PipelineTransformer {
         }
     }
 
-    private static class IdentifiedComponent<T> {
-        private final T component;
-        private final String name;
-
-        private IdentifiedComponent(final T component, final String name) {
-            this.component = component;
-            this.name = name;
-        }
-
-        T getComponent() {
-            return component;
-        }
-
-        String getName() {
-            return name;
-        }
-    }
-
     Duration getPeerForwarderDrainTimeout(final DataPrepperConfiguration dataPrepperConfiguration) {
         return Optional.ofNullable(dataPrepperConfiguration)
                 .map(DataPrepperConfiguration::getPeerForwarderConfiguration)
@@ -432,7 +413,7 @@ public class PipelineTransformer {
         if (source instanceof PipelineConnector)
             return buffer;
 
-        if(buffer.isWrittenOffHeapOnly())
+        if (buffer.isWrittenOffHeapOnly())
             return buffer;
 
         return circuitBreakerManager.getGlobalCircuitBreaker()
@@ -443,5 +424,23 @@ public class PipelineTransformer {
 
     public PipelinesDataFlowModel getPipelinesDataFlowModel() {
         return pipelinesDataFlowModel;
+    }
+
+    private static class IdentifiedComponent<T> {
+        private final T component;
+        private final String name;
+
+        private IdentifiedComponent(final T component, final String name) {
+            this.component = component;
+            this.name = name;
+        }
+
+        T getComponent() {
+            return component;
+        }
+
+        String getName() {
+            return name;
+        }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
@@ -195,8 +195,8 @@ public class Pipeline {
         return processorRegistry;
     }
 
-    public ProcessorRegistry getProcessorRegistry() {
-        return processorRegistry;
+    public void swapProcessors(List<Processor> newProcessors) {
+        processorRegistry.swapProcessors(newProcessors);
     }
 
     public int getReadBatchTimeoutInMillis() {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.core.pipeline;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.opensearch.dataprepper.DataPrepperShutdownOptions;
 import org.opensearch.dataprepper.core.acknowledgements.InactiveAcknowledgementSetManager;
@@ -141,10 +140,6 @@ public class Pipeline {
         this.processorRegistry = new ProcessorRegistry(List.of());
     }
 
-    AcknowledgementSetManager getAcknowledgementSetManager() {
-        return acknowledgementSetManager;
-    }
-
     /**
      * @return Unique name of this pipeline.
      */
@@ -195,15 +190,8 @@ public class Pipeline {
         return processorSets;
     }
 
-    /**
-     * @return a flat list of {@link Processor} of this pipeline or an empty list.
-     */
-    @VisibleForTesting
-    public List<Processor> getProcessors() {
-        return getProcessorSets().stream().flatMap(Collection::stream).collect(Collectors.toList());
-    }
 
-    public ProcessorRegistry getProcessorRegistry() {
+    public ProcessorProvider getProcessorProvider() {
         return processorRegistry;
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
@@ -195,6 +195,10 @@ public class Pipeline {
         return processorRegistry;
     }
 
+    public ProcessorRegistry getProcessorRegistry() {
+        return processorRegistry;
+    }
+
     public int getReadBatchTimeoutInMillis() {
         return readBatchTimeoutInMillis;
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
@@ -49,7 +49,7 @@ public class PipelineRunnerImpl implements PipelineRunner {
         final Map.Entry<Collection, CheckpointState> recordsReadFromBuffer = readFromBuffer(getBuffer(), getPipeline());
         Collection records = recordsReadFromBuffer.getKey();
         final CheckpointState checkpointState = recordsReadFromBuffer.getValue();
-        List<Processor> currentProcessors = pipeline.getProcessorRegistry().getProcessors();
+        List<Processor> currentProcessors = pipeline.getProcessorProvider().getProcessors();
         records = runProcessorsAndProcessAcknowledgements(currentProcessors, records);
         postToSink(getPipeline(), records);
         // Checkpoint the current batch read from the buffer after being processed by processors and sinks.

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
@@ -32,16 +32,15 @@ import java.util.stream.Collectors;
 public class PipelineRunnerImpl implements PipelineRunner {
     private static final Logger LOG = LoggerFactory.getLogger(PipelineRunnerImpl.class);
     private static final String INVALID_EVENT_HANDLES = "invalidEventHandles";
+    private boolean isEmptyRecordsLogged = false;
+    @VisibleForTesting
+    final Counter invalidEventHandlesCounter;
     private final Pipeline pipeline;
     private final PluginMetrics pluginMetrics;
-    private final List<Processor> processors;
-    private boolean isEmptyRecordsLogged = false;
-    @VisibleForTesting final Counter invalidEventHandlesCounter;
 
-    public PipelineRunnerImpl(final Pipeline pipeline, final List<Processor> processors) {
+    public PipelineRunnerImpl(final Pipeline pipeline) {
         this.pipeline = pipeline;
         this.pluginMetrics = PluginMetrics.fromNames("PipelineRunner", pipeline.getName());
-        this.processors = processors;
         this.invalidEventHandlesCounter = pluginMetrics.counter(INVALID_EVENT_HANDLES);
     }
 
@@ -50,7 +49,8 @@ public class PipelineRunnerImpl implements PipelineRunner {
         final Map.Entry<Collection, CheckpointState> recordsReadFromBuffer = readFromBuffer(getBuffer(), getPipeline());
         Collection records = recordsReadFromBuffer.getKey();
         final CheckpointState checkpointState = recordsReadFromBuffer.getValue();
-        records = runProcessorsAndProcessAcknowledgements(processors, records);
+        List<Processor> currentProcessors = pipeline.getProcessorRegistry().getProcessors();
+        records = runProcessorsAndProcessAcknowledgements(currentProcessors, records);
         postToSink(getPipeline(), records);
         // Checkpoint the current batch read from the buffer after being processed by processors and sinks.
         getBuffer().checkpoint(checkpointState);
@@ -62,7 +62,7 @@ public class PipelineRunnerImpl implements PipelineRunner {
         Collection records = readResult.getKey();
         //TODO Hacky way to avoid logging continuously - Will be removed as part of metrics implementation
         if (records.isEmpty()) {
-            if(!isEmptyRecordsLogged) {
+            if (!isEmptyRecordsLogged) {
                 LOG.debug(" {} Worker: No records received from buffer", pipeline.getName());
                 isEmptyRecordsLogged = true;
             }
@@ -79,7 +79,7 @@ public class PipelineRunnerImpl implements PipelineRunner {
         inputEvents.forEach(event -> {
             EventHandle eventHandle = event.getEventHandle();
             if (eventHandle != null && eventHandle instanceof DefaultEventHandle) {
-                InternalEventHandle internalEventHandle = (InternalEventHandle)(DefaultEventHandle)eventHandle;
+                InternalEventHandle internalEventHandle = (InternalEventHandle) eventHandle;
                 if (!outputEventsSet.contains(event)) {
                     eventHandle.release(true);
                 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
@@ -26,7 +26,7 @@ public class ProcessWorker implements Runnable {
             final Buffer readBuffer,
             final Pipeline pipeline) {
         this.readBuffer = readBuffer;
-        this.processors = pipeline.getProcessorRegistry().getProcessors();
+        this.processors = pipeline.getProcessorProvider().getProcessors();
         this.pipeline = pipeline;
         this.pipelineRunner = new PipelineRunnerImpl(pipeline);
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
@@ -7,13 +7,12 @@ package org.opensearch.dataprepper.core.pipeline;
 
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.processor.Processor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings({"rawtypes"})
 public class ProcessWorker implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ProcessWorker.class);
 
@@ -25,12 +24,11 @@ public class ProcessWorker implements Runnable {
 
     public ProcessWorker(
             final Buffer readBuffer,
-            final List<Processor> processors,
             final Pipeline pipeline) {
         this.readBuffer = readBuffer;
-        this.processors = processors;
+        this.processors = pipeline.getProcessorRegistry().getProcessors();
         this.pipeline = pipeline;
-        this.pipelineRunner = new PipelineRunnerImpl(pipeline, processors);
+        this.pipelineRunner = new PipelineRunnerImpl(pipeline);
     }
 
     @Override
@@ -84,7 +82,7 @@ public class ProcessWorker implements Runnable {
     private boolean areComponentsReadyForShutdown() {
         return isBufferReadyForShutdown() && processors.stream()
                 .map(Processor::isReadyForShutdown)
-                .allMatch(result -> result == true);
+                .allMatch(result -> result);
     }
 
     private boolean isBufferReadyForShutdown() {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessorProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessorProvider.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.core.pipeline;
+
+import org.opensearch.dataprepper.model.processor.Processor;
+
+import java.util.List;
+
+public interface ProcessorProvider {
+    List<Processor> getProcessors();
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessorRegistry.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessorRegistry.java
@@ -1,0 +1,27 @@
+package org.opensearch.dataprepper.core.pipeline;
+
+import org.opensearch.dataprepper.model.processor.Processor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@SuppressWarnings({"rawtypes"})
+public class ProcessorRegistry {
+    private volatile List<Processor> processors;
+
+    public ProcessorRegistry(List<Processor> initialProcessors) {
+        this.processors = new ArrayList<>(initialProcessors);
+    }
+
+    // Atomic swap of entire processor list
+    public void swapProcessors(List<Processor> newProcessors) {
+        Objects.requireNonNull(newProcessors, "New processors list cannot be null");
+        this.processors = new ArrayList<>(newProcessors);
+    }
+
+    // Get current processors for execution
+    public List<Processor> getProcessors() {
+        return processors;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessorRegistry.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessorRegistry.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Objects;
 
 @SuppressWarnings({"rawtypes"})
-public class ProcessorRegistry {
+public class ProcessorRegistry implements ProcessorProvider {
     private volatile List<Processor> processors;
 
     public ProcessorRegistry(List<Processor> initialProcessors) {
@@ -21,6 +21,7 @@ public class ProcessorRegistry {
     }
 
     // Get current processors for execution
+    @Override
     public List<Processor> getProcessors() {
         return processors;
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
@@ -5,10 +5,45 @@
 
 package org.opensearch.dataprepper.core.pipeline;
 
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.source.Source;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -21,44 +56,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import io.micrometer.core.instrument.Counter;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.CheckpointState;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
-import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.event.DefaultEventHandle;
-import org.opensearch.dataprepper.model.event.InternalEventHandle;
-import org.opensearch.dataprepper.model.processor.Processor;
-import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.sink.Sink;
-import org.opensearch.dataprepper.model.source.Source;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
-
-import java.util.AbstractMap;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @ExtendWith(MockitoExtension.class)
 class PipelineRunnerTest {
@@ -92,7 +89,7 @@ class PipelineRunnerTest {
     }
 
     private PipelineRunnerImpl createObjectUnderTest() {
-        return new PipelineRunnerImpl(pipeline, processors);
+        return new PipelineRunnerImpl(pipeline);
     }
 
     @BeforeEach
@@ -331,11 +328,11 @@ class PipelineRunnerTest {
         void testRunProcessorsAndProcessAcknowledgementsThrowsException() {
             List<Record<Event>> inputRecords = new ArrayList<>();
             final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
-            ((InternalEventHandle)defaultEventHandle).addAcknowledgementSet(acknowledgementSet);
+            defaultEventHandle.addAcknowledgementSet(acknowledgementSet);
             inputRecords.add(record);
             setupPipeline(false);
             // Have the processor throw an exception
-            when(processor.execute(inputRecords)).thenThrow(new RuntimeException());;
+            when(processor.execute(inputRecords)).thenThrow(new RuntimeException());
             final Processor skippedProcessor = mock(Processor.class);
             List<Processor> processors = List.of(processor, skippedProcessor);
             PipelineRunnerImpl pipelineRunner = createObjectUnderTest();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
@@ -65,6 +65,8 @@ class PipelineRunnerTest {
     @Mock
     Pipeline pipeline;
     @Mock
+    ProcessorProvider processorProvider;
+    @Mock
     Buffer buffer;
     @Mock
     Source source;
@@ -377,6 +379,8 @@ class PipelineRunnerTest {
             when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
             when(pipeline.publishToSinks(anyCollection())).thenReturn(
                     Collections.singletonList(CompletableFuture.completedFuture(null)));
+            when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
+            when(processorProvider.getProcessors()).thenReturn(processors);
 
             Map.Entry<Collection, CheckpointState> entry =
                     new AbstractMap.SimpleEntry<>(recordsList, checkpointState);
@@ -401,6 +405,8 @@ class PipelineRunnerTest {
             when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
             when(pipeline.publishToSinks(anyCollection())).thenReturn(
                     Collections.singletonList(CompletableFuture.completedFuture(null)));
+            when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
+            when(processorProvider.getProcessors()).thenReturn(processors);
 
             Map.Entry<Collection, CheckpointState> entry =
                     new AbstractMap.SimpleEntry<>(recordsList, checkpointState);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.processor.Processor;
+
+import java.time.Duration;
+import java.util.List;
 
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
@@ -13,12 +18,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.processor.Processor;
-
-import java.time.Duration;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessWorkerTest {
@@ -43,10 +42,10 @@ public class ProcessWorkerTest {
     }
 
     private ProcessWorker createObjectUnderTest() {
-        try(final MockedConstruction<PipelineRunnerImpl> ignored = mockConstruction(PipelineRunnerImpl.class, (mock, context) -> {
+        try (final MockedConstruction<PipelineRunnerImpl> ignored = mockConstruction(PipelineRunnerImpl.class, (mock, context) -> {
             pipelineRunner = mock;
         })) {
-            return new ProcessWorker(buffer, processors, pipeline);
+            return new ProcessWorker(buffer, pipeline);
         }
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
@@ -25,6 +25,9 @@ public class ProcessWorkerTest {
     private Pipeline pipeline;
 
     @Mock
+    private ProcessorProvider processorProvider;
+
+    @Mock
     private Processor processor;
 
     @Mock
@@ -39,6 +42,7 @@ public class ProcessWorkerTest {
         when(pipeline.isStopRequested()).thenReturn(false).thenReturn(true);
         when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(100));
         when(buffer.isEmpty()).thenReturn(true);
+        when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
     }
 
     private ProcessWorker createObjectUnderTest() {
@@ -51,25 +55,16 @@ public class ProcessWorkerTest {
 
     @Test
     void testProcessWorkerHappyPath() {
-        when(processor.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor);
-
         final ProcessWorker processWorker = createObjectUnderTest();
         doNothing().when(pipelineRunner).runAllProcessorsAndPublishToSinks();
-
         processWorker.run();
-
         verify(pipelineRunner, atLeastOnce()).runAllProcessorsAndPublishToSinks();
     }
 
     @Test
     void testProcessWorkerInitializesPipelineRunnerCorrectly() {
-        when(processor.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor);
-
         final ProcessWorker processWorker = createObjectUnderTest();
         processWorker.run();
-
         verify(pipelineRunner, atLeastOnce()).runAllProcessorsAndPublishToSinks();
     }
 
@@ -80,6 +75,7 @@ public class ProcessWorkerTest {
         when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
         when(buffer.isEmpty()).thenReturn(true);
         when(processor.isReadyForShutdown()).thenReturn(true);
+        when(processorProvider.getProcessors()).thenReturn(processors);
 
         final ProcessWorker processWorker = createObjectUnderTest();
 
@@ -98,6 +94,7 @@ public class ProcessWorkerTest {
         when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(1));
         when(buffer.isEmpty()).thenReturn(false, true);
         when(processor.isReadyForShutdown()).thenReturn(true);
+        when(processorProvider.getProcessors()).thenReturn(processors);
 
         final ProcessWorker processWorker = createObjectUnderTest();
 
@@ -116,6 +113,7 @@ public class ProcessWorkerTest {
         when(buffer.isEmpty()).thenReturn(false);
         when(pipeline.isForceStopReadingBuffers()).thenReturn(true);
         when(processor.isReadyForShutdown()).thenReturn(true);
+        when(processorProvider.getProcessors()).thenReturn(processors);
 
         final ProcessWorker processWorker = createObjectUnderTest();
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -5,64 +5,49 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate;
 
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
-import org.opensearch.dataprepper.model.buffer.Buffer;
-import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
-import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.configuration.PluginModel;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.plugin.PluginFactory;
-import org.opensearch.dataprepper.model.event.AggregateEventHandle;
-import org.opensearch.dataprepper.model.CheckpointState;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
-import org.opensearch.dataprepper.core.pipeline.Pipeline;
-import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSet;
 import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSetMetrics;
+import org.opensearch.dataprepper.core.pipeline.Pipeline;
 import org.opensearch.dataprepper.core.pipeline.ProcessWorker;
+import org.opensearch.dataprepper.core.pipeline.ProcessorProvider;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
+import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.AggregateEventHandle;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.AppendAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.AppendAggregateActionConfig;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.CountAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.CountAggregateActionConfig;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.HistogramAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.HistogramAggregateActionConfig;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterMode;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterAggregateAction;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterAggregateActionConfig;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.OutputFormat;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.PercentSamplerAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.PercentSamplerAggregateActionConfig;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.TailSamplerAggregateActionConfig;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.TailSamplerAggregateAction;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RemoveDuplicatesAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.PutAllAggregateAction;
-import org.opensearch.dataprepper.plugins.processor.aggregate.actions.OutputFormat;
-import org.opensearch.dataprepper.model.processor.Processor;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterAggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterAggregateActionConfig;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterMode;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RemoveDuplicatesAggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.TailSamplerAggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.TailSamplerAggregateActionConfig;
 
-import static org.awaitility.Awaitility.await;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
-
-
-import org.apache.commons.lang3.RandomStringUtils;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,20 +55,36 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 
 public class AggregateProcessorITWithAcks {
     private static final int testValue = 1;
     private static final int GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE = 2;
-    private static final int NUM_UNIQUE_EVENTS_PER_BATCH = 8;
     private static final int NUM_EVENTS_PER_BATCH = 5;
     private static final Duration TEST_TIMEOUT = Duration.ofSeconds(30);
 
     @Mock
     private Pipeline pipeline;
+    @Mock
+    private ProcessorProvider processorProvider;
     @Mock
     private Buffer buffer;
     @Mock
@@ -127,6 +128,7 @@ public class AggregateProcessorITWithAcks {
         pipeline = mock(Pipeline.class);
         source = mock(Source.class);
         buffer = mock(Buffer.class);
+        processorProvider = mock(ProcessorProvider.class);
         processors = List.of();
         aggregateProcessorConfig = mock(AggregateProcessorConfig.class);
         actionConfiguration = mock(PluginModel.class);
@@ -142,6 +144,8 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getOutputUnaggregatedEvents()).thenReturn(false);
         when(aggregateProcessorConfig.getIdentificationKeys()).thenReturn(identificationKeys);
         when(aggregateProcessorConfig.getWhenCondition()).thenReturn(null);
+        when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
+        when(processorProvider.getProcessors()).thenReturn(processors);
 
         records = getRecords(testKey, testValue, acknowledgementSet);
         acknowledgementSet.complete();
@@ -197,14 +201,14 @@ public class AggregateProcessorITWithAcks {
                 .thenReturn(aggregateAction);
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
 
             processWorker.run();
         }
@@ -228,14 +232,14 @@ public class AggregateProcessorITWithAcks {
 
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
 
             processWorker.run();
         }
@@ -260,14 +264,14 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
 
             processWorker.run();
         }
@@ -292,14 +296,14 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
 
 
             processWorker.run();
@@ -320,14 +324,14 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -350,14 +354,14 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
 
             processWorker.run();
         }
@@ -407,14 +411,14 @@ public class AggregateProcessorITWithAcks {
 
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -461,14 +465,14 @@ public class AggregateProcessorITWithAcks {
         });
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -491,14 +495,14 @@ public class AggregateProcessorITWithAcks {
                 .thenReturn(aggregateAction);
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -523,7 +527,7 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
@@ -531,7 +535,7 @@ public class AggregateProcessorITWithAcks {
                     .thenReturn(futureHelperResult);
 
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -558,14 +562,14 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -585,14 +589,14 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
         final Processor processor = new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
         processors = List.of(processor);
-        when(pipeline.getProcessors()).thenReturn(processors);
+        when(processorProvider.getProcessors()).thenReturn(processors);
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
         try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, processors, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)


### PR DESCRIPTION
To support Dynamic swapping of Processor instances, these code changes helps keep the Processor instances at one place so that we can hot swap the processor instances as an atomic operation.

 
### Issues Resolved
#5327 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
