### PR TITLE
Added custom headers to cloudwatch logs sink

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/README.md
+++ b/data-prepper-plugins/cloudwatch-logs/README.md
@@ -30,7 +30,7 @@ pipeline:
           max_request_size: 1mb
           retry_count: 5
           back_off_time: 500ms
-        custom_headers:
+        header_overrides:
           X-Custom-Header: "custom-value"
           X-Request-ID: "request-123"
           X-Source: "dataprepper"
@@ -60,7 +60,7 @@ pipeline:
 
 - `back_off_time` (Optional) : A string representing the amount of time in milliseconds between errored transmission re-attempts. Defaults to "500ms". (Min = "500ms", Max = "1000ms")
 
-- `custom_headers` (Optional) : A string map representing custom HTTP headers to include in CloudWatch Logs requests.
+- `header_overrides` (Optional) : A string map representing custom HTTP headers to include in CloudWatch Logs requests.
 
 ## Buffer Type Configuration
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
@@ -37,9 +37,10 @@ public final class CloudWatchLogsClientFactory {
     public static CloudWatchLogsClient createCwlClient(final AwsConfig awsConfig,
             final AwsCredentialsSupplier awsCredentialsSupplier,
             final Map<String, String> customHeaders) {
-        final AwsCredentialsProvider awsCredentialsProvider = awsConfig != null
-                ? awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig))
-                : awsCredentialsSupplier.getProvider(AwsCredentialsOptions.builder().build());
+        final AwsCredentialsOptions awsCredentialsOptions = awsConfig != null
+                ? convertToCredentialOptions(awsConfig)
+                : AwsCredentialsOptions.defaultOptions();
+        final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
         Region region = awsConfig != null ? awsConfig.getAwsRegion() : awsCredentialsSupplier.getDefaultRegion().get();
 
         if (awsCredentialsProvider == null || region == null) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
