### PR TITLE
Add read before saving global state item

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -176,7 +176,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
                     LOG.info("Partition owner {} did not acquire any partitions. Running partition creation supplier to create more partitions", ownerId);
                     createPartitions(partitionCreationSupplier.apply(globalStateMap));
                     partitionCreationSupplierInvocationsCounter.increment();
-                    giveUpAndSaveGlobalStateForPartitionCreation(acquiredGlobalStateForPartitionCreation.get(), globalStateMap);
+                    giveUpAndSaveGlobalStateForPartitionCreation(globalStateMap);
                 }
             }
         } finally {
@@ -545,7 +545,12 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         }
     }
 
-    private void giveUpAndSaveGlobalStateForPartitionCreation(final SourcePartitionStoreItem globalStateItemForPartitionCreation, final Map<String, Object> globalStateMap) {
+    private void giveUpAndSaveGlobalStateForPartitionCreation(final Map<String, Object> globalStateMap) {
+
+        final Optional<SourcePartitionStoreItem> globalStateItem = sourceCoordinationStore.getSourcePartitionItem(
+                sourceIdentifierWithGlobalStateType, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS);
+
+        final SourcePartitionStoreItem globalStateItemForPartitionCreation = globalStateItem.get();
 
         globalStateItemForPartitionCreation.setSourcePartitionStatus(SourcePartitionStatus.UNASSIGNED);
         globalStateItemForPartitionCreation.setPartitionOwner(null);


### PR DESCRIPTION
### Description
Fixes issue where conditional exception can happen when saving global state since it is now updated periodically.

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
