### PR TITLE
Fixes a regression in core where @SingleThread annotated processors are only running the last instance.

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorSwapPipelineIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorSwapPipelineIT.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.integration;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.configuration.PipelineModel;
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
@@ -39,6 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.opensearch.dataprepper.test.framework.DataPrepperTestRunner.BASE_PATH;
 
+@Disabled
 class ProcessorSwapPipelineIT {
     private static final Logger LOG = LoggerFactory.getLogger(ProcessorSwapPipelineIT.class);
     private static final String IN_MEMORY_IDENTIFIER = "ProcessorSwapPipelineIT";

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
@@ -20,6 +20,6 @@ public class BasicEventsTrackingTestProcessor extends BaseEventsTrackingProcesso
     private static final String PLUGIN_NAME = "basic_events_tracking_test";
 
     public BasicEventsTrackingTestProcessor() {
-        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP);
+        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP, -1);
     }
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/BasicEventsTrackingTestProcessor.java
@@ -18,8 +18,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class BasicEventsTrackingTestProcessor extends BaseEventsTrackingProcessor {
     private static final Map<String, AtomicInteger> PROCESSED_EVENTS_MAP = new ConcurrentHashMap<>();
     private static final String PLUGIN_NAME = "basic_events_tracking_test";
+    private static final int NUMBER_OF_PROCESS_WORKERS_NOT_CAPTURED = -1;
 
     public BasicEventsTrackingTestProcessor() {
-        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP, -1);
+        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP, NUMBER_OF_PROCESS_WORKERS_NOT_CAPTURED);
     }
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SingleThreadEventsTrackingTestProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SingleThreadEventsTrackingTestProcessor.java
@@ -5,9 +5,13 @@
 package org.opensearch.dataprepper.plugins;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.annotations.SingleThread;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.processor.Processor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,7 +25,22 @@ public class SingleThreadEventsTrackingTestProcessor extends BaseEventsTrackingP
     private static final String PLUGIN_NAME = "single_thread_events_tracking_test";
     private static final Map<String, AtomicInteger> PROCESSED_EVENTS_MAP = new ConcurrentHashMap<>();
 
