### PR TITLE
fix: Update System.env syntax for Gradle 9 compatibility

### DIFF
--- a/buildSrc/src/main/groovy/data-prepper.publish.gradle
+++ b/buildSrc/src/main/groovy/data-prepper.publish.gradle
@@ -19,8 +19,8 @@ afterEvaluate {
                 name = 'snapshots'
                 url = 'https://central.sonatype.com/repository/maven-snapshots/'
                 credentials {
-                    username "$System.env.SONATYPE_USERNAME"
-                    password "$System.env.SONATYPE_PASSWORD"
+                    username System.getenv("SONATYPE_USERNAME")
+                    password System.getenv("SONATYPE_PASSWORD")
                 }
             }
         }


### PR DESCRIPTION
This PR updates the Gradle build files to fix compatibility with Gradle 9.

## Problem
The current syntax using `$System.env.VARIABLE_NAME` for accessing environment variables is not compatible with Gradle 9.

This format is used in this repository for Sonatype credentials for SNAPSHOT publication. This fails with under Gradle 9.
```gradle
credentials {
    username = "$System.env.SONATYPE_USERNAME"
    password = "$System.env.SONATYPE_PASSWORD"
}
```

See [example failed workflow here](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/actions/runs/17023398832/job/48255946880#step:5:74).

## Solution
Update to use the `System.getenv()` method instead:
```gradle
credentials {
    username = System.getenv("SONATYPE_USERNAME")
    password = System.getenv("SONATYPE_PASSWORD")
}
```

Example fix which restored successful snapshots: https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/245