### PR TITLE
allow retry sagemaker batch job creation for longer time window

### DIFF
--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorConfig.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorConfig.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.A
 import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.ServiceName;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import java.util.Map;
         "It supports both synchronous and asynchronous invocations based on your use case.")
 public class MLProcessorConfig {
     private static final int DEFAULT_MAX_BATCH_SIZE = 100;
+    public static final Duration DEFAULT_RETRY_WINDOW = Duration.ofMinutes(10);
 
     @JsonProperty("aws")
     @NotNull
@@ -81,6 +83,11 @@ public class MLProcessorConfig {
 
     @JsonProperty("max_batch_size")
     private int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
+
+    @JsonPropertyDescription("The time duration for which the ml_inference processor retains events for retry attempts."
+            + "Supports ISO_8601 notation Strings (\"PT20.345S\", \"PT15M\", etc.) as well as simple notation Strings for seconds (\"60s\") and milliseconds (\"1500ms\")")
+    @JsonProperty("retry_time_window")
+    private Duration retryTimeWindow = DEFAULT_RETRY_WINDOW;
 
     @JsonProperty("dlq")
     private PluginModel dlq;

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/AbstractBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/AbstractBatchJobCreator.java
@@ -31,7 +31,6 @@ public abstract class AbstractBatchJobCreator implements MLBatchJobCreator {
     public static final String NUMBER_OF_RECORDS_FAILED_IN_BATCH_JOB = "recordsFailedInBatchJobCreation";
     public static final String NUMBER_OF_RECORDS_SUCCEEDED_IN_BATCH_JOB = "recordsSucceededInBatchJobCreation";
     protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    protected static final long MAX_RETRY_WINDOW_MS = 600_000; // 10 minutes
     protected static final int TOO_MANY_REQUESTS = 429;
     protected final MLProcessorConfig mlProcessorConfig;
     protected final AwsCredentialsSupplier awsCredentialsSupplier;
@@ -42,6 +41,7 @@ public abstract class AbstractBatchJobCreator implements MLBatchJobCreator {
     protected final List<String> tagsOnFailure;
     protected final MlCommonRequester mlCommonRequester;
     protected DlqPushHandler dlqPushHandler = null;
+    protected final long maxRetryTimeWindow;
     private static final Aws4Signer signer;
     static {
         signer = Aws4Signer.create();
@@ -61,6 +61,7 @@ public abstract class AbstractBatchJobCreator implements MLBatchJobCreator {
         this.tagsOnFailure = mlProcessorConfig.getTagsOnFailure();
         this.mlCommonRequester = new MlCommonRequester(signer, mlProcessorConfig, awsCredentialsSupplier);
         this.dlqPushHandler = dlqPushHandler;
+        this.maxRetryTimeWindow = mlProcessorConfig.getRetryTimeWindow().toMillis();
     }
 
     // Add common logic here that both subclasses can share
@@ -133,7 +134,7 @@ public abstract class AbstractBatchJobCreator implements MLBatchJobCreator {
         }
 
         boolean isExpired() {
-            return System.currentTimeMillis() - createdTime > MAX_RETRY_WINDOW_MS;
+            return System.currentTimeMillis() - createdTime > maxRetryTimeWindow;
         }
 
         void incrementRetryCount() {

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/BedrockBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/BedrockBatchJobCreator.java
@@ -268,7 +268,7 @@ public class BedrockBatchJobCreator extends AbstractBatchJobCreator {
             String errorMessage = String.format(
                     "Record expired after %d retries over %d minutes",
                     expiredRecord.getRetryCount(),
-                    MAX_RETRY_WINDOW_MS / 60000
+                    maxRetryTimeWindow / 60000
             );
 
             LOG.error(NOISY, "Record expired from throttle queue: {}", errorMessage);

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreator.java
@@ -51,6 +51,7 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
     // Added batch processing fields
     @Getter
     private final ConcurrentLinkedQueue<Record<Event>> batch_records = new ConcurrentLinkedQueue<>();
+    @Getter
     private final ConcurrentLinkedQueue<Record<Event>> processedBatchRecords = new ConcurrentLinkedQueue<>();
     @Getter
     private final ConcurrentLinkedQueue<RetryRecord> retryQueue = new ConcurrentLinkedQueue<>();
@@ -287,7 +288,7 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
                 expiredRecords.add(retryRecord.getRecord());
                 LOG.debug("Record expired after {} attempts over {} ms",
                         retryRecord.getRetryCount(),
-                        MAX_RETRY_WINDOW_MS);
+                        maxRetryTimeWindow);
                 return true;
             }
             return false;
@@ -312,10 +313,10 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
 
     private void handleExpiredRecords(List<Record<Event>> expiredRecords) {
         LOG.warn("{} records expired from retry queue after {} ms timeout",
-                expiredRecords.size(), MAX_RETRY_WINDOW_MS);
+                expiredRecords.size(), maxRetryTimeWindow);
         handleFailure(expiredRecords, processedBatchRecords,
                 new MLBatchJobException(HttpURLConnection.HTTP_BAD_REQUEST,
-                        "Records expired after " + MAX_RETRY_WINDOW_MS/(60*1000) + " minute retry window"),
+                        "Records expired after " + maxRetryTimeWindow/(60*1000) + " minute retry window"),
                 HttpURLConnection.HTTP_BAD_REQUEST);
     }
 

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/BedrockBatchJobCreatorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/BedrockBatchJobCreatorTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.ml_inference.processor.MLProcessorConfig.DEFAULT_RETRY_WINDOW;
 import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.NUMBER_OF_FAILED_BATCH_JOBS_CREATION;
 import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.NUMBER_OF_RECORDS_FAILED_IN_BATCH_JOB;
 import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.NUMBER_OF_RECORDS_SUCCEEDED_IN_BATCH_JOB;
@@ -66,6 +67,7 @@ public class BedrockBatchJobCreatorTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         when(mlProcessorConfig.getOutputPath()).thenReturn("s3://offlinebatch/output");
+        when(mlProcessorConfig.getRetryTimeWindow()).thenReturn(DEFAULT_RETRY_WINDOW);
         counter = new Counter() {
             @Override
             public void increment(double v) {}

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
@@ -36,18 +36,21 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -64,7 +67,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.MAX_RETRY_WINDOW_MS;
+import static org.opensearch.dataprepper.plugins.ml_inference.processor.MLProcessorConfig.DEFAULT_RETRY_WINDOW;
 import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.NUMBER_OF_FAILED_BATCH_JOBS_CREATION;
 import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.NUMBER_OF_RECORDS_FAILED_IN_BATCH_JOB;
 import static org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator.NUMBER_OF_RECORDS_SUCCEEDED_IN_BATCH_JOB;
@@ -95,6 +98,12 @@ public class SageMakerBatchJobCreatorTest {
     @Mock
     private PluginSetting pluginSetting;
 
+    @Mock
+    private Counter recordsSuccessCounter;
+
+    @Mock
+    private Counter recordsFailedCounter;
+
     private SageMakerBatchJobCreator sageMakerBatchJobCreator;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -112,13 +121,14 @@ public class SageMakerBatchJobCreatorTest {
         when(mlProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         final EventKey sourceKey = eventKeyFactory.createEventKey("key");
         when(mlProcessorConfig.getInputKey()).thenReturn(sourceKey);
+        when(mlProcessorConfig.getRetryTimeWindow()).thenReturn(DEFAULT_RETRY_WINDOW);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
         when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
         counter = mock(Counter.class);
         when(pluginMetrics.counter(NUMBER_OF_SUCCESSFUL_BATCH_JOBS_CREATION)).thenReturn(counter);
         when(pluginMetrics.counter(NUMBER_OF_FAILED_BATCH_JOBS_CREATION)).thenReturn(counter);
-        when(pluginMetrics.counter(NUMBER_OF_RECORDS_FAILED_IN_BATCH_JOB)).thenReturn(counter);
-        when(pluginMetrics.counter(NUMBER_OF_RECORDS_SUCCEEDED_IN_BATCH_JOB)).thenReturn(counter);
+        when(pluginMetrics.counter(NUMBER_OF_RECORDS_FAILED_IN_BATCH_JOB)).thenReturn(recordsFailedCounter);
+        when(pluginMetrics.counter(NUMBER_OF_RECORDS_SUCCEEDED_IN_BATCH_JOB)).thenReturn(recordsSuccessCounter);
         when(pluginSetting.getPipelineName()).thenReturn("pipeline_sagemaker");
         when(pluginSetting.getName()).thenReturn("pipeline_sagemaker");
 
@@ -646,7 +656,7 @@ public class SageMakerBatchJobCreatorTest {
             // Get retry queue and simulate record expiration
             ConcurrentLinkedQueue<AbstractBatchJobCreator.RetryRecord> retryQueue = sageMakerBatchJobCreator.getRetryQueue();
             AbstractBatchJobCreator.RetryRecord retryRecord = retryQueue.peek();
-            setPrivateField(retryRecord, "createdTime", System.currentTimeMillis() - (MAX_RETRY_WINDOW_MS + 1));
+            setPrivateField(retryRecord, "createdTime", System.currentTimeMillis() - (mlProcessorConfig.getRetryTimeWindow().toMillis() + 1));
 
             // Act - Process expired record
             when(dlqPushHandler.getDlqPluginSetting()).thenReturn(pluginSetting);
@@ -658,6 +668,180 @@ public class SageMakerBatchJobCreatorTest {
             assertEquals(1, processedBatchRecords.size());
             verify(dlqPushHandler).perform(any());
             verify(counter, times(1)).increment();
+        }
+    }
+
+    @Test
+    void testProcessBothRetryAndNewRecords() throws Exception {
+        // Create record A for retry queue
+        Event eventA = createMockEvent("test-bucket", "inputA.jsonl");
+        Record<Event> recordA = new Record<>(eventA);
+
+        // Create RetryRecord using reflection
+        Object retryRecordA = createRetryRecord(recordA);
+        sageMakerBatchJobCreator.getRetryQueue().add((AbstractBatchJobCreator.RetryRecord) retryRecordA);
+
+        // Create record B for batch_records
+        Event eventB = createMockEvent("test-bucket", "inputB.jsonl");
+        Record<Event> recordB = new Record<>(eventB);
+        List<Record<Event>> newRecords = Collections.singletonList(recordB);
+        List<Record<Event>> resultRecords = new ArrayList<>();
+
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            // Mock successful processing
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoffWithResult(any(), any()))
+                    .thenReturn(new RetryUtil.RetryResult(true, null, 3));
+
+            // Add record B to batch_records
+            sageMakerBatchJobCreator.createMLBatchJob(newRecords, resultRecords);
+            // Verify initial state
+            assertEquals(1, sageMakerBatchJobCreator.getRetryQueue().size(), "Retry queue should have record A");
+            assertEquals(1, sageMakerBatchJobCreator.getBatch_records().size(), "Batch records should have record B");
+
+            sageMakerBatchJobCreator.checkAndProcessBatch();
+            // Verify final state
+
+            // Verify retry queue is empty
+            assertTrue(sageMakerBatchJobCreator.getRetryQueue().isEmpty(),
+                    "Retry queue should be empty after processing");
+
+            // Verify batch_records is empty
+            assertTrue(sageMakerBatchJobCreator.getBatch_records().isEmpty(),
+                    "Batch records should be empty after processing");
+
+            // Verify success counters
+            verify(counter).increment();
+            verify(recordsSuccessCounter).increment(2); // Both records A and B
+        }
+    }
+
+    @Test
+    void testProcessBothRetryAndNewRecords_WithThrottledAgain() throws Exception {
+        // Create record A for retry queue
+        Event eventA = createMockEvent("test-bucket", "inputA.jsonl");
+        Record<Event> recordA = new Record<>(eventA);
+        Object retryRecordA = createRetryRecord(recordA);
+        sageMakerBatchJobCreator.getRetryQueue().add((AbstractBatchJobCreator.RetryRecord) retryRecordA);
+
+        // Create record B for batch_records
+        Event eventB = createMockEvent("test-bucket", "inputB.jsonl");
+        Record<Event> recordB = new Record<>(eventB);
+        List<Record<Event>> newRecords = Collections.singletonList(recordB);
+        List<Record<Event>> resultRecords = new ArrayList<>();
+
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            // Mock failure with throttling
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoffWithResult(any(), any()))
+                    .thenReturn(new RetryUtil.RetryResult(false, new MLBatchJobException(429, "Rate limited"), 1));
+
+            sageMakerBatchJobCreator.createMLBatchJob(newRecords, resultRecords);
+
+            // Verify initial state
+            assertEquals(1, sageMakerBatchJobCreator.getRetryQueue().size(),
+                    "Retry queue should have record A");
+            assertEquals(1, sageMakerBatchJobCreator.getBatch_records().size(),
+                    "Batch records should have record B");
+            // Get retry count of record A before processing
+            AbstractBatchJobCreator.RetryRecord retryRecordBefore =
+                    sageMakerBatchJobCreator.getRetryQueue().peek();
+            int initialRetryCount = getRetryCount(retryRecordBefore);
+
+            // Process both records - should be throttled
+            sageMakerBatchJobCreator.checkAndProcessBatch();
+
+            // Verify retry queue contains both records
+            assertEquals(2, sageMakerBatchJobCreator.getRetryQueue().size(),
+                    "Retry queue should contain both records after throttling");
+            assertEquals(0, sageMakerBatchJobCreator.getProcessedBatchRecords().size(),
+                    "Retry queue should contain both records after throttling");
+            // Verify batch_records is empty
+            assertTrue(sageMakerBatchJobCreator.getBatch_records().isEmpty(),
+                    "Batch records should be empty after processing");
+            // Verify record A's retry count was incremented
+            AbstractBatchJobCreator.RetryRecord updatedRetryRecordA =
+                    sageMakerBatchJobCreator.getRetryQueue().stream()
+                    .filter(r -> getRecordFromRetryRecord(r).getData().getJsonNode().get("key").asText().equals("inputA.jsonl"))
+                    .findFirst()
+                    .orElse(null);
+
+            assertNotNull(updatedRetryRecordA, "Record A should still be in retry queue");
+            assertEquals(initialRetryCount + 1, getRetryCount(updatedRetryRecordA),
+                    "Retry count for record A should be incremented");
+
+            // Verify record B was added to retry queue
+            boolean recordBInRetryQueue = sageMakerBatchJobCreator.getRetryQueue().stream()
+                    .anyMatch(r -> getRecordFromRetryRecord(r).getData().getJsonNode().get("key").asText().equals("inputB.jsonl"));
+            assertTrue(recordBInRetryQueue, "Record B should be in retry queue");
+        }
+    }
+
+    @Test
+    void testProcessBothRetryAndNewRecords_WithFailure() throws Exception {
+        // Create record A for retry queue
+        Event eventA = createMockEvent("test-bucket", "inputA.jsonl");
+        Record<Event> recordA = new Record<>(eventA);
+        Object retryRecordA = createRetryRecord(recordA);
+        sageMakerBatchJobCreator.getRetryQueue().add((AbstractBatchJobCreator.RetryRecord) retryRecordA);
+        when(eventA.toJsonString()).thenReturn("eventA");
+
+        // Create record B for batch_records
+        Event eventB = createMockEvent("test-bucket", "inputB.jsonl");
+        Record<Event> recordB = new Record<>(eventB);
+        List<Record<Event>> newRecords = Collections.singletonList(recordB);
+        List<Record<Event>> resultRecords = new ArrayList<>();
+        when(eventB.toJsonString()).thenReturn("eventB");
+
+        when(dlqPushHandler.getDlqPluginSetting()).thenReturn(pluginSetting);
+        // Capture DLQ objects
+        ArgumentCaptor<List<DlqObject>> dlqObjectsCaptor = ArgumentCaptor.forClass(List.class);
+
+        try (MockedStatic<RetryUtil> mockedRetryUtil = mockStatic(RetryUtil.class)) {
+            // Mock 404 failure response
+            mockedRetryUtil.when(() -> RetryUtil.retryWithBackoffWithResult(any(), any()))
+                    .thenReturn(new RetryUtil.RetryResult(false, new MLBatchJobException(404, "Not Found"), 3));
+            // Add record B to batch_records
+            sageMakerBatchJobCreator.createMLBatchJob(newRecords, resultRecords);
+
+            // Verify initial state
+            assertEquals(1, sageMakerBatchJobCreator.getRetryQueue().size(),
+                    "Retry queue should have record A");
+            assertEquals(1, sageMakerBatchJobCreator.getBatch_records().size(),
+                    "Batch records should have record B");
+
+            // Process both records - should fail with 404
+            sageMakerBatchJobCreator.checkAndProcessBatch();
+
+            // Verify final state
+            // Both records should be removed from their respective queues
+            assertTrue(sageMakerBatchJobCreator.getRetryQueue().isEmpty(),
+                    "Retry queue should be empty after failure");
+            assertTrue(sageMakerBatchJobCreator.getBatch_records().isEmpty(),
+                    "Batch records should be empty after failure");
+
+            // Verify both records were added to processedBatchRecords with failure tags
+            assertEquals(2, sageMakerBatchJobCreator.getProcessedBatchRecords().size(),
+                    "Both records should be in result records");
+
+            // Verify DLQ handling
+            verify(dlqPushHandler).perform(dlqObjectsCaptor.capture());
+            List<DlqObject> dlqObjects = dlqObjectsCaptor.getValue();
+            assertEquals(2, dlqObjects.size(), "Both records should be sent to DLQ");
+
+            // Verify DLQ objects content
+            Set<String> dlqKeys = dlqObjects.stream()
+                    .map(dlqObject -> ((MLBatchJobFailedDlqData) dlqObject.getFailedData()).getS3Key())
+                    .collect(Collectors.toSet());
+            assertTrue(dlqKeys.contains("inputA.jsonl"), "DLQ should contain record A");
+            assertTrue(dlqKeys.contains("inputB.jsonl"), "DLQ should contain record B");
+            // Verify all DLQ objects have correct status code
+            dlqObjects.forEach(dlqObject -> {
+                MLBatchJobFailedDlqData failedData = (MLBatchJobFailedDlqData) dlqObject.getFailedData();
+                assertEquals(404, failedData.getStatus(), "DLQ object should have 404 status code");
+                assertEquals("Failed to Create SageMaker batch job after 3 attempts: Not Found", failedData.getMessage(), "DLQ object should have correct error message");
+            });
+            // Verify counters
+            verify(counter).increment(); // Failure counter
+            verify(recordsFailedCounter).increment(2); // Both records failed
         }
     }
 
@@ -697,6 +881,40 @@ public class SageMakerBatchJobCreatorTest {
             field.set(object, value);
         } catch (Exception e) {
             throw new RuntimeException("Failed to set private field: " + fieldName, e);
+        }
+    }
+
+    private Object createRetryRecord(Record<Event> record) throws Exception {
+        // Get RetryRecord class
+        Class<?> retryRecordClass = Class.forName(
+                "org.opensearch.dataprepper.plugins.ml_inference.processor.common.AbstractBatchJobCreator$RetryRecord");
+
+        // Get constructor
+        Constructor<?> constructor = retryRecordClass.getDeclaredConstructor(
+                AbstractBatchJobCreator.class, Record.class);
+        constructor.setAccessible(true);
+
+        // Create instance
+        return constructor.newInstance(sageMakerBatchJobCreator, record);
+    }
+
+    private int getRetryCount(Object retryRecord) {
+        try {
+            Field retryCountField = retryRecord.getClass().getDeclaredField("retryCount");
+            retryCountField.setAccessible(true);
+            return (int) retryCountField.get(retryRecord);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get retry count", e);
+        }
+    }
+
+    private Record<Event> getRecordFromRetryRecord(Object retryRecord) {
+        try {
+            Field recordField = retryRecord.getClass().getDeclaredField("record");
+            recordField.setAccessible(true);
+            return (Record<Event>) recordField.get(retryRecord);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get record from RetryRecord", e);
         }
     }
 }


### PR DESCRIPTION
### Description
When setting minimum OCUs greater than 5 with S3Scan reading multiple files, ml processor would trigger SageMaker Batch API throttled. This PR adds retry mechanism to the throttled records in a  10 min time window, to retry throttled records until the throttling goes away which enhances the success rates overall. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