+    private static final List<SingleThreadEventsTrackingTestProcessor> PROCESSORS = new ArrayList<>();
+
+    @DataPrepperPluginConstructor
+    public SingleThreadEventsTrackingTestProcessor(final PipelineDescription pipelineDescription) {
+        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP, pipelineDescription.getNumberOfProcessWorkers());
+        PROCESSORS.add(this);
+    }
+
+    /**
+     * This is used only for testing in the setup.
+     */
     public SingleThreadEventsTrackingTestProcessor() {
-        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP);
+        super(PLUGIN_NAME, PROCESSED_EVENTS_MAP, -1);
+    }
+
+    public static List<SingleThreadEventsTrackingTestProcessor> getProcessors() {
+        return PROCESSORS;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
@@ -238,7 +238,7 @@ public class PipelineTransformer {
                 // Only allow ZeroBuffer for single-threaded pipelines with no @SingleThread processors
                 if (processorThreads == 1 && !hasSingleThreadedProcessors) {
                     ((SupportsPipelineRunner) pipelineDefinedBuffer).setPipelineRunner(
-                            new PipelineRunnerImpl(pipeline, pipeline.getProcessorProvider()));
+                            new PipelineRunnerImpl(pipeline, pipeline.getSingleThreadUnsafeProcessorProvider()));
                 } else {
                     if (hasSingleThreadedProcessors) {
                         throw new IllegalStateException(

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/PipelineTransformer.java
@@ -238,7 +238,7 @@ public class PipelineTransformer {
                 // Only allow ZeroBuffer for single-threaded pipelines with no @SingleThread processors
                 if (processorThreads == 1 && !hasSingleThreadedProcessors) {
                     ((SupportsPipelineRunner) pipelineDefinedBuffer).setPipelineRunner(
-                            new PipelineRunnerImpl(pipeline));
+                            new PipelineRunnerImpl(pipeline, pipeline.getProcessorProvider()));
                 } else {
                     if (hasSingleThreadedProcessors) {
                         throw new IllegalStateException(

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
@@ -236,8 +236,11 @@ public class Pipeline {
                         }
                     }
             ).collect(Collectors.toList());
+            final ProcessorRegistry processorRegistry = new ProcessorRegistry(processors);
+            processorExecutorService.submit(new ProcessWorker(buffer, this, processorRegistry));
+
+            // This registry is for the zero buffer
             this.processorRegistry.swapProcessors(processors);
-            processorExecutorService.submit(new ProcessWorker(buffer, this));
         }
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
@@ -37,10 +37,12 @@ public class PipelineRunnerImpl implements PipelineRunner {
     final Counter invalidEventHandlesCounter;
     private final Pipeline pipeline;
     private final PluginMetrics pluginMetrics;
+    private final ProcessorProvider processorProvider;
 
-    public PipelineRunnerImpl(final Pipeline pipeline) {
+    public PipelineRunnerImpl(final Pipeline pipeline, final ProcessorProvider processorProvider) {
         this.pipeline = pipeline;
         this.pluginMetrics = PluginMetrics.fromNames("PipelineRunner", pipeline.getName());
+        this.processorProvider = processorProvider;
         this.invalidEventHandlesCounter = pluginMetrics.counter(INVALID_EVENT_HANDLES);
     }
 
@@ -49,7 +51,7 @@ public class PipelineRunnerImpl implements PipelineRunner {
         final Map.Entry<Collection, CheckpointState> recordsReadFromBuffer = readFromBuffer(getBuffer(), getPipeline());
         Collection records = recordsReadFromBuffer.getKey();
         final CheckpointState checkpointState = recordsReadFromBuffer.getValue();
-        List<Processor> currentProcessors = pipeline.getProcessorProvider().getProcessors();
+        List<Processor> currentProcessors = processorProvider.getProcessors();
         records = runProcessorsAndProcessAcknowledgements(currentProcessors, records);
         postToSink(getPipeline(), records);
         // Checkpoint the current batch read from the buffer after being processed by processors and sinks.

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/ProcessWorker.java
@@ -24,11 +24,12 @@ public class ProcessWorker implements Runnable {
 
     public ProcessWorker(
             final Buffer readBuffer,
-            final Pipeline pipeline) {
+            final Pipeline pipeline,
+            final ProcessorProvider processorProvider) {
         this.readBuffer = readBuffer;
-        this.processors = pipeline.getProcessorProvider().getProcessors();
+        this.processors = processorProvider.getProcessors();
         this.pipeline = pipeline;
-        this.pipelineRunner = new PipelineRunnerImpl(pipeline);
+        this.pipelineRunner = new PipelineRunnerImpl(pipeline, processorProvider);
     }
 
     @Override

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerTest.java
@@ -91,7 +91,7 @@ class PipelineRunnerTest {
     }
 
     private PipelineRunnerImpl createObjectUnderTest() {
-        return new PipelineRunnerImpl(pipeline);
+        return new PipelineRunnerImpl(pipeline, processorProvider);
     }
 
     @BeforeEach
@@ -379,7 +379,6 @@ class PipelineRunnerTest {
             when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
             when(pipeline.publishToSinks(anyCollection())).thenReturn(
                     Collections.singletonList(CompletableFuture.completedFuture(null)));
-            when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
             when(processorProvider.getProcessors()).thenReturn(processors);
 
             Map.Entry<Collection, CheckpointState> entry =
@@ -405,7 +404,6 @@ class PipelineRunnerTest {
             when(pipeline.getName()).thenReturn(MOCK_PIPELINE_NAME);
             when(pipeline.publishToSinks(anyCollection())).thenReturn(
                     Collections.singletonList(CompletableFuture.completedFuture(null)));
-            when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
             when(processorProvider.getProcessors()).thenReturn(processors);
 
             Map.Entry<Collection, CheckpointState> entry =

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/ProcessWorkerTest.java
@@ -42,14 +42,13 @@ public class ProcessWorkerTest {
         when(pipeline.isStopRequested()).thenReturn(false).thenReturn(true);
         when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(100));
         when(buffer.isEmpty()).thenReturn(true);
-        when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
     }
 
     private ProcessWorker createObjectUnderTest() {
         try (final MockedConstruction<PipelineRunnerImpl> ignored = mockConstruction(PipelineRunnerImpl.class, (mock, context) -> {
             pipelineRunner = mock;
         })) {
-            return new ProcessWorker(buffer, pipeline);
+            return new ProcessWorker(buffer, pipeline, processorProvider);
         }
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -145,7 +145,7 @@ public class AggregateProcessorITWithAcks {
         when(aggregateProcessorConfig.getOutputUnaggregatedEvents()).thenReturn(false);
         when(aggregateProcessorConfig.getIdentificationKeys()).thenReturn(identificationKeys);
         when(aggregateProcessorConfig.getWhenCondition()).thenReturn(null);
-        when(pipeline.getProcessorProvider()).thenReturn(processorProvider);
+        when(pipeline.getSingleThreadUnsafeProcessorProvider()).thenReturn(processorProvider);
         when(processorProvider.getProcessors()).thenReturn(processors);
 
         records = getRecords(testKey, testValue, acknowledgementSet);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorITWithAcks.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.core.acknowledgements.DefaultAcknowledgementSe
 import org.opensearch.dataprepper.core.pipeline.Pipeline;
 import org.opensearch.dataprepper.core.pipeline.ProcessWorker;
 import org.opensearch.dataprepper.core.pipeline.ProcessorProvider;
+import org.opensearch.dataprepper.core.pipeline.ProcessorRegistry;
 import org.opensearch.dataprepper.core.pipeline.common.FutureHelper;
 import org.opensearch.dataprepper.core.pipeline.common.FutureHelperResult;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
@@ -208,7 +209,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
 
             processWorker.run();
         }
@@ -239,7 +240,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
 
             processWorker.run();
         }
@@ -271,7 +272,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
 
             processWorker.run();
         }
@@ -303,7 +304,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
 
 
             processWorker.run();
@@ -331,7 +332,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -361,7 +362,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
 
             processWorker.run();
         }
@@ -418,7 +419,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -472,7 +473,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -502,7 +503,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -535,7 +536,7 @@ public class AggregateProcessorITWithAcks {
                     .thenReturn(futureHelperResult);
 
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -569,7 +570,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)
@@ -596,7 +597,7 @@ public class AggregateProcessorITWithAcks {
             futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
                     .thenReturn(futureHelperResult);
 
-            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline);
+            final ProcessWorker processWorker = new ProcessWorker(buffer, pipeline, new ProcessorRegistry(processors));
             processWorker.run();
         }
         await().atMost(TEST_TIMEOUT)


### PR DESCRIPTION
### Description

This reworks the recent code for the `ProcessorProvider` to create a provider per processor thread. 

With this fix, the processor swaps will not work correctly, but this is not complete anyway.

**New integration test**

This includes an integration test which fails on `main`.

The test exactly shows what I expected to see, which is that the last processor instance is used by all threads.

```
Expected: <1>
     but: was <0>
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
		at org.opensearch.dataprepper.integration.ProcessorValidationIT.lambda$verifySingleThreadUsage$4(ProcessorValidationIT.java:217)
		at org.junit.jupiter.api.AssertAll.lambda$assertAll$0(AssertAll.java:68)
		at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
		at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
		at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
		at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
		at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
		at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
		at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
		at org.junit.jupiter.api.AssertAll.assertAll(AssertAll.java:77)
		... 133 more
	Suppressed: java.lang.AssertionError: 
Expected: <1>
     but: was <0>
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
		at org.opensearch.dataprepper.integration.ProcessorValidationIT.lambda$verifySingleThreadUsage$5(ProcessorValidationIT.java:218)
		at org.junit.jupiter.api.AssertAll.lambda$assertAll$0(AssertAll.java:68)
		at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
		at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
		at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
		at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
		at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
		at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
		at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
		at org.junit.jupiter.api.AssertAll.assertAll(AssertAll.java:77)
		... 133 more
	Suppressed: java.lang.AssertionError: 
Expected: <1>
     but: was <0>
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
		at org.opensearch.dataprepper.integration.ProcessorValidationIT.lambda$verifySingleThreadUsage$6(ProcessorValidationIT.java:219)
		at org.junit.jupiter.api.AssertAll.lambda$assertAll$0(AssertAll.java:68)
		at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
		at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
		at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
		at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
		at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
		at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
		at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
		at org.junit.jupiter.api.AssertAll.assertAll(AssertAll.java:77)
		... 133 more
	Suppressed: java.lang.AssertionError: 
Expected: <1>
     but: was <4>
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
		at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
		at org.opensearch.dataprepper.integration.ProcessorValidationIT.lambda$verifySingleThreadUsage$7(ProcessorValidationIT.java:220)
		at org.junit.jupiter.api.AssertAll.lambda$assertAll$0(AssertAll.java:68)
		at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
		at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
		at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
		at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
		at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
		at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
		at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
		at org.junit.jupiter.api.AssertAll.assertAll(AssertAll.java:77)
		... 133 more
```
 
### Issues Resolved

Resolves #5901
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
