### PR TITLE
Add caching support to AWS lambda processor

### DIFF
--- a/data-prepper-plugins/aws-lambda/build.gradle
+++ b/data-prepper-plugins/aws-lambda/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation libs.caffeine
     implementation 'software.amazon.awssdk:lambda'
     implementation 'software.amazon.awssdk:sdk-core'
     implementation 'software.amazon.awssdk:netty-nio-client'
@@ -20,6 +21,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'org.json:json'
     implementation libs.commons.lang3
+    testImplementation project(':data-prepper-test:test-event')
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.projectlombok:lombok:1.18.22'
     compileOnly 'org.projectlombok:lombok:1.18.20'

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/ResponseEventHandlingStrategy.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/ResponseEventHandlingStrategy.java
@@ -9,8 +9,9 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 public interface ResponseEventHandlingStrategy {
 
-    List<Record<Event>> handleEvents(List<Event> parsedEvents, List<Record<Event>> originalRecords);
+    List<Record<Event>> handleEvents(List<Event> parsedEvents, List<Record<Event>> originalRecords, BiConsumer<Event, Event> consumer);
 }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/InMemoryBuffer.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/InMemoryBuffer.java
@@ -68,8 +68,9 @@ public class InMemoryBuffer implements Buffer {
         records.add(record);
         Event event = record.getData();
         if (keys != null && keys.size() > 0) {
-            Event newEvent = JacksonEvent.fromEvent(event);
-            newEvent.clear();
+            Event newEvent = JacksonEvent.builder()
+                             .withEventType(event.getMetadata().getEventType())
+                             .build();
             for (final String key: keys) {
                 newEvent.put(key, event.get(key, Object.class));
             }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/InMemoryBufferSynchronized.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/accumlator/InMemoryBufferSynchronized.java
@@ -6,6 +6,7 @@ import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * A thread-safe extension of InMemoryBuffer.
@@ -13,11 +14,11 @@ import java.util.Collections;
 public class InMemoryBufferSynchronized extends InMemoryBuffer {
 
   public InMemoryBufferSynchronized(String batchOptionKeyName) {
-    this(batchOptionKeyName, new OutputCodecContext());
+    this(batchOptionKeyName, new OutputCodecContext(), null);
   }
 
-  public InMemoryBufferSynchronized(String batchOptionKeyName, OutputCodecContext outputCodecContext) {
-    super(batchOptionKeyName, outputCodecContext);
+  public InMemoryBufferSynchronized(String batchOptionKeyName, OutputCodecContext outputCodecContext, List<String> keys) {
+    super(batchOptionKeyName, outputCodecContext, keys);
 
      this.records = Collections.synchronizedList(new ArrayList<>());
   }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/config/LambdaCommonConfig.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/config/LambdaCommonConfig.java
@@ -15,8 +15,9 @@ import java.time.Duration;
 import lombok.Getter;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 
-@Getter
+import java.util.List;
 
+@Getter
 public abstract class LambdaCommonConfig {
 
   public static final int DEFAULT_CONNECTION_RETRIES = 3;
@@ -51,6 +52,14 @@ public abstract class LambdaCommonConfig {
   @JsonProperty("response_codec")
   @Valid
   private PluginModel responseCodecConfig;
+
+  @JsonPropertyDescription("Keys to send to lambda")
+  @JsonProperty("keys")
+  private List<String> keys;
+
+  public boolean hasKeys() {
+    return keys != null && keys.size() > 0;
+  }
 
   public abstract InvocationType getInvocationType();
 

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/AggregateResponseEventHandlingStrategy.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/AggregateResponseEventHandlingStrategy.java
@@ -13,11 +13,13 @@ import org.opensearch.dataprepper.plugins.lambda.common.ResponseEventHandlingStr
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 public class AggregateResponseEventHandlingStrategy implements ResponseEventHandlingStrategy {
 
     @Override
-    public List<Record<Event>> handleEvents(List<Event> parsedEvents, List<Record<Event>> originalRecords) {
+    public List<Record<Event>> handleEvents(List<Event> parsedEvents, List<Record<Event>> originalRecords,
+                                            BiConsumer<Event, Event> consumerUnused) {
 
         List<Record<Event>> resultRecords = new ArrayList<>();
         Event originalEvent = originalRecords.get(0).getData();

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKey.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKey.java
@@ -12,9 +12,14 @@ import java.util.List;
 import java.util.ArrayList;
 
 public class LambdaCacheKey {
-    private List<Object> keys;
+    private final List<Object> keys;
 
     public LambdaCacheKey(final List<Object> keys) {
+        for (final Object key : keys) {
+            if (!((key instanceof String) || (key instanceof Long) || (key instanceof Integer))) {
+                throw new RuntimeException("Only String and Long/Integer values are supported in cache");
+            }
+        }
         this.keys = keys;
     }
 
@@ -23,7 +28,7 @@ public class LambdaCacheKey {
         for (final String keyName : keyNames) {
             Object value = event.get(keyName, Object.class);
             if (!((value instanceof String) || (value instanceof Long) || (value instanceof Integer))) {
-                throw new RuntimeException("Only String and Number values are supported in cache");
+                throw new RuntimeException("Only String and Long/Integer values are supported in cache");
             }
             this.keys.add(value);
         }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKey.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKey.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.dataprepper.plugins.lambda.processor;
+
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class LambdaCacheKey {
+    private List<Object> keys;
+
+    public LambdaCacheKey(final List<Object> keys) {
+        this.keys = keys;
+    }
+
+    public LambdaCacheKey(final Event event, final List<String> keyNames) {
+        this.keys = new ArrayList<>();
+        for (final String keyName : keyNames) {
+            Object value = event.get(keyName, Object.class);
+            if (!((value instanceof String) || (value instanceof Long) || (value instanceof Integer))) {
+                throw new RuntimeException("Only String and Number values are supported in cache");
+            }
+            this.keys.add(value);
+        }
+    }
+
+    public int length() {
+        return keys.stream()
+                .mapToInt(key -> {
+                    if (key instanceof String) {
+                        return ((String) key).length();
+                    } else { // instance of Long/Integer
+                        return 8;
+                    }
+                })
+                .sum();
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LambdaCacheKey)) return false;
+        return keys.equals(((LambdaCacheKey)o).keys);
+    }
+
+    @Override
+    public int hashCode() {
+        return keys.hashCode();
+    }
+
+}

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorConfig.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorConfig.java
@@ -89,7 +89,7 @@ public class LambdaProcessorConfig extends LambdaCommonConfig {
 
   @AssertTrue(message = "keys must not be null or empty and response_mode must be 'merge' when using cache")
   boolean isValidCacheConfig() {
-    return cacheConfig == null || (hasKeys() && responseMode == LambdaResponseMode.MERGE);
+    return cacheConfig == null || (hasKeys() && responseMode == LambdaResponseMode.MERGE && getInvocationType() ==  InvocationType.REQUEST_RESPONSE);
   }
   public List<String> getTagsOnFailure() {
     return tagsOnFailure;

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaResponseMode.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaResponseMode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.lambda.processor;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum LambdaResponseMode {
+    REPLACE("replace"),
+    MERGE("merge");
+
+    private static final Map<String, LambdaResponseMode> OPTIONS_MAP = Arrays.stream(LambdaResponseMode.values())
+            .collect(Collectors.toMap(
+                    value -> value.option,
+                    value -> value
+            ));
+
+    private final String option;
+
+    LambdaResponseMode(final String option) {
+        this.option = option;
+    }
+
+    @JsonValue
+    public String getOption() {
+        return option;
+    }
+
+    @JsonCreator
+    public static LambdaResponseMode fromOption(final String option) {
+        return OPTIONS_MAP.get(option);
+    }
+
+}

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/sink/LambdaSink.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/sink/LambdaSink.java
@@ -157,7 +157,8 @@ public class LambdaSink extends AbstractSink<Record<Event>> {
         // Initialize the partial buffer
         statefulBuffer = new InMemoryBufferSynchronized(
                 lambdaSinkConfig.getBatchOptions().getKeyName(),
-                outputCodecContext
+                outputCodecContext,
+                null
         );
         sinkInitialized = Boolean.TRUE;
     }
@@ -190,7 +191,8 @@ public class LambdaSink extends AbstractSink<Record<Event>> {
                 // create a new partial buffer.
                 statefulBuffer = new InMemoryBufferSynchronized(
                         lambdaSinkConfig.getBatchOptions().getKeyName(),
-                        outputCodecContext
+                        outputCodecContext,
+                        null
                 );
                 flushBuffers(Collections.singletonList(bufferToFlush));
             }
@@ -215,7 +217,8 @@ public class LambdaSink extends AbstractSink<Record<Event>> {
                     // Create new partial buffer
                     statefulBuffer = new InMemoryBufferSynchronized(
                             lambdaSinkConfig.getBatchOptions().getKeyName(),
-                            outputCodecContext
+                            outputCodecContext,
+                            null
                     );
                 }
             }

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/AggregateResponseEventHandlingStrategyTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/AggregateResponseEventHandlingStrategyTest.java
@@ -67,7 +67,7 @@ public class AggregateResponseEventHandlingStrategyTest {
         List<Event> parsedEvents = Arrays.asList(parsedEvent1, parsedEvent2);
 
         // Act
-        List<Record<Event>> resultRecords = aggregateResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords);
+        List<Record<Event>> resultRecords = aggregateResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords, null);
 
         // Assert
         assertEquals(2, resultRecords.size());
@@ -88,7 +88,7 @@ public class AggregateResponseEventHandlingStrategyTest {
         when(eventHandle.getAcknowledgementSet()).thenReturn(null);
 
         // Act
-        List<Record<Event>> resultRecords = aggregateResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords);
+        List<Record<Event>> resultRecords = aggregateResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords, null);
 
         // Assert
         assertEquals(2, resultRecords.size());
@@ -105,7 +105,7 @@ public class AggregateResponseEventHandlingStrategyTest {
         List<Event> parsedEvents = new ArrayList<>();
 
         // Act
-        List<Record<Event>> resultRecords = aggregateResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords);
+        List<Record<Event>> resultRecords = aggregateResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords, null);
 
         // Assert
         assertEquals(0, resultRecords.size());

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKeyTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKeyTest.java
@@ -7,7 +7,9 @@ package org.opensearch.dataprepper.plugins.lambda.processor;
 
 import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.event.TestEventFactory;
@@ -55,6 +57,52 @@ public class LambdaCacheKeyTest {
         LambdaCacheKey lambdaCacheKey2 = new LambdaCacheKey(event, keyNames);
         assertThat(lambdaCacheKey, equalTo(lambdaCacheKey2));
     }
+
+    @Test
+    public void testInvalidLambdaCacheKeyWithEvent() {
+        List<String> keyNames = new ArrayList<>();
+        String testString = UUID.randomUUID().toString();
+        keyNames.add("key1");
+        keyNames.add("key2");
+        keyNames.add("key3");
+        Map<String, Object> data = new HashMap<>();
+        data.put("key1", testString);
+        data.put("key2", 0.2d);
+        data.put("key3", 12345);
+        Event event = TEST_EVENT_FACTORY.eventBuilder(EventBuilder.class)
+                .withData(data)
+                .withEventType("event")
+                .build();
+        assertThrows(RuntimeException.class, () ->  new LambdaCacheKey(event, keyNames));
+    }
+
+    @Test
+    public void testInvalidLambdaCacheKey() {
+        List<Object> keys = new ArrayList<>();
+        String testString = UUID.randomUUID().toString();
+        keys.add(testString);
+        keys.add(0.1d);
+        keys.add(2222L);
+        assertThrows(RuntimeException.class, () ->  new LambdaCacheKey(keys));
+    }
+
+    @Test
+    public void testLambdaCacheKeyDifferentOrderNotEqual() {
+        List<Object> keys = new ArrayList<>();
+        String testString = UUID.randomUUID().toString();
+        keys.add(testString);
+        keys.add(11);
+        keys.add(2222L);
+        LambdaCacheKey lambdaCacheKey = new LambdaCacheKey(keys);
+        List<Object> keys2 = new ArrayList<>();
+        keys2.add(testString);
+        keys2.add(2222L);
+        keys2.add(11);
+        LambdaCacheKey lambdaCacheKey2 = new LambdaCacheKey(keys2);
+        assertThat(lambdaCacheKey, not(equalTo(lambdaCacheKey2)));
+        assertThat(lambdaCacheKey, not(equalTo(new LambdaCacheKey(List.of()))));
+    }
+
 
 }
 

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKeyTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaCacheKeyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.lambda.processor;
+
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.EventFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class LambdaCacheKeyTest {
+    private static final EventFactory TEST_EVENT_FACTORY = TestEventFactory.getTestEventFactory();
+    @Test
+    public void testLambdaCacheKey() {
+        List<Object> keys = new ArrayList<>();
+        String testString = UUID.randomUUID().toString();
+        keys.add(testString);
+        keys.add(111);
+        keys.add(2222L);
+        LambdaCacheKey lambdaCacheKey = new LambdaCacheKey(keys);
+        assertThat(lambdaCacheKey.length(), equalTo(testString.length() + 16));
+        LambdaCacheKey lambdaCacheKey2 = new LambdaCacheKey(keys);
+        assertThat(lambdaCacheKey, equalTo(lambdaCacheKey2));
+    }
+
+    @Test
+    public void testLambdaCacheKeyWithEvent() {
+        List<String> keyNames = new ArrayList<>();
+        String testString = UUID.randomUUID().toString();
+        keyNames.add("key1");
+        keyNames.add("key2");
+        keyNames.add("key3");
+        Map<String, Object> data = new HashMap<>();
+        data.put("key1", testString);
+        data.put("key2", 2222L);
+        data.put("key3", 12345);
+        Event event = TEST_EVENT_FACTORY.eventBuilder(EventBuilder.class)
+                .withData(data)
+                .withEventType("event")
+                .build();
+        LambdaCacheKey lambdaCacheKey = new LambdaCacheKey(event, keyNames);
+        assertThat(lambdaCacheKey.length(), equalTo(testString.length() + 16));
+        LambdaCacheKey lambdaCacheKey2 = new LambdaCacheKey(event, keyNames);
+        assertThat(lambdaCacheKey, equalTo(lambdaCacheKey2));
+    }
+
+}
+

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/StrictResponseEventHandlingStrategyTest.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/processor/StrictResponseEventHandlingStrategyTest.java
@@ -37,7 +37,7 @@ public class StrictResponseEventHandlingStrategyTest {
         }
 
         // Act
-        List<Record<Event>> resultRecords = strictResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords);
+        List<Record<Event>> resultRecords = strictResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords, null);
 
         // Before Test, make sure that they are not the same
         for (int i = 0; i < oneRandomCount; i++) {
@@ -54,14 +54,14 @@ public class StrictResponseEventHandlingStrategyTest {
 
         // Act & Assert
         RuntimeException exception = assertThrows(StrictResponseModeNotRespectedException.class, () ->
-                strictResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords)
+                strictResponseEventHandlingStrategy.handleEvents(parsedEvents, originalRecords, null)
         );
     }
 
     @Test
     public void testHandleEvents_EmptyParsedEvents_ShouldNotThrowException() {
         // Act
-        List<Record<Event>> resultRecords = strictResponseEventHandlingStrategy.handleEvents(new ArrayList<>(), new ArrayList<>());
+        List<Record<Event>> resultRecords = strictResponseEventHandlingStrategy.handleEvents(new ArrayList<>(), new ArrayList<>(), null);
         // Ensure resultRecords is empty
         assertEquals(0, resultRecords.size());
     }

--- a/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/utils/LambdaTestSetupUtil.java
+++ b/data-prepper-plugins/aws-lambda/src/test/java/org/opensearch/dataprepper/plugins/lambda/utils/LambdaTestSetupUtil.java
@@ -54,6 +54,14 @@ public class LambdaTestSetupUtil {
         return new Record<>(getSampleEvent(), RecordMetadata.defaultMetadata());
     }
 
+    public static Record<Event> getSampleRecordWithKeysAndValues(final String message, final List<String> keys, final List<Object> values) {
+        Event event = JacksonEvent.fromMessage(message);
+        for (int i = 0; i < keys.size(); i++) {
+            event.put(keys.get(i), values.get(i));
+        }
+        return new Record(event);
+    }
+
     public static Event getSampleEvent() {
         return JacksonEvent.fromMessage(UUID.randomUUID().toString());
     }

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-multiple-type-keys-small-ttl.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-multiple-type-keys-small-ttl.yaml
@@ -1,0 +1,20 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+keys: [ "key1", "key2", "key3" ]
+cache:
+  ttl: 10
+  max_size: 1000000
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+
+
+
+

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-multiple-type-keys.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-multiple-type-keys.yaml
@@ -1,0 +1,19 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+keys: [ "key1", "key2", "key3" ]
+cache:
+  ttl: 200
+  max_size: 750
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+
+
+

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-nested-key.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-nested-key.yaml
@@ -1,0 +1,20 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+keys: [ "key1/key2/key3" ]
+cache:
+  ttl: 200
+  max_size: 750
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+
+
+
+

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-string-key.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-cache-string-key.yaml
@@ -1,0 +1,18 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+keys: [ "key1"]
+cache:
+  ttl: 1000
+  max_size: 1048576
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+
+

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-success-config-with-keys-merge-mode.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-success-config-with-keys-merge-mode.yaml
@@ -1,0 +1,17 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+keys: [ "key1" ]
+response_mode: "merge"
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+
+
+

--- a/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-success-config-with-keys.yaml
+++ b/data-prepper-plugins/aws-lambda/src/test/resources/lambda-processor-success-config-with-keys.yaml
@@ -1,0 +1,15 @@
+function_name: "lambdaProcessorTest"
+response_events_match: true
+tags_on_failure: [ "lambda_failure" ]
+keys: [ "key1" ]
+batch:
+  key_name: "osi_key"
+  threshold:
+    event_count: 100
+    maximum_size: 1mb
+    event_collect_timeout: 335
+aws:
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::1234567890:role/sample-pipeine-role"
+
+


### PR DESCRIPTION
### Description
Add caching support to `aws_lambda` processor.

The cache config can be added to existing lambda config as follows:

```
aws_lambda:
   <existing options>
    cache:
        ttl: <ttl in seconds>
        max_size: <maximum_size_in_bytes>
```

In addition, caching requires a set of keys whose values are used as cache keys. A new `keys` is added to the config at the top level so that even lambda processors without caching can used this option to send only a partial list of keys to the lambda function. The result from the lambda function can be either "merged" with the original Event contents or replace the original event contents. New config for this is 

```
aws_lambda:
   <existing options>
   keys: ["key1", "key2"]
   response_mode: "replace" (default) or "merge"

```

`keys` field is mandatory when using caching.
 
### Issues Resolved
Resolves #5788 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
