### PR TITLE
Support isolation.level config for Kafka consumer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/IsolationLevel.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/IsolationLevel.java
@@ -1,0 +1,33 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Map;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public enum IsolationLevel {
+    READ_UNCOMMITTED("read_uncommitted"),
+    READ_COMMITTED("read_committed");
+
+    private static final Map<String, IsolationLevel> OPTIONS_MAP = Arrays.stream(IsolationLevel.values())
+            .collect(Collectors.toMap(
+                    value -> value.type,
+                    value -> value
+            ));
+
+    private final String type;
+
+    IsolationLevel(final String type) {
+        this.type = type;
+    }
+
+    @JsonCreator
+    public static IsolationLevel fromTypeValue(final String type) {
+        return OPTIONS_MAP.get(type.toLowerCase());
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaIsolationLevelConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaIsolationLevelConfig.java
@@ -1,0 +1,5 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+public interface KafkaIsolationLevelConfig {
+    IsolationLevel getIsolationLevel();
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -41,6 +41,8 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfi
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaRegistryType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaIsolationLevelConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.IsolationLevel;
 
 import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
@@ -174,6 +176,12 @@ public class KafkaCustomConsumerFactory {
         properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, topicConfig.getFetchMaxWait());
         properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, (int)topicConfig.getFetchMinBytes());
         properties.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+        if (topicConfig instanceof KafkaIsolationLevelConfig) {
+            IsolationLevel isolationLevel = ((KafkaIsolationLevelConfig) topicConfig).getIsolationLevel();
+            if (isolationLevel != null) {
+                properties.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolationLevel.getType());
+            }
+        }
     }
 
     private void setSchemaRegistryProperties(final KafkaConsumerConfig kafkaConsumerConfig, final Properties properties, final TopicConfig topicConfig) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfig.java
@@ -13,11 +13,13 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.CommonTopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConsumerConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaKeyMode;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KmsConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaIsolationLevelConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.IsolationLevel;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
 import java.time.Duration;
 
-class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig {
+class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig, KafkaIsolationLevelConfig {
     static final boolean DEFAULT_AUTO_COMMIT = false;
     static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
     static final String DEFAULT_FETCH_MAX_BYTES = "50mb";
@@ -97,6 +99,9 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
 
     @JsonProperty("fetch_min_bytes")
     private String fetchMinBytes = DEFAULT_FETCH_MIN_BYTES;
+
+    @JsonProperty("isolation_level")
+    private IsolationLevel isolationLevel = IsolationLevel.READ_UNCOMMITTED;
 
     @Override
     public String getEncryptionId() {
@@ -211,5 +216,10 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
     @Override
     public Duration getHeartBeatInterval() {
         return heartBeatInterval;
+    }
+
+    @Override
+    public IsolationLevel getIsolationLevel() {
+        return isolationLevel;
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/IsolationLevelTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/IsolationLevelTest.java
@@ -1,0 +1,66 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.emptyString;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class IsolationLevelTest {
+
+    @ParameterizedTest
+    @EnumSource(IsolationLevel.class)
+    void fromTypeValue_should_return_expected_enum(final IsolationLevel value) {
+        assertThat(IsolationLevel.fromTypeValue(value.getType()), is(value));
+        assertThat(value, instanceOf(IsolationLevel.class));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IsolationLevelToKnownName.class)
+    void fromTypeValue_returns_expected_value(final IsolationLevel isolationLevel, final String knownString) {
+        assertThat(IsolationLevel.fromTypeValue(knownString), equalTo(isolationLevel));
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsolationLevel.class)
+    void getType_returns_non_empty_string_for_all_types(final IsolationLevel isolationLevel) {
+        assertThat(isolationLevel.getType(), notNullValue());
+        assertThat(isolationLevel.getType(), not(emptyString()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IsolationLevelToKnownName.class)
+    void getType_returns_expected_string(final IsolationLevel isolationLevel, final String expectedString) {
+        assertThat(isolationLevel.getType(), equalTo(expectedString));
+    }
+
+    @Test
+    void fromTypeValue_returns_null_for_unknown_string() {
+        assertThat(IsolationLevel.fromTypeValue("unknown"), nullValue());
+        assertThat(IsolationLevel.fromTypeValue("READ_COMMITED_WRONG_CASE"), nullValue());
+    }
+
+    static class IsolationLevelToKnownName implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(IsolationLevel.READ_UNCOMMITTED, "read_uncommitted"),
+                    arguments(IsolationLevel.READ_COMMITTED, "read_committed")
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfigTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
+import org.opensearch.dataprepper.plugins.kafka.configuration.IsolationLevel;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.FileReader;
@@ -93,5 +94,12 @@ class KafkaSourceConfigTest {
 		assertEquals(EncryptionType.NONE, encryptionConfig.getType());
         setField(EncryptionConfig.class, encryptionConfig, "type", EncryptionType.SSL);
 		assertEquals(EncryptionType.SSL, encryptionConfig.getType());
+	}
+
+	@Test
+	void test_isolation_level_deserialization_from_yaml() {
+		assertThat(kafkaSourceConfig.getTopics(), notNullValue());
+		SourceTopicConfig topic = (SourceTopicConfig) kafkaSourceConfig.getTopics().get(0);
+		assertEquals(IsolationLevel.READ_COMMITTED, topic.getIsolationLevel());
 	}
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfigTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.kafka.source;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.types.ByteCount;
+import org.opensearch.dataprepper.plugins.kafka.configuration.IsolationLevel;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,4 +54,19 @@ class SourceTopicConfigTest {
         setField(SourceTopicConfig.class, objectUnderTest, "fetchMaxBytes", "0b");
         assertThrows(RuntimeException.class, () -> objectUnderTest.getFetchMaxBytes());
     }
+
+    @Test
+    void verify_default_isolation_level() {
+        SourceTopicConfig objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.getIsolationLevel(), equalTo(IsolationLevel.READ_UNCOMMITTED));
+    }
+
+    @Test
+    void verify_custom_isolation_level() throws NoSuchFieldException, IllegalAccessException {
+        SourceTopicConfig objectUnderTest = createObjectUnderTest();
+
+        setField(SourceTopicConfig.class, objectUnderTest, "isolationLevel", IsolationLevel.READ_COMMITTED);
+        assertThat(objectUnderTest.getIsolationLevel(), equalTo(IsolationLevel.READ_COMMITTED));
+    }
+
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -22,6 +22,7 @@ log-pipeline:
           retry_backoff: PT100S
           consumer_max_poll_records: 500
           max_partition_fetch_bytes: "10mb"
+          isolation_level: read_committed
       schema:
         registry_url: http://localhost:8081/
         version: 1


### PR DESCRIPTION
### Description
This pull request adds support for the `isolation.level` Kafka consumer configuration in Data Prepper.

The following changes were made:

- Introduced a new method `getIsolationLevel()` in the `TopicConsumerConfig` interface.

- Implemented the new property `isolation_level` with a default value of `"read_uncommitted"` in both:

    - `SourceTopicConfig` (Kafka source plugin)

    - `BufferTopicConfig` (Kafka buffer plugin)

- Ensured backward compatibility by setting sensible defaults and integrating with existing configuration parsing logic.

- This allows users to configure Data Prepper to read only committed messages by setting `isolation_level: read_committed` in their pipeline YAML file.

This is especially useful when working with transactional Kafka producers and ensures message consistency in distributed systems.

### Issues Resolved
Resolves #5896
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
