### PR TITLE
Updates to Gatling 3.13 in the performance-test project

### DIFF
--- a/performance-test/README.md
+++ b/performance-test/README.md
@@ -18,8 +18,8 @@ example:
 To run TargetRpsSimulation. Source code available at `./performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/TargetRpsSimulation.java`
 
 ```shell
-# ./gradlew gatlingRun-<simulation-class-path>
-./gradlew :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.TargetRpsSimulation
+# ./gradlew gatlingRun --simulation=<simulation-class-path>
+./gradlew :performance-test:gatlingRun --simulation=org.opensearch.dataprepper.test.performance.TargetRpsSimulation
 ```
 
 ### Configurations
@@ -30,7 +30,7 @@ Supply the configurations as Java system variables on the command line.
 For example, you can configure the port and use HTTPS with a custom certificate with the following:
 
 ```
-./gradlew -Dport=7099 -Dprotocol=https -Dpath=/simple-sample-pipeline/logs -Djavax.net.ssl.keyStore=examples/demo/test_keystore.p12 :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.SingleRequestSimulation
+./gradlew -Dport=7099 -Dprotocol=https -Dpath=/simple-sample-pipeline/logs -Djavax.net.ssl.keyStore=examples/demo/test_keystore.p12 :performance-test:gatlingRun --simulation=org.opensearch.dataprepper.test.performance.SingleRequestSimulation
 ```
 
 **Available configuration options:**
@@ -51,7 +51,7 @@ This performance tool also works with [Amazon OpenSearch Ingestion](https://docs
 Setup your AWS credentials to meet your needs. Then run a command similar to the following:
 
 ```
-./gradlew -Dhost=<your-custom-dns>.<aws-region>.osis.amazonaws.com -Dprotocol=https -Dpath=<your-path> -Dport=443 -Dauthentication=aws_sigv4 -Daws_region=<aws-region> -Daws_service=osis :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.SingleRequestSimulation
+./gradlew -Dhost=<your-custom-dns>.<aws-region>.osis.amazonaws.com -Dprotocol=https -Dpath=<your-path> -Dport=443 -Dauthentication=aws_sigv4 -Daws_region=<aws-region> -Daws_service=osis :performance-test:gatlingRun --simulation=org.opensearch.dataprepper.test.performance.SingleRequestSimulation
 ```
 
 ### Verify Gatling scenarios compile

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -5,7 +5,7 @@
 
 plugins {
     id 'java'
-    id 'io.gatling.gradle' version '3.10.4'
+    id 'io.gatling.gradle' version '3.13.5'
     id 'com.gradleup.shadow' version '8.3.8'
 }
 
@@ -32,18 +32,6 @@ dependencies {
                 require '1.4.14'
             }
             because 'Keeps the version synced with logback-classic.'
-        }
-        zinc('org.scala-sbt:io_2.13') {
-            version {
-                require '1.9.7'
-            }
-            because 'Fixes CVE-2023-46122'
-        }
-        zinc('org.jline:jline') {
-            version {
-                require '3.25.0'
-            }
-            because 'CVE-2023-50572'
         }
     }
 }


### PR DESCRIPTION
### Description

This updates Gatline to 3.13 in the `performance-test` project. This version no longer has the zinc compiler and we don't use Scala anyway. It also uses `--simulation` instead of different Gradle task names. So I've updated the `README.md` file.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
