### PR TITLE
Require the smoke tests to pass before attempting to promote

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,6 @@ jobs:
 
   promote:
     runs-on: ubuntu-latest
-    if: ${{ (success() || failure()) && needs.build.result == 'success' }}
     needs: [build, validate-docker, validate-archive]
     permissions:
       contents: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -168,8 +168,6 @@ Once approved by two maintainers, the release build will be promoted to producti
 
 You can also deny a release by using _deny_ or _denied_ in the comment.
 
-**NOTE** The smoke tests currently report a build failure, even when they succeed. Thus, you need to manually verify the output.
-
 ### OpenSearch CI server build
 
 After two maintainers approve the GitHub issue, the [OpenSearch CI server](https://build.ci.opensearch.org/) will start a build.


### PR DESCRIPTION
### Description

Now that the smoke tests pass, update the release process to require success on these before promotion.

Updated the release instructions as well to remove a note related to this which is now obsolete.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
