### PR TITLE
Add support for including keys based on regex patterns for select entries processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
@@ -6,24 +6,37 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
 import org.opensearch.dataprepper.model.annotations.ExampleValues;
 import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 @JsonPropertyOrder
 @JsonClassDescription("The <code>select_entries</code> processor selects entries from an event.")
 public class SelectEntriesProcessorConfig {
-    @NotEmpty
-    @NotNull
+
     @JsonProperty("include_keys")
     @JsonPropertyDescription("A list of keys to be selected from an event.")
     private List<String> includeKeys;
+
+    @JsonProperty("include_keys_regex")
+    @JsonPropertyDescription("A list of regex patterns to match keys be selected from an event.")
+    private List<String> includeKeysRegex;
+
+    @JsonIgnore
+    private List<Pattern> includeKeysRegexPatterns;
+
+    @JsonProperty("include_keys_regex_pointer")
+    @JsonPropertyDescription("The pointer to a key or nested key to match the include_keys_regex patterns against.")
+    private String includeKeysRegexPointer;
 
     @JsonProperty("select_when")
     @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
@@ -38,8 +51,34 @@ public class SelectEntriesProcessorConfig {
         return includeKeys;
     }
 
+    public List<Pattern> getIncludeKeysRegex() {
+        return includeKeysRegexPatterns;
+    }
+
+    public String getIncludeKeysRegexPointer() {
+        return includeKeysRegexPointer;
+    }
+
     public String getSelectWhen() {
         return selectWhen;
+    }
+
+    @AssertTrue(message = "At least one of include_keys and include_keys_regex is required.")
+    boolean isValidIncludeKeys() {
+        return (includeKeys != null && !includeKeys.isEmpty()) || (includeKeysRegex != null && !includeKeysRegex.isEmpty());
+    }
+
+    @AssertTrue(message = "Invalid regex pattern found in include_keys_regex.")
+    boolean isValidIncludeKeysRegex() {
+        if (includeKeysRegex != null && !includeKeysRegex.isEmpty()) {
+            try {
+                includeKeysRegexPatterns = includeKeysRegex.stream().map(Pattern::compile).collect(Collectors.toList());
+            } catch (final PatternSyntaxException e) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }
 


### PR DESCRIPTION


### Description
This change adds new configuration parameters to the select entries processor

`include_keys_regex` -> A list of regex patterns to filter out keys to include from the event. Can be used alongside `include_keys`, and by default will only check keys at the root of the event

`include_keys_regex_pointer` -> A key pointing to a nested map that will lead to keys being included only from within this poointer. This will result in all other keys to be deleted if they are not in the `include_keys_regex_pointer` or in the `include_keys`. 

`include_keys` was previously required in this processor, and now at least one of `include_keys` or `include_keys_regex` is required.
 
### Issues Resolved
Related to #6087 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
