### PR TITLE
Gradle build support for publishing Maven snapshots.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       run: ./gradlew --parallel --max-workers 2 :release:archives:buildArchives
 
     - name: Build Maven Artifacts
-      run: ./gradlew publish
+      run: ./gradlew publishAllPublicationsToMavenRepository
 
     - name: Build Docker Image
       run: ./gradlew :release:docker:docker

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
     apply plugin: 'com.github.jk1.dependency-license-report'
 
     ext {
-        mavenPublicationRootFile = file("${rootProject.buildDir}/m2")
+        mavenPublicationRootFile = file(rootProject.layout.buildDirectory.dir('m2'))
     }
 
     spotless {

--- a/buildSrc/src/main/groovy/data-prepper.publish.gradle
+++ b/buildSrc/src/main/groovy/data-prepper.publish.gradle
@@ -15,6 +15,14 @@ afterEvaluate {
             maven {
                 url "file://${mavenPublicationRootFile.absolutePath}"
             }
+            maven {
+                name = 'snapshots'
+                url = 'https://aws.oss.sonatype.org/content/repositories/snapshots'
+                credentials {
+                    username "$System.env.SONATYPE_USERNAME"
+                    password "$System.env.SONATYPE_PASSWORD"
+                }
+            }
         }
         publications {
             mavenJava(MavenPublication) {


### PR DESCRIPTION
### Description

This is the first PR for Gradle build support for publishing Maven snapshots.

It adds a new Maven snapshot repository to publish to. I also updated the `release.yml` to publish only the Maven release artifacts. This will prevent publishing snapshots during the release build. Also updates a related usage to a non-deprecated Gradle API.

A second PR will come to add the actual GitHub Actions CI.
 
### Issues Resolved

Contributes toward #5796.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
