### PR TITLE
Add support for forwarding successful records from sinks using SinkContext

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfig.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.configuration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public class SinkForwardConfig {
+    @JsonProperty("pipelines")
+    List<String> pipelineNames;
+
+    @JsonProperty("with_metadata")
+    Map<String, Object> withMetadata;
+
+    @JsonProperty("with_data")
+    Map<String, Object> withData;
+
+    @JsonCreator
+    public SinkForwardConfig() {
+    }
+
+    @JsonCreator
+    public SinkForwardConfig(
+        @JsonProperty("pipelines") final List<String> pipelineNames,
+        @JsonProperty("with_data") final Map<String, Object> withData,
+        @JsonProperty("with_metadata") final Map<String, Object> withMetadata) {
+        this.pipelineNames = pipelineNames;
+        this.withData = withData;
+        this.withMetadata = withMetadata;
+    }
+
+    public List<String> getPipelineNames() {
+        return pipelineNames;
+    }
+
+    public Map<String, Object> getWithMetadata() {
+        return withMetadata;
+    }
+
+    public Map<String, Object> getWithData() {
+        return withData;
+    }
+}
+

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
@@ -34,8 +34,8 @@ public class SinkModel extends PluginModel {
         this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, includeKeys, excludeKeys, null, pluginSettings));
     }
 
