### PR TITLE
JMH measurement for Data Prepper Expressions and a Gradle convention plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,3 +8,11 @@ plugins {
     id 'java'
     id 'groovy-gradle-plugin'
 }
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation('me.champeau.jmh:me.champeau.jmh.gradle.plugin:0.7.3')
+}

--- a/buildSrc/src/main/groovy/data-prepper.jmh.gradle
+++ b/buildSrc/src/main/groovy/data-prepper.jmh.gradle
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'me.champeau.jmh'
+}

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'antlr'
     id 'idea'
     id 'data-prepper.publish'
+    id 'data-prepper.jmh'
 }
 
 group = 'org.opensearch.dataprepper.core'
@@ -34,6 +35,7 @@ dependencies {
     testImplementation testLibs.spring.test
     testImplementation libs.commons.lang3
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+    testImplementation project(':data-prepper-test:test-event')
 }
 
 generateGrammarSource {

--- a/data-prepper-expression/src/jmh/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluationMeasure.java
+++ b/data-prepper-expression/src/jmh/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluationMeasure.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.Map;
+
+public class ConditionalExpressionEvaluationMeasure {
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        private GenericExpressionEvaluator evaluator;
+        private Event event;
+
+        @Setup
+        public void setUp() {
+            final AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+            applicationContext.scan("org.opensearch.dataprepper.expression");
+            applicationContext.refresh();
+
+            evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+            final EventFactory eventFactory = TestEventFactory.getTestEventFactory();
+
+            final Map<String, Object> eventData = Map.of("key", "a");
+
+            event = eventFactory.eventBuilder(LogEventBuilder.class)
+                    .withData(eventData)
+                    .build();
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 5, time = 10)
+    public Object evaluate_simple_equality_expression(final BenchmarkState benchmarkState) {
+        final GenericExpressionEvaluator evaluator = benchmarkState.evaluator;
+        return evaluator.evaluate("/key == \"a\"", benchmarkState.event);
+    }
+}

--- a/data-prepper-plugins/http-source/build.gradle
+++ b/data-prepper-plugins/http-source/build.gradle
@@ -5,7 +5,7 @@
 
 plugins {
     id 'java'
-    id 'me.champeau.jmh' version '0.7.3'
+    id 'data-prepper.jmh'
 }
 
 dependencies {


### PR DESCRIPTION
### Description

This PR does two things:
1. Makes a Gradle convention plugin for JMH. Use this in the existing JMH measurement.
2. Adds a new JMH measurement for Data Prepper expressions.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
