### PR TITLE
Update s3 scan ack timeout and scan interval in rds transform template

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-template.yaml
@@ -69,6 +69,7 @@
       delete_s3_objects_on_read: true
       disable_s3_metadata_in_event: true
       scan:
+        acknowledgment_timeout: "PT10M"
         folder_partitions:
           depth: "<<FUNCTION_NAME:calculateDepthForRdsSource,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"
           max_objects_per_ownership: 50
@@ -78,7 +79,7 @@
               filter:
                 include_prefix: ["<<FUNCTION_NAME:getIncludePrefixForRdsSource,PARAMETER:$.<<pipeline-name>>.source.rds.s3_prefix>>"]
         scheduling:
-          interval: "60s"
+          interval: "20s"
   processor: "<<$.<<pipeline-name>>.processor>>"
   sink: "<<$.<<pipeline-name>>.sink>>"
   routes: "<<$.<<pipeline-name>>.routes>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.


### PR DESCRIPTION
### Description
Noticed long delay in s3 scan in RDS source, similar to what is described in #4988. Update s3 scan ack timeout to 10min and scan interval to 20s in rds transform template, same as [documentdb template](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/mongodb/src/main/resources/org/opensearch/dataprepper/transforms/templates/documentdb-template.yaml)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
