### PR TITLE
Updates the Postgresql JDBC driver to 42.7.1 to fix CVE-2025-49146.

### DIFF
--- a/data-prepper-plugins/rds-source/build.gradle
+++ b/data-prepper-plugins/rds-source/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     implementation 'com.zendesk:mysql-binlog-connector-java:0.29.2'
     implementation 'com.mysql:mysql-connector-j:8.4.0'
-    implementation 'org.postgresql:postgresql:42.7.4'
+    implementation 'org.postgresql:postgresql:42.7.7'
 
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'


### PR DESCRIPTION
### Description

Updates the Postgresql JDBC driver to 42.7.1 to fix CVE-2025-49146.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
