### PR TITLE
Refactor maven downloading logic to be dynamic

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -240,8 +240,8 @@ pipeline {
                                 string(credentialsId: 'data-prepper-s3-role', variable: 'DP_S3_ROLE_NAME'),
                                 string(credentialsId: 'data-prepper-aws-account-number', variable: 'DP_AWS_ACCOUNT_NUMBER'),
                                 string(credentialsId: 'data-prepper-s3-bucket-name', variable: 'DP_S3_BUCKET_NAME'),]) {
-                                    echo 'Downloading artifacts from S3...'
-                                    withAWS(role: "${DP_S3_ROLE_NAME}", roleAccount: "${DP_AWS_ACCOUNT_NUMBER}", duration: 900, roleSessionName: 'dp-jenkins-session', region: "${region}") {
+                                    echo 'Downloading artifacts from S3'
+                                    withAWS(role: "${DP_S3_ROLE_NAME}", roleAccount: "${DP_AWS_ACCOUNT_NUMBER}", duration: 900, roleSessionName: 'dp-jenkins-session', region: 'us-east-1') {
                                         s3Download(file: "${WORKSPACE}/maven", bucket: "${DP_S3_BUCKET_NAME}", path: "${downloadPath}", force: true)
                                     }
                                 }

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -235,13 +235,16 @@ pipeline {
                 stage('Download Maven Artifacts') {
                     steps {
                         script {
-                            mavenPath = "${DATA_PREPPER_ARTIFACT_STAGING_SITE}/${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/maven"
-                            group = 'org/opensearch/dataprepper'
-                            artifacts = ['data-prepper-api']
-                            fileTypes = ['-javadoc.jar', '.jar', '.pom', '-sources.jar', '.module']
-                            checksums = ['', '.md5', '.sha1', '.sha256', '.sha512']
-
-                            downloadArtifacts("$VERSION")
+                            downloadPath = "${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/maven"
+                            withCredentials([
+                                string(credentialsId: 'data-prepper-s3-role', variable: 'DP_S3_ROLE_NAME'),
+                                string(credentialsId: 'data-prepper-aws-account-number', variable: 'DP_AWS_ACCOUNT_NUMBER'),
+                                string(credentialsId: 'data-prepper-s3-bucket-name', variable: 'DP_S3_BUCKET_NAME'),]) {
+                                    echo 'Downloading artifacts from S3...'
+                                    withAWS(role: "${DP_S3_ROLE_NAME}", roleAccount: "${DP_AWS_ACCOUNT_NUMBER}", duration: 900, roleSessionName: 'dp-jenkins-session', region: "${region}") {
+                                        s3Download(file: "${WORKSPACE}/maven", bucket: "${DP_S3_BUCKET_NAME}", path: "${downloadPath}", force: true)
+                                    }
+                                }
                         }
                     }
                 }
@@ -275,19 +278,6 @@ pipeline {
                             sh "curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${release_url} -d '{\"tag_name\":\"${TAG}\",\"draft\":false,\"prerelease\":false}'"
                         }
                     }
-                }
-            }
-        }
-    }
-}
-
-def downloadArtifacts(version) {
-    dir('maven') {
-        for (artifact in artifacts) {
-            sh "mkdir -p ${group}/${artifact}/${version}"
-            for (fileType in fileTypes) {
-                for (checksum in checksums) {
-                    sh "curl -sSL ${mavenPath}/${group}/${artifact}/${version}/${artifact}-${version}${fileType}${checksum} -o ${group}/${artifact}/${version}/${artifact}-${version}${fileType}${checksum}"
                 }
             }
         }


### PR DESCRIPTION
### Description
This PR adds the change to download maven artifacts dynamically. I can confirm that related permissions have been added to jenkins. See the [diff](https://github.com/opensearch-project/opensearch-ci/issues/598#issuecomment-3005841573) of deployment stack. 
 
### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/5586
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
