### PR TITLE
Updates plugin framework test to use @DataPrepperPluginTest instead of extension

### DIFF
--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/DataPrepperPluginTest.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/DataPrepperPluginTest.java
@@ -9,6 +9,8 @@
 
 package org.opensearch.dataprepper.test.plugins;
 
+import org.opensearch.dataprepper.test.plugins.junit.DataPrepperPluginTestFramework;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -21,6 +23,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@DataPrepperPluginTestFramework
 public @interface DataPrepperPluginTest {
     /**
      * Provides the name of the plugin.

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/BaseDataPrepperPluginStandardTestSuite.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/BaseDataPrepperPluginStandardTestSuite.java
@@ -11,7 +11,6 @@ package org.opensearch.dataprepper.test.plugins.junit;
 
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.dataprepper.plugin.PluginProvider;
 
 import java.util.stream.Stream;
@@ -22,7 +21,6 @@ import java.util.stream.Stream;
  *
  * @since 2.13
  */
-@ExtendWith(DataPrepperPluginTestFrameworkExtension.class)
 public class BaseDataPrepperPluginStandardTestSuite {
     @TestFactory
     Stream<DynamicTest> standardDataPrepperPluginTests(

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestContextParameterResolver.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestContextParameterResolver.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+
+class DataPrepperPluginTestContextParameterResolver implements ParameterResolver {
+    @Override
+    public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+        return DataPrepperPluginTestContext.class.equals(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+        final Class<?> testClass = extensionContext.getRequiredTestClass();
+        final DataPrepperPluginTest annotation = testClass.getAnnotation(DataPrepperPluginTest.class);
+        if (annotation == null) {
+            throw new ParameterResolutionException("Missing @DataPrepperPluginTest annotation on class: " + testClass.getName());
+        }
+        return new DataPrepperPluginTestContext(annotation.pluginName(), annotation.pluginType());
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestFramework.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestFramework.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to enable the Data Prepper plugin test framework
+ * in JUnit.
+ * <p>
+ * Use {@link org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest} instead.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith({
+        DataPrepperPluginTestContextParameterResolver.class,
+        PluginProviderParameterResolver.class
+})
+public @interface DataPrepperPluginTestFramework {
+}

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestFrameworkExtension.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestFrameworkExtension.java
@@ -22,6 +22,7 @@ import java.util.Set;
 /**
  * A JUnit extension for using the Data Prepper plugin test framework.
  */
+@Deprecated
 public class DataPrepperPluginTestFrameworkExtension implements ParameterResolver {
     private static final Set<Class<?>> SUPPORTED_CLASSES = Set.of(
             DataPrepperPluginTestContext.class,

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/PluginProviderParameterResolver.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/PluginProviderParameterResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.opensearch.dataprepper.plugin.ClasspathPluginProvider;
+import org.opensearch.dataprepper.plugin.PluginProvider;
+
+public class PluginProviderParameterResolver implements ParameterResolver {
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return PluginProvider.class.equals(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return new ClasspathPluginProvider();
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/PluginProviderParameterResolver.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/PluginProviderParameterResolver.java
@@ -16,14 +16,14 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.opensearch.dataprepper.plugin.ClasspathPluginProvider;
 import org.opensearch.dataprepper.plugin.PluginProvider;
 
-public class PluginProviderParameterResolver implements ParameterResolver {
+class PluginProviderParameterResolver implements ParameterResolver {
     @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
         return PluginProvider.class.equals(parameterContext.getParameter().getType());
     }
 
     @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
         return new ClasspathPluginProvider();
     }
 }

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluggableInterface.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluggableInterface.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.test;
+
+public interface TestPluggableInterface {
+}

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPlugin.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPlugin.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.test;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+
+@DataPrepperPlugin(name = "test_plugin", pluginType = TestPluggableInterface.class, pluginConfigurationType = TestPluginConfiguration.class)
+public class TestPlugin {
+    @DataPrepperPluginConstructor
+    public TestPlugin(final TestPluginConfiguration configuration) {
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluginConfiguration.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluginConfiguration.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.test;
+
+public class TestPluginConfiguration {
+}

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/DataPrepperPluginIT.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/DataPrepperPluginIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins;
+
+import org.opensearch.dataprepper.plugins.test.TestPluggableInterface;
+import org.opensearch.dataprepper.test.plugins.junit.BaseDataPrepperPluginStandardTestSuite;
+
+@DataPrepperPluginTest(pluginName = "test_plugin", pluginType = TestPluggableInterface.class)
+class DataPrepperPluginIT extends BaseDataPrepperPluginStandardTestSuite {
+}

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestContextParameterResolverTest.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestContextParameterResolverTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+
+import java.lang.reflect.Parameter;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataPrepperPluginTestContextParameterResolverTest {
+    @Mock
+    private ParameterContext parameterContext;
+
+    @Mock
+    private ExtensionContext extensionContext;
+
+    @Mock
+    private Parameter parameter;
+
+    @DataPrepperPluginTest(pluginName = "test_plugin_annotated", pluginType = Processor.class)
+    private static class AnnotatedClass {
+    }
+
+    private static class UnannotatedClass {
+    }
+
+    private DataPrepperPluginTestContextParameterResolver createObjectUnderTest() {
+        return new DataPrepperPluginTestContextParameterResolver();
+    }
+
+    @Test
+    void supportsParameter_returns_true_for_supported_class() {
+        when(parameterContext.getParameter()).thenReturn(parameter);
+        when(parameter.getType()).thenReturn((Class)DataPrepperPluginTestContext.class);
+
+        assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Processor.class,
+            Sink.class,
+            Event.class,
+            EventKey.class
+    })
+    void supportsParameter_returns_false_for_some_unsupported_classes(final Class<?> unsupportedClass) {
+        when(parameterContext.getParameter()).thenReturn(parameter);
+        when(parameter.getType()).thenReturn((Class)unsupportedClass);
+
+        assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(false));
+    }
+
+    @Test
+    void resolveParameter_for_DataPrepperPluginTestContext_with_annotated_class_returns_context() {
+        when(extensionContext.getRequiredTestClass()).thenReturn((Class) DataPrepperPluginTestContextParameterResolverTest.AnnotatedClass.class);
+
+        final Object resolvedParameter = createObjectUnderTest().resolveParameter(parameterContext, extensionContext);
+
+        assertThat(resolvedParameter, instanceOf(DataPrepperPluginTestContext.class));
+
+        final DataPrepperPluginTestContext actualTestContext = (DataPrepperPluginTestContext) resolvedParameter;
+
+        assertThat(actualTestContext, notNullValue());
+        assertThat(actualTestContext.getPluginName(), equalTo("test_plugin_annotated"));
+        assertThat(actualTestContext.getPluginType(), equalTo(Processor.class));
+    }
+
+    @Test
+    void resolveParameter_for_DataPrepperPluginTestContext_with_unannotated_class_throws() {
+        when(extensionContext.getRequiredTestClass()).thenReturn((Class) DataPrepperPluginTestContextParameterResolverTest.UnannotatedClass.class);
+
+        final DataPrepperPluginTestContextParameterResolver objectUnderTest = createObjectUnderTest();
+
+        final ParameterResolutionException actualException = assertThrows(ParameterResolutionException.class, () -> objectUnderTest.resolveParameter(parameterContext, extensionContext));
+
+        assertThat(actualException.getMessage(), containsString("@DataPrepperPluginTest"));
+        assertThat(actualException.getMessage(), containsString(DataPrepperPluginTestContextParameterResolverTest.UnannotatedClass.class.getName()));
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/PluginProviderParameterResolverTest.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/PluginProviderParameterResolverTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.plugin.ClasspathPluginProvider;
+import org.opensearch.dataprepper.plugin.PluginProvider;
+
+import java.lang.reflect.Parameter;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PluginProviderParameterResolverTest {
+    @Mock
+    private ParameterContext parameterContext;
+
+    @Mock
+    private ExtensionContext extensionContext;
+
+    @Mock
+    private Parameter parameter;
+
+    private PluginProviderParameterResolver createObjectUnderTest() {
+        return new PluginProviderParameterResolver();
+    }
+
+    @Test
+    void supportsParameter_returns_true_for_supported_class() {
+        when(parameterContext.getParameter()).thenReturn(parameter);
+        when(parameter.getType()).thenReturn((Class)PluginProvider.class);
+
+        assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Processor.class,
+            Sink.class,
+            Event.class,
+            EventKey.class
+    })
+    void supportsParameter_returns_false_for_some_unsupported_classes(final Class<?> unsupportedClass) {
+        when(parameterContext.getParameter()).thenReturn(parameter);
+        when(parameter.getType()).thenReturn((Class)unsupportedClass);
+
+        assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(false));
+    }
+
+    @Test
+    void resolveParameter_for_PluginProvider() {
+        final Object resolvedParameter = createObjectUnderTest().resolveParameter(parameterContext, extensionContext);
+
+        assertThat(resolvedParameter, instanceOf(PluginProvider.class));
+        assertThat(resolvedParameter, instanceOf(ClasspathPluginProvider.class));
+    }
+}


### PR DESCRIPTION
### Description

Updated the approach to the plugin framework test to use only the `@DataPrepperPluginTest` annotation. This way we don't need to use `@ExtendWith(DataPrepperPluginTestFrameworkExtension.class)` as well. Deprecate the `DataPrepperPluginTestFrameworkExtension`.

This change also makes it easier to extend and I have some other upcoming changes that would make use of it.

I also added an integration test that runs the test framework for a test plugin.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
