### PR TITLE
Added support for flatten key with add_entries with iterate_on

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -73,10 +73,11 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
                         final String key = (entry.getKey() == null) ? null : recordEvent.formatString(entry.getKey(), expressionEvaluator);
                         final String metadataKey = entry.getMetadataKey();
                         final String iterateOn = entry.getIterateOn();
+                        final boolean flattenKey = entry.getFlattenKey();
                         if (Objects.isNull(iterateOn)) {
                             handleWithoutIterateOn(entry, recordEvent, key, metadataKey);
                         } else if (!Objects.isNull(key)) {
-                            handleWithIterateOn(entry, recordEvent, iterateOn, key);
+                            handleWithIterateOn(entry, recordEvent, iterateOn, flattenKey, key);
                         }
                     } catch (Exception e) {
                         LOG.atError()
@@ -145,10 +146,12 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
     private void handleWithIterateOn(final AddEntryProcessorConfig.Entry entry,
                                      final Event recordEvent,
                                      final String iterateOn,
+                                     final boolean flattenKey,
                                      final String key) {
         final List<Map<String, Object>> iterateOnList = recordEvent.get(iterateOn, List.class);
         if (iterateOnList != null) {
-            for (final Map<String, Object> item : iterateOnList) {
+            for (int i = 0; i < iterateOnList.size(); i++) {
+                final Map<String, Object> item = iterateOnList.get(i);
                 final Object value;
                 final Event context = JacksonEvent.builder()
                         .withEventMetadata(recordEvent.getMetadata())
@@ -160,9 +163,22 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
 
                 value = retrieveValue(entry, context);
                 if (!item.containsKey(key) || entry.getOverwriteIfKeyExists()) {
-                    item.put(key, value);
+                    if (flattenKey) {
+                        item.put(key, value);
+                    }  else {
+                        context.put(key, value);
+                    }
                 } else if (item.containsKey(key) && entry.getAppendIfKeyExists()) {
-                    mergeValueToMap(item, key, value);
+                    if (flattenKey) {
+                        mergeValueToMap(item, key, value);
+                    }  else {
+                        mergeValueToEvent(context, key, value);
+                    }
+                }
+                if (flattenKey){
+                    iterateOnList.set(i, item);
+                } else {
+                    iterateOnList.set(i, context.toMap());
                 }
             }
             recordEvent.put(iterateOn, iterateOnList);

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -53,7 +53,7 @@ public class AddEntryProcessorTests {
     void invalid_add_when_throws_InvalidPluginConfigurationException() {
         final String addWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false, addWhen, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false, addWhen, null, true, null)));
 
         when(expressionEvaluator.isValidExpressionStatement(addWhen)).thenReturn(false);
 
@@ -62,7 +62,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -76,7 +76,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleEntryIterativeAddValue() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Collections.emptyMap());
@@ -93,7 +93,7 @@ public class AddEntryProcessorTests {
         final String addToElementWhen = UUID.randomUUID().toString();
 
         when(expressionEvaluator.isValidExpressionStatement(addToElementWhen)).thenReturn(false);
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", addToElementWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", true, addToElementWhen)));
 
         assertThrows(InvalidPluginConfigurationException.class, this::createObjectUnderTest);
     }
