### PR TITLE
S3 scheduled scan should consider start time on subsequent scans

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplier.java
@@ -183,6 +183,9 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                                                  final LocalDateTime endDateTime,
                                                  final boolean isFirstScan) {
         if (!isFirstScan && schedulingOptions != null) {
+            if (startDateTime != null) {
+                return lastModifiedTime.isAfter(startDateTime);
+            }
             return true;
         } else if (Objects.isNull(startDateTime) && Objects.isNull(endDateTime)) {
             return true;


### PR DESCRIPTION
### Description
Previously, it was possible for subsequent s3 scans to ignore the start_time or range during scheduled scan so that old objects could be processed. This change just checks start time in all scan cases to ensure no older objects are discovered on subsequent scans
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
