### PR TITLE
Performance improvement by avoiding repeated parsing of the same expr…

### DIFF
--- a/data-prepper-expression/src/jmh/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluationMeasure.java
+++ b/data-prepper-expression/src/jmh/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluationMeasure.java
@@ -27,6 +27,24 @@ import java.util.Map;
 
 public class ConditionalExpressionEvaluationMeasure {
 
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 5, time = 10)
+    public Object evaluate_simple_function_expression(final BenchmarkState benchmarkState) {
+        final GenericExpressionEvaluator evaluator = benchmarkState.evaluator;
+        return evaluator.evaluate("length(/key) > 10", benchmarkState.event);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 5, time = 10)
+    public Object evaluate_simple_equality_expression(final BenchmarkState benchmarkState) {
+        final GenericExpressionEvaluator evaluator = benchmarkState.evaluator;
+        return evaluator.evaluate("/key == \"a\"", benchmarkState.event);
+    }
+
     @State(Scope.Benchmark)
     public static class BenchmarkState {
         private GenericExpressionEvaluator evaluator;
@@ -42,20 +60,11 @@ public class ConditionalExpressionEvaluationMeasure {
 
             final EventFactory eventFactory = TestEventFactory.getTestEventFactory();
 
-            final Map<String, Object> eventData = Map.of("key", "a");
+            final Map<String, Object> eventData = Map.of("key", "this is a test string with more than 10 characters");
 
             event = eventFactory.eventBuilder(LogEventBuilder.class)
                     .withData(eventData)
                     .build();
         }
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    @Warmup(iterations = 1)
-    @Measurement(iterations = 5, time = 10)
-    public Object evaluate_simple_equality_expression(final BenchmarkState benchmarkState) {
-        final GenericExpressionEvaluator evaluator = benchmarkState.evaluator;
-        return evaluator.evaluate("/key == \"a\"", benchmarkState.event);
     }
 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -25,7 +25,11 @@ import java.util.regex.Pattern;
 class ParseTreeCoercionService {
     private static final Pattern QUOTE_PATTERN = Pattern.compile("^\"{1,3}|\"{1,3}$");
     private static final Pattern ARGUMENT_SPLITTER = Pattern.compile("(?<!\\\\),");
-    private static final int INITIAL_ARG_LIST_SIZE = 4;
+    private static final int INITIAL_ARG_LIST_SIZE = 8;
+    private static final String INVALID_FUNCTION_FORMAT_OPEN = "Invalid function format: missing opening parenthesis";
+    private static final String INVALID_FUNCTION_FORMAT_CLOSE = "Invalid function format: missing closing parenthesis";
+    private static final String INVALID_STRING_ARG = "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.";
+    private static final String UNSUPPORTED_ARG_TYPE = "Unsupported type passed as function argument";
     private final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions;
     private final ExpressionFunctionProvider expressionFunctionProvider;
     private final Function<Object, Object> convertLiteralType;
@@ -96,12 +100,12 @@ class ParseTreeCoercionService {
     private FunctionMetadata parseFunctionMetadata(final String nodeStringValue) {
         final int funcNameIndex = nodeStringValue.indexOf("(");
         if (funcNameIndex == -1) {
-            throw new ExpressionCoercionException("Invalid function format: missing opening parenthesis");
+            throw new ExpressionCoercionException(INVALID_FUNCTION_FORMAT_OPEN);
         }
         final String functionName = nodeStringValue.substring(0, funcNameIndex);
         final int argsEndIndex = nodeStringValue.indexOf(")", funcNameIndex);
         if (argsEndIndex == -1) {
-            throw new ExpressionCoercionException("Invalid function format: missing closing parenthesis");
+            throw new ExpressionCoercionException(INVALID_FUNCTION_FORMAT_CLOSE);
         }
 
         List<Object> argList = new ArrayList<>(INITIAL_ARG_LIST_SIZE);
@@ -119,11 +123,11 @@ class ParseTreeCoercionService {
                 } else if (trimmedArg.charAt(0) == '"') {
                     if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length() - 1) != '"') {
                         throw new ExpressionCoercionException(
-                                "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
+                                INVALID_STRING_ARG);
                     }
                     argList.add(trimmedArg);
                 } else {
-                    throw new ExpressionCoercionException("Unsupported type passed as function argument");
+                    throw new ExpressionCoercionException(UNSUPPORTED_ARG_TYPE);
                 }
             }
         }
