### PR TITLE
Add metrics prefix to OTLP source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/PluginMetrics.java
@@ -57,7 +57,7 @@ public class PluginMetrics {
         return new PluginMetrics(metricsPrefix);
     }
 
-    private  PluginMetrics(final String metricsPrefix) {
+    private PluginMetrics(final String metricsPrefix) {
         this.metricsPrefix = metricsPrefix;
     }
 
@@ -81,8 +81,16 @@ public class PluginMetrics {
         return Metrics.timer(getMeterName(name), tags);
     }
 
+    public Timer timer(final String name, final String metricsPrefix) {
+        return Metrics.timer(new StringJoiner(MetricNames.DELIMITER).add(metricsPrefix).add(name).toString());
+    }
+
     public DistributionSummary summary(final String name) {
         return Metrics.summary(getMeterName(name));
+    }
+
+    public DistributionSummary summary(final String name, final String metricsPrefix) {
+        return Metrics.summary(new StringJoiner(MetricNames.DELIMITER).add(metricsPrefix).add(name).toString());
     }
 
     public <T extends Number> T gauge(final String name, T number) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/PluginMetricsTest.java
@@ -109,6 +109,16 @@ public class PluginMetricsTest {
     }
 
     @Test
+    public void testTimerWithMetricsPrefix() {
+        final Timer timer = objectUnderTest.timer("timer", PIPELINE_NAME);
+        assertEquals(
+                new StringJoiner(MetricNames.DELIMITER)
+                        .add(PIPELINE_NAME)
+                        .add("timer").toString(),
+                timer.getId().getName());
+    }
+
+    @Test
     public void testTimerWithTags() {
         final Timer timer = objectUnderTest.timerWithTags("timer", TAG_KEY, TAG_VALUE);
         assertEquals(
@@ -126,6 +136,16 @@ public class PluginMetricsTest {
         assertEquals(
                 new StringJoiner(MetricNames.DELIMITER)
                         .add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add("summary").toString(),
+                summary.getId().getName());
+    }
+
+    @Test
+    public void testSummaryWithMetricsPrefix() {
+        final DistributionSummary summary = objectUnderTest.summary("summary", PIPELINE_NAME);
+        assertEquals(
+                new StringJoiner(MetricNames.DELIMITER)
+                        .add(PIPELINE_NAME)
                         .add("summary").toString(),
                 summary.getId().getName());
     }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -154,7 +154,7 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), lessThanOrEqualTo(numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
     }
 
     @Test

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -49,21 +49,6 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
     private final DistributionSummary payloadSizeSummary;
     private final Timer requestProcessDuration;
 
-
-    public OTelLogsGrpcService(int bufferWriteTimeoutInMillis,
-                               final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
-                               final Buffer<Record<Object>> buffer,
-                               final PluginMetrics pluginMetrics) {
-        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
-        this.buffer = buffer;
-        this.oTelProtoDecoder = oTelProtoDecoder;
-
-        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
-        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
-        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
-        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
-    }
-
     public OTelLogsGrpcService(int bufferWriteTimeoutInMillis,
                                final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
                                final Buffer<Record<Object>> buffer,

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -71,12 +71,20 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
                                final String metricsPrefix) {
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
-        this.oTelProtoDecoder = oTelProtoDecoder;
 
-        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
-        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
-        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
-        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        if (metricsPrefix != null) {
+            requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
+            successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
+            payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
+            requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        } else {
+            requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
+            successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
+            payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
+            requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
+        }
+
+        this.oTelProtoDecoder = oTelProtoDecoder;
     }
 
     @Override

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -64,6 +64,20 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
         requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
     }
 
+    public OTelLogsGrpcService(int bufferWriteTimeoutInMillis,
+                               final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
+                               final Buffer<Record<Object>> buffer,
+                               final PluginMetrics pluginMetrics,
+                               final String metricsPrefix) {
+        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
+        this.buffer = buffer;
+        this.oTelProtoDecoder = oTelProtoDecoder;
+
+        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
+        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
+        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
+        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+    }
 
     @Override
     public void export(ExportLogsServiceRequest request, StreamObserver<ExportLogsServiceResponse> responseObserver) {

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -87,7 +87,8 @@ public class OTelLogsSource implements Source<Record<Object>> {
                     (int) (oTelLogsSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     oTelLogsSourceConfig.getOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
                     buffer,
-                    pluginMetrics
+                    pluginMetrics,
+                    null
             );
 
             ServerConfiguration serverConfiguration = ConvertConfiguration.convertConfiguration(oTelLogsSourceConfig);

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
@@ -387,7 +387,7 @@ public class OTelLogsGrpcServiceTest {
 
     private OTelLogsGrpcService generateOTelLogsGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder) {
         return new OTelLogsGrpcService(
-                bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);
+                bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics, null);
     }
 
     private static Stream<Arguments> getDecoderArguments() {

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
@@ -385,7 +385,6 @@ public class OTelLogsGrpcServiceTest {
         verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
     }
 
-
     private OTelLogsGrpcService generateOTelLogsGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder) {
         return new OTelLogsGrpcService(
                 bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -75,12 +75,22 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
 
-        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
-        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
-        recordsCreatedCounter = pluginMetrics.counter(RECORDS_CREATED, metricsPrefix);
-        recordsDroppedCounter = pluginMetrics.counter(RECORDS_DROPPED, metricsPrefix);
-        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
-        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        if (metricsPrefix != null) {
+            requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
+            successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
+            recordsCreatedCounter = pluginMetrics.counter(RECORDS_CREATED, metricsPrefix);
+            recordsDroppedCounter = pluginMetrics.counter(RECORDS_DROPPED, metricsPrefix);
+            payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
+            requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        } else {
+            requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
+            successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
+            recordsCreatedCounter = pluginMetrics.counter(RECORDS_CREATED);
+            recordsDroppedCounter = pluginMetrics.counter(RECORDS_DROPPED);
+            payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
+            requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
+        }
+
         this.oTelProtoDecoder = oTelProtoDecoder;
     }
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -67,6 +67,23 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
         this.oTelProtoDecoder = oTelProtoDecoder;
     }
 
+    public OTelMetricsGrpcService(int bufferWriteTimeoutInMillis,
+                                  final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
+                                  Buffer<Record<? extends Metric>> buffer,
+                                  final PluginMetrics pluginMetrics,
+                                  final String metricsPrefix) {
+        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
+        this.buffer = buffer;
+
+        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
+        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
+        recordsCreatedCounter = pluginMetrics.counter(RECORDS_CREATED, metricsPrefix);
+        recordsDroppedCounter = pluginMetrics.counter(RECORDS_DROPPED, metricsPrefix);
+        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
+        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        this.oTelProtoDecoder = oTelProtoDecoder;
+    }
+
     @Override
     public void export(final ExportMetricsServiceRequest request, final StreamObserver<ExportMetricsServiceResponse> responseObserver) {
         requestsReceivedCounter.increment();

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -50,23 +50,6 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
     private final DistributionSummary payloadSizeSummary;
     private final Timer requestProcessDuration;
 
-
-    public OTelMetricsGrpcService(int bufferWriteTimeoutInMillis,
-                                  final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
-                                  Buffer<Record<? extends Metric>> buffer,
-                                  final PluginMetrics pluginMetrics) {
-        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
-        this.buffer = buffer;
-
-        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
-        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
-        recordsCreatedCounter = pluginMetrics.counter(RECORDS_CREATED);
-        recordsDroppedCounter = pluginMetrics.counter(RECORDS_DROPPED);
-        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
-        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
-        this.oTelProtoDecoder = oTelProtoDecoder;
-    }
-
     public OTelMetricsGrpcService(int bufferWriteTimeoutInMillis,
                                   final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
                                   Buffer<Record<? extends Metric>> buffer,

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -85,7 +85,8 @@ public class OTelMetricsSource implements Source<Record<? extends Metric>> {
                     (int) (oTelMetricsSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     oTelMetricsSourceConfig.getOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
                     buffer,
-                    pluginMetrics
+                    pluginMetrics,
+                    null
             );
 
             ServerConfiguration serverConfiguration = ConvertConfiguration.convertConfiguration(oTelMetricsSourceConfig);

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcServiceTest.java
@@ -196,7 +196,7 @@ public class OTelMetricsGrpcServiceTest {
     }
 
     OTelMetricsGrpcService createObjectUnderTest(OTelProtoCodec.OTelProtoDecoder decoder) {
-        return new OTelMetricsGrpcService(bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);
+        return new OTelMetricsGrpcService(bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics, null);
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -68,6 +68,21 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
         requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
     }
 
+    public OTelTraceGrpcService(int bufferWriteTimeoutInMillis,
+                                final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
+                                final Buffer<Record<Object>> buffer,
+                                final PluginMetrics pluginMetrics,
+                                final String metricsPrefix) {
+        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
+        this.buffer = buffer;
+        this.oTelProtoDecoder = oTelProtoDecoder;
+
+        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
+        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
+        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
+        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+    }
+
 
     @Override
     public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> responseObserver) {

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -57,30 +57,24 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
     public OTelTraceGrpcService(int bufferWriteTimeoutInMillis,
                                 final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
                                 final Buffer<Record<Object>> buffer,
-                                final PluginMetrics pluginMetrics) {
-        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
-        this.buffer = buffer;
-        this.oTelProtoDecoder = oTelProtoDecoder;
-
-        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
-        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
-        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
-        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
-    }
-
-    public OTelTraceGrpcService(int bufferWriteTimeoutInMillis,
-                                final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
-                                final Buffer<Record<Object>> buffer,
                                 final PluginMetrics pluginMetrics,
                                 final String metricsPrefix) {
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
-        this.oTelProtoDecoder = oTelProtoDecoder;
 
-        requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
-        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
-        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
-        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        if (metricsPrefix != null) {
+            requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED, metricsPrefix);
+            successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
+            payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
+            requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+        } else {
+            requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
+            successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
+            payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
+            requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
+        }
+
+        this.oTelProtoDecoder = oTelProtoDecoder;
     }
 
 

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -85,7 +85,8 @@ public class OTelTraceSource implements Source<Record<Object>> {
                     (int)(oTelTraceSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     oTelTraceSourceConfig.getOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
                     buffer,
-                    pluginMetrics
+                    pluginMetrics,
+                    null
             );
 
             ServerConfiguration serverConfiguration = ConvertConfiguration.convertConfiguration(oTelTraceSourceConfig);

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -338,7 +338,6 @@ public class OTelTraceGrpcServiceTest {
         JSONAssert.assertEquals(expected, result, false);
     }
 
-
     private OTelTraceGrpcService generateOTelTraceGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder) {
         return new OTelTraceGrpcService(
                 bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -340,7 +340,7 @@ public class OTelTraceGrpcServiceTest {
 
     private OTelTraceGrpcService generateOTelTraceGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder) {
         return new OTelTraceGrpcService(
-                bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics);
+                bufferWriteTimeoutInMillis, decoder, buffer, mockPluginMetrics, null);
     }
 
     private ExportTraceServiceRequest createFullTraceRequest() {

--- a/data-prepper-plugins/otlp-source/src/main/java/org/opensearch/dataprepper/plugins/source/otlp/OTLPSource.java
+++ b/data-prepper-plugins/otlp-source/src/main/java/org/opensearch/dataprepper/plugins/source/otlp/OTLPSource.java
@@ -90,17 +90,17 @@ public class OTLPSource implements Source<Record<Object>> {
       final OTelLogsGrpcService oTelLogsGrpcService = new OTelLogsGrpcService(
           (int) (otlpSourceConfig.getRequestTimeoutInMillis() * 0.8),
           otlpSourceConfig.getLogsOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
-          buffer, pluginMetrics);
+          buffer, pluginMetrics, "otlpTracesSource_");
 
       final OTelMetricsGrpcService oTelMetricsGrpcService = new OTelMetricsGrpcService(
           (int) (otlpSourceConfig.getRequestTimeoutInMillis() * 0.8),
           otlpSourceConfig.getMetricsOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
-          metricBuffer, pluginMetrics);
+          metricBuffer, pluginMetrics, "otlpMetricsSource_");
 
       final OTelTraceGrpcService oTelTraceGrpcService = new OTelTraceGrpcService(
           (int) (otlpSourceConfig.getRequestTimeoutInMillis() * 0.8),
           otlpSourceConfig.getTracesOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
-          buffer, pluginMetrics);
+          buffer, pluginMetrics, "otlpLogsSource_");
 
       ServerConfiguration serverConfiguration = ConvertConfiguration.convertConfiguration(otlpSourceConfig);
       CreateServer createServer = new CreateServer(serverConfiguration, LOG, pluginMetrics, "otlp", pipelineName);

--- a/data-prepper-plugins/otlp-source/src/main/java/org/opensearch/dataprepper/plugins/source/otlp/OTLPSource.java
+++ b/data-prepper-plugins/otlp-source/src/main/java/org/opensearch/dataprepper/plugins/source/otlp/OTLPSource.java
@@ -90,17 +90,17 @@ public class OTLPSource implements Source<Record<Object>> {
       final OTelLogsGrpcService oTelLogsGrpcService = new OTelLogsGrpcService(
           (int) (otlpSourceConfig.getRequestTimeoutInMillis() * 0.8),
           otlpSourceConfig.getLogsOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
-          buffer, pluginMetrics, "otlpTracesSource_");
+          buffer, pluginMetrics, "otlp.logs");
 
       final OTelMetricsGrpcService oTelMetricsGrpcService = new OTelMetricsGrpcService(
           (int) (otlpSourceConfig.getRequestTimeoutInMillis() * 0.8),
           otlpSourceConfig.getMetricsOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
-          metricBuffer, pluginMetrics, "otlpMetricsSource_");
+          metricBuffer, pluginMetrics, "otlp.metrics");
 
       final OTelTraceGrpcService oTelTraceGrpcService = new OTelTraceGrpcService(
           (int) (otlpSourceConfig.getRequestTimeoutInMillis() * 0.8),
           otlpSourceConfig.getTracesOutputFormat() == OTelOutputFormat.OPENSEARCH ? new OTelProtoOpensearchCodec.OTelProtoDecoder() : new OTelProtoStandardCodec.OTelProtoDecoder(),
-          buffer, pluginMetrics, "otlpLogsSource_");
+          buffer, pluginMetrics, "otlp.traces");
 
       ServerConfiguration serverConfiguration = ConvertConfiguration.convertConfiguration(otlpSourceConfig);
       CreateServer createServer = new CreateServer(serverConfiguration, LOG, pluginMetrics, "otlp", pipelineName);


### PR DESCRIPTION
### Description
This change adds logic for some plugin metrics to take in a metrics prefix. This helps the user to differentiate between the OTLP source and sink metrics, as well as different traces/metrics/logs received from the source. Some example output metric names:
- `otlp.metrics.payloadSize.sum`
- `otlp.metrics.requestProcessDuration.count`
- `otlp.traces.successRequests.count`
- `otlp.traces.requestProcessDuration.sum`
- `otlp.traces.requestProcessDuration.count`
- `otlp.logs.payloadSize.count`
- `otlp.logs.payloadSize.sum`

 Also verified that the individual OTel logs, metrics, and traces sources had their metrics unchanged.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).