@@ -12,21 +12,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import jakarta.validation.Constraint;
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
-import jakarta.validation.Payload;
 
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public class CloudWatchLogsSinkConfig {
     public static final int DEFAULT_RETRY_COUNT = 5;
@@ -62,10 +52,10 @@ public class CloudWatchLogsSinkConfig {
     @Max(50)
     private int workers = DEFAULT_NUM_WORKERS;
 
-    @JsonProperty("custom_headers")
+    @JsonProperty("header_overrides")
     @Size(max = 10, message = "Maximum 10 custom headers allowed")
     @ValidCustomHeaders
-    private Map<String, String> customHeaders = new HashMap<>();
+    private Map<String, String> headerOverrides = new HashMap<>();
 
     public AwsConfig getAwsConfig() {
         return awsConfig;
@@ -95,81 +85,8 @@ public class CloudWatchLogsSinkConfig {
         return workers;
     }
 
-    public Map<String, String> getCustomHeaders() {
-        return customHeaders;
+    public Map<String, String> getHeaderOverrides() {
+        return headerOverrides;
     }
 
-}
-
-/**
- * Custom validation annotation for HTTP headers.
- */
-@Documented
-@Constraint(validatedBy = ValidCustomHeaders.CustomHeadersValidator.class)
-@Target({ElementType.FIELD})
-@Retention(RetentionPolicy.RUNTIME)
-@interface ValidCustomHeaders {
-    String message() default "Invalid custom headers configuration";
-    Class<?>[] groups() default {};
-    Class<? extends Payload>[] payload() default {};
-    
-    /**
-     * Custom validator for HTTP headers.
-     */
-    class CustomHeadersValidator implements ConstraintValidator<ValidCustomHeaders, Map<String, String>> {
-        
-        private static final Pattern VALID_HEADER_NAME_PATTERN = 
-            Pattern.compile("^[!#$%&'*+\\-.0-9A-Z^_`a-z|~]+$");
-        
-        @Override
-        public void initialize(ValidCustomHeaders constraintAnnotation) {
-            // No initialization needed
-        }
-        
-        @Override
-        public boolean isValid(Map<String, String> headers, ConstraintValidatorContext context) {
-            if (headers == null || headers.isEmpty()) {
-                return true; // Empty headers are valid
-            }
-            
-            for (Map.Entry<String, String> entry : headers.entrySet()) {
-                String headerName = entry.getKey();
-                String headerValue = entry.getValue();
-                
-                // Check for null header name
-                if (headerName == null) {
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate("Header name cannot be null")
-                           .addConstraintViolation();
-                    return false;
-                }
-                
-                // Check for null header value
-                if (headerValue == null) {
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate("Header '" + headerName + "' has an empty value")
-                           .addConstraintViolation();
-                    return false;
-                }
-                
-                // Validate header name format
-                if (!VALID_HEADER_NAME_PATTERN.matcher(headerName).matches()) {
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate("Invalid header name '" + headerName + "'")
-                           .addConstraintViolation();
-                    return false;
-                }
-                
-                // Validate header value is not empty
-                if (headerValue.trim().isEmpty()) {
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate("Header '" + headerName + "' has an empty value")
-                           .addConstraintViolation();
-                    return false;
-                }
-            }
-            
-            return true;
-        }
-    }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ValidCustomHeaders.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ValidCustomHeaders.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Custom validation annotation for HTTP headers.
+ */
+@Documented
+@Constraint(validatedBy = ValidCustomHeaders.CustomHeadersValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCustomHeaders {
+    String message() default "Invalid custom headers configuration";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    
+    /**
+     * Custom validator for HTTP headers.
+     */
+    class CustomHeadersValidator implements ConstraintValidator<ValidCustomHeaders, Map<String, String>> {
+        
+        private static final Pattern VALID_HEADER_NAME_PATTERN = 
+            Pattern.compile("^[!#$%&'*+\\-.0-9A-Z^_`a-z|~]+$");
+        
+        @Override
+        public void initialize(ValidCustomHeaders constraintAnnotation) {
+            // No initialization needed
+        }
+        
+        @Override
+        public boolean isValid(Map<String, String> headers, ConstraintValidatorContext context) {
+            if (headers == null || headers.isEmpty()) {
+                return true; // Empty headers are valid
+            }
+            
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                String headerName = entry.getKey();
+                String headerValue = entry.getValue();
+                
+                // Check for null header name
+                if (headerName == null) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate("Header name cannot be null")
+                           .addConstraintViolation();
+                    return false;
+                }
+                
+                // Check for null header value
+                if (headerValue == null) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate("Header '" + headerName + "' has an empty value")
+                           .addConstraintViolation();
+                    return false;
+                }
+                
+                // Validate header name format
+                if (!VALID_HEADER_NAME_PATTERN.matcher(headerName).matches()) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate("Invalid header name '" + headerName + "'")
+                           .addConstraintViolation();
+                    return false;
+                }
+                
+                // Validate header value is not empty
+                if (headerValue.trim().isEmpty()) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate("Header '" + headerName + "' has an empty value")
+                           .addConstraintViolation();
+                    return false;
+                }
+            }
+            
+            return true;
+        }
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -47,7 +47,7 @@ class CloudWatchLogsSinkTest {
     private AwsCredentialsSupplier mockCredentialSupplier;
     private AwsConfig mockAwsConfig;
     private ThresholdConfig thresholdConfig;
-    private Map<String, String> mockCustomHeaders;
+    private Map<String, String> mockHeaderOverrides;
     private CloudWatchLogsMetrics mockCloudWatchLogsMetrics;
     private CloudWatchLogsClient mockClient;
     private static final String TEST_LOG_GROUP = "testLogGroup";
@@ -64,14 +64,14 @@ class CloudWatchLogsSinkTest {
         mockCredentialSupplier = mock(AwsCredentialsSupplier.class);
         mockAwsConfig = mock(AwsConfig.class);
         thresholdConfig = new ThresholdConfig();
-        mockCustomHeaders = new HashMap<>();
-        mockCustomHeaders.put("X-Test-Header", "test-value");
+        mockHeaderOverrides = new HashMap<>();
+        mockHeaderOverrides.put("X-Test-Header", "test-value");
         mockCloudWatchLogsMetrics = mock(CloudWatchLogsMetrics.class);
         mockClient = mock(CloudWatchLogsClient.class);
 
         when(mockCloudWatchLogsSinkConfig.getAwsConfig()).thenReturn(mockAwsConfig);
         when(mockCloudWatchLogsSinkConfig.getThresholdConfig()).thenReturn(thresholdConfig);
-        when(mockCloudWatchLogsSinkConfig.getCustomHeaders()).thenReturn(new HashMap<>());
+        when(mockCloudWatchLogsSinkConfig.getHeaderOverrides()).thenReturn(new HashMap<>());
         when(mockCloudWatchLogsSinkConfig.getLogGroup()).thenReturn(TEST_LOG_GROUP);
         when(mockCloudWatchLogsSinkConfig.getLogStream()).thenReturn(TEST_LOG_STREAM);
         when(mockCloudWatchLogsSinkConfig.getMaxRetries()).thenReturn(3);
@@ -160,9 +160,9 @@ class CloudWatchLogsSinkTest {
     }
 
     @Test
-    void WHEN_custom_headers_is_empty_THEN_empty_map_is_passed_to_client_factory() {
+    void WHEN_header_overrides_is_empty_THEN_empty_map_is_passed_to_client_factory() {
         Map<String, String> emptyHeaders = new HashMap<>();
-        when(mockCloudWatchLogsSinkConfig.getCustomHeaders()).thenReturn(emptyHeaders);
+        when(mockCloudWatchLogsSinkConfig.getHeaderOverrides()).thenReturn(emptyHeaders);
         
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
@@ -179,8 +179,8 @@ class CloudWatchLogsSinkTest {
     }
 
     @Test
-    void WHEN_custom_headers_is_provided_THEN_headers_are_passed_to_client_factory() {
-        when(mockCloudWatchLogsSinkConfig.getCustomHeaders()).thenReturn(mockCustomHeaders);
+    void WHEN_header_overrides_is_provided_THEN_headers_are_passed_to_client_factory() {
+        when(mockCloudWatchLogsSinkConfig.getHeaderOverrides()).thenReturn(mockHeaderOverrides);
         
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
@@ -192,13 +192,13 @@ class CloudWatchLogsSinkTest {
             mockedStatic.verify(() -> CloudWatchLogsClientFactory.createCwlClient(
                     eq(mockAwsConfig), 
                     eq(mockCredentialSupplier), 
-                    eq(mockCustomHeaders)));
+                    eq(mockHeaderOverrides)));
         }
     }
 
     @Test
-    void WHEN_sink_initialization_with_custom_headers_THEN_sink_is_ready() {
-        when(mockCloudWatchLogsSinkConfig.getCustomHeaders()).thenReturn(mockCustomHeaders);
+    void WHEN_sink_initialization_with_header_overrides_THEN_sink_is_ready() {
+        when(mockCloudWatchLogsSinkConfig.getHeaderOverrides()).thenReturn(mockHeaderOverrides);
         
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactoryTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactoryTest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
 
 class CloudWatchLogsClientFactoryTest {
     private AwsConfig mockAwsConfig;

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,29 +105,29 @@ class CloudWatchLogsSinkConfigTest {
     }
 
     @Test
-    void GIVEN_new_sink_config_WHEN_get_custom_headers_called_SHOULD_return_empty_map() {
-        assertThat(new CloudWatchLogsSinkConfig().getCustomHeaders(), notNullValue());
-        assertThat(new CloudWatchLogsSinkConfig().getCustomHeaders().isEmpty(), equalTo(true));
+    void GIVEN_new_sink_config_WHEN_get_header_overrides_called_SHOULD_return_empty_map() {
+        assertThat(new CloudWatchLogsSinkConfig().getHeaderOverrides(), notNullValue());
+        assertThat(new CloudWatchLogsSinkConfig().getHeaderOverrides().isEmpty(), equalTo(true));
     }
 
     @Test
-    void GIVEN_custom_headers_set_WHEN_get_custom_headers_called_SHOULD_return_configured_value() throws NoSuchFieldException, IllegalAccessException {
+    void GIVEN_header_overrides_set_WHEN_get_header_overrides_called_SHOULD_return_configured_value() throws NoSuchFieldException, IllegalAccessException {
         Map<String, String> headers = new HashMap<>();
         headers.put("X-Custom-Header", "custom-value");
         headers.put("X-Request-ID", "request-123");
 
-        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "customHeaders", headers);
+        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "headerOverrides", headers);
 
-        assertThat(cloudWatchLogsSinkConfig.getCustomHeaders(), equalTo(headers));
+        assertThat(cloudWatchLogsSinkConfig.getHeaderOverrides(), equalTo(headers));
     }
 
     @Test
-    void GIVEN_empty_custom_headers_WHEN_get_custom_headers_called_SHOULD_return_empty_headers() throws NoSuchFieldException, IllegalAccessException {
+    void GIVEN_empty_header_overrides_WHEN_get_header_overrides_called_SHOULD_return_empty_headers() throws NoSuchFieldException, IllegalAccessException {
         Map<String, String> emptyHeaders = new HashMap<>();
-        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "customHeaders", emptyHeaders);
+        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "headerOverrides", emptyHeaders);
 
-        assertThat(cloudWatchLogsSinkConfig.getCustomHeaders(), equalTo(emptyHeaders));
-        assertThat(cloudWatchLogsSinkConfig.getCustomHeaders().isEmpty(), equalTo(true));
+        assertThat(cloudWatchLogsSinkConfig.getHeaderOverrides(), equalTo(emptyHeaders));
+        assertThat(cloudWatchLogsSinkConfig.getHeaderOverrides().isEmpty(), equalTo(true));
     }
 
     @Test
@@ -140,29 +139,29 @@ class CloudWatchLogsSinkConfigTest {
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "logStream", LOG_STREAM);
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "thresholdConfig", thresholdConfig);
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "awsConfig", awsConfig);
-        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "customHeaders", headers);
+        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "headerOverrides", headers);
 
         assertThat(cloudWatchLogsSinkConfig.getLogGroup(), equalTo(LOG_GROUP));
         assertThat(cloudWatchLogsSinkConfig.getLogStream(), equalTo(LOG_STREAM));
         assertThat(cloudWatchLogsSinkConfig.getAwsConfig(), equalTo(awsConfig));
         assertThat(cloudWatchLogsSinkConfig.getThresholdConfig(), equalTo(thresholdConfig));
-        assertThat(cloudWatchLogsSinkConfig.getCustomHeaders(), equalTo(headers));
+        assertThat(cloudWatchLogsSinkConfig.getHeaderOverrides(), equalTo(headers));
     }
 
     @Test
-    void GIVEN_sink_config_without_custom_headers_WHEN_accessed_SHOULD_maintain_backward_compatibility() throws NoSuchFieldException, IllegalAccessException {
+    void GIVEN_sink_config_without_header_overrides_WHEN_accessed_SHOULD_maintain_backward_compatibility() throws NoSuchFieldException, IllegalAccessException {
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "logGroup", LOG_GROUP);
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "logStream", LOG_STREAM);
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "thresholdConfig", thresholdConfig);
         ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "awsConfig", awsConfig);
 
