### PR TITLE
Change m365 lookback days to 0 and number of worker threads to 7

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365Source.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365Source.java
@@ -49,7 +49,7 @@ public class Office365Source extends CrawlerSourcePlugin {
     private final Office365AuthenticationInterface office365AuthProvider;
     private final Office365Service office365Service;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
-    private static final int OFFICE365_LOOKBACK_HOURS = 7 * 24;
+    private static final int OFFICE365_LOOKBACK_HOURS = 0;
 
     @DataPrepperPluginConstructor
     public Office365Source(final PluginMetrics pluginMetrics,

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
@@ -21,6 +21,8 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
  */
 @Getter
 public class Office365SourceConfig implements CrawlerSourceConfig {
+    private static final int NUMBER_OF_WORKERS = 7;
+
     /**
      * The Office 365 tenant ID that uniquely identifies the Microsoft Entra organization.
      */
@@ -46,7 +48,7 @@ public class Office365SourceConfig implements CrawlerSourceConfig {
 
     @Override
     public int getNumberOfWorkers() {
-        return DEFAULT_NUMBER_OF_WORKERS;
+        return NUMBER_OF_WORKERS;
     }
 
     @Override

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
@@ -57,6 +57,6 @@ class Office365SourceConfigTest {
         Office365SourceConfig config = createConfig();
 
         assertFalse(config.isAcknowledgments());
-        assertEquals(1, config.getNumberOfWorkers());
+        assertEquals(7, config.getNumberOfWorkers());
     }
 }


### PR DESCRIPTION
### Description

This commit makes two changes.

1. Change m365 connector default lookback days to 0 per requested. There will be next change to make it configureable soon.

2. Change number of worker threads based on performance test. During performance test we observe the avg m365 api latency is 235ms. With 7 threads, assuming all threads are busy the TPM would be around 1800 request per minute. It would optimize the throughput while not breach 2000 TPM API limit.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
