### PR TITLE
Improve extension loading by prioritizing dependencies, collect extension plugin errors on apply

### DIFF
--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
@@ -144,7 +144,7 @@ public class ExtensionLoader {
         }
     }
 
-    private String convertClassToName(final Class<? extends ExtensionPlugin> extensionClass) {
+    String convertClassToName(final Class<? extends ExtensionPlugin> extensionClass) {
         final String className = extensionClass.getSimpleName();
         return classNameToPluginName(className);
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionsApplier.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionsApplier.java
@@ -5,7 +5,11 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import org.opensearch.dataprepper.core.validation.PluginErrorCollector;
+import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
 import org.opensearch.dataprepper.model.plugin.ExtensionPlugin;
+import org.opensearch.dataprepper.validation.PluginError;
+import org.opensearch.dataprepper.validation.PluginErrorsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,6 +19,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Named("extensionsApplier")
 class ExtensionsApplier {
@@ -22,14 +27,20 @@ class ExtensionsApplier {
 
     private final DataPrepperExtensionPoints dataPrepperExtensionPoints;
     private final ExtensionLoader extensionLoader;
+    private final PluginErrorCollector pluginErrorCollector;
+    private final PluginErrorsHandler pluginErrorsHandler;
     private List<? extends ExtensionPlugin> loadedExtensionPlugins = Collections.emptyList();
 
     @Inject
     ExtensionsApplier(
             final DataPrepperExtensionPoints dataPrepperExtensionPoints,
-            final ExtensionLoader extensionLoader) {
+            final ExtensionLoader extensionLoader,
+            final PluginErrorCollector pluginErrorCollector,
+            final PluginErrorsHandler pluginErrorsHandler) {
         this.dataPrepperExtensionPoints = dataPrepperExtensionPoints;
         this.extensionLoader = extensionLoader;
+        this.pluginErrorCollector = pluginErrorCollector;
+        this.pluginErrorsHandler = pluginErrorsHandler;
     }
 
     @PostConstruct
@@ -39,12 +50,37 @@ class ExtensionsApplier {
         LOG.info("Loaded {} extensions: {}", loadedExtensionPlugins.size(),  loadedExtensionPlugins);
 
         for (ExtensionPlugin extensionPlugin : loadedExtensionPlugins) {
-            extensionPlugin.apply(dataPrepperExtensionPoints);
+            try {
+                extensionPlugin.apply(dataPrepperExtensionPoints);
+            } catch (Exception e) {
+                final PluginError pluginError = PluginError.builder()
+                        .componentType(PipelinesDataFlowModel.EXTENSION_PLUGIN_TYPE)
+                        .pluginName(extensionLoader.convertClassToName(extensionPlugin.getClass()))
+                        .exception(e)
+                        .build();
+                pluginErrorCollector.collectPluginError(pluginError);
+                LOG.error("Failed to apply extension plugin {}", extensionPlugin.getClass(), e);
+            }
         }
+
+        handlePluginErrors();
     }
 
     @PreDestroy
     public void shutdownExtensions() {
         loadedExtensionPlugins.forEach(ExtensionPlugin::shutdown);
+    }
+
+    private void handlePluginErrors() {
+        final List<PluginError> extensionPluginErrors = pluginErrorCollector.getPluginErrors()
+                .stream().filter(pluginError -> PipelinesDataFlowModel.EXTENSION_PLUGIN_TYPE
+                        .equals(pluginError.getComponentType()))
+                .collect(Collectors.toList());
+
+        if (!extensionPluginErrors.isEmpty()) {
+            pluginErrorsHandler.handleErrors(extensionPluginErrors);
+            throw new RuntimeException(
+                    "One or more extension plugins could not be applied correctly.");
+        }
     }
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginCreatorContext.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/PluginCreatorContext.java
@@ -23,11 +23,6 @@ public class PluginCreatorContext {
     @Bean(name = "extensionsLoaderComparator")
     public Comparator<ExtensionLoader.ExtensionPluginWithContext> extensionsLoaderComparator() {
         return (extensionOne, extensionTwo) -> {
-            // First, compare by configuration status (configured ones first)
-            int configCompare = Boolean.compare(extensionTwo.isConfigured(), extensionOne.isConfigured());
-            if (configCompare != 0) {
-                return configCompare;
-            }
 
             // Get the provided and dependent classes for both extensions
             Class<?>[] extensionOneProvidedClasses = extensionOne.getProvidedClasses();
@@ -43,6 +38,12 @@ public class PluginCreatorContext {
             // If extensionTwo provides any classes that extensionOne depends on, extensionTwo should go first
             if (containsAnyExtensionDependencies(extensionTwoProvidedClasses, extensionOneDependentClasses)) {
                 return 1;
+            }
+
+            // Lastly, compare by configuration status (configured ones before non-configured ones)
+            int configCompare = Boolean.compare(extensionTwo.isConfigured(), extensionOne.isConfigured());
+            if (configCompare != 0) {
+                return configCompare;
             }
 
             return 0;

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorContextTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorContextTest.java
@@ -63,8 +63,15 @@ public class PluginCreatorContextTest {
         when(context2.getProvidedClasses()).thenReturn(new Class<?>[]{});
         when(context2.getDependentClasses()).thenReturn(classes);
         assertThat(extensionsLoaderComparator.compare(context1, context2), equalTo(-1));
+
+        when(context1.getDependentClasses()).thenReturn(new Class<?>[]{});
+        when(context1.getProvidedClasses()).thenReturn(new Class<?>[]{});
+        when(context2.getProvidedClasses()).thenReturn(new Class<?>[]{});
+        when(context2.getProvidedClasses()).thenReturn(new Class<?>[]{});
+
         when(context1.isConfigured()).thenReturn(false);
         when(context2.isConfigured()).thenReturn(true);
+
         assertThat(extensionsLoaderComparator.compare(context1, context2), greaterThan(0));
         when(context1.isConfigured()).thenReturn(true);
         when(context2.isConfigured()).thenReturn(false);

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorContextTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorContextTest.java
@@ -77,4 +77,42 @@ public class PluginCreatorContextTest {
         when(context2.isConfigured()).thenReturn(false);
         assertThat(extensionsLoaderComparator.compare(context1, context2), lessThan(0));
     }
+
+    @Test
+    public void test_extensionsLoaderComparator_prioritizes_dependencies() {
+        final Class<?>[] classes = {DefaultPluginFactory.class};
+
+        ExtensionLoader.ExtensionPluginWithContext context1 = mock(ExtensionLoader.ExtensionPluginWithContext.class);
+        ExtensionLoader.ExtensionPluginWithContext context2 = mock(ExtensionLoader.ExtensionPluginWithContext.class);
+        Comparator<ExtensionLoader.ExtensionPluginWithContext> extensionsLoaderComparator = pluginCreatorContext.extensionsLoaderComparator();
+        assertNotNull(extensionsLoaderComparator);
+
+        when(context1.isConfigured()).thenReturn(false);
+        when(context1.getDependentClasses()).thenReturn(new Class<?>[]{});
+        when(context1.getProvidedClasses()).thenReturn(classes);
+
+        when(context2.isConfigured()).thenReturn(true);
+        when(context2.getProvidedClasses()).thenReturn(new Class<?>[]{});
+        when(context2.getDependentClasses()).thenReturn(classes);
+
+        assertThat(extensionsLoaderComparator.compare(context1, context2), equalTo(-1));
+    }
+
+    @Test
+    public void test_extensionsLoaderComparator_falls_back_to_if_configured_when_there_are_no_dependencies() {
+        ExtensionLoader.ExtensionPluginWithContext context1 = mock(ExtensionLoader.ExtensionPluginWithContext.class);
+        ExtensionLoader.ExtensionPluginWithContext context2 = mock(ExtensionLoader.ExtensionPluginWithContext.class);
+        Comparator<ExtensionLoader.ExtensionPluginWithContext> extensionsLoaderComparator = pluginCreatorContext.extensionsLoaderComparator();
+        assertNotNull(extensionsLoaderComparator);
+
+        when(context1.isConfigured()).thenReturn(false);
+        when(context1.getDependentClasses()).thenReturn(new Class<?>[]{});
+        when(context1.getProvidedClasses()).thenReturn(new Class<?>[]{});
+
+        when(context2.isConfigured()).thenReturn(true);
+        when(context2.getProvidedClasses()).thenReturn(new Class<?>[]{});
+        when(context2.getDependentClasses()).thenReturn(new Class<?>[]{});
+
+        assertThat(extensionsLoaderComparator.compare(context1, context2), equalTo(1));
+    }
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
@@ -161,16 +161,10 @@ class AwsSecretsSupplierTest {
 
     @ParameterizedTest
     @MethodSource("exceptionProvider")
-    void testConstructorWithGetSecretValueFailure(final Class<Throwable> e) {
-        when(secretsManagerClient.getSecretValue(eq(getSecretValueRequest))).thenThrow(e);
+    void testConstructorWithGetSecretValueFailure(final Class<Throwable> exceptionClass) {
+        when(secretsManagerClient.getSecretValue(eq(getSecretValueRequest))).thenThrow(exceptionClass);
         assertThrows(RuntimeException.class, () -> new AwsSecretsSupplier(
                 secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER, awsCredentialsSupplier));
-    }
-
-    private static Stream<Arguments> exceptionProvider() {
-        return Stream.of(
-                Arguments.of(AwsServiceException.class),
-                Arguments.of(RuntimeException.class));
     }
 
     @Test
@@ -248,5 +242,10 @@ class AwsSecretsSupplierTest {
         objectUnderTest = createObjectUnderTest();
         assertThrows(RuntimeException.class,
                 () -> objectUnderTest.updateValue(TEST_AWS_SECRET_CONFIGURATION_NAME, "key", "newValue"));
+    }
+
+    private static Stream<Arguments> exceptionProvider() {
+        return Stream.of(Arguments.of(AwsServiceException.class),
+                Arguments.of(RuntimeException.class));
     }
 }


### PR DESCRIPTION
### Description
Improve extension loading by prioritizing dependencies rather than prioritizing configured plugins. collect extension plugin errors on apply
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
