### PR TITLE
Fix query size for query_lookup to return more than 10 documents

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManager.java
@@ -172,6 +172,7 @@ public class ExistingDocumentQueryManager implements Runnable {
                 m.searches(s -> s
                         .header(h -> h.index(index))
                         .body(b -> b
+                                .size(values.size())
                                 .source(source -> source.filter(f -> f.includes(queryTerm)))
                                 .query(Query.of(q -> q
                                         .terms(TermsQuery.of(t -> t


### PR DESCRIPTION
### Description
The default query size was 10 documents so when many needed to be retried only 10 would be queried at a time, rather than all, and this resulted in some docuents not getting queried and getting returned for indexing and causing duplicates
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
