### PR TITLE
Add support for convering keys to lowercase/uppercase in RenameKeyProcessor

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/TransformOption.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/TransformOption.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.processor.keyvalue;
+package org.opensearch.dataprepper.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -39,7 +39,7 @@ public enum TransformOption {
         return transformName;
     }
 
-    Function<String, String> getTransformFunction() {
+    public Function<String, String> getTransformFunction() {
         return transformFunction;
     }
 

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/TransformOptionTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/TransformOptionTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.processor.keyvalue;
+package org.opensearch.dataprepper.common;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.common.TransformOption;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.common.TransformOption;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.model.annotations.ExampleValues;
 import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.common.TransformOption;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;

--- a/data-prepper-plugins/mutate-event-processors/build.gradle
+++ b/data-prepper-plugins/mutate-event-processors/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     testImplementation project(':data-prepper-test:test-event')
     testImplementation testLibs.slf4j.simple
     testImplementation testLibs.spring.test
+    testImplementation project(':data-prepper-test:test-common')
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessor.java
@@ -42,33 +42,26 @@ public class RenameKeyProcessor extends AbstractProcessor<Record<Event>, Record<
         this.expressionEvaluator = expressionEvaluator;
         this.transformOption = config.getTransformOption();
 
-        boolean entriesProvided = config.getEntries() != null;
-        boolean transformOptionProvided = (transformOption != null && transformOption != TransformOption.NONE);
-        if ((!entriesProvided ^ transformOptionProvided)) {
-            throw new InvalidPluginConfigurationException("Only one of 'entries' or 'transform_key' should be specified.");
-        }
-        if (config.getEntries() == null || config.getEntries().size() == 0) {
-            return;
-        }
-        config.getEntries().forEach(entry -> {
-            if (entry.getRenameWhen() != null
+        if (config.getEntries() != null) {
+            config.getEntries().forEach(entry -> {
+                if (entry.getRenameWhen() != null
                     && !expressionEvaluator.isValidExpressionStatement(entry.getRenameWhen())) {
                 throw new InvalidPluginConfigurationException(
                         String.format("rename_when %s is not a valid expression statement. See https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/ for valid expression syntax",
                                 entry.getRenameWhen()));
-            }
-            if (entry.getFromKey() == null && entry.getFromKeyPattern() == null) {
-                throw new InvalidPluginConfigurationException("Either from_key or from_key_regex must be specified. ");
-            }
-            if (entry.getFromKey() != null && entry.getFromKeyPattern()  != null) {
-                throw new InvalidPluginConfigurationException("Only one of from_key or from_key_regex should be specified.");
-            }
-        });
+                }
+                if (entry.getFromKey() == null && entry.getFromKeyPattern() == null) {
+                    throw new InvalidPluginConfigurationException("Either from_key or from_key_regex must be specified. ");
+                }
+                if (entry.getFromKey() != null && entry.getFromKeyPattern()  != null) {
+                    throw new InvalidPluginConfigurationException("Only one of from_key or from_key_regex should be specified.");
+                }
+            });
+        }
     }
 
     private void transformEvent(final Event event, Map<String, Object> map, final String keyPrefix) {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
-            Object result = null;
             try {
                 if (entry.getValue() instanceof Map) {
                     transformEvent(event, (Map<String, Object>)entry.getValue(), keyPrefix+entry.getKey()+"/");

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -137,5 +138,11 @@ public class RenameKeyProcessorConfig {
     public TransformOption getTransformOption() {
         return transformOption;
     }
+
+    @AssertTrue(message = "entries and transform_key are mutually exclusive options. entries or transform_key is required.")
+    boolean isValidConfig() {
+        return (transformOption != null && transformOption != TransformOption.NONE)  ^ entries != null;
+    }
+
 
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.common.TransformOption;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.model.annotations.ExampleValues;
 import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
@@ -116,12 +117,25 @@ public class RenameKeyProcessorConfig {
         }
     }
 
-    @NotEmpty
-    @NotNull
     @Valid
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = "transform_key", allowedValues = {"null", "none"})
+    })
     private List<Entry> entries;
+
+    @JsonProperty(value = "transform_key", defaultValue = "none")
+    @JsonPropertyDescription("Allows transforming the key's name such as making the name all lowercase.")
+    @AlsoRequired(values = {
+            @AlsoRequired.Required(name = "entries", allowedValues = {"null"})
+    })
+    private TransformOption transformOption = TransformOption.NONE;
 
     public List<Entry> getEntries() {
         return entries;
     }
+
+    public TransformOption getTransformOption() {
+        return transformOption;
+    }
+
 }

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventKey;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.common.TransformOption;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.Test;
@@ -224,7 +225,53 @@ public class RenameKeyProcessorTests {
         assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("thisisamessage"));
     }
 
