### PR TITLE
Convert null message to empty string in DLQ to avoid NPE

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -679,7 +679,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             .withFailedData(FailedDlqData.builder()
                     .withDocument(event.toJsonString())
                     .withIndex(index)
-                    .withMessage(message)
+                    .withMessage(message != null ? message : "")
                     .build())
             .withPluginName(PLUGIN_NAME)
             .withPipelineName(pipeline)


### PR DESCRIPTION
### Description
Currently, writing to a DLQ with an empty message leads to an error as seen in #5974. Ideally we find out the cause of this missing data, but writing with an empty message is better than having pipeline worker crash
 
### Issues Resolved
Resolves #5974
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
