### PR TITLE
Emit DimensionalTimeSliceCrawler worker partition process latency metric

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/DimensionalTimeSliceWorkerProgressState.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/DimensionalTimeSliceWorkerProgressState.java
@@ -17,4 +17,7 @@ public class DimensionalTimeSliceWorkerProgressState implements SaasWorkerProgre
 
     @JsonProperty("dimensionType")
     private String dimensionType;
+
+    @JsonProperty("partitionCreationTime")
+    private Instant partitionCreationTime;
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/DimensionalTimeSliceWorkerProgressStateTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/DimensionalTimeSliceWorkerProgressStateTest.java
@@ -32,6 +32,7 @@ public class DimensionalTimeSliceWorkerProgressStateTest {
         assertNull(state.getStartTime());
         assertNull(state.getEndTime());
         assertNull(state.getDimensionType());
+        assertNull(state.getPartitionCreationTime());
     }
 
     @Test
@@ -40,12 +41,14 @@ public class DimensionalTimeSliceWorkerProgressStateTest {
                 "  \"@class\": \"org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.DimensionalTimeSliceWorkerProgressState\",\n" +
                 "  \"startTime\": \"2024-10-20T02:27:15.717Z\",\n" +
                 "  \"endTime\": \"2024-10-20T03:27:15.717Z\",\n" +
+                "  \"partitionCreationTime\": \"2024-11-21T04:29:15.719Z\",\n" +
                 "  \"dimensionType\": \"Exchange\"\n" +
                 "}";
 
         DimensionalTimeSliceWorkerProgressState state = objectMapper.readValue(json, DimensionalTimeSliceWorkerProgressState.class);
         assertEquals(Instant.parse("2024-10-20T02:27:15.717Z"), state.getStartTime());
         assertEquals(Instant.parse("2024-10-20T03:27:15.717Z"), state.getEndTime());
+        assertEquals(Instant.parse("2024-11-21T04:29:15.719Z"), state.getPartitionCreationTime());
         assertEquals("Exchange", state.getDimensionType());
     }
 }


### PR DESCRIPTION
### Description

**What?**

This commit emits two additional metrics for DimensionalTimeSliceCrawler

metric WorkerPartitionWaitTime measures the wait time before a worker partition starts being processed after creation.

metric WorkerPartitionProcessLatency measures the duration between pulling data from source to writing to buffer in a worker partition.

**Why?**

These two metrics will provide visibility how long it takes to process a partition after being created.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO 
### Check List
- [x] New functionality includes testing. Tested locally and verified data being emitted
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
