### PR TITLE
Add endpoint override support to CloudWatch Logs sink

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/README.md
+++ b/data-prepper-plugins/cloudwatch-logs/README.md
@@ -34,6 +34,7 @@ pipeline:
           X-Custom-Header: "custom-value"
           X-Request-ID: "request-123"
           X-Source: "dataprepper"
+        endpoint: "https://logs.us-west-2.amazonaws.com"
 ```
 
 ## AWS Configuration
@@ -61,6 +62,8 @@ pipeline:
 - `back_off_time` (Optional) : A string representing the amount of time in milliseconds between errored transmission re-attempts. Defaults to "500ms". (Min = "500ms", Max = "1000ms")
 
 - `header_overrides` (Optional) : A string map representing custom HTTP headers to include in CloudWatch Logs requests.
+
+- `endpoint` (Optional) : A string representing a custom CloudWatch Logs endpoint URL to override the default service endpoint.
 
 ## Buffer Type Configuration
 

--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
@@ -140,7 +140,7 @@ public class CloudWatchLogsIT {
         when(awsConfig.getAwsStsExternalId()).thenReturn(null);
         when(awsConfig.getAwsStsHeaderOverrides()).thenReturn(null);
         when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
-        cloudWatchLogsClient = CloudWatchLogsClientFactory.createCwlClient(awsConfig, awsCredentialsSupplier);
+        cloudWatchLogsClient = CloudWatchLogsClientFactory.createCwlClient(awsConfig, awsCredentialsSupplier, new HashMap<>(), null);
         logGroupName = System.getProperty("tests.cloudwatch.log_group");
         logStreamName = createLogStream(logGroupName);
         pluginMetrics = mock(PluginMetrics.class);

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -71,7 +71,7 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
         if (awsConfig == null && awsCredentialsSupplier == null) {
             throw new RuntimeException("Missing awsConfig and awsCredentialsSupplier");
         }
-        CloudWatchLogsClient cloudWatchLogsClient = CloudWatchLogsClientFactory.createCwlClient(awsConfig, awsCredentialsSupplier, headerOverrides);
+        CloudWatchLogsClient cloudWatchLogsClient = CloudWatchLogsClientFactory.createCwlClient(awsConfig, awsCredentialsSupplier, headerOverrides, cloudWatchLogsSinkConfig.getEndpoint());
         if (cloudWatchLogsClient == null) {
             throw new RuntimeException("cloudWatchLogsClient is null");
         }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfig.java
@@ -57,6 +57,9 @@ public class CloudWatchLogsSinkConfig {
     @ValidCustomHeaders
     private Map<String, String> headerOverrides = new HashMap<>();
 
+    @JsonProperty("endpoint")
+    private String endpoint;
+
     public AwsConfig getAwsConfig() {
         return awsConfig;
     }
@@ -87,6 +90,10 @@ public class CloudWatchLogsSinkConfig {
 
     public Map<String, String> getHeaderOverrides() {
         return headerOverrides;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
     }
 
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -100,7 +100,7 @@ class CloudWatchLogsSinkTest {
     void WHEN_sink_is_initialized_THEN_sink_is_ready_returns_true() {
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();
@@ -115,7 +115,7 @@ class CloudWatchLogsSinkTest {
         when(mockCloudWatchLogsSinkConfig.getAwsConfig()).thenReturn(null);
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             assertThrows(RuntimeException.class, ()-> getTestCloudWatchSink());
@@ -126,7 +126,7 @@ class CloudWatchLogsSinkTest {
     void WHEN_given_sample_empty_records_THEN_records_are_processed() {
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();
@@ -145,7 +145,7 @@ class CloudWatchLogsSinkTest {
     void WHEN_given_sample_empty_records_THEN_records_are_not_processed() {
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();
@@ -166,7 +166,7 @@ class CloudWatchLogsSinkTest {
         
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();
@@ -174,7 +174,8 @@ class CloudWatchLogsSinkTest {
             mockedStatic.verify(() -> CloudWatchLogsClientFactory.createCwlClient(
                     eq(mockAwsConfig), 
                     eq(mockCredentialSupplier), 
-                    eq(emptyHeaders)));
+                    eq(emptyHeaders),
+                    any()));
         }
     }
 
@@ -184,7 +185,7 @@ class CloudWatchLogsSinkTest {
         
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();
@@ -192,7 +193,8 @@ class CloudWatchLogsSinkTest {
             mockedStatic.verify(() -> CloudWatchLogsClientFactory.createCwlClient(
                     eq(mockAwsConfig), 
                     eq(mockCredentialSupplier), 
-                    eq(mockHeaderOverrides)));
+                    eq(mockHeaderOverrides),
+                    any()));
         }
     }
 
@@ -202,7 +204,7 @@ class CloudWatchLogsSinkTest {
         
         try(MockedStatic<CloudWatchLogsClientFactory> mockedStatic = mockStatic(CloudWatchLogsClientFactory.class)) {
             mockedStatic.when(() -> CloudWatchLogsClientFactory.createCwlClient(any(AwsConfig.class),
-                            any(AwsCredentialsSupplier.class), any()))
+                            any(AwsCredentialsSupplier.class), any(), any()))
                     .thenReturn(mockClient);
 
             CloudWatchLogsSink testCloudWatchSink = getTestCloudWatchSink();

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/CloudWatchLogsSinkConfigTest.java
@@ -309,4 +309,17 @@ class CloudWatchLogsSinkConfigTest {
         assertThat(config.getHeaderOverrides(), aMapWithSize(0));
         assertThat(config.getHeaderOverrides().size(), lessThanOrEqualTo(10));
     }
+
+    @Test
+    void GIVEN_new_sink_config_WHEN_get_endpoint_called_SHOULD_return_null() {
+        assertThat(new CloudWatchLogsSinkConfig().getEndpoint(), equalTo(null));
+    }
+
+    @Test
+    void GIVEN_endpoint_configured_SHOULD_return_the_configured_value() throws NoSuchFieldException, IllegalAccessException {
+        String testEndpoint = "https://logs.us-west-2.amazonaws.com";
+        
+        ReflectivelySetField.setField(cloudWatchLogsSinkConfig.getClass(), cloudWatchLogsSinkConfig, "endpoint", testEndpoint);
+        assertThat(cloudWatchLogsSinkConfig.getEndpoint(), equalTo(testEndpoint));
+    }
 }


### PR DESCRIPTION
### Description
Adds optional `endpoint` configuration property to CloudWatch Logs sink plugin to allow overriding the default CloudWatch Logs service endpoint.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
