### PR TITLE
[Fix] Add sleep in zero buffer read when no data is flowing

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/buffer/ZeroBuffer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/buffer/ZeroBuffer.java
@@ -82,8 +82,6 @@ public class ZeroBuffer<T extends Record<?>> implements Buffer<T>, SupportsPipel
             try {
                 Thread.sleep(DEFAULT_READ_SLEEP_MILLIS);
             } catch (InterruptedException e) {
-                // Restore the interrupted status
-                Thread.currentThread().interrupt();
                 LOG.debug("Thread interrupted while waiting for data in empty buffer, returning empty result");
             }
             return Map.entry(Collections.emptySet(), EMPTY_CHECKPOINT);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/buffer/ZeroBufferTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/buffer/ZeroBufferTests.java
@@ -223,10 +223,6 @@ public class ZeroBufferTests {
             
             assertTrue(result.getKey().isEmpty());
             assertEquals(ZeroBuffer.EMPTY_CHECKPOINT, result.getValue());
-            assertTrue(Thread.currentThread().isInterrupted());
-            
-            // Clear the interrupted status
-            Thread.interrupted();
         }
     }
 


### PR DESCRIPTION
### Description
The ZeroBuffer was causing high CPU usage when no data was flowing through the pipeline. The read() method (called by [ProcessWorker#run](https://github.com/opensearch-project/data-prepper/blob/844eac121a3b7d594572e2f2dae1d5fcea10ebf3/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java#L34-L45) method) would continuously return immediately when no data is flowing, creating a tight loop that consumed excessive CPU resources.

This PR:
- Added a 1-second sleep in the read() method when no data is available. This prevents the tight loop and significantly reduces CPU usage during idle periods.
- Added unit test to verify sleep behavior

Testing:
- Profiled zero buffer pipeline run before and after the changes and confirmed that `ProcessWorker#run` no longer takes most of the cpu time.

 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
