### PR TITLE
Expand necessary OpenSearch permissions for data prepper

### DIFF
--- a/data-prepper-plugins/opensearch/opensearch_security.md
+++ b/data-prepper-plugins/opensearch/opensearch_security.md
@@ -18,6 +18,8 @@ or by using user credential assigned with a role that has the below required per
 - `cluster_all`
 - `indices:admin/template/get`
 - `indices:admin/template/put`
+- `indices:data/write/bulk`
+- `indices:data/write/bulks`
 
 Note that `indices:admin/template/*` need to be in cluster permissions.
 
@@ -25,7 +27,7 @@ Note that `indices:admin/template/*` need to be in cluster permissions.
 
 - `Index`: `otel-v1*`; `Index permissions`: `indices_all`
 - `Index`: `.opendistro-ism-config`; `Index permissions`: `indices_all`
-- `Index`: `*`; `Index permission`: `manage_aliases`
+- `Index`: `*`; `Index permission`: `manage_aliases`, `indices:admin/get`, `indices:admin/create`, `indices:data/write/index`, `indices:data/write/bulk`, `indices:data/write/bulk*`, `indices:admin/mapping/put`
 
 `Field level security` and `Anonymization` should be left with default values.
 


### PR DESCRIPTION
### Description
PR expands OpenSearch permissions documentation for Data Prepper.

Additional permissions were compiled by trial and error based on logs from Data Prepper and OpenSearch. So the sets can still miss some other permissions, but Data Prepper sent data fine to cluster during my testing.
 
### Issues Resolved
Resolves #6009 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
