### PR TITLE
Add logging for when secret is unable to be retrieved

### DIFF
--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionsApplier.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionsApplier.java
@@ -6,6 +6,8 @@
 package org.opensearch.dataprepper.plugin;
 
 import org.opensearch.dataprepper.model.plugin.ExtensionPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -16,6 +18,8 @@ import java.util.List;
 
 @Named("extensionsApplier")
 class ExtensionsApplier {
+    private static final Logger LOG = LoggerFactory.getLogger(ExtensionsApplier.class);
+
     private final DataPrepperExtensionPoints dataPrepperExtensionPoints;
     private final ExtensionLoader extensionLoader;
     private List<? extends ExtensionPlugin> loadedExtensionPlugins = Collections.emptyList();
@@ -31,6 +35,8 @@ class ExtensionsApplier {
     @PostConstruct
     void applyExtensions() {
         loadedExtensionPlugins = extensionLoader.loadExtensions();
+
+        LOG.info("Loaded {} extensions: {}", loadedExtensionPlugins.size(),  loadedExtensionPlugins);
 
         for (ExtensionPlugin extensionPlugin : loadedExtensionPlugins) {
             extensionPlugin.apply(dataPrepperExtensionPoints);


### PR DESCRIPTION
### Description
Adds error log that is swallowed for when secret can't be retrieved.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