@@ -102,7 +102,7 @@ public class AddEntryProcessorTests {
     void using_add_to_element_when_without_iterate_on_throws_InvalidPluginConfigurationException() {
         final String addToElementWhen = UUID.randomUUID().toString();
 
-        assertThrows(InvalidPluginConfigurationException.class, () -> createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, addToElementWhen)));
+        assertThrows(InvalidPluginConfigurationException.class, () -> createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, true, addToElementWhen)));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class AddEntryProcessorTests {
         when(expressionEvaluator.isValidExpressionStatement(addToElementWhen)).thenReturn(true);
         when(expressionEvaluator.evaluateConditional(eq(addToElementWhen), any(Event.class))).thenReturn(false);
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", addToElementWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", true, addToElementWhen)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Collections.emptyMap());
@@ -132,7 +132,7 @@ public class AddEntryProcessorTests {
         when(expressionEvaluator.isValidExpressionStatement(addToElementWhen)).thenReturn(true);
         when(expressionEvaluator.evaluateConditional(eq(addToElementWhen), any(Event.class))).thenReturn(true);
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", addToElementWhen)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", true, addToElementWhen)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Collections.emptyMap());
@@ -146,7 +146,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleEntryIterativeAddValue_key_exists() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, "message", true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Map.of("newMessage", 5));
@@ -160,7 +160,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleEntryIterativeAddValue_overwriteIfKeyExists() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, "message", null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, "message", true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Map.of("newMessage", 5));
@@ -174,7 +174,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleEntryIterativeAddValue_appendIfKeyExists() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, true,null, "message", null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, true,null, "message", true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Map.of("newMessage", 5));
@@ -193,7 +193,7 @@ public class AddEntryProcessorTests {
             Event eventArg = invocation.getArgument(1);
             return eventArg.get("testKey", String.class);
         });
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, valueExpression, false, false,null, "message", null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, valueExpression, false, false,null, "message", true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Map.of("testKey", "testValue"));
@@ -211,7 +211,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void test_iterate_on_add_format() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, TEST_FORMAT, null, false, false,null, "message", null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, TEST_FORMAT, null, false, false,null, "message", true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Map<String, Object>> mapList = List.of(Map.of(
@@ -232,8 +232,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, null),
-                createEntry("message2", null, 4, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, true, null),
+                createEntry("message2", null, 4, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -249,7 +249,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleNoOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -264,7 +264,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -279,8 +279,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiOverwriteMixedAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, null, null),
-                createEntry("message", null, 4, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, true, false,null, null, true, null),
+                createEntry("message", null, 4, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -295,7 +295,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendValueToExistingSimpleField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final String currentValue = "old_message";
@@ -308,7 +308,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendValueToExistingListField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("message", null, 3, null, null, false, true,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Object> listValue = new ArrayList<>();
@@ -323,7 +323,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testIntAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -337,7 +337,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBoolAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, true, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, true, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -351,7 +351,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testStringAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, "string", null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, "string", null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -365,7 +365,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testNullAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -391,7 +391,7 @@ public class AddEntryProcessorTests {
     public void testNestedAddProcessorTests() {
         TestObject obj = new TestObject();
         obj.a = "test";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, obj, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, obj, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -406,7 +406,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testArrayAddProcessorTests() {
         Object[] array = new Object[] { 1, 1.2, "string", true, null };
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, array, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, array, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -421,7 +421,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testFloatAddProcessorTests() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("newMessage", null, 1.2, null, null, false, false,null, null, null)));
+                .thenReturn(createListOfEntries(createEntry("newMessage", null, 1.2, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -436,7 +436,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testAddSingleFormatEntry() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null, null, null)));
+                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -451,8 +451,8 @@ public class AddEntryProcessorTests {
     @Test
     public void testAddMultipleFormatEntries() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null, null, null),
-                        createEntry("date-time2", null, null, ANOTHER_TEST_FORMAT, null, false, false,null, null, null)));
+                .thenReturn(createListOfEntries(createEntry("date-time", null, null, TEST_FORMAT, null, false, false,null, null, true, null),
+                        createEntry("date-time2", null, null, ANOTHER_TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -469,7 +469,7 @@ public class AddEntryProcessorTests {
     public void testFormatOverwritesExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, true, false,null, null, null)));
+                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, true, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -484,7 +484,7 @@ public class AddEntryProcessorTests {
     public void testFormatNotOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, false, false,null, null, null)));
+                        createListOfEntries(createEntry("time", null, null, TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -498,7 +498,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendFormatValueToExistingSimpleField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("time", null, 3, TEST_FORMAT, null, false, true,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("time", null, 3, TEST_FORMAT, null, false, true,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -511,7 +511,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAppendFormatValueToExistingListField() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("date-time", null, 3, TEST_FORMAT, null, false, true,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("date-time", null, 3, TEST_FORMAT, null, false, true,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -529,7 +529,7 @@ public class AddEntryProcessorTests {
     public void testFormatPrecedesValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("date-time", null, "date-time-value", TEST_FORMAT, null, false, false,null, null, null)));
+                        createListOfEntries(createEntry("date-time", null, "date-time-value", TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -544,7 +544,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testFormatVariousDataTypes() {
         when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(
-                "newField", null, null, "${number-key}-${boolean-key}-${string-key}", null, false, false, null, null, null)));
+                "newField", null, null, "${number-key}-${boolean-key}-${string-key}", null, false, false, null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
@@ -556,7 +556,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBadFormatThenEntryNotAdded() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, null, BAD_TEST_FORMAT, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, null, BAD_TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -570,7 +570,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMetadataKeySetWithBadFormatThenEntryNotAdded() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null,"data-time", null, BAD_TEST_FORMAT, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null,"data-time", null, BAD_TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("date", "date-value", "time", "time-value"));
@@ -586,7 +586,7 @@ public class AddEntryProcessorTests {
     public void testKeyIsNotAdded_when_addWhen_condition_is_false() {
         final String addWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false, addWhen, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, 3, null, null, false, false, addWhen, null, true, null)));
         when(expressionEvaluator.isValidExpressionStatement(addWhen)).thenReturn(true);
 
         final AddEntryProcessor processor = createObjectUnderTest();
@@ -604,7 +604,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeyIsNotAdded_when_addWhen_condition_is_false() {
         final String addWhen = UUID.randomUUID().toString();
 
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newMessage", 3, null, null, false, false, addWhen, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newMessage", 3, null, null, false, false, addWhen, null, true, null)));
         when(expressionEvaluator.isValidExpressionStatement(addWhen)).thenReturn(true);
 
         final AddEntryProcessor processor = createObjectUnderTest();
@@ -623,9 +623,9 @@ public class AddEntryProcessorTests {
     @Test
     public void testMetadataKeySetWithDifferentDataTypes() {
         when(mockConfig.getEntries()).thenReturn(createListOfEntries(
-            createEntry(null, "newField", "newValue", null, null, false, false,null, null, null),
-            createEntry(null, "newIntField", 123, null, null, false, false,null, null, null),
-            createEntry(null, "newBooleanField", true, null, null, false, false,null, null, null)
+            createEntry(null, "newField", "newValue", null, null, false, false,null, null, true, null),
+            createEntry(null, "newIntField", 123, null, null, false, false,null, null, true, null),
+            createEntry(null, "newBooleanField", true, null, null, false, false,null, null, true, null)
             ));
 
         final AddEntryProcessor processor = createObjectUnderTest();
@@ -642,7 +642,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetWithFormatNotOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, false, false,null, null, null)));
+                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("date", "date-value", "time", "time-value"));
@@ -658,7 +658,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetWithFormatOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, true, false,null, null, null)));
+                        createListOfEntries(createEntry(null, "time", null, TEST_FORMAT, null, true, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("date", "date-value", "time", "time-value"));
@@ -674,7 +674,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetAppendToExistingSimpleValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null, null, null)));
+                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final String currentValue = "time-value1";
@@ -689,7 +689,7 @@ public class AddEntryProcessorTests {
     public void testMetadataKeySetAppendToExistingListValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null, null, null)));
