### PR TITLE
Updates the staging stack to to allow multiple accounts to read from S3

### DIFF
--- a/release/staging-resources-cdk/README.md
+++ b/release/staging-resources-cdk/README.md
@@ -52,13 +52,13 @@ The following CDK commands all require defining context. The context variables a
 
 * `archivesBucketName` - The name of the S3 bucket you will use to deploy. This bucket must be in the same region as your stack.
 * `dataPrepperOrganization` - The name of the GitHub organization which has the `data-prepper` repository. This allows you to create staging environments for forks. The default value is `opensearch-project`.
-* `ciAccountId` - The AWS account Id of the OpenSearch CI release/build server.
+* `ciAccountIds` - The AWS account Ids of the OpenSearch CI release/build server and test environments. This is a comma-delimited value and requires at least one account.
 
 The following command will deploy the CDK stack and create a new S3 bucket. If you'd like to use an existing S3 bucket, see the section below
 for deploying individual stacks.
 
 ```
-cdk deploy --all --context archivesBucketName={s3-bucket-name} --context dataPrepperOrganization={data-prepper-organization-name} --context ciAccountId={opensearch-ci-account-id}
+cdk deploy --all --context archivesBucketName={s3-bucket-name} --context dataPrepperOrganization={data-prepper-organization-name} --context ciAccountIds={opensearch-ci-account-id}
 ```
 
 #### Deploy to Use an Existing S3 Bucket


### PR DESCRIPTION
### Description

Updates the staging stack to allow multiple accounts to access the read permissions. This will allow us to grant access to the OpenSearch CI test accounts. 

 
### Issues Resolved

Contributes toward #5796.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