-    public SinkModel(final String pluginName, final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final List<String> forwardToPipelineNames, final Map<String, Object> pluginSettings) {
-        this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, includeKeys, excludeKeys, forwardToPipelineNames, pluginSettings));
+    public SinkModel(final String pluginName, final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final SinkForwardConfig forwardConfig, final Map<String, Object> pluginSettings) {
+        this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, includeKeys, excludeKeys, forwardConfig, pluginSettings));
     }
 
     private SinkModel(final String pluginName, final SinkInternalJsonModel sinkInnerModel) {
@@ -60,8 +60,8 @@ public class SinkModel extends PluginModel {
         return this.<SinkInternalJsonModel>getInternalJsonModel().excludeKeys;
     }
 
-    public List<String> getForwardPipelineNames() {
-        return this.<SinkInternalJsonModel>getInternalJsonModel().forwardToPipelineNames;
+    public SinkForwardConfig getForwardConfig() {
+        return this.<SinkInternalJsonModel>getInternalJsonModel().forwardConfig;
     }
 
     /**
@@ -82,7 +82,7 @@ public class SinkModel extends PluginModel {
 
         private final List<String> includeKeys;
         private final List<String> excludeKeys;
-        private final List<String> forwardToPipelineNames;
+        private final SinkForwardConfig forwardConfig;
 
         private SinkModelBuilder(final PluginModel pluginModel) {
             this.pluginModel = pluginModel;
@@ -90,11 +90,11 @@ public class SinkModel extends PluginModel {
             this.tagsTargetKey = null;
             this.includeKeys = Collections.emptyList();
             this.excludeKeys = Collections.emptyList();
-            this.forwardToPipelineNames = Collections.emptyList();
+            this.forwardConfig = null;
         }
 
         public SinkModel build() {
-            return new SinkModel(pluginModel.getPluginName(), routes, tagsTargetKey, includeKeys, excludeKeys, forwardToPipelineNames, pluginModel.getPluginSettings());
+            return new SinkModel(pluginModel.getPluginName(), routes, tagsTargetKey, includeKeys, excludeKeys, forwardConfig, pluginModel.getPluginSettings());
         }
     }
 
@@ -122,19 +122,19 @@ public class SinkModel extends PluginModel {
 
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @JsonProperty("forward_to")
-        private final List<String> forwardToPipelineNames;
+        private final SinkForwardConfig forwardConfig;
 
         @JsonCreator
-        private SinkInternalJsonModel(@JsonProperty("routes") final List<String> routes, @JsonProperty("tags_target_key") final String tagsTargetKey, @JsonProperty("include_keys") final List<String> includeKeys, @JsonProperty("exclude_keys") final List<String> excludeKeys, @JsonProperty("forward_to") final List<String> forwardToPipelineNames) {
-            this(routes, tagsTargetKey, includeKeys, excludeKeys, forwardToPipelineNames, new HashMap<>());
+        private SinkInternalJsonModel(@JsonProperty("routes") final List<String> routes, @JsonProperty("tags_target_key") final String tagsTargetKey, @JsonProperty("include_keys") final List<String> includeKeys, @JsonProperty("exclude_keys") final List<String> excludeKeys, @JsonProperty("forward_to") final SinkForwardConfig forwardConfig) {
+            this(routes, tagsTargetKey, includeKeys, excludeKeys, forwardConfig, new HashMap<>());
         }
 
-        private SinkInternalJsonModel(final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final List<String> forwardToPipelineNames, final Map<String, Object> pluginSettings) {
+        private SinkInternalJsonModel(final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final SinkForwardConfig forwardConfig, final Map<String, Object> pluginSettings) {
             super(pluginSettings);
             this.routes = routes != null ? routes : Collections.emptyList();
             this.includeKeys = includeKeys != null ? validateKeys(includeKeys, "include_keys") : Collections.emptyList();
             this.excludeKeys = excludeKeys != null ? validateKeys(excludeKeys, "exclude_keys") : Collections.emptyList();
-            this.forwardToPipelineNames = forwardToPipelineNames != null ? forwardToPipelineNames : Collections.emptyList();
+            this.forwardConfig = forwardConfig;
             this.tagsTargetKey = tagsTargetKey;
             validateConfiguration();
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
@@ -31,7 +31,11 @@ import java.util.stream.Collectors;
 public class SinkModel extends PluginModel {
 
     public SinkModel(final String pluginName, final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final Map<String, Object> pluginSettings) {
-        this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, includeKeys, excludeKeys, pluginSettings));
+        this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, includeKeys, excludeKeys, null, pluginSettings));
+    }
+
+    public SinkModel(final String pluginName, final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final List<String> forwardToPipelineNames, final Map<String, Object> pluginSettings) {
+        this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, includeKeys, excludeKeys, forwardToPipelineNames, pluginSettings));
     }
 
     private SinkModel(final String pluginName, final SinkInternalJsonModel sinkInnerModel) {
@@ -56,6 +60,9 @@ public class SinkModel extends PluginModel {
         return this.<SinkInternalJsonModel>getInternalJsonModel().excludeKeys;
     }
 
+    public List<String> getForwardPipelineNames() {
+        return this.<SinkInternalJsonModel>getInternalJsonModel().forwardToPipelineNames;
+    }
 
     /**
      * Gets the tags target key associated with this Sink.
@@ -75,6 +82,7 @@ public class SinkModel extends PluginModel {
 
         private final List<String> includeKeys;
         private final List<String> excludeKeys;
+        private final List<String> forwardToPipelineNames;
 
         private SinkModelBuilder(final PluginModel pluginModel) {
             this.pluginModel = pluginModel;
@@ -82,10 +90,11 @@ public class SinkModel extends PluginModel {
             this.tagsTargetKey = null;
             this.includeKeys = Collections.emptyList();
             this.excludeKeys = Collections.emptyList();
+            this.forwardToPipelineNames = Collections.emptyList();
         }
 
         public SinkModel build() {
-            return new SinkModel(pluginModel.getPluginName(), routes, tagsTargetKey, includeKeys, excludeKeys, pluginModel.getPluginSettings());
+            return new SinkModel(pluginModel.getPluginName(), routes, tagsTargetKey, includeKeys, excludeKeys, forwardToPipelineNames, pluginModel.getPluginSettings());
         }
     }
 
@@ -111,16 +120,21 @@ public class SinkModel extends PluginModel {
         @JsonProperty("exclude_keys")
         private final List<String> excludeKeys;
 
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JsonProperty("forward_to")
+        private final List<String> forwardToPipelineNames;
+
         @JsonCreator
-        private SinkInternalJsonModel(@JsonProperty("routes") final List<String> routes, @JsonProperty("tags_target_key") final String tagsTargetKey, @JsonProperty("include_keys") final List<String> includeKeys, @JsonProperty("exclude_keys") final List<String> excludeKeys) {
-            this(routes, tagsTargetKey, includeKeys, excludeKeys, new HashMap<>());
+        private SinkInternalJsonModel(@JsonProperty("routes") final List<String> routes, @JsonProperty("tags_target_key") final String tagsTargetKey, @JsonProperty("include_keys") final List<String> includeKeys, @JsonProperty("exclude_keys") final List<String> excludeKeys, @JsonProperty("forward_to") final List<String> forwardToPipelineNames) {
+            this(routes, tagsTargetKey, includeKeys, excludeKeys, forwardToPipelineNames, new HashMap<>());
         }
 
-        private SinkInternalJsonModel(final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final Map<String, Object> pluginSettings) {
+        private SinkInternalJsonModel(final List<String> routes, final String tagsTargetKey, final List<String> includeKeys, final List<String> excludeKeys, final List<String> forwardToPipelineNames, final Map<String, Object> pluginSettings) {
             super(pluginSettings);
             this.routes = routes != null ? routes : Collections.emptyList();
             this.includeKeys = includeKeys != null ? validateKeys(includeKeys, "include_keys") : Collections.emptyList();
             this.excludeKeys = excludeKeys != null ? validateKeys(excludeKeys, "exclude_keys") : Collections.emptyList();
+            this.forwardToPipelineNames = forwardToPipelineNames != null ? forwardToPipelineNames : Collections.emptyList();
             this.tagsTargetKey = tagsTargetKey;
             validateConfiguration();
         }
@@ -146,7 +160,7 @@ public class SinkModel extends PluginModel {
 
     static class SinkModelDeserializer extends AbstractPluginModelDeserializer<SinkModel, SinkInternalJsonModel> {
         SinkModelDeserializer() {
-            super(SinkModel.class, SinkInternalJsonModel.class, SinkModel::new, () -> new SinkInternalJsonModel(null, null, null, null));
+            super(SinkModel.class, SinkInternalJsonModel.class, SinkModel::new, () -> new SinkInternalJsonModel(null, null, null, null, null));
         }
     }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
@@ -8,7 +8,6 @@ package org.opensearch.dataprepper.model.sink;
 import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.InternalEventHandle;
 import org.opensearch.dataprepper.model.event.EventMetadata;
 
 import java.util.Collection;
@@ -64,20 +63,7 @@ public class SinkContext {
         }
     }
 
-    public SinkForwardRecordsContext prepareRecordsForForwarding(final Collection<Record<Event>> records) {
-        for (Map.Entry<String, HeadlessPipeline> entry: forwardToPipelines.entrySet()) {
-            records.forEach((record) -> {
-                InternalEventHandle eventHandle = (InternalEventHandle)record.getData().getEventHandle();
-                if (eventHandle != null) {
-                    eventHandle.acquireReference();
-                }
-            });
-        }
-        return new SinkForwardRecordsContext();
-
-    }
-
-    public boolean forwardRecords(final SinkForwardRecordsContext sinkForwardRecordsContext, final Collection<Record<Event>> records, final Map<String, Object> withData, final Map<String, Object> withMetadata) {
+    public boolean forwardRecords(final SinkForwardRecordsContext sinkForwardRecordsContext, final Map<String, Object> withData, final Map<String, Object> withMetadata) {
         if (forwardToPipelines.size() == 0) {
             return false;
         }
@@ -87,8 +73,9 @@ public class SinkContext {
                 return false;
             }
         }
+        List<Record<Event>> records = sinkForwardRecordsContext.getRecords();
 
-        if (records == null) {
+        if (records.size() == 0) {
             return true;
         }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
@@ -5,7 +5,42 @@
 
 package org.opensearch.dataprepper.model.sink;
 
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.InternalEventHandle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 public class SinkForwardRecordsContext {
-    public SinkForwardRecordsContext() {}
+    List<Record<Event>> records;
+
+    public SinkForwardRecordsContext() {
+        records = new ArrayList<>();
+    }
+    
+    public void addRecord(Record<Event> record) {
+        InternalEventHandle eventHandle = (InternalEventHandle)record.getData().getEventHandle();
+        if (eventHandle != null) {
+            eventHandle.acquireReference();
+        }
+        records.add(record);
+    }
+
+    public void addRecords(Collection<Record<Event>> newRecords) {
+        newRecords.forEach((record) -> {
+            Event event = record.getData();
+            InternalEventHandle eventHandle = (InternalEventHandle)event.getEventHandle();
+            if (eventHandle != null) {
+                eventHandle.acquireReference();
+            }
+        });
+        records.addAll(newRecords);
+    }
+
+    public List<Record<Event>> getRecords() {
+        return records;
+    }
 }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
@@ -15,12 +15,16 @@ import java.util.List;
 
 public class SinkForwardRecordsContext {
     List<Record<Event>> records;
+    boolean forwardPipelinesPresent;
 
-    public SinkForwardRecordsContext() {
+    public SinkForwardRecordsContext(SinkContext sinkContext) {
+        forwardPipelinesPresent =  (sinkContext != null && sinkContext.getForwardToPipelines().size() > 0);
         records = new ArrayList<>();
     }
     
     public void addRecord(Record<Event> record) {
+        if (!forwardPipelinesPresent)
+            return;
         InternalEventHandle eventHandle = (InternalEventHandle)record.getData().getEventHandle();
         if (eventHandle != null) {
             eventHandle.acquireReference();
@@ -29,6 +33,8 @@ public class SinkForwardRecordsContext {
     }
 
     public void addRecords(Collection<Record<Event>> newRecords) {
+        if (!forwardPipelinesPresent)
+            return;
         newRecords.forEach((record) -> {
             Event event = record.getData();
             InternalEventHandle eventHandle = (InternalEventHandle)event.getEventHandle();

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.sink;
+
+public class SinkForwardRecordsContext {
+    public SinkForwardRecordsContext() {}
+}
+

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfigTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfigTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+public class SinkForwardConfigTest {
+
+    @Test
+    void testDefaults() {
+        final SinkForwardConfig sinkForwardConfig = new SinkForwardConfig();
+        assertThat(sinkForwardConfig.getPipelineNames(), nullValue());
+        assertThat(sinkForwardConfig.getWithData(), nullValue());
+        assertThat(sinkForwardConfig.getWithMetadata(), nullValue());
+    }
+
+    @Test
+    void testCustomValues() {
+        List<String> pipelines = mock(List.class);
+        Map<String, Object> withData = mock(Map.class);
+        Map<String, Object> withMetadata = mock(Map.class);
+        SinkForwardConfig sinkForwardConfig = new SinkForwardConfig(pipelines, withData, withMetadata);
+        assertThat(sinkForwardConfig.getPipelineNames(), equalTo(pipelines));
+        assertThat(sinkForwardConfig.getWithData(), equalTo(withData));
+        assertThat(sinkForwardConfig.getWithMetadata(), equalTo(withMetadata));
+    }
+}
+

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
@@ -172,10 +172,14 @@ class SinkModelTest {
 
     @Test
     void sinkModel_with_forward_pipelines() {
+        SinkForwardConfig sinkForwardConfig = mock(SinkForwardConfig.class);
+        List<String> forwardPipelineList = List.of("forward-pipeline1", "forward-pipeline2");
+        when(sinkForwardConfig.getPipelineNames()).thenReturn(forwardPipelineList);
         final Map<String, Object> pluginSettings = new LinkedHashMap<>();
-        final SinkModel sinkModel = new SinkModel("customSinkPlugin", Arrays.asList("routeA", "routeB"), null, List.of(), Arrays.asList("abc", "bcd", "efg"), Arrays.asList("forward-pipeline1", "forward-pipeline2"), pluginSettings);
+        
+        final SinkModel sinkModel = new SinkModel("customSinkPlugin", Arrays.asList("routeA", "routeB"), null, List.of(), Arrays.asList("abc", "bcd", "efg"), sinkForwardConfig, pluginSettings);
 
-        assertThat(sinkModel.getForwardPipelineNames(), equalTo(Arrays.asList("forward-pipeline1", "forward-pipeline2")));
+        assertThat(sinkModel.getForwardConfig().getPipelineNames(), equalTo(forwardPipelineList));
     }
 
     @Test
@@ -221,8 +225,7 @@ class SinkModelTest {
             assertThat(actualSinkModel.getExcludeKeys(), notNullValue());
             assertThat(actualSinkModel.getExcludeKeys(), empty());
             assertThat(actualSinkModel.getTagsTargetKey(), nullValue());
-            assertThat(actualSinkModel.getForwardPipelineNames(), notNullValue());
-            assertThat(actualSinkModel.getForwardPipelineNames(), empty());
+            assertThat(actualSinkModel.getForwardConfig(), nullValue());
 
         }
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
@@ -171,6 +171,14 @@ class SinkModelTest {
     }
 
     @Test
+    void sinkModel_with_forward_pipelines() {
+        final Map<String, Object> pluginSettings = new LinkedHashMap<>();
+        final SinkModel sinkModel = new SinkModel("customSinkPlugin", Arrays.asList("routeA", "routeB"), null, List.of(), Arrays.asList("abc", "bcd", "efg"), Arrays.asList("forward-pipeline1", "forward-pipeline2"), pluginSettings);
+
+        assertThat(sinkModel.getForwardPipelineNames(), equalTo(Arrays.asList("forward-pipeline1", "forward-pipeline2")));
+    }
+
+    @Test
     void sinkModel_with_invalid_exclude_keys() {
         final Map<String, Object> pluginSettings = new LinkedHashMap<>();
         assertThrows(InvalidPluginConfigurationException.class, () -> new SinkModel("customSinkPlugin", Arrays.asList("routeA", "routeB"), null, List.of(), List.of("/bcd"), pluginSettings));
@@ -213,7 +221,8 @@ class SinkModelTest {
             assertThat(actualSinkModel.getExcludeKeys(), notNullValue());
             assertThat(actualSinkModel.getExcludeKeys(), empty());
             assertThat(actualSinkModel.getTagsTargetKey(), nullValue());
-            assertThat(actualSinkModel.getTagsTargetKey(), nullValue());
+            assertThat(actualSinkModel.getForwardPipelineNames(), notNullValue());
+            assertThat(actualSinkModel.getForwardPipelineNames(), empty());
 
         }
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
@@ -86,7 +86,7 @@ public class SinkContextTest {
         when(record.getData()).thenReturn(event);
         when(event.getMetadata()).thenReturn(eventMetadata);
         Collection<Record<Event>> records = Collections.singletonList(record);
-        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext();
+        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
 
         assertThat(sinkContext.forwardRecords(sinkForwardRecordsContext, Map.of("datakey1", "datavalue1"), Map.of("metadataKey1", "metadataValue1")), equalTo(true));
         verify(forwardPipeline1, times(0)).sendEvents(eq(records));
@@ -119,7 +119,7 @@ public class SinkContextTest {
         assertThat(forwardToPipelines.get("forward-pipeline2"), equalTo(null));
         HeadlessPipeline forwardPipeline1 = mock(HeadlessPipeline.class);
         assertThrows(RuntimeException.class, () -> sinkContext.setForwardToPipelines(Map.of("forward-pipeline1", forwardPipeline1)));
-        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext();
+        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
         Record<Event> record = mock(Record.class);
         Event event = mock(Event.class);
         DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
@@ -145,7 +145,7 @@ public class SinkContextTest {
         when(record.getData()).thenReturn(event);
         when(event.getEventHandle()).thenReturn(eventHandle);
         
-        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext();
+        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
         sinkForwardRecordsContext.addRecords(List.of(record));
         assertThat(sinkContext.forwardRecords(sinkForwardRecordsContext, Map.of(), Map.of()), equalTo(false));
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
@@ -8,12 +8,22 @@ package org.opensearch.dataprepper.model.sink;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class SinkContextTest {
     private SinkContext sinkContext;
@@ -24,11 +34,13 @@ public class SinkContextTest {
         final List<String> testRoutes = Collections.emptyList();
         final List<String> testIncludeKeys = Collections.emptyList();
         final List<String> testExcludeKeys = Collections.emptyList();
-        sinkContext = new SinkContext(testTagsTargetKey, testRoutes, testIncludeKeys, testExcludeKeys);
+        final List<String> testForwardToPipelineNames = Collections.emptyList();
+        sinkContext = new SinkContext(testTagsTargetKey, testRoutes, testIncludeKeys, testExcludeKeys, testForwardToPipelineNames);
         assertThat(sinkContext.getTagsTargetKey(), equalTo(testTagsTargetKey));
         assertThat(sinkContext.getRoutes(), equalTo(testRoutes));
         assertThat(sinkContext.getIncludeKeys(), equalTo(testIncludeKeys));
         assertThat(sinkContext.getExcludeKeys(), equalTo(testExcludeKeys));
+        assertThat(sinkContext.getForwardToPipelines(), equalTo(Collections.emptyMap()));
 
     }
 
@@ -43,5 +55,56 @@ public class SinkContextTest {
 
     }
 
+    @Test
+    public void testForwardToPipelinesWithPipelineMap() {
+        final String testTagsTargetKey = RandomStringUtils.randomAlphabetic(6);
+        final List<String> testRoutes = Collections.emptyList();
+        final List<String> testIncludeKeys = Collections.emptyList();
+        final List<String> testExcludeKeys = Collections.emptyList();
+        final List<String> testForwardToPipelineNames = List.of("forward-pipeline1", "forward-pipeline2");
+        sinkContext = new SinkContext(testTagsTargetKey, testRoutes, testIncludeKeys, testExcludeKeys, testForwardToPipelineNames);
+        Map<String, HeadlessPipeline> forwardToPipelines = sinkContext.getForwardToPipelines();
+        assertThat(forwardToPipelines.get("forward-pipeline1"), equalTo(null));
+        assertThat(forwardToPipelines.get("forward-pipeline2"), equalTo(null));
+        HeadlessPipeline forwardPipeline1 = mock(HeadlessPipeline.class);
+        HeadlessPipeline forwardPipeline2 = mock(HeadlessPipeline.class);
+        sinkContext.setForwardToPipelines(Map.of("forward-pipeline1", forwardPipeline1, "forward-pipeline2", forwardPipeline2));
+        forwardToPipelines = sinkContext.getForwardToPipelines();
+        assertThat(forwardToPipelines.get("forward-pipeline1"), equalTo(forwardPipeline1));
+        assertThat(forwardToPipelines.get("forward-pipeline2"), equalTo(forwardPipeline2));
+        Collection<Record<Event>> records = mock(Collection.class);
+        assertThat(sinkContext.forwardRecords(records), equalTo(true));
+        verify(forwardPipeline1, times(1)).sendEvents(eq(records));
+        verify(forwardPipeline2, times(1)).sendEvents(eq(records));
+    }
+
+    @Test
+    public void testForwardToPipelinesWithPipelineMapAndFailureCases() {
+        final String testTagsTargetKey = RandomStringUtils.randomAlphabetic(6);
+        final List<String> testRoutes = Collections.emptyList();
+        final List<String> testIncludeKeys = Collections.emptyList();
+        final List<String> testExcludeKeys = Collections.emptyList();
+        final List<String> testForwardToPipelineNames = List.of("forward-pipeline1", "forward-pipeline2");
+        sinkContext = new SinkContext(testTagsTargetKey, testRoutes, testIncludeKeys, testExcludeKeys, testForwardToPipelineNames);
+        Map<String, HeadlessPipeline> forwardToPipelines = sinkContext.getForwardToPipelines();
+        assertThat(forwardToPipelines.get("forward-pipeline1"), equalTo(null));
+        assertThat(forwardToPipelines.get("forward-pipeline2"), equalTo(null));
+        HeadlessPipeline forwardPipeline1 = mock(HeadlessPipeline.class);
+        assertThrows(RuntimeException.class, () -> sinkContext.setForwardToPipelines(Map.of("forward-pipeline1", forwardPipeline1)));
+        Collection<Record<Event>> records = mock(Collection.class);
+        assertThat(sinkContext.forwardRecords(records), equalTo(false));
+    }
+
+    @Test
+    public void testWithNoForwardToPipelines() {
+        final String testTagsTargetKey = RandomStringUtils.randomAlphabetic(6);
+        final List<String> testRoutes = Collections.emptyList();
+        final List<String> testIncludeKeys = Collections.emptyList();
+        final List<String> testExcludeKeys = Collections.emptyList();
+        final List<String> testForwardToPipelineNames = Collections.emptyList();
+        sinkContext = new SinkContext(testTagsTargetKey, testRoutes, testIncludeKeys, testExcludeKeys, testForwardToPipelineNames);
+        Collection<Record<Event>> records = mock(Collection.class);
+        assertThat(sinkContext.forwardRecords(records), equalTo(false));
+    }
 }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContextTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 
 import static org.mockito.Mockito.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 public class SinkForwardRecordsContextTest {
     
@@ -25,7 +27,31 @@ public class SinkForwardRecordsContextTest {
 
     @Test
     public void testSinkForwardRecordContextBasic() {
-        sinkForwardRecordsContext = new SinkForwardRecordsContext();
+        SinkContext sinkContext = mock(SinkContext.class);
+        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of());
+        sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
+        Event event = mock(Event.class);
+        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+        doNothing().when(eventHandle).acquireReference();
+        Record<Event> record1 = mock(Record.class);
+        Record<Event> record2 = mock(Record.class);
+        Record<Event> record3 = mock(Record.class);
+        when(record1.getData()).thenReturn(event);
+        when(record2.getData()).thenReturn(event);
+        when(record3.getData()).thenReturn(event);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        sinkForwardRecordsContext.addRecord(record1);
+        sinkForwardRecordsContext.addRecords(List.of(record2, record3));
+        List<Record<Event>> records = sinkForwardRecordsContext.getRecords();
+        assertThat(records.size(), equalTo(0));
+    }
+
+    @Test
+    public void testSinkForwardRecordContextWithForwardingPipelines() {
+        SinkContext sinkContext = mock(SinkContext.class);
+        HeadlessPipeline headlessPipeline = mock(HeadlessPipeline.class);
+        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of("pipeline1", headlessPipeline));
+        sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
         Event event = mock(Event.class);
         DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
         doNothing().when(eventHandle).acquireReference();
@@ -42,4 +68,3 @@ public class SinkForwardRecordsContextTest {
         assertThat(records.size(), equalTo(3));
     }
 }
-

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContextTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.sink;
+
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+
+import static org.mockito.Mockito.mock;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+public class SinkForwardRecordsContextTest {
+    
+    SinkForwardRecordsContext sinkForwardRecordsContext;
+
+    @Test
+    public void testSinkForwardRecordContextBasic() {
+        sinkForwardRecordsContext = new SinkForwardRecordsContext();
+        Event event = mock(Event.class);
+        DefaultEventHandle eventHandle = mock(DefaultEventHandle.class);
+        doNothing().when(eventHandle).acquireReference();
+        Record<Event> record1 = mock(Record.class);
+        Record<Event> record2 = mock(Record.class);
+        Record<Event> record3 = mock(Record.class);
+        when(record1.getData()).thenReturn(event);
+        when(record2.getData()).thenReturn(event);
+        when(record3.getData()).thenReturn(event);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        sinkForwardRecordsContext.addRecord(record1);
+        sinkForwardRecordsContext.addRecords(List.of(record2, record3));
+        List<Record<Event>> records = sinkForwardRecordsContext.getRecords();
+        assertThat(records.size(), equalTo(3));
+    }
+}
+

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ForwardingHeadlessPipelinesIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ForwardingHeadlessPipelinesIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+class ForwardingHeadlessPipelinesIT {
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessorPipelineIT.class);
+    private static final String IN_MEMORY_IDENTIFIER_DLQ = "PipelineDLQIT";
+    private static final String IN_MEMORY_IDENTIFIER_FORWARD = "ForwardPipelineIT";
+    private static final String PIPELINE_DLQ_TEST_CONFIGURATION= "pipeline-dlq.yaml";
+    private static final String FORWARD_PIPELINE_TEST_CONFIGURATION= "forward-pipeline.yaml";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    private void createPipeline(final String pipelineConfiguration) {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(pipelineConfiguration)
+                .build();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+        dataPrepperTestRunner.start();
+        LOG.info("Started test runner.");
+    }
+
+    @AfterEach
+    void tearDown() {
+        LOG.info("Test tear down. Stop the test runner.");
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void pipeline_forward_test() {
+        createPipeline(FORWARD_PIPELINE_TEST_CONFIGURATION);
+
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        LOG.info("Submitting a batch of record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER_FORWARD, inputRecords);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_FORWARD), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_FORWARD).size(), equalTo(2*recordsToCreate));
+
+        final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_FORWARD);
+
+        for (int i = 0; i < sinkRecords.size(); i++) {
+            final Record<Event> inputRecord = inputRecords.get(i%recordsToCreate);
+            final Record<Event> sinkRecord = sinkRecords.get(i);
+            assertThat(sinkRecord, notNullValue());
+            final Event recordData = sinkRecord.getData();
+            assertThat(recordData, notNullValue());
+            assertThat(
+                    recordData.get("message", String.class),
+                    equalTo(inputRecord.getData().get("message", String.class)));
+            assertThat(recordData.get("test1", String.class),
+                    equalTo("knownUpdatedPrefix1" + i%recordsToCreate));
+
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/HeadlessPipelinesIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/HeadlessPipelinesIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+class HeadlessPipelinesIT {
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessorPipelineIT.class);
+    private static final String IN_MEMORY_IDENTIFIER_DLQ = "PipelineDLQIT";
+    private static final String IN_MEMORY_IDENTIFIER_FORWARD = "ForwardPipelineIT";
+    private static final String PIPELINE_DLQ_TEST_CONFIGURATION= "pipeline-dlq.yaml";
+    private static final String FORWARD_PIPELINE_TEST_CONFIGURATION= "forward-pipeline.yaml";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    private void createPipeline(final String pipelineConfiguration) {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(pipelineConfiguration)
+                .build();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+        dataPrepperTestRunner.start();
+        LOG.info("Started test runner.");
+    }
+
+    @AfterEach
+    void tearDown() {
+        LOG.info("Test tear down. Stop the test runner.");
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void dlq_pipeline_test() {
+        createPipeline(PIPELINE_DLQ_TEST_CONFIGURATION);
+
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        LOG.info("Submitting a batch of record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER_DLQ, inputRecords);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_DLQ), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_DLQ).size(), equalTo(recordsToCreate));
+
+        final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_DLQ);
+
+        for (int i = 0; i < sinkRecords.size(); i++) {
+            final Record<Event> inputRecord = inputRecords.get(i);
+            final Record<Event> sinkRecord = sinkRecords.get(i);
+            assertThat(sinkRecord, notNullValue());
+            final Event recordData = sinkRecord.getData();
+            assertThat(recordData, notNullValue());
+            assertThat(
+                    recordData.get("message", String.class),
+                    equalTo(inputRecord.getData().get("message", String.class)));
+            assertThat(recordData.get("test1", String.class),
+                    equalTo(null));
+
+        }
+    }
+
+    @Test
+    void pipeline_forward_test() {
+        createPipeline(FORWARD_PIPELINE_TEST_CONFIGURATION);
+
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        LOG.info("Submitting a batch of record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER_FORWARD, inputRecords);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_FORWARD), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_FORWARD).size(), equalTo(2*recordsToCreate));
+
+        final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_FORWARD);
+
+        for (int i = 0; i < sinkRecords.size(); i++) {
+            final Record<Event> inputRecord = inputRecords.get(i%recordsToCreate);
+            final Record<Event> sinkRecord = sinkRecords.get(i);
+            assertThat(sinkRecord, notNullValue());
+            final Event recordData = sinkRecord.getData();
+            assertThat(recordData, notNullValue());
+            assertThat(
+                    recordData.get("message", String.class),
+                    equalTo(inputRecord.getData().get("message", String.class)));
+            assertThat(recordData.get("test1", String.class),
+                    equalTo("knownUpdatedPrefix1" + i%recordsToCreate));
+
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/HeadlessPipelinesIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/HeadlessPipelinesIT.java
@@ -78,6 +78,7 @@ class HeadlessPipelinesIT {
 
         final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER_DLQ);
 
+        assertThat(sinkRecords.size(), equalTo(recordsToCreate));
         for (int i = 0; i < sinkRecords.size(); i++) {
             final Record<Event> inputRecord = inputRecords.get(i);
             final Record<Event> sinkRecord = sinkRecords.get(i);

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySink.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySink.java
@@ -44,7 +44,7 @@ public class InMemorySink implements Sink<Record<Event>> {
         inMemorySinkAccessor.addEvents(testingKey, records);
         boolean result = inMemorySinkAccessor.getResult();
         if (doForward) {
-            sinkContext.forwardRecords(records);
+            sinkContext.forwardRecords(records, null, null);
         } else {
             records.stream().forEach((record) -> {
                 EventHandle eventHandle = ((Event)record.getData()).getEventHandle();

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessor.java
@@ -18,16 +18,21 @@ import java.util.Collection;
 public class SimpleProcessor implements Processor<Record<Event>, Record<Event>> {
     private final EventKey eventKey1;
     private final String valuePrefix1;
+    private final boolean throwException;
     int count = 0;
 
     @DataPrepperPluginConstructor
     public SimpleProcessor(final SimpleProcessorConfig simpleProcessorConfig) {
         eventKey1 = simpleProcessorConfig.getKey1();
         valuePrefix1 = simpleProcessorConfig.getValuePrefix1();
+        throwException = simpleProcessorConfig.getThrowException();
     }
 
     @Override
     public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
+        if (throwException) {
+            throw new RuntimeException("Throwing Exception");
+        }
         for (final Record<Event> record : records) {
             record.getData().put(eventKey1, valuePrefix1 + count);
             count++;

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessorConfig.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessorConfig.java
@@ -13,6 +13,7 @@ public class SimpleProcessorConfig {
     @EventKeyConfiguration(EventKeyFactory.EventAction.PUT)
     private EventKey key1;
     private String valuePrefix1;
+    private boolean throwException;
 
     public EventKey getKey1() {
         return key1;
@@ -20,5 +21,9 @@ public class SimpleProcessorConfig {
 
     public String getValuePrefix1() {
         return valuePrefix1;
+    }
+
+    public boolean getThrowException() {
+        return throwException;
     }
 }

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/forward-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/forward-pipeline.yaml
@@ -12,7 +12,8 @@ test-forward-pipeline:
   sink:
     - in_memory:
         testing_key: ForwardPipelineIT
-        forward_to: [ "pipeline2"]
+        forward_to:
+          pipelines: [ "pipeline2"]
 
 pipeline2:
   sink:

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/forward-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/forward-pipeline.yaml
@@ -1,0 +1,24 @@
+test-forward-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: ForwardPipelineIT
+
+  processor:
+    - simple_test:
+        key1: /test1
+        value_prefix1: knownUpdatedPrefix1
+
+  sink:
+    - in_memory:
+        testing_key: ForwardPipelineIT
+        forward_to: [ "pipeline2"]
+
+pipeline2:
+  sink:
+    - in_memory:
+        testing_key: ForwardPipelineIT
+
+
+
+

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/pipeline-dlq.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/pipeline-dlq.yaml
@@ -1,0 +1,23 @@
+test-dlq-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: PipelineDLQIT
+
+  processor:
+    - simple_test:
+        key1: /test1
+        value_prefix1: knownPrefix1
+        throw_exception: true
+
+  sink:
+    - in_memory:
+        testing_key: PipelineDLQNone
+
+dlq_pipeline:
+  sink:
+    - in_memory:
+        testing_key: PipelineDLQIT
+
+
+

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/PipelineRunnerImpl.java
@@ -109,6 +109,7 @@ public class PipelineRunnerImpl implements PipelineRunner {
                 }
             } catch (final Exception e) {
                 if (pipeline.getFailurePipeline() != null) {
+                    LOG.error("A processor threw an exception. This batch of Events will be sent to DLQ. ", e);
                     pipeline.getFailurePipeline().sendEvents(records);
                 } else if (inputEvents != null) {
                     LOG.error("A processor threw an exception. This batch of Events will be dropped, and their EventHandles will be released: ", e);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
@@ -347,9 +347,9 @@ class PipelineTransformerTests {
         final PipelineTransformer pipelineTransformer =
                 createObjectUnderTest(TestDataProvider.MISSING_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE);
 
-        final Map<String, Pipeline> connectedPipelines =pipelineTransformer.transformConfiguration(this.pipelinesDataFlowModel);
-        assertThat(connectedPipelines.size(), equalTo(0));
-        assertThat(pluginErrorCollector.getPluginErrors().size(), equalTo(2));
+        final RuntimeException actualException = assertThrows(RuntimeException.class, () -> pipelineTransformer.transformConfiguration(this.pipelinesDataFlowModel));
+        assertThat(actualException.getMessage(),
+                        equalTo("Invalid configuration, expected source test-pipeline-1 for pipeline test-pipeline-2 is missing"));
     }
 
     @Test

--- a/data-prepper-core/src/test/resources/missing_source_multiple_pipeline_configuration.yml
+++ b/data-prepper-core/src/test/resources/missing_source_multiple_pipeline_configuration.yml
@@ -1,13 +1,12 @@
 # this configuration file is solely for testing formatting
 test-pipeline-1:
+  source:
+    stdin:
   buffer:
     bounded_blocking: #to check non object nodes for plugins
   sink:
     - pipeline:
           name: "test-pipeline-2"
 test-pipeline-2:
-  source:
-    pipeline:
-      name: "test-pipeline-1"
   sink:
     - file:

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/model/PipelineConfiguration.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/model/PipelineConfiguration.java
@@ -137,7 +137,7 @@ public class PipelineConfiguration {
         final Map<String, Object> settingsMap = Optional
                 .ofNullable(sinkModel.getPluginSettings())
                 .orElseGet(HashMap::new);
-        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes(), sinkModel.getIncludeKeys(), sinkModel.getExcludeKeys()));
+        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes(), sinkModel.getIncludeKeys(), sinkModel.getExcludeKeys(), sinkModel.getForwardPipelineNames()));
     }
 
     private Integer getWorkersFromPipelineModel(final PipelineModel pipelineModel) {

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/model/PipelineConfiguration.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/model/PipelineConfiguration.java
@@ -137,7 +137,8 @@ public class PipelineConfiguration {
         final Map<String, Object> settingsMap = Optional
                 .ofNullable(sinkModel.getPluginSettings())
                 .orElseGet(HashMap::new);
-        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes(), sinkModel.getIncludeKeys(), sinkModel.getExcludeKeys(), sinkModel.getForwardConfig().getPipelineNames()));
+        List<String> pipelineNames = sinkModel.getForwardConfig() == null ? null : sinkModel.getForwardConfig().getPipelineNames();
+        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes(), sinkModel.getIncludeKeys(), sinkModel.getExcludeKeys(), pipelineNames));
     }
 
     private Integer getWorkersFromPipelineModel(final PipelineModel pipelineModel) {

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/model/PipelineConfiguration.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/model/PipelineConfiguration.java
@@ -137,7 +137,7 @@ public class PipelineConfiguration {
         final Map<String, Object> settingsMap = Optional
                 .ofNullable(sinkModel.getPluginSettings())
                 .orElseGet(HashMap::new);
-        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes(), sinkModel.getIncludeKeys(), sinkModel.getExcludeKeys(), sinkModel.getForwardPipelineNames()));
+        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes(), sinkModel.getIncludeKeys(), sinkModel.getExcludeKeys(), sinkModel.getForwardConfig().getPipelineNames()));
     }
 
     private Integer getWorkersFromPipelineModel(final PipelineModel pipelineModel) {

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
@@ -69,7 +69,7 @@ public class FileSink implements Sink<Record<Object>> {
 
     @Override
     public void output(final Collection<Record<Object>> records) {
-        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext();
+        SinkForwardRecordsContext sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
         lock.lock();
         Collection<Record<Event>> events = new ArrayList<>();
 

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
@@ -88,7 +88,7 @@ public class FileSink implements Sink<Record<Object>> {
             }
 
             if (doForward) {
-                sinkContext.forwardRecords(events);
+                sinkContext.forwardRecords(events, null, null);
             }
             try {
                 writer.flush();


### PR DESCRIPTION
### Description
Add support for forwarding successful records from sinks using SinkContext.
A new config option is added to all sinks
```
forward_to: 
  pipelines: [ <list of sub-pipepine names> ]
  with_data:
       key: value
  with_metadata:
       key: value
```
 
### Issues Resolved
Resolves #5985 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