@@ -131,11 +135,11 @@ class ParseTreeCoercionService {
         return new FunctionMetadata(functionName, argList);
     }
 
-    private static class FunctionMetadata {
+    private static final class FunctionMetadata {
         final String functionName;
         final List<Object> argList;
 
-        private FunctionMetadata(String functionName, List<Object> argList) {
+        private FunctionMetadata(final String functionName, final List<Object> argList) {
             this.functionName = functionName.intern();
             this.argList = argList;
         }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -5,73 +5,42 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+import org.opensearch.dataprepper.model.event.Event;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.Serializable;
-import java.util.Map;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 @Named
 class ParseTreeCoercionService {
     private final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions;
-    private ExpressionFunctionProvider expressionFunctionProvider;
-    private Function<Object, Object> convertLiteralType;
-
-    @Inject
-    public ParseTreeCoercionService(
-            final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions,
-            final ExpressionFunctionProvider expressionFunctionProvider) {
-        this.literalTypeConversions = literalTypeConversions;
-        convertLiteralType = (value) -> {
-            if (literalTypeConversions.containsKey(value.getClass())) {
-                return literalTypeConversions.get(value.getClass()).apply(value);
-            } else {
-                throw new ExpressionCoercionException("Unsupported type for value " + value);
-            }
-        };
-        this.expressionFunctionProvider = expressionFunctionProvider;
-    }
+    private final ExpressionFunctionProvider expressionFunctionProvider;
+    private final Function<Object, Object> convertLiteralType;
+    private final ConcurrentMap<String, FunctionMetadata> cachedFunctionStrings = new ConcurrentHashMap<>();
 
     public Object coercePrimaryTerminalNode(final TerminalNode node, final Event event) {
+        Objects.requireNonNull(node, "TerminalNode cannot be null");
         final int nodeType = node.getSymbol().getType();
         final String nodeStringValue = node.getText();
         switch (nodeType) {
             case DataPrepperExpressionParser.Function:
-                final int funcNameIndex = nodeStringValue.indexOf("(");
-                final String functionName = nodeStringValue.substring(0, funcNameIndex);
-                final int argsEndIndex = nodeStringValue.indexOf(")", funcNameIndex);
-                List<Object> argList = new ArrayList<>();
+                FunctionMetadata functionMetadata = cachedFunctionStrings.get(nodeStringValue);
 
-                // Check if the function has at least one argument
-                 if(argsEndIndex > funcNameIndex + 1) {
-                    final String argsStr = nodeStringValue.substring(funcNameIndex + 1, argsEndIndex);
-                    // Split at commas if there's no backslash before the commas, because commas can
-                    // be part of a function parameter
-                    final String[] args = argsStr.split("(?<!\\\\),");
-                    
-                    for (final String arg : args) {
-                        String trimmedArg = arg.trim();
-                        if (trimmedArg.charAt(0) == '/') {
-                            argList.add(trimmedArg);
-                        } else if (trimmedArg.charAt(0) == '"') {
-                            if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length() - 1) != '"') {
-                                throw new RuntimeException(
-                                        "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
-                            }
-                            argList.add(trimmedArg);
-                        } else {
-                            throw new RuntimeException("Unsupported type passed as function argument");
-                        }
-                    }
+                if (functionMetadata == null) {
+                    functionMetadata = parseFunctionMetadata(nodeStringValue);
+                    cachedFunctionStrings.putIfAbsent(nodeStringValue, functionMetadata);
                 }
-             
-                return expressionFunctionProvider.provideFunction(functionName, argList, event, convertLiteralType);
+
+                return expressionFunctionProvider.provideFunction(functionMetadata.functionName, functionMetadata.argList, event, convertLiteralType);
             case DataPrepperExpressionParser.EscapedJsonPointer:
                 final String jsonPointerWithoutQuotes = nodeStringValue.substring(1, nodeStringValue.length() - 1);
                 return resolveJsonPointerValue(jsonPointerWithoutQuotes, event);
@@ -103,12 +72,73 @@ class ParseTreeCoercionService {
         }
     }
 
+    @Inject
+    public ParseTreeCoercionService(
+            final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions,
+            final ExpressionFunctionProvider expressionFunctionProvider) {
+        this.literalTypeConversions = literalTypeConversions;
+        convertLiteralType = (value) -> {
+            if (literalTypeConversions.containsKey(value.getClass())) {
+                return literalTypeConversions.get(value.getClass()).apply(value);
+            } else {
+                throw new ExpressionCoercionException("Unsupported type for value " + value);
+            }
+        };
+        this.expressionFunctionProvider = expressionFunctionProvider;
+    }
+
     public <T> T coerce(final Object obj, Class<T> clazz) throws ExpressionCoercionException {
         if (obj.getClass().isAssignableFrom(clazz)) {
             return (T) obj;
         }
         throw new ExpressionCoercionException(
                 "Unable to cast " + obj.getClass().getName() + " into " + clazz.getName());
+    }
+
+    private FunctionMetadata parseFunctionMetadata(final String nodeStringValue) {
+        final int funcNameIndex = nodeStringValue.indexOf("(");
+        if (funcNameIndex == -1) {
+            throw new ExpressionCoercionException("Invalid function format: missing opening parenthesis");
+        }
+        final String functionName = nodeStringValue.substring(0, funcNameIndex);
+        final int argsEndIndex = nodeStringValue.indexOf(")", funcNameIndex);
+        if (argsEndIndex == -1) {
+            throw new ExpressionCoercionException("Invalid function format: missing closing parenthesis");
+        }
+
+        List<Object> argList = new ArrayList<>();
+        if (argsEndIndex > funcNameIndex + 1) {
+            final String argsStr = nodeStringValue.substring(funcNameIndex + 1, argsEndIndex);
+            final String[] args = argsStr.split("(?<!\\\\),");
+
+            for (final String arg : args) {
+                String trimmedArg = arg.trim();
+                if (trimmedArg.isEmpty()) {
+                    continue;
+                }
+                if (trimmedArg.charAt(0) == '/') {
+                    argList.add(trimmedArg);
+                } else if (trimmedArg.charAt(0) == '"') {
+                    if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length() - 1) != '"') {
+                        throw new ExpressionCoercionException(
+                                "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
+                    }
+                    argList.add(trimmedArg);
+                } else {
+                    throw new ExpressionCoercionException("Unsupported type passed as function argument");
+                }
+            }
+        }
+
+        FunctionMetadata metadata = new FunctionMetadata();
+        metadata.functionName = functionName;
+        metadata.argList = argList;
+        return metadata;
+    }
+
+    private static class FunctionMetadata {
+        String functionName;
+        List<Object> argList;
     }
 
     private Object resolveJsonPointerValue(final String jsonPointer, final Event event) {

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -36,13 +36,8 @@ class ParseTreeCoercionService {
         final String nodeStringValue = node.getText();
         switch (nodeType) {
             case DataPrepperExpressionParser.Function:
+                cachedFunctionStrings.computeIfAbsent(nodeStringValue, this::parseFunctionMetadata);
                 FunctionMetadata functionMetadata = cachedFunctionStrings.get(nodeStringValue);
-
-                if (functionMetadata == null) {
-                    functionMetadata = parseFunctionMetadata(nodeStringValue);
-                    cachedFunctionStrings.putIfAbsent(nodeStringValue, functionMetadata);
-                }
-
                 return expressionFunctionProvider.provideFunction(functionMetadata.functionName, functionMetadata.argList, event, convertLiteralType);
             case DataPrepperExpressionParser.EscapedJsonPointer:
                 final String jsonPointerWithoutQuotes = nodeStringValue.substring(1, nodeStringValue.length() - 1);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -78,6 +78,8 @@ class ParseTreeCoercionService {
     public ParseTreeCoercionService(
             final Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions,
             final ExpressionFunctionProvider expressionFunctionProvider) {
+        Objects.requireNonNull(literalTypeConversions, "literalTypeConversions cannot be null");
+        Objects.requireNonNull(expressionFunctionProvider, "expressionFunctionProvider cannot be null");
         this.literalTypeConversions = literalTypeConversions;
         convertLiteralType = (value) -> {
             if (literalTypeConversions.containsKey(value.getClass())) {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 class ParseTreeCoercionServiceParameterizedTest {
@@ -91,7 +93,7 @@ class ParseTreeCoercionServiceParameterizedTest {
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn("now()");
         final Event testEvent = mock(Event.class);
-        when(expressionFunctionProvider.provideFunction("now", java.util.Collections.emptyList(), testEvent, null))
+        when(expressionFunctionProvider.provideFunction(eq("now"), eq(java.util.Collections.<Object>emptyList()), eq(testEvent), any()))
                 .thenReturn("2023-01-01");
         
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
@@ -115,7 +117,7 @@ class ParseTreeCoercionServiceParameterizedTest {
 
     private static Stream<Arguments> provideFunctionErrorCases() {
         return Stream.of(
-            Arguments.of("test(\"unclosed", "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`."),
+            Arguments.of("test(\"unclosed", "Invalid function format: missing closing parenthesis"),
             Arguments.of("test(123)", "Unsupported type passed as function argument")
         );
     }
@@ -126,7 +128,7 @@ class ParseTreeCoercionServiceParameterizedTest {
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn("test(\"\")");
         final Event testEvent = mock(Event.class);
-        when(expressionFunctionProvider.provideFunction("test", java.util.List.of("\"\""), testEvent, null))
+        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("\"\"")), eq(testEvent), any()))
                 .thenReturn("result");
         
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
@@ -140,7 +142,7 @@ class ParseTreeCoercionServiceParameterizedTest {
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn("test(/key, \"value\")");
         final Event testEvent = mock(Event.class);
-        when(expressionFunctionProvider.provideFunction("test", java.util.List.of("/key", "\"value\""), testEvent, null))
+        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("/key", "\"value\"")), eq(testEvent), any()))
                 .thenReturn("result");
         
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ParseTreeCoercionServiceParameterizedTest {
+
+    @Mock
+    private TerminalNode terminalNode;
+
+    @Mock
+    private Token token;
+
+    private final LiteralTypeConversionsConfiguration literalTypeConversionsConfiguration =
+            new LiteralTypeConversionsConfiguration();
+    private final ExpressionFunctionProvider expressionFunctionProvider = mock(ExpressionFunctionProvider.class);
+    private final ParseTreeCoercionService objectUnderTest = new ParseTreeCoercionService(
+            literalTypeConversionsConfiguration.literalTypeConversions(), expressionFunctionProvider);
+
+    @ParameterizedTest
+    @MethodSource("provideTerminalNodeTypes")
+    void testCoerceTerminalNodeTypes(int tokenType) {
+        when(token.getType()).thenReturn(tokenType);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        final Event testEvent = mock(Event.class);
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        assertThat(result, equalTo(tokenType));
+    }
+
+    private static Stream<Arguments> provideTerminalNodeTypes() {
+        return Stream.of(
+            Arguments.of(DataPrepperExpressionParser.COMMA),
+            Arguments.of(DataPrepperExpressionParser.SET_DELIMITER)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideFunctionWithMissingParenthesis")
+    void testFunctionWithMissingParenthesis(String functionText, String expectedMessage) {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn(functionText);
+        final Event testEvent = mock(Event.class);
+        
+        final ExpressionCoercionException exception = assertThrows(ExpressionCoercionException.class,
+                () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent));
+        
+        assertThat(exception.getMessage(), equalTo(expectedMessage));
+    }
+
+    private static Stream<Arguments> provideFunctionWithMissingParenthesis() {
+        return Stream.of(
+            Arguments.of("lengtharg", "Invalid function format: missing opening parenthesis"),
+            Arguments.of("length(arg", "Invalid function format: missing closing parenthesis"),
+            Arguments.of("lengtharg)", "Invalid function format: missing opening parenthesis")
+        );
+    }
+
+    @Test
+    void testFunctionWithNoArguments() {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("now()");
+        final Event testEvent = mock(Event.class);
+        when(expressionFunctionProvider.provideFunction("now", java.util.Collections.emptyList(), testEvent, null))
+                .thenReturn("2023-01-01");
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        assertThat(result, equalTo("2023-01-01"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideFunctionErrorCases")
+    void testFunctionErrorCases(String functionText, String expectedMessage) {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn(functionText);
+        final Event testEvent = mock(Event.class);
+        
+        final ExpressionCoercionException exception = assertThrows(ExpressionCoercionException.class,
+                () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent));
+        
+        assertThat(exception.getMessage(), equalTo(expectedMessage));
+    }
+
+    private static Stream<Arguments> provideFunctionErrorCases() {
+        return Stream.of(
+            Arguments.of("test(\"unclosed", "Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`."),
+            Arguments.of("test(123)", "Unsupported type passed as function argument")
+        );
+    }
+
+    @Test
+    void testFunctionWithEmptyStringArgument() {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("test(\"\")");
+        final Event testEvent = mock(Event.class);
+        when(expressionFunctionProvider.provideFunction("test", java.util.List.of("\"\""), testEvent, null))
+                .thenReturn("result");
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        assertThat(result, equalTo("result"));
+    }
+
+    @Test
+    void testFunctionWithMultipleArguments() {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("test(/key, \"value\")");
+        final Event testEvent = mock(Event.class);
+        when(expressionFunctionProvider.provideFunction("test", java.util.List.of("/key", "\"value\""), testEvent, null))
+                .thenReturn("result");
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        assertThat(result, equalTo("result"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConstructorNullParameters")
+    void testConstructorWithNullParameters(Map<Class<? extends java.io.Serializable>, Function<Object, Object>> conversions, ExpressionFunctionProvider provider) {
+        assertThrows(NullPointerException.class, 
+                () -> new ParseTreeCoercionService(conversions, provider));
+    }
+
+    private static Stream<Arguments> provideConstructorNullParameters() {
+        ExpressionFunctionProvider mockProvider = mock(ExpressionFunctionProvider.class);
+        LiteralTypeConversionsConfiguration config = new LiteralTypeConversionsConfiguration();
+        return Stream.of(
+            Arguments.of(null, mockProvider),
+            Arguments.of(config.literalTypeConversions(), null)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\"test\"", "\"\"\"test\"\"\"", "\"test with spaces\""})
+    void testStringTypeWithDifferentQuotePatterns(String input) {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.String);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn(input);
+        final Event testEvent = mock(Event.class);
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        // Should strip quotes
+        String expected = input.replaceAll("^\"{1,3}|\"{1,3}$", "");
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
+    void testJsonPointerWithNullValue() {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.JsonPointer);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("/nonexistent");
+        final Event testEvent = mock(Event.class);
+        when(testEvent.get("/nonexistent", Object.class)).thenReturn(null);
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        assertThat(result, equalTo(null));
+    }
+
+    @Test
+    void testConvertLiteralTypeWithUnsupportedType() {
+        // Create a service with limited type conversions to test the error path
+        Map<Class<? extends java.io.Serializable>, Function<Object, Object>> limitedConversions = new HashMap<>();
+        ParseTreeCoercionService limitedService = new ParseTreeCoercionService(limitedConversions, expressionFunctionProvider);
+        
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.JsonPointer);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("/key");
+        final Event testEvent = mock(Event.class);
+        when(testEvent.get("/key", Object.class)).thenReturn("unsupported");
+        
+        assertThrows(ExpressionCoercionException.class,
+                () -> limitedService.coercePrimaryTerminalNode(terminalNode, testEvent));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
@@ -137,6 +137,20 @@ class ParseTreeCoercionServiceParameterizedTest {
     }
 
     @Test
+    void testFunctionWithEmptyArgument() {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("test(/key, , \"value\")");
+        final Event testEvent = mock(Event.class);
+        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("/key", "\"value\"")), eq(testEvent), any()))
+                .thenReturn("result");
+        
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        
+        assertThat(result, equalTo("result"));
+    }
+
+    @Test
     void testFunctionWithMultipleArguments() {
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         when(terminalNode.getSymbol()).thenReturn(token);


### PR DESCRIPTION
### Description
Performance improvement with the following changes
-  Avoiding the repeated parsing of the same expression by caching the results in a local concurrent hashmap.
- Strings are moved to static final at the class level
- Regex expressions are compiled once used in the logic
- Default size initialization where it makes sense


`./gradlew -p data-prepper-expression jmh` command output before the change

```
Benchmark                                                                    Mode  Cnt        Score       Error  Units
ConditionalExpressionEvaluationMeasure.evaluate_simple_equality_expression  thrpt   25   980653.219 ± 22128.012  ops/s
ConditionalExpressionEvaluationMeasure.evaluate_simple_function_expression  thrpt   25  1049733.191 ±  4418.161  ops/s
```

`./gradlew -p data-prepper-expression jmh` command output after the change

```
Benchmark                                                                    Mode  Cnt        Score       Error  Units
ConditionalExpressionEvaluationMeasure.evaluate_simple_equality_expression  thrpt   25  1003822.290 ± 21842.189  ops/s
ConditionalExpressionEvaluationMeasure.evaluate_simple_function_expression  thrpt   25  1312741.590 ± 10707.145  ops/s
```

23.5%  improved in function expression evolution
 
### Issues Resolved
Resolves #6020
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
