### PR TITLE
Fix JacksonEvent delete for fields with slashes in field names

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -389,7 +389,7 @@ public class JacksonEvent implements Event {
         }
 
         if (!baseNode.isMissingNode()) {
-            ((ObjectNode) baseNode).remove(leafKey);
+            ((ObjectNode) baseNode).remove(leafKey.replace("~1", "/"));
         }
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -647,6 +647,29 @@ public class JacksonEventTest {
     }
 
     @Test
+    public void testDelete_withSlashInFieldName_jsonPointerEscaping() {
+        final Map<String, Object> dataWithSlash = new HashMap<>();
+        dataWithSlash.put("foo/bar", "allow");
+        event = JacksonEvent.builder()
+                .withEventType(eventType)
+                .withData(dataWithSlash)
+                .build();
+
+        // Verify the field exists before deletion
+        assertThat(event.get("foo~1bar", String.class), is(equalTo("allow")));
+        assertThat(event.containsKey("foo~1bar"), is(true));
+
+        event.delete("foo~1bar");
+
+        // Verify the field is actually deleted
+        assertThat(event.get("foo~1bar", String.class), is(nullValue()));
+        assertThat(event.containsKey("foo~1bar"), is(false));
+        
+        // Verify the event is now empty
+        assertThat(event.toMap().size(), is(0));
+    }
+
+    @Test
     public void testContainsKeyReturnsTrueForEmptyStringKey() {
         assertThat(event.containsKey(""), is(true));
     }


### PR DESCRIPTION
### Description
This change fixes a bug in JacksonEvent.delete() where fields containing forward slashes in their names could not be properly deleted when using JSON Pointer escaped keys.

**Problem:** When attempting to delete a field like `{"A/B": "allow"}` using the JSON Pointer escaped key `"A~1B"`, the deletion would fail because ObjectNode.remove() was looking for a field literally named "A~1B" instead of the actual field name "A/B".

**Solution:** Modified the delete method to unescape JSON Pointer field names by converting `~1` back to `/` before calling ObjectNode.remove(). This allows the ObjectNode to find and remove the correct field.

**Testing:** Added `testDelete_withSlashInFieldName_jsonPointerEscaping()` test that verifies fields with forward slashes in their names can be successfully deleted using JSON Pointer escaped keys.
 
### Issues Resolved
Resolves #5953 
 
### Check List
- [Y ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
