### PR TITLE
fixes OTLP sink metric names to use dot notation instead of underscores

### DIFF
--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetricsTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetricsTest.java
@@ -90,18 +90,18 @@ class OtlpSinkMetricsTest {
     void testRecordResponseCodeCounters() {
         // 5xx
         sinkMetrics.recordResponseCode(503);
-        verify(pluginMetrics).counter("http_5xx_responses");
+        verify(pluginMetrics).counter("http5xxResponses");
         verify(counterMock).increment();
 
         // 4xx
         sinkMetrics.recordResponseCode(404);
-        verify(pluginMetrics).counter("http_4xx_responses");
+        verify(pluginMetrics).counter("http4xxResponses");
         // total increments called twice so far
         verify(counterMock, times(2)).increment();
 
         // 2xx
         sinkMetrics.recordResponseCode(200);
-        verify(pluginMetrics).counter("http_2xx_responses");
+        verify(pluginMetrics).counter("http2xxResponses");
         verify(counterMock, times(3)).increment();
     }
 


### PR DESCRIPTION
### Description
This PR updates the OTLP sink metrics to use dot notation (.) instead of underscore (_) in metric names.
This aligns with the convention used across other Data Prepper plugins and improves consistency and compatibility with metric backends that treat dot-separated tokens as hierarchy.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