+    @Test
+    public void test_transformKey_converting_allkeys_lowercase() {
+        Map<String, Object> data = Map.of("KeY1", 1, "kEy2", Map.of("keY3", Map.of("key4", "value4", "KEY5", 5.555)));
+        when(mockConfig.getEntries()).thenReturn(null);
+        when(mockConfig.getTransformOption()).thenReturn(TransformOption.LOWERCASE);
+        Record<Event> record = buildRecordWithEvent(data);
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.size(), equalTo(1));
+        assertThat(editedRecords.get(0).getData().containsKey("key1"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("key2"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("key2/key3"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("key2/key3/key4"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("key2/key3/key5"), is(true));
+    }
 
+    @Test
+    public void test_transformKey_converting_allkeys_uppercase() {
+        Map<String, Object> data = Map.of("KeY1", 1, "kEy2", Map.of("keY3", Map.of("key4", "value4", "KEY5", 5.555)));
+        when(mockConfig.getEntries()).thenReturn(null);
+        when(mockConfig.getTransformOption()).thenReturn(TransformOption.UPPERCASE);
+        Record<Event> record = buildRecordWithEvent(data);
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.size(), equalTo(1));
+        assertThat(editedRecords.get(0).getData().containsKey("KEY1"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("KEY2"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("KEY2/KEY3"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("KEY2/KEY3/KEY4"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("KEY2/KEY3/KEY5"), is(true));
+    }
+
+    @Test
+    public void test_transformKey_converting_allkeys_capitalize() {
+        Map<String, Object> data = Map.of("key1", 1, "key2", Map.of("key3", Map.of("key4", "value4", "Key5", 5.555)));
+        when(mockConfig.getEntries()).thenReturn(null);
+        when(mockConfig.getTransformOption()).thenReturn(TransformOption.CAPITALIZE);
+        Record<Event> record = buildRecordWithEvent(data);
+        final RenameKeyProcessor processor = createObjectUnderTest();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.size(), equalTo(1));
+        assertThat(editedRecords.get(0).getData().containsKey("Key1"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("Key2"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("Key2/Key3"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("Key2/Key3/Key4"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("Key2/Key3/Key5"), is(true));
+    }
 
     private RenameKeyProcessor createObjectUnderTest() {
         return new RenameKeyProcessor(pluginMetrics, mockConfig, expressionEvaluator);

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
@@ -65,7 +65,7 @@ public class RenameKeyProcessorTests {
     }
 
     @Test
-    void invalid_config_tests_with_entries_and_transform_options() throws NoSuchFieldException, IllegalAccessException {
+    void invalid_config_tests_with_entries_and_transform_options_both_present() throws NoSuchFieldException, IllegalAccessException {
         final String renameWhen = UUID.randomUUID().toString();
         List<RenameKeyProcessorConfig.Entry> entries = createListOfEntries(createEntry("message", null,"newMessage", true, renameWhen));
 
@@ -74,13 +74,32 @@ public class RenameKeyProcessorTests {
         ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "entries", entries);
         ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "transformOption", TransformOption.LOWERCASE);
         assertFalse(renameKeyProcessorConfig.isValidConfig());
-        ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "transformOption", TransformOption.NONE);
-        assertTrue(renameKeyProcessorConfig.isValidConfig());
-        ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "transformOption", TransformOption.LOWERCASE);
+    }
+
+    @Test
+    void invalid_config_tests_with_entries_and_transform_options_both_not_present() throws NoSuchFieldException, IllegalAccessException {
+        RenameKeyProcessorConfig renameKeyProcessorConfig = new RenameKeyProcessorConfig();
         ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "entries", null);
-        assertTrue(renameKeyProcessorConfig.isValidConfig());
         ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "transformOption", TransformOption.NONE);
         assertFalse(renameKeyProcessorConfig.isValidConfig());
+    }
+
+    @Test
+    void invalid_config_tests_with_entries_and_transform_options_valid_entries() throws NoSuchFieldException, IllegalAccessException {
+        final String renameWhen = UUID.randomUUID().toString();
+        List<RenameKeyProcessorConfig.Entry> entries = createListOfEntries(createEntry("message", null,"newMessage", true, renameWhen));
+        RenameKeyProcessorConfig renameKeyProcessorConfig = new RenameKeyProcessorConfig();
+        ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "entries", entries);
+        ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "transformOption", TransformOption.NONE);
+        assertTrue(renameKeyProcessorConfig.isValidConfig());
+    }
+
+    @Test
+    void invalid_config_tests_with_entries_and_transform_options_valid_transformation() throws NoSuchFieldException, IllegalAccessException {
+        RenameKeyProcessorConfig renameKeyProcessorConfig = new RenameKeyProcessorConfig();
+        ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "entries", null);
+        ReflectivelySetField.setField(RenameKeyProcessorConfig.class, renameKeyProcessorConfig, "transformOption", TransformOption.UPPERCASE);
+        assertTrue(renameKeyProcessorConfig.isValidConfig());
     }
 
     @Test


### PR DESCRIPTION
### Description
Add support for convering keys to lowercase/uppercase in RenameKeyProcessor.
Reused existing TransformOption in KeyValue processor in RenameKeyProcessor.

Addresses part of the issue #5757 
 
### Issues Resolved
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
