### PR TITLE
Finish updating the newline codec to use the EventBuilder.

### DIFF
--- a/data-prepper-plugins/newline-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedInputCodec.java
+++ b/data-prepper-plugins/newline-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedInputCodec.java
@@ -10,7 +10,8 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
-import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.log.Log;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.io.BufferedReader;
@@ -27,11 +28,13 @@ public class NewlineDelimitedInputCodec implements InputCodec {
     private static final String MESSAGE_FIELD_NAME = "message";
     private final int skipLines;
     private final String headerDestination;
+    private final EventFactory eventFactory;
 
     @DataPrepperPluginConstructor
     public NewlineDelimitedInputCodec(
             final NewlineDelimitedInputConfig config,
             final EventFactory eventFactory) {
+        this.eventFactory = eventFactory;
         Objects.requireNonNull(config);
         skipLines = config.getSkipLines();
 
@@ -77,7 +80,9 @@ public class NewlineDelimitedInputCodec implements InputCodec {
             }
             eventData.put(MESSAGE_FIELD_NAME, line);
 
-            final Event event = JacksonLog.builder().withData(eventData).build();
+            final Log event = eventFactory.eventBuilder(LogEventBuilder.class)
+                    .withData(eventData)
+                    .build();
             eventConsumer.accept(new Record<>(event));
         }
     }

--- a/data-prepper-plugins/newline-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedInputCodecTest.java
+++ b/data-prepper-plugins/newline-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedInputCodecTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
-class NewlineDelimitedCodecTest {
+class NewlineDelimitedInputCodecTest {
 
     @Mock
     private NewlineDelimitedInputConfig config;


### PR DESCRIPTION
### Description

Finish updating the newline codec to use the EventBuilder. It appears that part of the work was done, but it wasn't quite finished until now. Also, renamed the unit test to match the class name.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
