### PR TITLE
Enable Point in time for Amazon OpenSearch Serverless

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
@@ -149,9 +149,8 @@ public class SearchAccessorStrategy {
             return new OpenSearchAccessor(clientRefresher,
                     SearchContextType.NONE);
         } else {
-            if (SearchContextType.POINT_IN_TIME.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType()) ||
-                SearchContextType.SCROLL.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
-                throw new InvalidPluginConfigurationException("A search_context_type of point_in_time or scroll is not supported for serverless collections");
+            if ( SearchContextType.SCROLL.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
+                throw new InvalidPluginConfigurationException("A search_context_type of scroll is not supported for serverless collections");
             }
 
             LOG.info("Using search_context_type set in the config: '{}'", openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType().toString().toLowerCase());


### PR DESCRIPTION
### Description
From Nov 19, 2024, Amazon OpenSearch Serverless supports Point in Time (PIT).
https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-opensearch-serverless-pit-search/?nc1=h_ls
So we can enable Point in time for Amazon OpenSearch Serverless
https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java#L152
 
### Issues Resolved
Resolves #[#5493](https://github.com/opensearch-project/data-prepper/issues/5493)
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
[https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/#default-search-behavior](https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/#default-search-behavior)
```　
For Amazon OpenSearch Serverless collections, search_after will be used because neither point_in_time nor scroll are supported by collections.
```
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
