### PR TITLE
Add ZSTD compression engine for Kafka Buffer

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/CompressionOption.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/CompressionOption.java
@@ -17,6 +17,7 @@ public enum CompressionOption {
     NONE("none"),
     GZIP("gzip"),
     SNAPPY("snappy"),
+    ZSTD("zstd"),
     AUTOMATIC("automatic");
 
     private static final Map<String, CompressionOption> OPTIONS_MAP = Arrays.stream(CompressionOption.values())
@@ -28,13 +29,15 @@ public enum CompressionOption {
     private static final Map<String, DecompressionEngine> DECOMPRESSION_ENGINE_MAP = Map.of(
             "none", new NoneDecompressionEngine(),
             "gzip", new GZipDecompressionEngine(),
-            "snappy", new SnappyDecompressionEngine()
+            "snappy", new SnappyDecompressionEngine(),
+            "zstd", new ZstdDecompressionEngine()
     );
 
     private static final Map<String, CompressionEngine> COMPRESSION_ENGINE_MAP = Map.of(
             "none", new NoneCompressionEngine(),
             "gzip", new GZipCompressionEngine(),
-            "snappy", new SnappyCompressionEngine()
+            "snappy", new SnappyCompressionEngine(),
+            "zstd", new ZstdCompressionEngine()
     );
 
     private final String option;

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/ZstdCompressionEngine.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/ZstdCompressionEngine.java
@@ -1,0 +1,14 @@
+package org.opensearch.dataprepper.plugins.codec;
+
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream;
+import org.opensearch.dataprepper.model.codec.CompressionEngine;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ZstdCompressionEngine implements CompressionEngine {
+    @Override
+    public OutputStream createOutputStream(OutputStream outputStream) throws IOException {
+        return new ZstdCompressorOutputStream(outputStream);
+    }
+}

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/ZstdDecompressionEngine.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/ZstdDecompressionEngine.java
@@ -1,0 +1,14 @@
+package org.opensearch.dataprepper.plugins.codec;
+
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
+import org.opensearch.dataprepper.model.codec.DecompressionEngine;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ZstdDecompressionEngine implements DecompressionEngine {
+    @Override
+    public InputStream createInputStream(InputStream responseInputStream) throws IOException {
+        return new ZstdCompressorInputStream(responseInputStream);
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -121,6 +121,7 @@ public class KafkaCustomProducer<T> {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             OutputStream compressedOutputStream = compressionConfig.getCompressionEngine().createOutputStream(byteArrayOutputStream);
             compressedOutputStream.write(bytes);
+            compressedOutputStream.close();
             send(topicName, key, byteArrayOutputStream.toByteArray()).get();
 
             topicMetrics.update(producer);
@@ -175,6 +176,7 @@ public class KafkaCustomProducer<T> {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         OutputStream compressedOutputStream = compressionConfig.getCompressionEngine().createOutputStream(byteArrayOutputStream);
         compressedOutputStream.write(bytes);
+        compressedOutputStream.close();
 
         send(topicName, key, byteArrayOutputStream.toByteArray());
     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -513,4 +513,15 @@ class KafkaBufferTest {
         
         assertThat(kafkaBuffer.getCustomCompressionOption().name(), equalTo("NONE"));
     }
+
+    @Test
+    void test_compressionOption_supports_all_kafka_compression_types() {
+        String[] kafkaCompressionTypes = {"none", "gzip", "snappy", "zstd"};
+        
+        for (String compressionType : kafkaCompressionTypes) {
+            CompressionOption option = CompressionOption.fromOptionValue(compressionType);
+            assertThat("CompressionOption should support Kafka compression type to ensure that KafkaBuffer compresses data properly when encryption is enabled: " + compressionType,
+                      option, org.hamcrest.Matchers.notNullValue());
+        }
+    }
 }


### PR DESCRIPTION
### Description
Also add unit test to ensure that Kafka supported compression types are implemented at a minimum.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
