### PR TITLE
Add json serialization for DefaultTraceGroupFields

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFields.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFields.java
@@ -64,17 +64,6 @@ public class DefaultTraceGroupFields implements TraceGroupFields, Serializable {
         return Objects.equals(endTime, that.endTime) && Objects.equals(durationInNanos, that.durationInNanos) && Objects.equals(statusCode, that.statusCode);
     }
 
-    /*
-    @Override
-    public String toString() {
-        return "DefaultTraceGroupFields{" +
-                "endTime=" + endTime +
-                ", durationInNanos=" + durationInNanos +
-                ", statusCode='" + statusCode + '\'' +
-                '}';
-    }
-    */
-
     @Override
     public String getEndTime() {
         return endTime;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFields.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFields.java
@@ -5,13 +5,24 @@
 
 package org.opensearch.dataprepper.model.trace;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+
 /**
  * The default implementation of {@link TraceGroupFields}, the attributes associated with an entire trace.
  *
  * @since 1.2
  */
-public class DefaultTraceGroupFields implements TraceGroupFields {
+public class DefaultTraceGroupFields implements TraceGroupFields, Serializable {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private String endTime;
     private Long durationInNanos;
     private Integer statusCode;
@@ -19,12 +30,50 @@ public class DefaultTraceGroupFields implements TraceGroupFields {
     // required for serialization
     DefaultTraceGroupFields() {}
 
+    DefaultTraceGroupFields(final String endTime, final Long durationInNanos, final Integer statusCode) {
+        this.endTime = endTime;
+        this.durationInNanos = durationInNanos;
+        this.statusCode = statusCode;
+    }
+
     private DefaultTraceGroupFields(final Builder builder) {
 
         this.endTime = builder.endTime;
         this.durationInNanos = builder.durationInNanos;
         this.statusCode = builder.statusCode;
     }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        String json = OBJECT_MAPPER.writeValueAsString(this);
+        out.writeUTF(json);
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        String json = in.readUTF();
+        DefaultTraceGroupFields temp = OBJECT_MAPPER.readValue(json, DefaultTraceGroupFields.class);
+        this.endTime = temp.endTime;
+        this.durationInNanos = temp.durationInNanos;
+        this.statusCode = temp.statusCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DefaultTraceGroupFields that = (DefaultTraceGroupFields) o;
+        return Objects.equals(endTime, that.endTime) && Objects.equals(durationInNanos, that.durationInNanos) && Objects.equals(statusCode, that.statusCode);
+    }
+
+    /*
+    @Override
+    public String toString() {
+        return "DefaultTraceGroupFields{" +
+                "endTime=" + endTime +
+                ", durationInNanos=" + durationInNanos +
+                ", statusCode='" + statusCode + '\'' +
+                '}';
+    }
+    */
 
     @Override
     public String getEndTime() {
@@ -39,15 +88,6 @@ public class DefaultTraceGroupFields implements TraceGroupFields {
     @Override
     public Integer getStatusCode() {
         return statusCode;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other instanceof DefaultTraceGroupFields) {
-            final DefaultTraceGroupFields o = (DefaultTraceGroupFields) other;
-            return (endTime.equals(o.endTime) && durationInNanos.equals(o.durationInNanos) && statusCode.equals(o.statusCode));
-        }
-        return false;
     }
 
     public static Builder builder() {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -232,7 +232,13 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     @Override
     public void setTraceGroupFields(final TraceGroupFields traceGroupFields) {
-        this.put(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
+        EventMetadata metadata = getMetadata();
+        Object oldTraceGroupFields = metadata.getAttribute(TRACE_GROUP_FIELDS_KEY);
+        if (oldTraceGroupFields != null) {
+            metadata.setAttribute(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
+        } else {
+            this.put(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
+        }
     }
 
     public static Builder builder() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
@@ -9,7 +9,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.TestObject;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
 import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -19,6 +25,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class DefaultTraceGroupFieldsTest {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String TEST_END_TIME = UUID.randomUUID().toString();
     private static final Long TEST_DURATION = 123L;
     private static final Integer TEST_STATUS_CODE = 200;
@@ -111,4 +118,25 @@ public class DefaultTraceGroupFieldsTest {
 
         assertThat(result, is(notNullValue()));
     }
+
+    @Test
+    public void testSerialization() throws Exception {
+        final DefaultTraceGroupFields result = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(TEST_DURATION)
+                .withStatusCode(TEST_STATUS_CODE)
+                .withEndTime(TEST_END_TIME)
+                .build();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(result);
+        }
+
+        byte[] data = baos.toByteArray();
+    
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data))) {
+            DefaultTraceGroupFields result2 = (DefaultTraceGroupFields) ois.readObject();
+            assertThat(result, equalTo(result2));
+        }
+    }
+
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
@@ -78,6 +78,15 @@ public class DefaultTraceGroupFieldsTest {
     }
 
     @Test
+    public void testEquals_withDifferentValues() {
+        final DefaultTraceGroupFields traceGroupFields =
+            new DefaultTraceGroupFields(TEST_END_TIME, TEST_DURATION - 1, TEST_STATUS_CODE);
+        assertThat(traceGroupFields, is(not(equalTo(null))));
+        Integer tmp = 5;
+        assertThat(traceGroupFields, is(not(equalTo(tmp))));
+    }
+
+    @Test
     public void testEquals_withDifferentStatusCode() {
         final DefaultTraceGroupFields traceGroupFields = DefaultTraceGroupFields.builder()
                 .withDurationInNanos(TEST_DURATION)

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -298,6 +298,20 @@ public class JacksonSpanTest {
     }
 
     @Test
+    public void testSetAndGetTraceGroupFieldsInMetadata() {
+        final TraceGroupFields testTraceGroupFields = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(200L)
+                .withStatusCode(404)
+                .withEndTime("Different end time")
+                .build();
+        jacksonSpan.getMetadata().setAttribute(JacksonSpan.TRACE_GROUP_FIELDS_KEY, new DefaultTraceGroupFields());
+        jacksonSpan.setTraceGroupFields(testTraceGroupFields);
+        final TraceGroupFields traceGroupFields = jacksonSpan.getTraceGroupFields();
+        assertThat(traceGroupFields, is(equalTo(traceGroupFields)));
+        assertThat(traceGroupFields, is(equalTo(testTraceGroupFields)));
+    }
+
+    @Test
     public void testToJsonStringAllParameters() throws JsonProcessingException, JSONException {
         final String jsonResult = jacksonSpan.toJsonString();
         final Map<String, Object> resultMap = mapper.readValue(jsonResult, new TypeReference<Map<String, Object>>() {});


### PR DESCRIPTION
### Description
Add json serialization for DefaultTraceGroupFields so that serialization/deserialization occurs properly for the metadata stored when OTEL output_format is used.
 
### Issues Resolved
Resolves #5930 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
