### PR TITLE
Keeping the backward compatibility when empty array added 

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -362,19 +362,14 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
 
     private void mergeValue(final Object value, Supplier<Object> getter, Consumer<Object> setter) {
         final Object currentValue = getter.get();
-        final List<Object> mergedValue;
+        final List<Object> mergedValue = new ArrayList<>();
         if (currentValue instanceof List) {
-            mergedValue = new ArrayList<>((List<Object>)currentValue);
+            mergedValue.addAll((List<Object>) currentValue);
         } else {
-            mergedValue = new ArrayList<>(2);
             mergedValue.add(currentValue);
         }
-        
-        if (value instanceof List) {
-            mergedValue.addAll((List<Object>)value);
-        } else {
-            mergedValue.add(value);
-        }
+
+        mergedValue.add(value);
         setter.accept(mergedValue);
     }
 }


### PR DESCRIPTION


### Description
During the recent refactoring in `AddEntry` processor made a small change in the behavior when adding an empty array followed by some value into the same exact key. Reverting back to the original original behavior here.

Given the processor
```
processor:
    - add_entries:
        entries:
          - key: "actor/user/groups"
            value: []
          - key: "actor/user/groups"
            value: ["hello"]
            append_if_key_exists: true
```

Event
```
{"message": "something"} 

```

Before this PR merged, the output will be 
```
{"message": "something", "actor":{"user":{"groups":["hello"]} 
```

After this PR merged:
```
{"message": "something", "actor":{"user":{"groups":[["hello"]]}
```
 
### Issues Resolved
Keeping the backward compatibility for the empty array addition using AddEntry processor.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