-        // Verify that existing functionality works without custom headers
+        // Verify that existing functionality works without header overrides
         assertThat(cloudWatchLogsSinkConfig.getLogGroup(), equalTo(LOG_GROUP));
         assertThat(cloudWatchLogsSinkConfig.getLogStream(), equalTo(LOG_STREAM));
         assertThat(cloudWatchLogsSinkConfig.getAwsConfig(), equalTo(awsConfig));
         assertThat(cloudWatchLogsSinkConfig.getThresholdConfig(), equalTo(thresholdConfig));
-        assertThat(cloudWatchLogsSinkConfig.getCustomHeaders(), notNullValue());
-        assertThat(cloudWatchLogsSinkConfig.getCustomHeaders().isEmpty(), equalTo(true));
+        assertThat(cloudWatchLogsSinkConfig.getHeaderOverrides(), notNullValue());
+        assertThat(cloudWatchLogsSinkConfig.getHeaderOverrides().isEmpty(), equalTo(true));
         assertThat(cloudWatchLogsSinkConfig.getWorkers(), equalTo(CloudWatchLogsSinkConfig.DEFAULT_NUM_WORKERS));
         assertThat(cloudWatchLogsSinkConfig.getMaxRetries(), equalTo(CloudWatchLogsSinkConfig.DEFAULT_RETRY_COUNT));
     }
