### PR TITLE
Update microsoft office365 plugin name to follow OSI naming convention

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/utils/Constants.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/utils/Constants.java
@@ -14,7 +14,7 @@ package org.opensearch.dataprepper.plugins.source.microsoft_office365.utils;
  * The type Constants.
  */
 public class Constants {
-    public static final String PLUGIN_NAME = "microsoft-office365";
+    public static final String PLUGIN_NAME = "microsoft_office365";
     public static final String[] CONTENT_TYPES = {
             "Audit.AzureActiveDirectory",
             "Audit.Exchange",


### PR DESCRIPTION
**What?**

This commit changes microsoft office365 plugin name from microsoft-office365 to microsoft_office365.

**Why?**

Following the OSI naming convention to use underscore

Signed-off-by: Wenjie Yao <wjyao@amazon.com>
 
### Check List
- [N/A] New functionality includes testing.
- [N/A ] New functionality has a documentation issue. Please link to it in this PR.
  - [N/A ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
