### PR TITLE
Refresh Office365 secrets from secrets plugin

### DIFF
--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariable.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariable.java
@@ -52,6 +52,11 @@ public class AwsPluginConfigVariable implements PluginConfigVariable {
         secretsSupplier.refresh(secretId);
     }
 
+    public void refreshAndRetrieveValue() {
+        secretsSupplier.refresh(secretId);
+        this.secretValue = secretsSupplier.retrieveValue(secretId, secretKey);
+    }
+
 
     @Override
     public boolean isUpdatable() {

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariableTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigVariableTest.java
@@ -90,4 +90,12 @@ class AwsPluginConfigVariableTest {
         verify(secretsSupplier, times(1)).refresh(secretId);
     }
 
+
+    @Test
+    void testRefreshAndRetrieveValue() {
+        objectUnderTest.refreshAndRetrieveValue();
+        verify(secretsSupplier, times(1)).refresh(secretId);
+        verify(secretsSupplier, times(1)).retrieveValue(secretId, secretKey);
+    }
+
 }

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/build.gradle
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(path: ':data-prepper-plugins:aws-plugin-api')
     implementation project(path: ':data-prepper-plugins:buffer-common')
     implementation project(path: ':data-prepper-plugins:common')
+    implementation project(path: ':data-prepper-plugins:aws-plugin')
 
     // Microsoft Graph API dependencies
     implementation 'com.microsoft.graph:microsoft-graph:5.65.0'

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/auth/Oauth2Config.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/auth/Oauth2Config.java
@@ -5,19 +5,21 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.source.microsoft_office365.auth;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
 import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-
 @Getter
-public class AuthenticationConfiguration {
-    @JsonProperty("oauth2")
-    @NotNull
-    private Oauth2Config oauth2;
+public class Oauth2Config {
+    @JsonProperty("client_id")
+    private PluginConfigVariable clientId;
+
+    @JsonProperty("client_secret")
+    private PluginConfigVariable clientSecret;
 }

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceTest.java
@@ -71,9 +71,6 @@ class Office365SourceTest {
     private AuthenticationConfiguration authenticationConfiguration;
 
     @Mock
-    private AuthenticationConfiguration.OAuth2Credentials oauth2Credentials;
-
-    @Mock
     private EnhancedSourceCoordinator sourceCoordinator;
 
     @Mock

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/auth/Office365AuthenticationProviderTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/auth/Office365AuthenticationProviderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.plugins.source.microsoft_office365.Office365SourceConfig;
+import org.opensearch.dataprepper.plugins.aws.AwsPluginConfigVariable;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -13,14 +14,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,16 +47,24 @@ class Office365AuthenticationProviderTest {
     private AuthenticationConfiguration authConfig;
 
     @Mock
-    private AuthenticationConfiguration.OAuth2Credentials oAuth2Credentials;
+    private Oauth2Config oAuth2Config;
+
+    @Mock
+    private AwsPluginConfigVariable clientIdVariable;
+
+    @Mock
+    private AwsPluginConfigVariable clientSecretVariable;
 
     private Office365AuthenticationProvider authProvider;
 
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
         when(config.getAuthenticationConfiguration()).thenReturn(authConfig);
-        when(authConfig.getOauth2()).thenReturn(oAuth2Credentials);
-        when(oAuth2Credentials.getClientId()).thenReturn("testClientId");
-        when(oAuth2Credentials.getClientSecret()).thenReturn("testClientSecret");
+        when(authConfig.getOauth2()).thenReturn(oAuth2Config);
+        when(oAuth2Config.getClientId()).thenReturn(clientIdVariable);
+        when(oAuth2Config.getClientSecret()).thenReturn(clientSecretVariable);
+        when(clientIdVariable.getValue()).thenReturn("testClientId");
+        when(clientSecretVariable.getValue()).thenReturn("testClientSecret");
         when(config.getTenantId()).thenReturn("testTenantId");
 
         authProvider = new Office365AuthenticationProvider(config);
@@ -61,6 +78,10 @@ class Office365AuthenticationProviderTest {
         // Test init
         authProvider.initCredentials();
         assertEquals("testAccessToken", authProvider.getAccessToken());
+
+        // Verify that refreshAndRetrieveValue was called on both config variables
+        verify(clientIdVariable).refreshAndRetrieveValue();
+        verify(clientSecretVariable).refreshAndRetrieveValue();
 
         // Clear the token and test renew directly
         ReflectivelySetField.setField(Office365AuthenticationProvider.class, authProvider, "accessToken", null);
@@ -102,6 +123,59 @@ class Office365AuthenticationProviderTest {
         IllegalStateException exception = assertThrows(IllegalStateException.class,
                 () -> authProvider.renewCredentials());
         assertEquals("Invalid token response: missing access_token", exception.getMessage());
+    }
+
+    @Test
+    void testGetAccessTokenWithLazyInitialization() throws NoSuchFieldException, IllegalAccessException {
+        mockSuccessfulTokenResponse();
+
+        // Ensure access token is null initially
+        ReflectivelySetField.setField(Office365AuthenticationProvider.class, authProvider, "accessToken", null);
+
+        // Call getAccessToken which should trigger initialization
+        String token = authProvider.getAccessToken();
+
+        assertEquals("testAccessToken", token);
+        verify(clientIdVariable).refreshAndRetrieveValue();
+        verify(clientSecretVariable).refreshAndRetrieveValue();
+    }
+
+    @Test
+    void testConcurrentAccessTokenInitialization() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        mockSuccessfulTokenResponse();
+
+        // Ensure access token is null initially
+        ReflectivelySetField.setField(Office365AuthenticationProvider.class, authProvider, "accessToken", null);
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String[] results = new String[threadCount];
+
+        // Start multiple threads trying to get access token simultaneously
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            executor.submit(() -> {
+                try {
+                    results[index] = authProvider.getAccessToken();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to complete
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        // Verify all threads got the same token
+        for (String result : results) {
+            assertEquals("testAccessToken", result);
+        }
+
+        // Verify initCredentials was called only once due to double-checked locking
+        verify(clientIdVariable, times(1)).refreshAndRetrieveValue();
+        verify(clientSecretVariable, times(1)).refreshAndRetrieveValue();
     }
 
     private void mockSuccessfulTokenResponse() {


### PR DESCRIPTION
### Description
Refresh Office365 secrets from secrets plugin. 

Currently, Office365 plugin secrets are not being updated in the source config, so we resolve this by introducing `AwsPluginConfigVariable.refreshAndRetrieveValue()` which manually refreshes the secrets when Office365 source plugin has an authentication failure, then retrieves the value from the `secretsSupplier`.

Tested by running data-prepper locally and verfying on new `renewCredentials()` that updating the secret value in secrets manager console will result in the pipeline using the new client secret
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
