### PR TITLE
Updates the Jenkins library to 10.2.2 to fix Maven publication.

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.0.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@10.2.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description

Updates the Jenkins library to 10.2.2 to fix Maven publication.

This matches the version from `opensearch-protobufs`:

https://github.com/opensearch-project/opensearch-protobufs/blob/abd05755f5deef237e1fe27ebe8527df68ebd004/jenkins/release.jenkinsFile#L1

The most recent build failed on Maven publication:

https://build.ci.opensearch.org/job/release-data-prepper/21/
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
