### PR TITLE
Fixes the unit tests for enabling point-in-time on AOS Serverless

### DIFF
--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
@@ -227,8 +227,8 @@ public class SearchAccessStrategyTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"POINT_IN_TIME", "SCROLL"})
-    void serverless_flag_true_throws_InvalidPluginConfiguration_if_search_context_type_is_point_in_time_or_scroll(final String searchContextType) {
+    @ValueSource(strings = {"SCROLL"})
+    void serverless_flag_true_throws_InvalidPluginConfiguration_if_search_context_type_scroll(final String searchContextType) {
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
         when(awsAuthenticationConfiguration.isServerlessCollection()).thenReturn(true);


### PR DESCRIPTION
### Description

Support for point-in-time search on AOS Serverless was added in PR #6050. However, the unit tests were not updated and now they fail. This PR fixes that.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
