### PR TITLE
add uuid in the batch job name

### DIFF
--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/MLBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/MLBatchJobCreator.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 public interface MLBatchJobCreator {
@@ -22,7 +23,8 @@ public interface MLBatchJobCreator {
 
     default String generateJobName() {
         String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
-        String jobName = "DataPrepper-batch-job-" + timestamp;
+        String instanceId = UUID.randomUUID().toString();
+        String jobName = String.format("batch-job-%s-%s", timestamp, instanceId);
 
         jobName = JOB_NAME_PATTERN.matcher(jobName).replaceAll("");
         return jobName.substring(0, Math.min(63, jobName.length()));

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreator.java
@@ -27,8 +27,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.net.HttpURLConnection;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -46,7 +44,6 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final AwsCredentialsSupplier awsCredentialsSupplier;
     private final S3Client s3Client;
-    private final DateTimeFormatter dateTimeFormatter;
     private final Lock batchProcessingLock;
     // Added batch processing fields
     @Getter
@@ -66,7 +63,6 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
         super(mlProcessorConfig, awsCredentialsSupplier, pluginMetrics, dlqPushHandler);
         this.awsCredentialsSupplier = awsCredentialsSupplier;
         this.s3Client = createS3Client(mlProcessorConfig, awsCredentialsSupplier);
-        this.dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
         this.maxBatchSize = mlProcessorConfig.getMaxBatchSize();
         this.batchProcessingLock = new ReentrantLock();
     }
@@ -294,9 +290,9 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
     private String generateManifest(Collection<Record<Event>> records, String customerBucket, String prefix) {
         try {
             // Generate timestamp
-            String timestamp = LocalDateTime.now().format(dateTimeFormatter);
-            String folderName = prefix + "batch-" + timestamp;
-            String fileName = folderName + "/batch-" + timestamp + ".manifest";
+            String jobName = generateJobName();
+            String folderName = prefix + jobName;
+            String fileName = folderName + "/" + jobName + ".manifest";
 
             // Construct JSON output
             JSONArray manifestArray = new JSONArray();

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
@@ -49,8 +49,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -537,6 +541,17 @@ public class SageMakerBatchJobCreatorTest {
         // Verify results
         assertEquals(NUM_THREADS, processAttemptsCount.get(), "All threads should have attempted processing");
         assertTrue(sageMakerBatchJobCreator.getBatch_records().isEmpty(), "Batch should be empty after processing");
+    }
+
+    @Test
+    void generateJobName_ReturnsValidJobName() {
+        // when
+        String jobName = sageMakerBatchJobCreator.generateJobName();
+
+        // then
+        assertNotNull(jobName);
+        assertThat(jobName.length(), lessThanOrEqualTo(63));
+        assertThat(jobName, matchesPattern("^batch-job-\\d{17}-[a-f0-9-]{1,36}$"));
     }
 
     // Helper methods


### PR DESCRIPTION
### Description
Add uuid into the batch job name to avoid edge cases when multiple OCUs creating job at the same time use the same job name. 
Verified the PR locally against an AOS domain. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
