### PR TITLE
Adds a null check when reading an S3EventNotification for records. So…

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParser.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParser.java
@@ -20,7 +20,7 @@ public class S3EventNotificationParser implements S3NotificationParser {
             final JsonNode eventNode = getS3EventNode(parsedNode, objectMapper);
 
             final S3EventNotification s3EventNotification = objectMapper.treeToValue(eventNode, S3EventNotification.class);
-            if (s3EventNotification.getRecords() != null) {
+            if (s3EventNotification != null && s3EventNotification.getRecords() != null) {
                 return new ParsedMessage(message, s3EventNotification.getRecords());
             } else {
                 LOG.debug("SQS message with ID:{} does not have any S3 event notification records.", message.messageId());


### PR DESCRIPTION
### Description

Some recent change has `SqsWorkerTest` failing. resulted in `ObjectMapper::treeToValue` return null for an empty string.
 
```
SqsWorkerTest > processSqsMessages_should_not_interact_with_S3Service_if_input_is_not_valid_JSON(String) > [1]  FAILED
    java.lang.NullPointerException: Cannot invoke "org.opensearch.dataprepper.plugins.source.s3.S3EventNotification.getRecords()" because "s3EventNotification" is null

SqsWorkerTest > WithSuccessfulDeletion > processSqsMessages_should_invoke_delete_if_input_is_not_valid_JSON_and_delete_on_error(String) > [1]  FAILED
    java.lang.NullPointerException: Cannot invoke "org.opensearch.dataprepper.plugins.source.s3.S3EventNotification.getRecords()" because "s3EventNotification" is null
```

Upon debugging I see that `objectMapper.treeToValue(eventNode, S3EventNotification.class);` is being called with an empty string and returning `null`.

The solution is to add a null check.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
