### PR TITLE
Add disable_checkpointing flag for ddb source stream

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -16,6 +16,9 @@ public class StreamConfig {
     @JsonProperty("view_on_remove")
     private StreamViewType viewForRemoves = StreamViewType.NEW_IMAGE;
 
+    @JsonProperty("disable_checkpointing")
+    private boolean disableCheckpointing = false;
+
     public StreamStartPosition getStartPosition() {
         return startPosition;
     }
@@ -23,5 +26,7 @@ public class StreamConfig {
     public StreamViewType getStreamViewForRemoves() {
         return viewForRemoves;
     }
+
+    public boolean isDisableCheckpointing() { return disableCheckpointing; }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -78,6 +78,9 @@ public class ShardConsumerFactory {
         if (progressState.isPresent()) {
             // We can't checkpoint with acks yet
             sequenceNumber = acknowledgementSet == null ? null : progressState.get().getSequenceNumber();
+            if (streamConfig.isDisableCheckpointing()) {
+                sequenceNumber = null;
+            }
             waitForExport = progressState.get().shouldWaitForExport();
             if (progressState.get().getStartTime() != 0) {
                 startTime = Instant.ofEpochMilli(progressState.get().getStartTime());

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactoryTest.java
@@ -9,9 +9,11 @@ import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -26,6 +28,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetShardIteratorResponse;
 import software.amazon.awssdk.services.dynamodb.model.InternalServerErrorException;
+import software.amazon.awssdk.services.dynamodb.model.ShardIteratorType;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
 
 import java.time.Instant;
@@ -33,6 +36,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -119,6 +123,31 @@ class ShardConsumerFactoryTest {
         Runnable consumer = consumerFactory.createConsumer(streamPartition, null, null);
         assertThat(consumer, notNullValue());
         verify(dynamoDbStreamsClient).getShardIterator(any(GetShardIteratorRequest.class));
+
+        verify(streamApiInvocations).increment();
+    }
+
+    @Test
+    public void test_create_shardConsumer_correctly_with_is_disable_checkpointing_enabled_starts_from_trim_horizon() {
+
+        final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(streamConfig.isDisableCheckpointing()).thenReturn(true);
+        StreamProgressState state = new StreamProgressState();
+        state.setWaitForExport(false);
+        state.setSequenceNumber(UUID.randomUUID().toString());
+        state.setStartTime(Instant.now().toEpochMilli());
+        streamPartition = new StreamPartition(streamArn, shardId, Optional.of(state));
+
+        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
+        Runnable consumer = consumerFactory.createConsumer(streamPartition, acknowledgementSet, null);
+        assertThat(consumer, notNullValue());
+
+        final ArgumentCaptor<GetShardIteratorRequest> captor = ArgumentCaptor.forClass(GetShardIteratorRequest.class);
+        verify(dynamoDbStreamsClient).getShardIterator(captor.capture());
+
+        final GetShardIteratorRequest getShardIteratorRequest = captor.getValue();
+        assertThat(getShardIteratorRequest.sequenceNumber(), equalTo(null));
+        assertThat(getShardIteratorRequest.shardIteratorType(), equalTo(ShardIteratorType.TRIM_HORIZON));
 
         verify(streamApiInvocations).increment();
     }


### PR DESCRIPTION
### Description
This change adds a `disable_checkpointing` flag to the stream configuration for the DDB source. When enabled, the source will start processing shards from the TRIM_HORIZON whenever they are acquired regardless of checkpoint.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
