### PR TITLE
Reduce m365 worker thread count from 7 to 2

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
@@ -21,7 +21,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
  */
 @Getter
 public class Office365SourceConfig implements CrawlerSourceConfig {
-    private static final int NUMBER_OF_WORKERS = 7;
+    private static final int NUMBER_OF_WORKERS = 2;
 
     /**
      * The Office 365 tenant ID that uniquely identifies the Microsoft Entra organization.

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
@@ -57,6 +57,6 @@ class Office365SourceConfigTest {
         Office365SourceConfig config = createConfig();
 
         assertFalse(config.isAcknowledgments());
-        assertEquals(7, config.getNumberOfWorkers());
+        assertEquals(2, config.getNumberOfWorkers());
     }
 }


### PR DESCRIPTION
This commit reduces the m365 worker thread count from 7 to 2. This is because the worker thread is per host and we need to ensure there are not too many threads in total to avoid api throttling.

The suggestion is to estimate based on 2 ~ 4 OCU. Original 7 is the estimated based on total threads. Changing to 2 would fit for 4 OCU.

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
