### PR TITLE
Adds a nightly build to produce Maven SNAPSHOT artifacts

### DIFF
--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -23,15 +23,16 @@ jobs:
       - name: Checkout Data Prepper
         uses: actions/checkout@v4
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: Publish snapshots to Maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew --no-daemon publishAllPublicationsToSnapshotsRepository

--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -1,0 +1,37 @@
+name: Publish SNAPSHOT artifacts to Maven snapshot repository.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * Mon-Fri'
+
+jobs:
+  build-and-publish-snapshots:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Checkout Data Prepper
+        uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Publish snapshots to Maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew --no-daemon publishAllPublicationsToSnapshotsRepository

--- a/buildSrc/src/main/groovy/data-prepper.publish.gradle
+++ b/buildSrc/src/main/groovy/data-prepper.publish.gradle
@@ -17,7 +17,7 @@ afterEvaluate {
             }
             maven {
                 name = 'snapshots'
-                url = 'https://aws.oss.sonatype.org/content/repositories/snapshots'
+                url = 'https://central.sonatype.com/repository/maven-snapshots/'
                 credentials {
                     username "$System.env.SONATYPE_USERNAME"
                     password "$System.env.SONATYPE_PASSWORD"


### PR DESCRIPTION
### Description

Adds a nightly build to produce Maven `SNAPSHOT` artifacts to the OpenSearch Maven snapshot repo. This runs every weekday at 5:00 UTC.

This PR requires new permissions from the @opensearch-project/engineering-effectiveness team.
 
### Issues Resolved

Resolves #5796
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
