### PR TITLE
Add support for spaces and dollar signs in JacksonEventKey

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -180,6 +180,8 @@ class JacksonEventKey implements EventKey {
                     || c == '/'
                     || c == '['
                     || c == ']'
+                    || c == ' '
+                    || c == '$'
             )) {
 
                 return false;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -69,7 +69,13 @@ class JacksonEventKeyTest {
             "key_with_underscore",
             "key@with@at",
             "key[with]brackets",
-            "key~1withtilda"
+            "key~1withtilda",
+            "key with space",
+            "key$with$dollar",
+            " key_with_space_prefix",
+            "key_with_space_suffix ",
+            "$key_with_dollar_prefix",
+            "key_with_dollar_suffix$"
     })
     void getKey_returns_expected_result(final String key) {
         assertThat(new JacksonEventKey(key).getKey(), equalTo(key));
@@ -152,7 +158,13 @@ class JacksonEventKeyTest {
             "key-with-hyphen, true",
             "key_with_underscore, true",
             "key@with@at, true",
-            "key[with]brackets, true"
+            "key[with]brackets, true",
+            "key with space, true",
+            "key$with$dollar, true",
+            " key_with_space_prefix, true",
+            "key_with_space_suffix , true",
+            "$key_with_dollar_prefix, true",
+            "key_with_dollar_suffix$, true"
     })
     void isValidEventKey_returns_expected_result(final String key, final boolean isValid) {
         assertThat(JacksonEventKey.isValidEventKey(key), equalTo(isValid));
@@ -197,7 +209,7 @@ class JacksonEventKeyTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"key 1", "key$1", "key&1", "key^1", "key%1", "key_1"})
+    @ValueSource(strings = {"key&1", "key^1", "key%1", "key_1"})
     public void testReplaceInvalidKeyChars(final String key) {
         assertThat(JacksonEventKey.replaceInvalidCharacters(key), equalTo("key_1"));
         assertThat(JacksonEventKey.replaceInvalidCharacters(null), equalTo(null));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -230,7 +230,7 @@ public class JacksonEventTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"key 1", "key$1", "key&1", "key^1", "key%1", "key_1"})
+    @ValueSource(strings = {"key&1", "key^1", "key%1", "key_1"})
     public void testReplaceInvalidKeyChars(final String key) {
         assertThat(JacksonEvent.replaceInvalidKeyChars(key), equalTo("key_1"));
         assertThat(JacksonEvent.replaceInvalidKeyChars(key.substring(0,3)), equalTo("key"));
@@ -238,7 +238,7 @@ public class JacksonEventTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"key 1", "key$1", "key&1", "key^1", "key%1", "key_1"})
+    @ValueSource(strings = {"key&1", "key^1", "key%1", "key_1"})
     public void testPutWithReplaceInvalidKeyChars(final String key) {
         final String value = UUID.randomUUID().toString();
 
@@ -247,7 +247,7 @@ public class JacksonEventTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"key 1", "key$1", "key&1", "key^1", "key%1"})
+    @ValueSource(strings = {"key&1", "key^1", "key%1"})
     public void testPutWithoutReplaceInvalidKeyChars(final String key) {
         final String value = UUID.randomUUID().toString();
 
@@ -283,14 +283,12 @@ public class JacksonEventTest {
         final Map<String, Object> data1 = new HashMap<>();
         final Map<String, Object> data2 = new HashMap<>();
         final Map<String, Object> data3 = new HashMap<>();
-        data3.put("key$5", "value5");
+        data3.put("key^5", "value5");
         data2.put("key^3", 3);
         data2.put("key%4", data3);
-        data1.put("key 1", "value1");
         data1.put("key&2", data2);
 
         event.put("foo", data1, true);
-        assertThat(event.get("foo/key_1", String.class), equalTo("value1"));
         assertThat(event.get("foo/key_2/key_3", Integer.class), equalTo(3));
         assertThat(event.get("foo/key_2/key_4/key_5", String.class), equalTo("value5"));
     }
@@ -301,14 +299,12 @@ public class JacksonEventTest {
         final Map<String, Object> data1 = new HashMap<>();
         final Map<String, Object> data2 = new HashMap<>();
         final Map<String, Object> data3 = new HashMap<>();
-        data3.put("key$5", "value5");
+        data3.put("key^5", "value5");
         data2.put("key^3", 3);
         data2.put("key%4", data3);
-        data1.put("key 1", "value1");
         data1.put("key&2", data2);
 
         event.put(key, data1, true);
-        assertThat(event.get("foo/key_1", String.class), equalTo("value1"));
         assertThat(event.get("foo/key_2/key_3", Integer.class), equalTo(3));
         assertThat(event.get("foo/key_2/key_4/key_5", String.class), equalTo("value5"));
     }

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
@@ -148,7 +148,7 @@ class CsvProcessorTest {
         when(processorConfig.getNormalizeKeys()).thenReturn(true);
         csvProcessor = createObjectUnderTest();
 
-        Record<Event> eventUnderTest = createMessageEvent("key 1,key$2,key^3\n1,2,3");
+        Record<Event> eventUnderTest = createMessageEvent("key%1,key&2,key^3\n1,2,3");
         final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
         final Event parsedEvent = getSingleEvent(editedEvents);
         assertThatKeyEquals(parsedEvent, "key_1", "1");
@@ -184,7 +184,7 @@ class CsvProcessorTest {
 
         final Map<String, Object> eventData = new HashMap<>();
         eventData.put("message","1,2,3");
-        eventData.put("header","col 1,col$2,col^3");
+        eventData.put("header","col%1,col&2,col^3");
         Record<Event> eventUnderTest = buildRecordWithEvent(eventData);
         final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
         final Event parsedEvent = getSingleEvent(editedEvents);

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -300,7 +300,7 @@ public class KeyValueProcessorTests {
     void testInvalidKeyCharsReplacement() {
         when(mockConfig.getDestination()).thenReturn(null);
         when(mockConfig.getNormalizeKeys()).thenReturn(true);
-        final Record<Event> record = getMessage("key 1=value1&key^2=value2");
+        final Record<Event> record = getMessage("key%1=value1&key^2=value2");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
         final Event event = editedRecords.get(0).getData();
 

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
@@ -153,8 +153,8 @@ public class ParseJsonProcessorTest {
         when(processorConfig.getDepth()).thenReturn(0);
         when(processorConfig.getNormalizeKeys()).thenReturn(true);
         parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
-        Map<String, Object> data = Map.of("key 1", "value1", "key^2", 1, "key$3", Map.of("key%5", Map.of("key&6", "value6")));
-        Map<String, Object> expectedResult = Map.of("key_1", "value1", "key_2", 1, "key_3", Map.of("key_5", Map.of("key_6","value6")));
+        Map<String, Object> data = Map.of("key^2", 1, "key%5", Map.of("key&6", "value6"));
+        Map<String, Object> expectedResult = Map.of("key_2", 1, "key_5", Map.of("key_6", "value6"));
         final String serializedMessage = objectMapper.writeValueAsString(data);
         final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
         assertThatKeyEquals(parsedEvent, source, expectedResult);


### PR DESCRIPTION
Signed-off-by: Alekhya Parisha <aparisha@amazon.com>

### Description
- Updated isValidKey method to allow spaces and dollar signs in keys
- Modified tests to reflect new valid characters
- ddresses GitHub issue #[5978](https://github.com/opensearch-project/data-prepper/issues/5978): Add support for additional characters in JackonEventKey

 
### Issues Resolved
Resolves #5978 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
