### PR TITLE
Resolves CVEs by updating Netty to 4.1.125 and commons-lang to 3.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,8 +233,8 @@ subprojects {
                     details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.124.Final'
                     details.because 'Fixes CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.124.Final'
-                    details.because 'Fixes CVE-2025-55163, CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                    details.useVersion '4.1.125.Final'
+                    details.because 'Fixes CVE-2025-58057, CVE-2025-58056, CVE-2025-55163, CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
                 details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -57,7 +57,7 @@ dependencyResolutionManagement {
             library('guava-core', 'com.google.guava', 'guava').versionRef('guava')
             version('reflections', '0.10.2')
             library('reflections-core', 'org.reflections', 'reflections').versionRef('reflections')
-            library('commons-lang3', 'org.apache.commons', 'commons-lang3').version('3.14.0')
+            library('commons-lang3', 'org.apache.commons', 'commons-lang3').version('3.18.0')
             library('commons-io', 'commons-io', 'commons-io').version('2.15.1')
             library('commons-codec', 'commons-codec', 'commons-codec').version('1.16.0')
             library('commons-compress', 'org.apache.commons', 'commons-compress').version('1.24.0')


### PR DESCRIPTION
### Description

Resolves CVEs:
* Netty 4.1.125: CVE-2025-58057, CVE-2025-58056,
* commons-lang 3.18.0: CVE-2025-48924
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
