### PR TITLE
Look up logical type for decimal values and use correct scale parquet…

### DIFF
--- a/data-prepper-plugins/parquet-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/GenericRecordJsonEncoder.java
+++ b/data-prepper-plugins/parquet-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/GenericRecordJsonEncoder.java
@@ -5,6 +5,7 @@
 package org.opensearch.dataprepper.plugins.codec.parquet;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -15,6 +16,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
@@ -50,7 +52,7 @@ public class GenericRecordJsonEncoder {
 
     public String serialize(GenericRecord value) {
         StringBuilder buffer = new StringBuilder();
-        serialize(value, buffer, new IdentityHashMap<>(128) );
+        serialize(value, buffer, new IdentityHashMap<>(128), null);
         String result = buffer.toString();
         return result;
     }
@@ -59,7 +61,9 @@ public class GenericRecordJsonEncoder {
             " \">>> CIRCULAR REFERENCE CANNOT BE PUT IN JSON STRING, ABORTING RECURSION <<<\" ";
 
     /** Renders a Java datum as <a href="http://www.json.org/">JSON</a>. */
-    private void serialize(final Object datum, final StringBuilder buffer, final IdentityHashMap<Object, Object> seenObjects) {
+    private void serialize(final Object datum, final StringBuilder buffer,
+                           final IdentityHashMap<Object, Object> seenObjects,
+                           final Integer decimalScale) {
         if (isRecord(datum)) {
             if (seenObjects.containsKey(datum)) {
                 buffer.append(TOSTRING_CIRCULAR_REFERENCE_ERROR_TEXT);
@@ -70,10 +74,29 @@ public class GenericRecordJsonEncoder {
             int count = 0;
             Schema schema = getRecordSchema(datum);
             for (Schema.Field f : schema.getFields()) {
-                serialize(f.name(), buffer, seenObjects);
+                serialize(f.name(), buffer, seenObjects, null); // field name
                 buffer.append(": ");
+
                 Function<Object, Object> logicalTypeConverter = getLogicalTypeConverter(f);
-                serialize(logicalTypeConverter.apply(getField(datum, f.name(), f.pos())), buffer, seenObjects);
+
+                boolean serializedDecimal = false;
+                Schema fieldSchema = f.schema();
+                if (fieldSchema.getType() == Schema.Type.UNION) {
+                    for (Schema s : fieldSchema.getTypes()) {
+                        if (s.getType() != Schema.Type.NULL) {
+                            if (s.getType() == Schema.Type.BYTES &&
+                                    s.getLogicalType() instanceof LogicalTypes.Decimal) {
+                                serialize(logicalTypeConverter.apply(getField(datum, f.name(), f.pos())), buffer, seenObjects, ((LogicalTypes.Decimal) s.getLogicalType()).getScale());
+                                serializedDecimal = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (!serializedDecimal) {
+                    serialize(logicalTypeConverter.apply(getField(datum, f.name(), f.pos())), buffer, seenObjects, null);
+                }
                 if (++count < schema.getFields().size())
                     buffer.append(", ");
             }
@@ -90,7 +113,7 @@ public class GenericRecordJsonEncoder {
             long last = array.size()-1;
             int i = 0;
             for (Object element : array) {
-                serialize(element, buffer, seenObjects);
+                serialize(element, buffer, seenObjects, null);
                 if (i++ < last)
                     buffer.append(", ");
             }
@@ -107,9 +130,9 @@ public class GenericRecordJsonEncoder {
             @SuppressWarnings(value="unchecked")
             Map<Object,Object> map = (Map<Object,Object>)datum;
             for (Map.Entry<Object,Object> entry : map.entrySet()) {
-                serialize(entry.getKey(), buffer, seenObjects);
+                serialize(entry.getKey(), buffer, seenObjects, null);
                 buffer.append(": ");
-                serialize(entry.getValue(), buffer, seenObjects);
+                serialize(entry.getValue(), buffer, seenObjects, null);
                 if (++count < map.size())
                     buffer.append(", ");
             }
@@ -120,15 +143,24 @@ public class GenericRecordJsonEncoder {
             writeEscapedString(datum.toString(), buffer);
             buffer.append("\"");
         } else if (isBytes(datum)) {
-            final String bytesAsString = StandardCharsets.UTF_8.decode((ByteBuffer) datum).toString();
-            final Optional<BigDecimal> bytesAsBigDecimal = getBigDecimal(bytesAsString);
-            if (bytesAsBigDecimal.isPresent()) {
-                buffer.append(bytesAsBigDecimal.get().doubleValue());
+            if (decimalScale != null) {
+                ByteBuffer sourceBuffer = (ByteBuffer) datum;
+                byte[] bytesArray = new byte[sourceBuffer.remaining()];
+                sourceBuffer.duplicate().get(bytesArray);
+                BigInteger unscaledValue = new BigInteger(bytesArray);
+                BigDecimal decimal = new BigDecimal(unscaledValue, decimalScale);
+                buffer.append(decimal.doubleValue());
             } else {
-                buffer.append("{\"bytes\": \"");
-                ByteBuffer bytes = ((ByteBuffer) datum).duplicate();
-                writeEscapedString(new String(bytes.array(), StandardCharsets.ISO_8859_1), buffer);
-                buffer.append("\"}");
+                final String bytesAsString = StandardCharsets.UTF_8.decode((ByteBuffer) datum).toString();
+                final Optional<BigDecimal> bytesAsBigDecimal = getBigDecimal(bytesAsString);
+                if (bytesAsBigDecimal.isPresent()) {
+                    buffer.append(bytesAsBigDecimal.get().doubleValue());
+                } else {
+                    buffer.append("{\"bytes\": \"");
+                    ByteBuffer bytes = ((ByteBuffer) datum).duplicate();
+                    writeEscapedString(new String(bytes.array(), StandardCharsets.ISO_8859_1), buffer);
+                    buffer.append("\"}");
+                }
             }
         } else if (((datum instanceof Float) &&       // quote Nan & Infinity
                 (((Float)datum).isInfinite() || ((Float)datum).isNaN()))
@@ -143,7 +175,7 @@ public class GenericRecordJsonEncoder {
                 return;
             }
             seenObjects.put(datum, datum);
-            serialize(datum, buffer, seenObjects);
+            serialize(datum, buffer, seenObjects, null);
             seenObjects.remove(datum);
         } else {
             // This fallback is the reason why GenericRecord toString does not


### PR DESCRIPTION
… codec reader

### Description
This chamge looks up the logical type of the parquet field for UNION types with BigDecimal and converts to decimal using the scale defined in the parquet schema.
 
### Issues Resolved
Resolves #5189 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
