### PR TITLE
Support cross-region reads from S3 via S3 client

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ClientBuilderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ClientBuilderFactory.java
@@ -37,6 +37,7 @@ public class S3ClientBuilderFactory {
         LOG.info("Creating S3 client");
             return S3Client.builder()
                 .region(s3SourceConfig.getAwsAuthenticationOptions().getAwsRegion())
+                .crossRegionAccessEnabled(true)
                 .credentialsProvider(credentialsProvider)
                     .overrideConfiguration(ClientOverrideConfiguration.builder()
                             .retryPolicy(retryPolicy -> retryPolicy.numRetries(5).build())
@@ -52,6 +53,7 @@ public class S3ClientBuilderFactory {
         LOG.info("Creating S3 Async client");
         return S3AsyncClient.builder()
                 .region(s3SourceConfig.getAwsAuthenticationOptions().getAwsRegion())
+                .crossRegionAccessEnabled(true)
                 .httpClient(NettyNioAsyncHttpClient.builder()
                         .maxConcurrency(200)
                         .connectionTimeout(Duration.ofMinutes(1)).build())


### PR DESCRIPTION
### Description

Enables cross-region support for the `s3` source, both for SQS and scan. This is enabled by enabling the `crossRegionAccessEnabled` flag on the S3 client.
 
### Issues Resolved

Resolves #4470
Resolves #4811
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