+                        createListOfEntries(createEntry(null, "time", "time-value2", null, null, false, true,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final List<Object> listValue = new ArrayList<>();
@@ -704,38 +704,38 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMetadataKeyAndKeyBothNotSetThrows() {
-        assertThrows(IllegalArgumentException.class, () -> createEntry(null, null, "newValue", null, null, false, false,null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> createEntry(null, null, "newValue", null, null, false, false,null, null, true, null));
     }
 
     @Test
     public void testMetadataKeyAndKeyBothSetThrows() {
-        assertThrows(IllegalArgumentException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", null, null, false, false,null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", null, null, false, false,null, null, true, null));
     }
 
     @Test
     public void testOnlyOneTypeOfValueIsSupported() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", "/newFormat", null, false, false,null, null, null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "newValue", "/newFormat", null, false, false,null, null, true, null));
     }
 
     @Test
     public void testOnlyOneTypeOfValueIsSupportedWithExpressionAndFormat() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, "/newFormat", "length(/message)", false, false,null, null, null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, "/newFormat", "length(/message)", false, false,null, null, true, null));
     }
 
     @Test
     public void testOnlyOneTypeOfValueIsSupportedWithValueAndExpressionAndFormat() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "value", "/newFormat", "length(/message)", false, false,null, null, null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", "value", "/newFormat", "length(/message)", false, false,null, null, true, null));
     }
 
     @Test
     public void testWithAllValuesNull() {
-        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, null, null, false, false,null, null, null));
+        assertThrows(RuntimeException.class, () -> createEntry("newKey", "newMetadataKey", null, null, null, false, false,null, null, true, null));
     }
 
     @Test
     public void testValueExpressionWithArithmeticExpression() {
         String valueExpression = "/number-key";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, true, null)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         Random random = new Random();
@@ -749,7 +749,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithStringExpression() {
         String valueExpression = "/string-key";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, true, null)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         String randomString = UUID.randomUUID().toString();
