### PR TITLE
Added flush remaining request for OpensearchSink  on graceful shutdown 

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -161,7 +161,6 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private final ExecutorService queryExecutorService;
 
   private final int processWorkerThreads;
-  private static final long FLUSH_TIMEOUT_WAIT_MS = 300000L; // 5 minutes timeout for flushing during shutdown
 
   @DataPrepperPluginConstructor
   public OpenSearchSink(final PluginSetting pluginSetting,
@@ -677,29 +676,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest = bulkRequestMap.get(threadId);
       if (bulkRequest != null && bulkRequest.getOperationsCount() > 0) {
         LOG.info("Flushing bulk request with {} operations for thread {}", bulkRequest.getOperationsCount(), threadId);
-		Duration retryTime = Duration.ZERO;
-        boolean success = false;
-        while (!success && retryTime.toMillis() <= FLUSH_TIMEOUT_WAIT_MS) {
-          try {
-            flushBatch(bulkRequest);
-            success = true;
-            LOG.info("Successfully flushed bulk request for thread {}", threadId);
-          } catch (Exception e) {
-            LOG.warn("Error flushing bulk request during shutdown retrying in 1 Seconds, remaining time: {}sec", (FLUSH_TIMEOUT_WAIT_MS - retryTime.toMillis())/1000, e);
-            try {
-              	Thread.sleep( 1000L);
-				retryTime = retryTime.plusMillis(1000L);
-            } catch (InterruptedException ie) {
-              Thread.currentThread().interrupt();
-              LOG.warn("Interrupted while waiting to retry bulk flush");
-              break;
-            }
-          }
-		}
-      }
-    }
-
-    // Clear the maps after flushing
+		flushBatch(bulkRequest);
+		LOG.info("Successfully flushed bulk request for thread {}", threadId);
+	  }
+	}
     bulkRequestMap.clear();
     lastFlushTimeMap.clear();
   }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -685,12 +685,12 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             LOG.info("Successfully flushed bulk request for thread {} on attempt {}", threadId, retryCount + 1);
           } catch (Exception e) {
             retryCount++;
-            LOG.warn("Error flushing bulk request during shutdown attempt {}, retrying in : {} Seconds", retryCount, retryCount*1000L);
+            LOG.warn("Error flushing bulk request during shutdown attempt {}, retrying in : {} Seconds.", retryCount, retryCount*1000L, e);
             try {
               Thread.sleep(retryCount * 1000L);
             } catch (InterruptedException ie) {
               Thread.currentThread().interrupt();
-              LOG.warn("Interrupted while waiting to retry bulk flush");
+              LOG.warn("Interrupted while waiting to retry bulk flush", ie);
               break;
             }
           }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -78,7 +78,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -664,8 +663,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
    * flushRemainingBulkRequests Flush the remaining bulk requests during shutdown
    * This is necessary to ensure that any remaining operations are sent to OpenSearch before the sink is shut down.
    * It iterates through the bulkRequestMap, flushing each bulk request that has operations left.
-   * If an error occurs during the flush, it retries until sinkShutdownTimeout
-   * */
+   */
   private void flushRemainingBulkRequests() {
     if (bulkRequestMap.isEmpty()) {
       return;


### PR DESCRIPTION
### Description
On graceful shutdown request opensearch sink should try to flush the remaining request at hand before cleaning up resources.
There is data loss because opensearch sink not flushing the remaining request on shutdown phase.
 
### Issues Resolved
Resolves #5887
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
