### PR TITLE
Updates several dependencies to address CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ allprojects {
     }
 
     checkstyle {
-        toolVersion = '10.12.3'
+        toolVersion = '10.26.1'
     }
 }
 
@@ -147,9 +147,9 @@ subprojects {
             }
             implementation('net.minidev:json-smart') {
                 version {
-                    require '2.5.0'
+                    require '2.5.2'
                 }
-                because 'CVE from transitive dependencies'
+                because 'CVE from transitive dependencies, including CVE-2024-57699'
             }
             implementation('org.jetbrains.kotlin:kotlin-stdlib') {
                 version {
@@ -217,6 +217,12 @@ subprojects {
                 }
                 because 'CVE-2024-25710, CVE-2024-26308'
             }
+            implementation('commons-beanutils:commons-beanutils') {
+                version {
+                    require '1.11.0'
+                }
+                because 'CVE-2025-48734'
+            }
         }
     }
 
@@ -224,11 +230,11 @@ subprojects {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty') {
                 if (details.requested.name == 'netty') {
-                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.108.Final'
-                    details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.123.Final'
+                    details.because 'Fixes CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.108.Final'
-                    details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                    details.useVersion '4.1.123.Final'
+                    details.because 'Fixes CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
                 details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -32,16 +32,16 @@ dependencies {
     implementation project(':data-prepper-plugins:encryption-plugin')
     // bump io.confluent:* dependencies correspondingly when bumping org.apache.kafka.*
     // https://docs.confluent.io/platform/current/release-notes/index.html
-    implementation 'org.apache.kafka:kafka-clients:3.6.1'
-    implementation 'org.apache.kafka:connect-json:3.6.1'
+    implementation 'org.apache.kafka:kafka-clients:3.9.1'
+    implementation 'org.apache.kafka:connect-json:3.9.1'
     implementation project(':data-prepper-plugins:http-common')
     implementation libs.avro.core
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
     implementation libs.commons.lang3
-    implementation 'io.confluent:kafka-avro-serializer:7.6.0'
-    implementation 'io.confluent:kafka-json-schema-serializer:7.6.0'
-    implementation 'io.confluent:kafka-schema-registry-client:7.6.0'
+    implementation 'io.confluent:kafka-avro-serializer:7.9.1'
+    implementation 'io.confluent:kafka-json-schema-serializer:7.9.1'
+    implementation 'io.confluent:kafka-schema-registry-client:7.9.1'
     implementation 'software.amazon.awssdk:sts'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:kafka'
@@ -77,8 +77,8 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
     integrationTestImplementation testLibs.junit.vintage
-    integrationTestImplementation 'io.confluent:kafka-schema-registry:7.6.0'
-    integrationTestImplementation ('io.confluent:kafka-schema-registry:7.6.0:tests') {
+    integrationTestImplementation 'io.confluent:kafka-schema-registry:7.9.1'
+    integrationTestImplementation ('io.confluent:kafka-schema-registry:7.9.1:tests') {
         exclude group: 'org.glassfish.jersey.containers', module: 'jersey-container-servlet'
         exclude group: 'org.glassfish.jersey.inject', module: 'jersey-hk2'
         exclude group: 'org.glassfish.jersey.ext', module: 'jersey-bean-validation'

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,7 +61,7 @@ dependencyResolutionManagement {
             library('commons-io', 'commons-io', 'commons-io').version('2.15.1')
             library('commons-codec', 'commons-codec', 'commons-codec').version('1.16.0')
             library('commons-compress', 'org.apache.commons', 'commons-compress').version('1.24.0')
-            version('parquet', '1.15.1')
+            version('parquet', '1.15.2')
             library('parquet-common', 'org.apache.parquet', 'parquet-common').versionRef('parquet')
             library('parquet-avro', 'org.apache.parquet', 'parquet-avro').versionRef('parquet')
             library('parquet-column', 'org.apache.parquet', 'parquet-column').versionRef('parquet')


### PR DESCRIPTION
### Description

Resolves the following CVEs by updating dependencies:

* CVE-2025-46762 - Parquet 1.15.2
* CVE-2025-48734 - commons-beanutils 1.11.0 and Checkstyle 10.26.1
* CVE-2024-57699 - json-smart 2.5.2
* CVE-2025-24970 - Netty 4.1.123
* CVE-2025-27817 - Apache Kafka 3.9.1 and Confluent Kafka 7.9.1

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
