### PR TITLE
Add check for null compression option

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -80,8 +80,9 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
         super(kafkaBufferConfig.getCustomMetricPrefix().orElse(pluginSetting.getName()+"buffer"), pluginSetting.getPipelineName());
 
         CompressionOption manualCompressionConfig = CompressionOption.NONE;
+        // If encryption at rest is enabled, disable Kafka built-in compression and do it manually (manualCompressionConfig)
         if (kafkaBufferConfig.getTopic().encryptionAtRestEnabled()) {
-            // If encryption is enabled, disable Kafka built-in compression and do it manually.
+            // If the user specifies a CompressionType, we use that type as our manualCompressionConfig and disable the builtin-Kafka compression by setting compressionType to NONE.
             if (kafkaBufferConfig.getKafkaProducerProperties() != null && kafkaBufferConfig.getKafkaProducerProperties().getCompressionType() != null) {
                 manualCompressionConfig = CompressionOption.fromOptionValue(kafkaBufferConfig.getKafkaProducerProperties().getCompressionType());
                 kafkaBufferConfig.getKafkaProducerProperties().setCompressionType(CompressionOption.NONE.name().toLowerCase());

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -71,6 +71,8 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
     private AtomicBoolean shutdownInProgress;
     private ByteDecoder byteDecoder;
 
+    private CompressionOption customCompressionOption;
+
     @DataPrepperPluginConstructor
     public KafkaBuffer(final PluginSetting pluginSetting, final KafkaBufferConfig kafkaBufferConfig,
                        final AcknowledgementSetManager acknowledgementSetManager,
@@ -79,7 +81,7 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
                        final EncryptionSupplier encryptionSupplier) {
         super(kafkaBufferConfig.getCustomMetricPrefix().orElse(pluginSetting.getName()+"buffer"), pluginSetting.getPipelineName());
 
-        CompressionOption customCompressionOption = CompressionOption.NONE;
+        customCompressionOption = CompressionOption.NONE;
         // If encryption at rest is enabled, disable Kafka built-in compression and do it manually (customCompressionOption)
         if (kafkaBufferConfig.getTopic().encryptionAtRestEnabled()) {
             // If the user specifies a CompressionType, we use that type as our customCompressionOption and disable the builtin-Kafka compression by setting compressionType to NONE.
@@ -263,5 +265,9 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
 
     private static void resetMdc() {
         MDC.remove(KafkaMdc.MDC_KAFKA_PLUGIN_KEY);
+    }
+
+    public CompressionOption getCustomCompressionOption() {
+        return customCompressionOption;
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -82,7 +82,7 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
         CompressionOption manualCompressionConfig = CompressionOption.NONE;
         if (kafkaBufferConfig.getTopic().encryptionAtRestEnabled()) {
             // If encryption is enabled, disable Kafka built-in compression and do it manually.
-            if (kafkaBufferConfig.getKafkaProducerProperties() != null) {
+            if (kafkaBufferConfig.getKafkaProducerProperties() != null && kafkaBufferConfig.getKafkaProducerProperties().getCompressionType() != null) {
                 manualCompressionConfig = CompressionOption.fromOptionValue(kafkaBufferConfig.getKafkaProducerProperties().getCompressionType());
                 kafkaBufferConfig.getKafkaProducerProperties().setCompressionType(CompressionOption.NONE.name().toLowerCase());
             }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -481,4 +481,16 @@ class KafkaBufferTest {
         
         verify(producer).produceRecords(record);
     }
+
+    @Test
+    void test_kafkaBuffer_with_encryption_and_null_compressionType() throws Exception {
+        when(bufferConfig.getTopic().encryptionAtRestEnabled()).thenReturn(true);
+        when(kafkaProducerProperties.getCompressionType()).thenReturn(null);
+        kafkaBuffer = createObjectUnderTest();
+        
+        Record<Event> record = new Record<Event>(JacksonEvent.fromMessage(UUID.randomUUID().toString()));
+        kafkaBuffer.doWrite(record, 10000);
+        
+        verify(producer).produceRecords(record);
+    }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -41,6 +41,7 @@ import org.opensearch.dataprepper.plugins.kafka.producer.KafkaCustomProducer;
 import org.opensearch.dataprepper.plugins.kafka.producer.KafkaCustomProducerFactory;
 import org.opensearch.dataprepper.plugins.kafka.producer.ProducerWorker;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
+import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.slf4j.MDC;
 
 import java.time.Duration;
@@ -492,5 +493,25 @@ class KafkaBufferTest {
         kafkaBuffer.doWrite(record, 10000);
         
         verify(producer).produceRecords(record);
+    }
+
+    @Test
+    void test_customCompressionOption_with_encryption_enabled_and_gzip_compression() {
+        when(bufferConfig.getTopic().encryptionAtRestEnabled()).thenReturn(true);
+        when(kafkaProducerProperties.getCompressionType()).thenReturn("gzip");
+        
+        kafkaBuffer = createObjectUnderTest();
+        
+        assertThat(kafkaBuffer.getCustomCompressionOption().name(), equalTo("GZIP"));
+        verify(kafkaProducerProperties).setCompressionType("none");
+    }
+
+    @Test
+    void test_customCompressionOption_with_encryption_disabled() {
+        when(bufferConfig.getTopic().encryptionAtRestEnabled()).thenReturn(false);
+        
+        kafkaBuffer = createObjectUnderTest();
+        
+        assertThat(kafkaBuffer.getCustomCompressionOption().name(), equalTo("NONE"));
     }
 }


### PR DESCRIPTION
### Description
Fixes null pointer issue that is causing pipeline creation failure when producer properties exists and the CompressionOption is null.

### Issues Resolved
Resolves #5841
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
