### PR TITLE
Fixes two new projects which were added after the PR to re-organize test projects

### DIFF
--- a/data-prepper-plugins/detect-format-processor/build.gradle
+++ b/data-prepper-plugins/detect-format-processor/build.gradle
@@ -9,11 +9,11 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation project(':data-prepper-test-common')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation project(':data-prepper-test-event')
+    testImplementation project(':data-prepper-test:test-common')
+    testImplementation project(':data-prepper-test:test-event')
     testImplementation libs.commons.lang3
 }
 

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/build.gradle
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-    testImplementation project(path: ':data-prepper-test-common')
+    testImplementation project(':data-prepper-test:test-common')
 
     implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'


### PR DESCRIPTION
### Description

The PR #5726 was created before two new projects were added: `detect-format-processor` and `microsoft-office365-source`. After merging it, these projects began to fail.

This PR fixes how those projects pull in test dependencies.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
