### PR TITLE
Allow flush interval to be 0 for immediate flush in sqs sink

### DIFF
--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatch.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatch.java
@@ -67,7 +67,7 @@ public class SqsSinkBatch {
         this.codecContext = codecContext;
         this.queueUrl = queueUrl;
         this.sqsClient = sqsClient;
-        lastFlushedTime = Instant.now().getEpochSecond();
+        lastFlushedTime = Instant.now().toEpochMilli();
         flushReady = false;
         fifoQueue = queueUrl.endsWith(SQS_FIFO_SUFFIX);
         entries = new HashMap<>();
@@ -268,7 +268,7 @@ public class SqsSinkBatch {
             entries.clear();
             entries = newEntries;
         }
-        lastFlushedTime = Instant.now().getEpochSecond();
+        lastFlushedTime = Instant.now().toEpochMilli();
         return entries.size() == 0;
     }
 

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkService.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkService.java
@@ -266,13 +266,13 @@ public class SqsSinkService extends SqsSinkExecutor {
 
     @Override
     public boolean exceedsFlushTimeInterval() {
-        long now = Instant.now().getEpochSecond();
+        long nowMillis = Instant.now().toEpochMilli();
         boolean result = false;
 
         for (Map.Entry<String, SqsSinkBatch> qUrlEntry: batchUrlMap.entrySet()) {
             String qUrl = qUrlEntry.getKey();
             SqsSinkBatch batch = qUrlEntry.getValue();
-            if (now - batch.getLastFlushedTime() > thresholdConfig.getFlushInterval()) {
+            if (nowMillis - batch.getLastFlushedTime() > thresholdConfig.getFlushInterval() * 1000L) {
                 batch.setFlushReady();
                 result = true;
             }

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsThresholdConfig.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsThresholdConfig.java
@@ -28,7 +28,7 @@ public class SqsThresholdConfig {
     private ByteCount maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
 
     @JsonProperty("flush_interval")
-    @DurationMin(seconds = 60)
+    @DurationMin(seconds = 0)
     @DurationMax(seconds = 3600)
     private Duration flushInterval = Duration.ofSeconds(DEFAULT_FLUSH_INTERVAL_TIME);
 
@@ -43,6 +43,5 @@ public class SqsThresholdConfig {
     public long getFlushInterval() {
         return flushInterval.getSeconds();
     }
-
 }
 


### PR DESCRIPTION
### Description
This PR enables immediate flushing in the SQS sink by allowing a flush interval of 0 seconds and improving timing precision from seconds to milliseconds. Added unit test coverage to verifies that events are marked for immediate flushing when interval is 0.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
