### PR TITLE
S3 sink without path_prefix provided should write to bucket root

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
@@ -35,7 +35,8 @@ public class KeyGenerator {
      */
     public String generateKeyForEvent(final Event event) {
         final String pathPrefix = s3BucketSelector != null ? s3BucketSelector.getPathPrefix() : ObjectKey.buildingPathPrefix(s3SinkConfig, event, expressionEvaluator);
+        final String safePathPrefix = pathPrefix != null ? pathPrefix : "";
         final String namePattern = ObjectKey.objectFileName(s3SinkConfig, extensionProvider.getExtension(), event, expressionEvaluator);
-        return (!pathPrefix.isEmpty()) ? pathPrefix + namePattern : namePattern;
+        return (!safePathPrefix.isEmpty()) ? safePathPrefix + namePattern : namePattern;
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKey.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKey.java
@@ -5,14 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
-import java.util.regex.Pattern;
-
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.s3keyindex.S3ObjectIndexUtility;
 import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
 
 /**
  * Building the path prefix and name pattern.
@@ -49,6 +49,9 @@ public class ObjectKey {
                                                      final Event event,
                                                      final ExpressionEvaluator expressionEvaluator) {
         String pathPrefix = s3SinkConfig.getObjectKeyOptions().getPathPrefix();
+        if (pathPrefix == null) {
+            return "";
+        }
         String pathPrefixExpressionResult = expressionEvaluator != null ? event.formatString(pathPrefix, expressionEvaluator, REPLACEMENT_FOR_NON_EXISTENT_KEYS) : pathPrefix;
         StringBuilder s3ObjectPath = new StringBuilder();
         if (pathPrefixExpressionResult != null && !pathPrefixExpressionResult.isEmpty()) {

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKeyTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKeyTest.java
@@ -9,10 +9,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 
@@ -36,7 +39,7 @@ class ObjectKeyTest {
     private Event event;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         when(s3SinkConfig.getObjectKeyOptions()).thenReturn(objectKeyOptions);
     }
 
@@ -85,4 +88,19 @@ class ObjectKeyTest {
         Assertions.assertNotNull(objectFileName);
         Assertions.assertTrue(objectFileName.contains(".json"));
     }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void test_buildingPathPrefix_with_null_formatString_result(final String pathPrefix) {
+        when(objectKeyOptions.getPathPrefix()).thenReturn(pathPrefix);
+        Event event = JacksonEvent.builder()
+                .withData("{}")
+                .withEventType("event")
+                .build();
+        Assertions.assertDoesNotThrow(() -> {
+            String pathPrefixResult = ObjectKey.buildingPathPrefix(s3SinkConfig, event, expressionEvaluator);
+            Assertions.assertEquals("", pathPrefixResult);
+        });
+    }
+
 }


### PR DESCRIPTION
### Description
`object_key` and `path_prefix` configuration options under S3 sink are optional. If not provided, S3 sink should write to the root of the bucket, but in the current state, it is failing. This code change fixes it.
 
### Issues Resolved
Resolves #6090
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
