### PR TITLE
Adds sts_header_overrides to the AWS plugin extension configuration.

### DIFF
--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
@@ -9,8 +9,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 import software.amazon.awssdk.regions.Region;
 
-public class AwsStsConfiguration {
+import java.util.Map;
 
+public class AwsStsConfiguration {
     @JsonProperty("region")
     @Size(min = 1, message = "Region cannot be empty string")
     private String awsRegion;
@@ -19,11 +20,19 @@ public class AwsStsConfiguration {
     @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
     private String awsStsRoleArn;
 
+    @JsonProperty("sts_header_overrides")
+    @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
+    private Map<String, String> awsStsHeaderOverrides;
+
     public Region getAwsRegion() {
         return awsRegion != null ? Region.of(awsRegion) : null;
     }
 
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
+    }
+
+    public Map<String, String> getStsHeaderOverrides() {
+        return awsStsHeaderOverrides;
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -66,8 +66,16 @@ class CredentialsProviderFactory {
     }
 
     private AwsCredentialsProvider createStsCredentials(final AwsCredentialsOptions credentialsOptions) {
-
-        final String stsRoleArn = credentialsOptions.getStsRoleArn() == null ? defaultStsConfiguration.getAwsStsRoleArn() : credentialsOptions.getStsRoleArn();
+        final boolean useDefaultStsRoleArn;
+        final String stsRoleArn;
+        if(credentialsOptions.getStsRoleArn() != null) {
+            stsRoleArn = credentialsOptions.getStsRoleArn();
+            useDefaultStsRoleArn = false;
+        }
+        else {
+            stsRoleArn = defaultStsConfiguration.getAwsStsRoleArn();
+            useDefaultStsRoleArn = true;
+        }
 
         validateStsRoleArn(stsRoleArn);
 
@@ -85,7 +93,12 @@ class CredentialsProviderFactory {
             assumeRoleRequestBuilder = assumeRoleRequestBuilder.externalId(credentialsOptions.getStsExternalId());
         }
 
-        final Map<String, String> awsStsHeaderOverrides = credentialsOptions.getStsHeaderOverrides();
+        final Map<String, String> awsStsHeaderOverrides;
+        if(useDefaultStsRoleArn) {
+            awsStsHeaderOverrides = defaultStsConfiguration.getStsHeaderOverrides();
+        } else {
+            awsStsHeaderOverrides = credentialsOptions.getStsHeaderOverrides();
+        }
 
         if(awsStsHeaderOverrides != null && !awsStsHeaderOverrides.isEmpty()) {
             assumeRoleRequestBuilder = assumeRoleRequestBuilder

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
@@ -7,11 +7,13 @@ package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -24,7 +26,6 @@ public class AwsStsConfigurationTest {
     @ParameterizedTest
     @MethodSource("getRegions")
     void testStsConfiguration(final Region region) throws JsonProcessingException {
-
         final String defaultConfigurationAsString = "{\"region\": \"" + region.toString() + "\", \"sts_role_arn\": \"arn:aws:iam::123456789012:role/test-role\"}";
 
         final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(defaultConfigurationAsString, AwsStsConfiguration.class);
@@ -32,6 +33,16 @@ public class AwsStsConfigurationTest {
         assertThat(objectUnderTest, notNullValue());
         assertThat(objectUnderTest.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/test-role"));
         assertThat(objectUnderTest.getAwsRegion(), equalTo(region));
+    }
+
+    @Test
+    void getStsHeaderOverrides() throws JsonProcessingException {
+        final String jsonConfiguration = "{\"sts_role_arn\": \"arn:aws:iam::123456789012:role/test-role\", \"sts_header_overrides\": {\"abc\": \"123\", \"def\": \"456\"}}";
+
+        final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(jsonConfiguration, AwsStsConfiguration.class);
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/test-role"));
+        assertThat(objectUnderTest.getStsHeaderOverrides(), equalTo(Map.of("abc", "123", "def", "456")));
     }
 
     private static List<Region> getRegions() {

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -194,7 +194,7 @@ class CredentialsProviderFactoryTest {
         }
 
         @Test
-        void providerFromOptions_should_return_s3Client_with_sts_role_arn_when_no_region() {
+        void providerFromOptions_should_return_stsClient_with_sts_role_arn_when_no_region() {
             when(awsCredentialsOptions.getRegion()).thenReturn(null);
             when(awsCredentialsOptions.getStsRoleArn()).thenReturn(testStsRole);
 
@@ -208,6 +208,88 @@ class CredentialsProviderFactoryTest {
             assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
 
             verify(stsClientBuilder, never()).region(any(Region.class));
+        }
+
+        @Test
+        void providerFromOptions_should_override_STS_Headers_when_default_HeaderOverrides_when_set_and_using_default_STS_role_ARN() {
+            final String headerName1 = UUID.randomUUID().toString();
+            final String headerValue1 = UUID.randomUUID().toString();
+            final String headerName2 = UUID.randomUUID().toString();
+            final String headerValue2 = UUID.randomUUID().toString();
+            final Map<String, String> overrideHeaders = Map.of(headerName1, headerValue1, headerName2, headerValue2);
+
+            final String defaultStsRole = createStsRole();
+            when(defaultStsConfiguration.getAwsStsRoleArn()).thenReturn(defaultStsRole);
+            when(defaultStsConfiguration.getStsHeaderOverrides()).thenReturn(overrideHeaders);
+
+            when(awsCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+
+            final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<StsAssumeRoleCredentialsProvider> credentialsProviderMockedStatic = mockStatic(StsAssumeRoleCredentialsProvider.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                credentialsProviderMockedStatic.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(stsCredentialsProviderBuilder);
+                actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+
+            final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+            verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
+
+            final AssumeRoleRequest actualAssumeRoleRequest = assumeRoleRequestArgumentCaptor.getValue();
+            assertThat(actualAssumeRoleRequest.roleArn(), equalTo(defaultStsRole));
+            assertThat(actualAssumeRoleRequest.roleSessionName(), startsWith("Data-Prepper-"));
+            assertThat(actualAssumeRoleRequest.roleSessionName().length(), lessThanOrEqualTo(MAXIMUM_ROLE_SESSION_LENGTH));
+            assertThat(actualAssumeRoleRequest.overrideConfiguration(), notNullValue());
+            assertThat(actualAssumeRoleRequest.overrideConfiguration().isPresent(), equalTo(true));
+            final AwsRequestOverrideConfiguration overrideConfiguration = actualAssumeRoleRequest.overrideConfiguration().get();
+            assertThat(overrideConfiguration.headers(), notNullValue());
+            assertThat(overrideConfiguration.headers().size(), equalTo(2));
+            assertThat(overrideConfiguration.headers(), hasKey(headerName1));
+            assertThat(overrideConfiguration.headers(), hasKey(headerName2));
+            assertThat(overrideConfiguration.headers().get(headerName1), notNullValue());
+            assertThat(overrideConfiguration.headers().get(headerName1).size(), equalTo(1));
+            assertThat(overrideConfiguration.headers().get(headerName1), hasItem(headerValue1));
+            assertThat(overrideConfiguration.headers().get(headerName2), notNullValue());
+            assertThat(overrideConfiguration.headers().get(headerName2).size(), equalTo(1));
+            assertThat(overrideConfiguration.headers().get(headerName2), hasItem(headerValue2));
+
+            verify(awsCredentialsOptions, never()).getStsHeaderOverrides();
+        }
+
+        @Test
+        void providerFromOptions_should_not_override_STS_Headers_when_HeaderOverrides_are_empty_and_using_default_STS_role_ARN() {
+            final String defaultStsRole = createStsRole();
+            when(defaultStsConfiguration.getAwsStsRoleArn()).thenReturn(defaultStsRole);
+            when(awsCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+
+            final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+            final AwsCredentialsProvider actualCredentialsProvider;
+
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<StsAssumeRoleCredentialsProvider> credentialsProviderMockedStatic = mockStatic(StsAssumeRoleCredentialsProvider.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                credentialsProviderMockedStatic.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(stsCredentialsProviderBuilder);
+                actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+
+            final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+            verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
+
+            final AssumeRoleRequest actualAssumeRoleRequest = assumeRoleRequestArgumentCaptor.getValue();
+            assertThat(actualAssumeRoleRequest.roleArn(), equalTo(defaultStsRole));
+            assertThat(actualAssumeRoleRequest.roleSessionName(), startsWith("Data-Prepper-"));
+            assertThat(actualAssumeRoleRequest.roleSessionName().length(), lessThanOrEqualTo(MAXIMUM_ROLE_SESSION_LENGTH));
+            assertThat(actualAssumeRoleRequest.overrideConfiguration(), notNullValue());
+            assertThat(actualAssumeRoleRequest.overrideConfiguration().isPresent(), equalTo(false));
         }
 
         @Test


### PR DESCRIPTION
### Description

Adds `sts_header_overrides` to the AWS plugin extension configuration.
 
### Issues Resolved

Resolves #6078.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