@@ -274,7 +273,7 @@ class CloudWatchLogsSinkConfigTest {
 
     // Size Validation Tests
     @Test
-    void GIVEN_exactly_10_custom_headers_WHEN_accessed_THEN_should_be_valid() throws Exception {
+    void GIVEN_exactly_10_header_overrides_WHEN_accessed_THEN_should_be_valid() throws Exception {
         CloudWatchLogsSinkConfig config = new CloudWatchLogsSinkConfig();
         Map<String, String> exactlyTenHeaders = new HashMap<>();
         
@@ -282,14 +281,14 @@ class CloudWatchLogsSinkConfigTest {
             exactlyTenHeaders.put("Header-" + i, "value-" + i);
         }
         
-        ReflectivelySetField.setField(config.getClass(), config, "customHeaders", exactlyTenHeaders);
+        ReflectivelySetField.setField(config.getClass(), config, "headerOverrides", exactlyTenHeaders);
         
-        assertThat(config.getCustomHeaders(), aMapWithSize(10));
-        assertThat(config.getCustomHeaders().size(), lessThanOrEqualTo(10));
+        assertThat(config.getHeaderOverrides(), aMapWithSize(10));
+        assertThat(config.getHeaderOverrides().size(), lessThanOrEqualTo(10));
     }
 
     @Test
-    void GIVEN_less_than_10_custom_headers_WHEN_accessed_THEN_should_be_valid() throws Exception {
+    void GIVEN_less_than_10_header_overrides_WHEN_accessed_THEN_should_be_valid() throws Exception {
         CloudWatchLogsSinkConfig config = new CloudWatchLogsSinkConfig();
         Map<String, String> fiveHeaders = new HashMap<>();
         
@@ -297,17 +296,17 @@ class CloudWatchLogsSinkConfigTest {
             fiveHeaders.put("Header-" + i, "value-" + i);
         }
         
-        ReflectivelySetField.setField(config.getClass(), config, "customHeaders", fiveHeaders);
+        ReflectivelySetField.setField(config.getClass(), config, "headerOverrides", fiveHeaders);
         
-        assertThat(config.getCustomHeaders(), aMapWithSize(5));
-        assertThat(config.getCustomHeaders().size(), lessThanOrEqualTo(10));
+        assertThat(config.getHeaderOverrides(), aMapWithSize(5));
+        assertThat(config.getHeaderOverrides().size(), lessThanOrEqualTo(10));
     }
 
     @Test
-    void GIVEN_default_config_WHEN_accessed_THEN_custom_headers_should_be_empty() {
+    void GIVEN_default_config_WHEN_accessed_THEN_header_overrides_should_be_empty() {
         CloudWatchLogsSinkConfig config = new CloudWatchLogsSinkConfig();
         
-        assertThat(config.getCustomHeaders(), aMapWithSize(0));
-        assertThat(config.getCustomHeaders().size(), lessThanOrEqualTo(10));
+        assertThat(config.getHeaderOverrides(), aMapWithSize(0));
+        assertThat(config.getHeaderOverrides().size(), lessThanOrEqualTo(10));
     }
 }


### PR DESCRIPTION
### Description
This change adds support for custom HTTP headers in the CloudWatch Logs sink plugin. Users can now configure custom headers that will be included in all CloudWatch Logs API requests. The implementation includes:

• New custom_headers configuration option in CloudWatchLogsSinkConfig
• Updated CloudWatchLogsClientFactory to accept and apply custom headers to the AWS SDK client
• Comprehensive validation for header names and values following HTTP standards
• Maximum limit of 10 custom headers to prevent configuration bloat
• Logging of configured headers (names only, values redacted for security)
• Full backward compatibility - existing configurations continue to work unchanged

### Issues Resolved
Resolves #5905 

### Check List
• [x] New functionality includes testing.
  • Added comprehensive unit tests for configuration validation
  • Added tests for client factory header integration
  • Added tests for sink initialization with custom headers
• [ ] New functionality has a documentation issue. Please link to it in this PR.
  • [x] New functionality has javadoc added
• [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).