### PR TITLE
Remove redundant concatOperator bean for Plus(+) symbol(Fix#5984)

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorConfiguration.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorConfiguration.java
@@ -274,11 +274,6 @@ class OperatorConfiguration {
     }
 
     @Bean
-    public AddBinaryOperator concatOperator() {
-        return new AddBinaryOperator(DataPrepperExpressionParser.PLUS, null); 
-    }
-
-    @Bean
     public GenericTypeOfOperator typeOfOperator() {
         return new GenericTypeOfOperator(DataPrepperExpressionParser.TYPEOF, typeOf);
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -51,7 +51,6 @@ class ParseTreeEvaluatorListenerTest {
             operatorConfiguration.lessThanOperator(), operatorConfiguration.lessThanOrEqualOperator(),
             operatorConfiguration.regexEqualOperator(), operatorConfiguration.regexNotEqualOperator(),
             operatorConfiguration.typeOfOperator(),
-            operatorConfiguration.concatOperator(),
             operatorConfiguration.addOperator(),
             operatorConfiguration.subtractOperator(),
             operatorConfiguration.multiplyOperator(),
@@ -348,6 +347,26 @@ class ParseTreeEvaluatorListenerTest {
         final String notStatement = String.format("not /%s", testKey);
         final Event testEvent = createTestEvent(data);
         assertThat(evaluateStatementOnEvent(notStatement, testEvent), is(false));
+    }
+
+    @Test
+    void testSimpleAddOperatorExpressionWithInteger() {
+        final String integerKey1 = "integerKey1";
+        final String integerKey2 = "integerKey2";
+        final Map<String, Integer> data = Map.of(integerKey1, 1, integerKey2, 2);
+        final String addStatement = String.format("/%s + /%s", integerKey1, integerKey2);
+        final Event testEvent = createTestEvent(data);
+        assertThat(evaluateStatementOnEvent(addStatement, testEvent), equalTo(3));
+    }
+
+    @Test
+    void testSimpleAddOperatorExpressionWithString() {
+        final String stringKey1 = "stringKey1";
+        final String stringKey2 = "stringKey2";
+        final Map<String, String> data = Map.of(stringKey1, "a", stringKey2, "b");
+        final String addStatement = String.format("/%s + /%s", stringKey1, stringKey2);
+        final Event testEvent = createTestEvent(data);
+        assertThat(evaluateStatementOnEvent(addStatement, testEvent), equalTo("ab"));
     }
 
     @Test


### PR DESCRIPTION
**Description**

This commit removes redundant concatOperator bean for Plus(+) symbol.

Both concatOperator and addOperator bean configured in OperatorConfiguration are using Plus symbol but the each symbol should have one corresponding operator. It is because OperatorProvider creates HashMap with symbol as key and operator as value. Currently addOperator overwrites concatOpeator, but in some rare scenario concatOperator could overwrite addOperator and cause NPE.

Note that both addOperator and concatOperator use AddBinaryOperator class as implementation, which means addOperator covers concatOperator functionality. It is safe to remove concatOperator bean.

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x ] New functionality includes testing.
- [N/A ] New functionality has a documentation issue. Please link to it in this PR.
  - [ N/A] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
