### PR TITLE
Introducing additional flag to control the output content formatting behavior

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceClient.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceClient.java
@@ -58,6 +58,7 @@ public class ConfluenceClient implements CrawlerClient<PaginationCrawlerWorkerPr
     private final ExecutorService executorService;
     private final CrawlerSourceConfig configuration;
     private final int bufferWriteTimeoutInSeconds = 10;
+    private final boolean preserveContentFormatting;
 
     public ConfluenceClient(ConfluenceService service,
                             ConfluenceIterator confluenceIterator,
@@ -67,6 +68,7 @@ public class ConfluenceClient implements CrawlerClient<PaginationCrawlerWorkerPr
         this.confluenceIterator = confluenceIterator;
         this.executorService = executorServiceProvider.get();
         this.configuration = sourceConfig;
+        this.preserveContentFormatting = sourceConfig.isPreserveContentFormatting();
     }
 
     @Override
@@ -114,7 +116,11 @@ public class ConfluenceClient implements CrawlerClient<PaginationCrawlerWorkerPr
                     try {
                         ObjectNode contentJsonObj = objectMapper.readValue(contentJson, new TypeReference<>() {
                         });
-                        return HtmlToTextConversionUtil.convertHtmlToText(contentJsonObj, "body/view/value");
+                        if (preserveContentFormatting) {
+                            return contentJsonObj;
+                        } else {
+                            return HtmlToTextConversionUtil.convertHtmlToText(contentJsonObj, "body/view/value");
+                        }
                     } catch (JsonProcessingException e) {
                         throw new RuntimeException(e);
                     }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceSourceConfig.java
@@ -35,4 +35,10 @@ public class ConfluenceSourceConfig extends AtlassianSourceConfig implements Cra
     public String getOauth2UrlContext() {
         return "confluence";
     }
+
+    /**
+     * boolean flag to control whether to preserve the original formatting or not
+     */
+    @JsonProperty("preserve_formatting")
+    private boolean preserveContentFormatting;
 }


### PR DESCRIPTION


### Description
Currently, Confluence source plugin is converting the extracted page content to plain text before it sends it over the downstream. This change gives a configurable option to control this behavior. Introducing a new flag called `preserve_formatting` when set to True keeps the original original page formatting as it is. The default value is false which is the current behavior.

```
confluence-connector-pipeline:
  source:
    confluence:
      hosts: ["https://santhoshgandhe.atlassian.net/"]
      acknowledgments: true
      preserve_formatting: false
      ...........
```
 
### Issues Resolved
Resolves #6013 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
