### PR TITLE
Fix downloading path from S3 and to maven lib

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -235,7 +235,7 @@ pipeline {
                 stage('Download Maven Artifacts') {
                     steps {
                         script {
-                            downloadPath = "${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/maven"
+                            def downloadPath = "${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/maven/"
                             withCredentials([
                                 string(credentialsId: 'data-prepper-s3-role', variable: 'DP_S3_ROLE_NAME'),
                                 string(credentialsId: 'data-prepper-aws-account-number', variable: 'DP_AWS_ACCOUNT_NUMBER'),
@@ -252,8 +252,8 @@ pipeline {
                     steps {
                         script {
                             publishToMaven(
-                                signingArtifactsPath: "${WORKSPACE}/maven",
-                                mavenArtifactsPath: "${WORKSPACE}/maven",
+                                signingArtifactsPath: "${WORKSPACE}/maven/${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/maven",
+                                mavenArtifactsPath: "${WORKSPACE}/maven/${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/maven",
                                 autoPublish: true
                             )
                         }


### PR DESCRIPTION
### Description
Fix downloading path from S3 and to maven lib
 
### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/5586
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