@@ -762,7 +762,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithBooleanExpression() {
         String valueExpression = "/number-key > 5";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("num_key", null, null, null, valueExpression, false, false,null, null, true, null)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         when(expressionEvaluator.evaluate(valueExpression, record.getData())).thenReturn(false);
@@ -774,7 +774,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithIntegerFunctions() {
         String valueExpression = "length(/string-key)";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("length_key", null, null, null, valueExpression, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("length_key", null, null, null, valueExpression, false, false,null, null, true, null)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
         String randomString = UUID.randomUUID().toString();
@@ -787,7 +787,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithIntegerFunctionsAndMetadataKey() {
         String valueExpression = "length(/date)";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "length_key", null, null, valueExpression, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "length_key", null, null, valueExpression, false, false,null, null, true, null)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("key", "value"));
         String randomString = UUID.randomUUID().toString();
@@ -800,7 +800,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testValueExpressionWithStringExpressionWithMetadataKey() {
         String valueExpression = "/date";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newkey", null, null, valueExpression, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(null, "newkey", null, null, valueExpression, false, false,null, null, true, null)));
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("message", Map.of("key", "value"));
         String randomString = UUID.randomUUID().toString();
@@ -812,7 +812,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddSingleFieldWithDynamicKey() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("value_as_name");
@@ -826,7 +826,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddSingleFieldWithDynamicExpression() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}_${getMetadata(\"id\")}", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}_${getMetadata(\"id\")}", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("value_as_name", Map.of("id", 1));
@@ -842,8 +842,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddMultipleFieldsWithDynamicKeys() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, null),
-                createEntry("${message}_2", null, 4, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, true, null),
+                createEntry("${message}_2", null, 4, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("value_as_name");
@@ -859,7 +859,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddFieldWithInvalidInputKeyThenNoChangeToEvent() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("value_as_name");
@@ -873,7 +873,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testAddFieldWithInvalidDynamicKeyThenNoChangeToEvent() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, null)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("name_with_invalid_chars|[$");
@@ -882,6 +882,32 @@ public class AddEntryProcessorTests {
         assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
         assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("name_with_invalid_chars|[$"));
         assertThat(editedRecords.get(0).getData().toMap().size(), is(1));
+    }
+
+    @Test
+    public void testAddNestedEntryIterateOn() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("nested/newMessage", null, 3, null, null, false, false,null, "message", false, null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of("key", 5)); // [{"key": 5}]
+        final Record<Event> record = getEvent(mapList);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("key", 5, "nested", Map.of("newMessage", 3))))); // [{"key": 5, "nested": {"newMessage":3}}]
+    }
+
+    @Test
+    public void testAddFlattenedNestedEntryIterateOn() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("nested/newMessage", null, 3, null, null, false, false,null, "message", true, null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final List<Map<String, Object>> mapList = List.of(Map.of("key", 5)); // [{"key": 5}]
+        final Record<Event> record = getEvent(mapList);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", List.class),
+                equalTo(List.of(Map.of("key", 5, "nested/newMessage", 3)))); // [{"key": 5, "nested/newMessage": 3}}]
     }
 
     private AddEntryProcessor createObjectUnderTest() {
@@ -898,10 +924,11 @@ public class AddEntryProcessorTests {
             final boolean appendIfKeyExists,
             final String addWhen,
             final String iterateOn,
+            final boolean flattenKey,   
             final String addToElementWhen) {
         return new AddEntryProcessorConfig.Entry(
                 key, metadataKey, value, format, valueExpression, overwriteIfKeyExists, appendIfKeyExists, addWhen,
-                iterateOn, addToElementWhen);
+                iterateOn, flattenKey, addToElementWhen);
     }
 
     private List<AddEntryProcessorConfig.Entry> createListOfEntries(final AddEntryProcessorConfig.Entry... entries) {


### PR DESCRIPTION
### Description
Fixes an issue where nested keys could not be added when used with `iterate_on`. Achieved this by adding a new flag `flatten_key` which when set to `true` with `iterate_on` flattens the key to be added and when set to `false` adds nested keys to elements. 

The default is set to `true` to prevent existing behaviour from breaking. Even though this is against the standard of `false` being the default value, the behaviour on `false` will eventually be the default behaviour. This is because when not using `iterate_on` the processor does add nested keys currently, meaning behavioural equivalence is achieved when `flatten_key` is set to false, making it easier to make this default in the next major release.
 
### Issues Resolved
Resolves #5910
 
### Check List
- [Y] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [Y] New functionality has javadoc added
- [Y] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
