### PR TITLE
Update Netty to 4.1.124 to fix CVE-2025-55163.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,11 +230,11 @@ subprojects {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty') {
                 if (details.requested.name == 'netty') {
-                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.123.Final'
+                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.124.Final'
                     details.because 'Fixes CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.123.Final'
-                    details.because 'Fixes CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                    details.useVersion '4.1.124.Final'
+                    details.because 'Fixes CVE-2025-55163, CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
                 details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'


### PR DESCRIPTION
### Description

Updates Netty to 4.1.124 to fix CVE-2025-55163.
 
### Issues Resolved

N/A

Fixes CVE-2025-55163.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
