### PR TITLE
Fix issue where event handles are not released for cloudwatch logs sink, add more tests

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -7,10 +7,16 @@ package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.ThresholdConfig;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.RejectedLogEventsInfo;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,13 +24,15 @@ import java.util.List;
 import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 
 class CloudWatchLogsDispatcherTest {
     private CloudWatchLogsDispatcher cloudWatchLogsDispatcher;
-    private  CloudWatchLogsClient mockCloudWatchLogsClient;
+    private CloudWatchLogsClient mockCloudWatchLogsClient;
     private CloudWatchLogsMetrics mockCloudWatchLogsMetrics;
     private Executor mockExecutor;
     private static final int RETRY_COUNT = 5;
@@ -71,12 +79,174 @@ class CloudWatchLogsDispatcherTest {
                 .build();
     }
 
+    private void executeDispatcherRunnable() {
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(mockExecutor).execute(runnableCaptor.capture());
+        runnableCaptor.getValue().run();
+    }
+
     @Test
     void GIVEN_valid_input_log_events_SHOULD_call_executor() {
         cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
-        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
-        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, getSampleEventHandles());
 
-        verify(mockExecutor, atMostOnce()).execute(any(CloudWatchLogsDispatcher.Uploader.class));
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        when(response.rejectedLogEventsInfo()).thenReturn(null);
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        eventHandles.forEach(eventHandle -> verify(eventHandle).release(true));
+    }
+
+    @Test
+    void GIVEN_too_old_events_SHOULD_not_release_old_events() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        final RejectedLogEventsInfo rejectedInfo = mock(RejectedLogEventsInfo.class);
+
+        // Set first 2 events as too old
+        when(rejectedInfo.tooOldLogEventEndIndex()).thenReturn(2);
+        when(rejectedInfo.tooNewLogEventStartIndex()).thenReturn(null);
+        when(response.rejectedLogEventsInfo()).thenReturn(rejectedInfo);
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // First two events should not be released
+        verify(eventHandles.get(0), never()).release(true);
+        verify(eventHandles.get(1), never()).release(true);
+
+        // Remaining events should be released
+        for (int i = 2; i < eventHandles.size(); i++) {
+            verify(eventHandles.get(i)).release(true);
+        }
+    }
+
+    @Test
+    void GIVEN_too_new_events_SHOULD_not_release_new_events() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        final RejectedLogEventsInfo rejectedInfo = mock(RejectedLogEventsInfo.class);
+
+        // Set last 3 events as too new
+        when(rejectedInfo.tooOldLogEventEndIndex()).thenReturn(null);
+        when(rejectedInfo.tooNewLogEventStartIndex()).thenReturn(eventHandles.size() - 3);
+        when(response.rejectedLogEventsInfo()).thenReturn(rejectedInfo);
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // Events before tooNewStartIndex should be released
+        for (int i = 0; i < eventHandles.size() - 3; i++) {
+            verify(eventHandles.get(i)).release(true);
+        }
+
+        // Last three events should not be released
+        for (int i = eventHandles.size() - 3; i < eventHandles.size(); i++) {
+            verify(eventHandles.get(i), never()).release(true);
+        }
+    }
+
+    @Test
+    void GIVEN_both_old_and_new_rejected_events_SHOULD_only_release_valid_events() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        final RejectedLogEventsInfo rejectedInfo = mock(RejectedLogEventsInfo.class);
+
+        // Set first 2 events as too old and last 2 as too new
+        when(rejectedInfo.tooOldLogEventEndIndex()).thenReturn(2);
+        when(rejectedInfo.tooNewLogEventStartIndex()).thenReturn(eventHandles.size() - 2);
+        when(response.rejectedLogEventsInfo()).thenReturn(rejectedInfo);
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // First two events should not be released (too old)
+        verify(eventHandles.get(0), never()).release(true);
+        verify(eventHandles.get(1), never()).release(true);
+
+        // Middle events should be released
+        for (int i = 2; i < eventHandles.size() - 2; i++) {
+            verify(eventHandles.get(i)).release(true);
+        }
+
+        // Last two events should not be released (too new)
+        verify(eventHandles.get(eventHandles.size() - 2), never()).release(true);
+        verify(eventHandles.get(eventHandles.size() - 1), never()).release(true);
+    }
+
+    @Test
+    void GIVEN_client_exception_SHOULD_retry() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+            .thenThrow(SdkClientException.create("Test exception"))
+            .thenReturn(mock(PutLogEventsResponse.class));
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestSuccessCounter(1);
+    }
+
+    @Test
+    void GIVEN_cloudwatch_exception_SHOULD_retry() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+            .thenThrow(CloudWatchLogsException.class)
+            .thenReturn(mock(PutLogEventsResponse.class));
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestSuccessCounter(1);
+    }
+
+    @Test
+    void GIVEN_max_retries_exceeded_SHOULD_not_release_events() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher();
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+            .thenThrow(CloudWatchLogsException.class);
+
+        List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseRequestSuccessCounter(1);
+
+        // No events should be released after max retries
+        eventHandles.forEach(eventHandle -> verify(eventHandle, never()).release(true));
     }
 }


### PR DESCRIPTION


### Description
This change fixes an issue with acknowledgments not happening correctly in the cloudwatch sink, as the event handles are not released after sending to cloudwatch. Also adds more unit tests
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
