### PR TITLE
Test framework support for loading plugin instances

### DIFF
--- a/data-prepper-plugins/drop-events-processor/build.gradle
+++ b/data-prepper-plugins/drop-events-processor/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    testImplementation project(':data-prepper-test:plugin-test-framework')
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsProcessorIT.java
+++ b/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsProcessorIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.drop;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+import org.opensearch.dataprepper.test.plugins.PluginConfigurationFile;
+import org.opensearch.dataprepper.test.plugins.junit.BaseDataPrepperPluginStandardTestSuite;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@DataPrepperPluginTest(pluginName = "drop_events", pluginType = Processor.class)
+class DropEventsProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
+    @Test
+    void drops_records_when_value_is_empty_string(
+            @PluginConfigurationFile("drop_when_value_is_empty_string.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest,
+            final EventFactory eventFactory) {
+
+        final List<Event> allEvents = new LinkedList<>();
+        final List<Event> expectedEventsAfterProcessor = new LinkedList<>();
+        for(int i = 0; i < 5; i++) {
+
+            final boolean shouldKeepEvent = i % 2 == 0;
+
+            final String keyValue = shouldKeepEvent ? UUID.randomUUID().toString() : "";
+            final Event event = eventFactory.eventBuilder(LogEventBuilder.class)
+                    .withData(Map.of(
+                            "my_key", keyValue
+                            ,"some_other_key", UUID.randomUUID().toString()
+                    ))
+                    .build();
+
+            allEvents.add(event);
+            if(shouldKeepEvent) {
+                expectedEventsAfterProcessor.add(event);
+            }
+        }
+
+        final List<Record<Event>> inputRecords = allEvents.stream()
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        final Collection<Record<Event>> outputRecords = objectUnderTest.execute(inputRecords);
+
+        assertThat(outputRecords, notNullValue());
+
+        final List<Event> outputEvents = outputRecords.stream().map(Record::getData).collect(Collectors.toList());
+
+        assertThat(outputEvents, equalTo(expectedEventsAfterProcessor));
+    }
+}

--- a/data-prepper-plugins/drop-events-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/drop/drop_when_value_is_empty_string.yaml
+++ b/data-prepper-plugins/drop-events-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/drop/drop_when_value_is_empty_string.yaml
@@ -1,0 +1,8 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - drop_events:
+        drop_when: /my_key == ""
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorIT.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorIT.java
@@ -10,10 +10,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mock;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -23,6 +26,7 @@ import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationExcepti
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+import org.opensearch.dataprepper.test.plugins.PluginConfigurationFile;
 import org.opensearch.dataprepper.test.plugins.junit.BaseDataPrepperPluginStandardTestSuite;
 
 import java.util.ArrayList;
@@ -30,7 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -44,99 +47,28 @@ import static org.opensearch.dataprepper.plugins.processor.grok.GrokProcessorTes
 
 @DataPrepperPluginTest(pluginName = "grok", pluginType = Processor.class)
 public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
-    private PluginSetting pluginSetting;
-    private PluginMetrics pluginMetrics;
-    private GrokProcessorConfig grokProcessorConfig;
-    private GrokProcessor grokProcessor;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
-    private final String PLUGIN_NAME = "grok";
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
+    };
     private String messageInput;
-
-    @Mock
-    private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
     public void setup() {
-
-        pluginSetting = completePluginSettingForGrokProcessor(
-                GrokProcessorConfig.DEFAULT_BREAK_ON_MATCH,
-                GrokProcessorConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
-                Collections.emptyMap(),
-                GrokProcessorConfig.DEFAULT_NAMED_CAPTURES_ONLY,
-                Collections.emptyList(),
-                Collections.emptyList(),
-                GrokProcessorConfig.DEFAULT_PATTERNS_FILES_GLOB,
-                Collections.emptyMap(),
-                GrokProcessorConfig.DEFAULT_TIMEOUT_MILLIS,
-                GrokProcessorConfig.DEFAULT_TARGET_KEY,
-                null,
-                null);
-
-        pluginSetting.setPipelineName("grokPipeline");
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
-
         // This is a COMMONAPACHELOG pattern with the following format
         // COMMONAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
         // Note that rawrequest is missing from the log below, which means that it will not be captured unless keep_empty_captures is true
         messageInput = "127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326";
     }
 
-    @AfterEach
-    public void tearDown() {
-        if(grokProcessor != null) {
-            grokProcessor.shutdown();
-        }
-    }
-
-    private PluginSetting completePluginSettingForGrokProcessor(final boolean breakOnMatch,
-                                                              final boolean keepEmptyCaptures,
-                                                              final Map<String, List<String>> match,
-                                                              final boolean namedCapturesOnly,
-                                                              final List<String> keysToOverwrite,
-                                                              final List<String> patternsDirectories,
-                                                              final String patternsFilesGlob,
-                                                              final Map<String, String> patternDefinitions,
-                                                              final int timeoutMillis,
-                                                              final String targetKey,
-                                                              final String grokWhen,
-                                                              final List<String> tagsOnMatchFailure
-) {
-        final Map<String, Object> settings = new HashMap<>();
-        settings.put(GrokProcessorConfig.BREAK_ON_MATCH, breakOnMatch);
-        settings.put(GrokProcessorConfig.NAMED_CAPTURES_ONLY, namedCapturesOnly);
-        settings.put(GrokProcessorConfig.MATCH, match);
-        settings.put(GrokProcessorConfig.KEEP_EMPTY_CAPTURES, keepEmptyCaptures);
-        settings.put(GrokProcessorConfig.KEYS_TO_OVERWRITE, keysToOverwrite);
-        settings.put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
-        settings.put(GrokProcessorConfig.PATTERN_DEFINITIONS, patternDefinitions);
-        settings.put(GrokProcessorConfig.PATTERNS_FILES_GLOB, patternsFilesGlob);
-        settings.put(GrokProcessorConfig.TIMEOUT_MILLIS, timeoutMillis);
-        settings.put(GrokProcessorConfig.TARGET_KEY, targetKey);
-        settings.put(GrokProcessorConfig.GROK_WHEN, grokWhen);
-        settings.put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatchFailure);
-
-        return new PluginSetting(PLUGIN_NAME, settings);
-    }
-
     @Test
-    public void testMatchNoCapturesWithExistingAndNonExistingKey() throws JsonProcessingException {
-        final String nonMatchingPattern = "%{SYSLOGBASE}";
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList(nonMatchingPattern));
-        matchConfig.put("bad_key", Collections.singletonList(nonMatchingPattern));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    void testMatchNoCapturesWithExistingAndNonExistingKey(
+            @PluginConfigurationFile("match_no_captures_with_existing_and_non_existing_key.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
 
         final Record<Event> record = buildRecordWithEvent(testData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -144,14 +76,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testSingleMatchSinglePatternWithDefaults() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testSingleMatchSinglePatternWithDefaults(
+            @PluginConfigurationFile("single_match_single_pattern.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
         final Record<Event> record = buildRecordWithEvent(testData);
@@ -170,7 +96,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -178,19 +104,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testSingleMatchMultiplePatternWithBreakOnMatchFalse() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        final List<String> patternsToMatchMessage = new ArrayList<>();
-        patternsToMatchMessage.add("%{COMMONAPACHELOG}");
-        patternsToMatchMessage.add("%{IPORHOST:custom_client_field}");
-
-        matchConfig.put("message", patternsToMatchMessage);
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.BREAK_ON_MATCH, false);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testSingleMatchMultiplePatternWithBreakOnMatchFalse(
+            @PluginConfigurationFile("single_match_multiple_pattern_with_break_on_match_false.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
 
@@ -211,7 +126,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -219,14 +134,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testSingleMatchTypeConversionWithDefaults() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("\"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response:int} (?:%{NUMBER:bytes:float}|-)"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testSingleMatchTypeConversionWithDefaults(
+            @PluginConfigurationFile("single_match_type_conversion.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
 
@@ -242,7 +151,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -250,16 +159,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testMultipleMatchWithBreakOnMatchFalse() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
-        matchConfig.put("extra_field", Collections.singletonList("%{GREEDYDATA} %{IPORHOST:host}"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.BREAK_ON_MATCH, false);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testMultipleMatchWithBreakOnMatchFalse(
+            @PluginConfigurationFile("multiple_match_with_break_on_match_false.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
         testData.put("extra_field", "My host IP is 192.0.2.1");
@@ -282,7 +183,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -290,15 +191,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testMatchWithKeepEmptyCapturesTrue() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.KEEP_EMPTY_CAPTURES, true);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testMatchWithKeepEmptyCapturesTrue(
+            @PluginConfigurationFile("match_with_keep_empty_captures_true.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", messageInput);
 
@@ -319,7 +213,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -327,15 +221,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testMatchWithNamedCapturesOnlyFalse() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{GREEDYDATA} %{IPORHOST:host} %{NUMBER}"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.NAMED_CAPTURES_ONLY, false);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testMatchWithNamedCapturesOnlyFalse(
+            @PluginConfigurationFile("match_with_named_captures_only_false.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "This is my greedy data before matching 192.0.2.1 123456");
 
@@ -349,7 +236,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -357,18 +244,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testPatternDefinitions() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{GREEDYDATA:greedy_data} %{CUSTOMPHONENUMBERPATTERN:my_number}"));
-
-        final Map<String, String> patternDefinitions = new HashMap<>();
-        patternDefinitions.put("CUSTOMPHONENUMBERPATTERN", "\\d\\d\\d-\\d\\d\\d-\\d\\d\\d");
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.PATTERN_DEFINITIONS, patternDefinitions);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testPatternDefinitions(
+            @PluginConfigurationFile("pattern_definitions.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "This is my greedy data before matching with my phone number 123-456-789");
 
@@ -381,7 +258,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -389,15 +266,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testPatternsDirWithDefaultPatternsFilesGlob() throws JsonProcessingException {
-        final String patternDirectory = "./src/test/resources/test_patterns";
-
-        final List<String> patternsDirectories = new ArrayList<>();
-        patternsDirectories.add(patternDirectory);
-
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("My birthday is %{CUSTOMBIRTHDAYPATTERN:my_birthday} and my phone number is %{CUSTOMPHONENUMBERPATTERN:my_number}"));
-
+    public void testPatternsDirWithDefaultPatternsFilesGlob(
+            @PluginConfigurationFile("patterns_dir_with_default_patterns_files_glob.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "My birthday is April 15, 1991 and my phone number is 123-456-789");
 
@@ -408,14 +278,9 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
         resultData.put("my_birthday", "April 15, 1991");
         resultData.put("my_number", "123-456-789");
 
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -423,15 +288,8 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testPatternsDirWithCustomPatternsFilesGlob() throws JsonProcessingException {
-        final String patternDirectory = "./src/test/resources/test_patterns";
-
-        final List<String> patternsDirectories = new ArrayList<>();
-        patternsDirectories.add(patternDirectory);
-
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("My phone number is %{CUSTOMPHONENUMBERPATTERN:my_number}"));
-
+    public void testPatternsDirWithCustomPatternsFilesGlob(
+            @PluginConfigurationFile("patterns_dir_with_custom_patterns_files_glob.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "My phone number is 123-456-789");
 
@@ -441,42 +299,18 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
         resultData.put("message", "My phone number is 123-456-789");
         resultData.put("my_number", "123-456-789");
 
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
-        pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_FILES_GLOB, "*1.txt");
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
         assertRecordsAreEqual(grokkedRecords.get(0), resultRecord);
-
-        final Map<String, List<String>> matchConfigWithPatterns2Pattern = new HashMap<>();
-        matchConfigWithPatterns2Pattern.put("message", Collections.singletonList("My birthday is %{CUSTOMBIRTHDAYPATTERN:my_birthday}"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfigWithPatterns2Pattern);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-
-        Throwable throwable = assertThrows(InvalidPluginConfigurationException.class, () -> new GrokProcessor(
-                pluginMetrics, grokProcessorConfig, expressionEvaluator));
-        assertThat(throwable.getCause(), instanceOf(IllegalArgumentException.class));
-        assertThat("No definition for key 'CUSTOMBIRTHDAYPATTERN' found, aborting", equalTo(throwable
-                .getCause().getMessage()));
     }
 
     @Test
-    public void testMatchWithNamedCapturesSyntax() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{GREEDYDATA:greedy_data} (?<mynumber>\\d\\d\\d-\\d\\d\\d-\\d\\d\\d)"));
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testMatchWithNamedCapturesSyntax(
+            @PluginConfigurationFile("match_with_named_captures_syntax.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", "This is my greedy data before matching with my phone number 123-456-789");
 
@@ -489,7 +323,7 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
 
         final Record<Event> resultRecord = buildRecordWithEvent(resultData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
@@ -497,71 +331,154 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
     }
 
     @Test
-    public void testMatchWithNoCapturesAndTags() throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{GREEDYDATA:greedy_data} (?<mynumber>\\d\\d\\d-\\d\\d\\d-\\d\\d\\d)"));
-        final String tagOnMatchFailure1 = UUID.randomUUID().toString();
-        final String tagOnMatchFailure2 = UUID.randomUUID().toString();
-
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, List.of(tagOnMatchFailure1, tagOnMatchFailure2));
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
-
+    public void testMatchWithNoCapturesAndTags(
+            @PluginConfigurationFile("match_with_no_captures_and_tags.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest) throws JsonProcessingException {
         final Map<String, Object> testData = new HashMap();
         testData.put("log", "This is my greedy data before matching with my phone number 123-456-789");
 
         final Record<Event> record = buildRecordWithEvent(testData);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) objectUnderTest.execute(Collections.singletonList(record));
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertRecordsAreEqual(grokkedRecords.get(0), record);
-        assertTrue(((Event)record.getData()).getMetadata().getTags().contains(tagOnMatchFailure1));
-        assertTrue(((Event)record.getData()).getMetadata().getTags().contains(tagOnMatchFailure2));
+        assertTrue(((Event) record.getData()).getMetadata().getTags().contains("some_test_tag_1"));
+        assertTrue(((Event) record.getData()).getMetadata().getTags().contains("some_test_tag_2"));
     }
 
-    @Test
-    public void testCompileNonRegisteredPatternThrowsIllegalArgumentException() {
+    @Nested
+    class ClassicTestApproach {
+        private PluginSetting pluginSetting;
+        private PluginMetrics pluginMetrics;
+        private GrokProcessorConfig grokProcessorConfig;
+        private GrokProcessor grokProcessor;
+        private final String PLUGIN_NAME = "grok";
 
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
+        @Mock
+        private ExpressionEvaluator expressionEvaluator;
 
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList("%{NONEXISTENTPATTERN}"));
+        @BeforeEach
+        public void setup() {
 
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+            pluginSetting = completePluginSettingForGrokProcessor(
+                    GrokProcessorConfig.DEFAULT_BREAK_ON_MATCH,
+                    GrokProcessorConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
+                    Collections.emptyMap(),
+                    GrokProcessorConfig.DEFAULT_NAMED_CAPTURES_ONLY,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    GrokProcessorConfig.DEFAULT_PATTERNS_FILES_GLOB,
+                    Collections.emptyMap(),
+                    GrokProcessorConfig.DEFAULT_TIMEOUT_MILLIS,
+                    GrokProcessorConfig.DEFAULT_TARGET_KEY,
+                    null,
+                    null);
 
-        assertThrows(InvalidPluginConfigurationException.class, () -> new GrokProcessor(
-                pluginMetrics, grokProcessorConfig, expressionEvaluator));
-    }
+            pluginSetting.setPipelineName("grokPipeline");
+            grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+            pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
+        }
 
-    @ParameterizedTest
-    @MethodSource("getGrokPatternInputAndOutput")
-    void testDataPrepperBuiltInGrokPatterns(final String matchPattern, final String logInput, final String expectedGrokResultJson) throws JsonProcessingException {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", Collections.singletonList(matchPattern));
+        @AfterEach
+        public void tearDown() {
+            if (grokProcessor != null) {
+                grokProcessor.shutdown();
+            }
+        }
 
-        pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
-        grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
-        grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
+        private PluginSetting completePluginSettingForGrokProcessor(final boolean breakOnMatch,
+                                                                    final boolean keepEmptyCaptures,
+                                                                    final Map<String, List<String>> match,
+                                                                    final boolean namedCapturesOnly,
+                                                                    final List<String> keysToOverwrite,
+                                                                    final List<String> patternsDirectories,
+                                                                    final String patternsFilesGlob,
+                                                                    final Map<String, String> patternDefinitions,
+                                                                    final int timeoutMillis,
+                                                                    final String targetKey,
+                                                                    final String grokWhen,
+                                                                    final List<String> tagsOnMatchFailure
+        ) {
+            final Map<String, Object> settings = new HashMap<>();
+            settings.put(GrokProcessorConfig.BREAK_ON_MATCH, breakOnMatch);
+            settings.put(GrokProcessorConfig.NAMED_CAPTURES_ONLY, namedCapturesOnly);
+            settings.put(GrokProcessorConfig.MATCH, match);
+            settings.put(GrokProcessorConfig.KEEP_EMPTY_CAPTURES, keepEmptyCaptures);
+            settings.put(GrokProcessorConfig.KEYS_TO_OVERWRITE, keysToOverwrite);
+            settings.put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
+            settings.put(GrokProcessorConfig.PATTERN_DEFINITIONS, patternDefinitions);
+            settings.put(GrokProcessorConfig.PATTERNS_FILES_GLOB, patternsFilesGlob);
+            settings.put(GrokProcessorConfig.TIMEOUT_MILLIS, timeoutMillis);
+            settings.put(GrokProcessorConfig.TARGET_KEY, targetKey);
+            settings.put(GrokProcessorConfig.GROK_WHEN, grokWhen);
+            settings.put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatchFailure);
 
-        final Map<String, Object> testData = new HashMap();
-        testData.put("message", logInput);
+            return new PluginSetting(PLUGIN_NAME, settings);
+        }
 
-        final Record<Event> record = buildRecordWithEvent(testData);
+        @Test
+        public void testPatternsDirWithCustomPatternsFilesGlobFails() {
+            final String patternDirectory = "./src/test/resources/test_patterns";
 
-        final Map<String, Object> expectedGrokResult = OBJECT_MAPPER.readValue(expectedGrokResultJson, MAP_TYPE_REFERENCE);
-        expectedGrokResult.put("message", logInput);
+            final List<String> patternsDirectories = new ArrayList<>();
+            patternsDirectories.add(patternDirectory);
+
+            final Map<String, List<String>> matchConfigWithPatternsMissingPattern = new HashMap<>();
+            matchConfigWithPatternsMissingPattern.put("message", Collections.singletonList("My birthday is %{CUSTOMBIRTHDAYPATTERN:my_birthday}"));
+
+            pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_DIRECTORIES, patternsDirectories);
+            pluginSetting.getSettings().put(GrokProcessorConfig.PATTERNS_FILES_GLOB, "*1.txt");
+            pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfigWithPatternsMissingPattern);
+            grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+
+            Throwable throwable = assertThrows(InvalidPluginConfigurationException.class, () -> new GrokProcessor(
+                    pluginMetrics, grokProcessorConfig, expressionEvaluator));
+            assertThat(throwable.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat("No definition for key 'CUSTOMBIRTHDAYPATTERN' found, aborting", equalTo(throwable
+                    .getCause().getMessage()));
+        }
+
+        @Test
+        public void testCompileNonRegisteredPatternThrowsIllegalArgumentException() {
+            grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
+
+            final Map<String, List<String>> matchConfig = new HashMap<>();
+            matchConfig.put("message", Collections.singletonList("%{NONEXISTENTPATTERN}"));
+
+            pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
+            grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+
+            assertThrows(InvalidPluginConfigurationException.class, () -> new GrokProcessor(
+                    pluginMetrics, grokProcessorConfig, expressionEvaluator));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(GrokPatternInputAndOutputArgumentsProvider.class)
+        void testDataPrepperBuiltInGrokPatterns(final String matchPattern, final String logInput, final String expectedGrokResultJson) throws JsonProcessingException {
+            final Map<String, List<String>> matchConfig = new HashMap<>();
+            matchConfig.put("message", Collections.singletonList(matchPattern));
+
+            pluginSetting.getSettings().put(GrokProcessorConfig.MATCH, matchConfig);
+            grokProcessorConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), GrokProcessorConfig.class);
+            grokProcessor = new GrokProcessor(pluginMetrics, grokProcessorConfig, expressionEvaluator);
+
+            final Map<String, Object> testData = new HashMap();
+            testData.put("message", logInput);
+
+            final Record<Event> record = buildRecordWithEvent(testData);
+
+            final Map<String, Object> expectedGrokResult = OBJECT_MAPPER.readValue(expectedGrokResultJson, MAP_TYPE_REFERENCE);
+            expectedGrokResult.put("message", logInput);
 
 
-        final Record<Event> resultRecord = buildRecordWithEvent(expectedGrokResult);
+            final Record<Event> resultRecord = buildRecordWithEvent(expectedGrokResult);
 
-        final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+            final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
 
-        assertThat(grokkedRecords.size(), equalTo(1));
-        assertThat(grokkedRecords.get(0), notNullValue());
-        assertRecordsAreEqual(grokkedRecords.get(0), resultRecord);
+            assertThat(grokkedRecords.size(), equalTo(1));
+            assertThat(grokkedRecords.get(0), notNullValue());
+            assertRecordsAreEqual(grokkedRecords.get(0), resultRecord);
+        }
     }
 
     private void assertRecordsAreEqual(final Record<Event> first, final Record<Event> second) throws JsonProcessingException {
@@ -573,32 +490,35 @@ public class GrokProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
         }
     }
 
-    private static Stream<Arguments> getGrokPatternInputAndOutput() {
-        return Stream.of(
-                Arguments.of("%{VPC_FLOW_LOG}",
-                        "2 123456789010 eni-1235b8ca123456789 203.0.113.12 172.31.16.139 0 0 1 4 336 1432917027 1432917142 ACCEPT OK",
-                        "{\"srcaddr\":\"203.0.113.12\",\"dstport\":0,\"account-id\":\"123456789010\",\"start\":1432917027,\"dstaddr\":\"172.31.16.139\",\"version\":\"2\",\"packets\":4,\"protocol\":1,\"bytes\":336,\"srcport\":0,\"action\":\"ACCEPT\",\"end\":1432917142,\"log-status\":\"OK\",\"interface-id\":\"eni-1235b8ca123456789\"}"
-                ),
-                Arguments.of("%{VPC_FLOW_LOG}",
-                        "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA",
-                        "{\"srcaddr\":\"-\",\"account-id\":\"123456789010\",\"start\":1431280876,\"action\":\"-\",\"dstaddr\":\"-\",\"end\":1431280934,\"log-status\":\"NODATA\",\"version\":\"2\",\"interface-id\":\"eni-1235b8ca123456789\"}"
-                ),
-                Arguments.of("%{ALB_ACCESS_LOG}",
-                        "https 2017-11-20T22:05:36 long-bill-lb 77.222.19.149:41148 10.168.203.134:23662 0.000201 0.401924 0.772005 500 200 262 455 \"GET https://elmagek.no-ip.org:443/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206 HTTP/1.1\" \"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\" DH-RSA-AES256-GCM-SHA384 TLSv1.2 arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9 \"Root=1-58337364-23a8c76965a2ef7629b185e134\" \"my-domain\" \"my-chosen-cert-arn\" 1000 2018-11-20T22:05:36 \"my-action\" \"my-redirect-url\" \"my-error-reason\" \"target:port1 target:port2\" \"target1 target2\" \"class\" \"reason\"",
-                        "{\"sent_bytes\":455,\"request_processing_time\":\"0.000201\",\"ssl_protocol\":\"TLSv1.2\",\"actions_executed\":\"my-action\",\"trace_id\":\"Root=1-58337364-23a8c76965a2ef7629b185e134\",\"elb\":\"long-bill-lb\",\"received_bytes\":262,\"domain\":\"elmagek.no-ip.org\",\"response_processing_time\":\"0.772005\",\"domain_name\":\"my-domain\",\"classification_reason\":\"reason\",\"ssl_cipher\":\"DH-RSA-AES256-GCM-SHA384\",\"redirect_url\":\"my-redirect-url\",\"target_processing_time\":\"0.401924\",\"target_group_arn\":\"arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9\",\"user_agent\":\"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\",\"target_status_code\":\"200\",\"http_method\":\"GET\",\"matched_rule_priority\":1000,\"http_version\":\"HTTP/1.1\",\"http_port\":\"443\",\"client\":\"77.222.19.149:41148\",\"error_reason\":\"my-error-reason\",\"target_list\":\"target:port1 target:port2\",\"target\":\"10.168.203.134:23662\",\"classification\":\"class\",\"time\":\"2017-11-20T22:05:36\",\"type\":\"https\",\"request_uri\":\"/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206\",\"request_creation_time\":\"2018-11-20T22:05:36\",\"target_status_code_list\":\"target1 target2\",\"protocol\":\"https\",\"elb_status_code\":\"500\",\"chosen_cert_arn\":\"my-chosen-cert-arn\"}"
-                ),
-                Arguments.of("%{ALB_ACCESS_LOG_GENERAL_URI}",
-                        "https 2017-11-20T22:05:36 long-bill-lb 77.222.19.149:41148 10.168.203.134:23662 0.000201 0.401924 0.772005 500 200 262 455 \"GET https://elmagek.no-ip.org:443/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206 HTTP/1.1\" \"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\" DH-RSA-AES256-GCM-SHA384 TLSv1.2 arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9 \"Root=1-58337364-23a8c76965a2ef7629b185e134\" \"my-domain\" \"my-chosen-cert-arn\" 1000 2018-11-20T22:05:36 \"my-action\" \"my-redirect-url\" \"my-error-reason\" \"target:port1 target:port2\" \"target1 target2\" \"class\" \"reason\"",
-                        "{\"request_processing_time\":\"0.000201\",\"ssl_protocol\":\"TLSv1.2\",\"actions_executed\":\"my-action\",\"trace_id\":\"Root=1-58337364-23a8c76965a2ef7629b185e134\",\"elb\":\"long-bill-lb\",\"received_bytes\":262,\"response_processing_time\":\"0.772005\",\"domain_name\":\"my-domain\",\"classification_reason\":\"reason\",\"ssl_cipher\":\"DH-RSA-AES256-GCM-SHA384\",\"redirect_url\":\"my-redirect-url\",\"target_processing_time\":\"0.401924\",\"target_group_arn\":\"arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9\",\"user_agent\":\"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\",\"target_status_code\":\"200\",\"http_method\":\"GET\",\"matched_rule_priority\":1000,\"http_version\":\"HTTP/1.1\",\"http_uri\":\"https://elmagek.no-ip.org:443/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206\",\"client\":\"77.222.19.149:41148\",\"error_reason\":\"my-error-reason\",\"target_list\":\"target:port1 target:port2\",\"target\":\"10.168.203.134:23662\",\"classification\":\"class\",\"time\":\"2017-11-20T22:05:36\",\"type\":\"https\",\"request_creation_time\":\"2018-11-20T22:05:36\",\"target_status_code_list\":\"target1 target2\",\"elb_status_code\":\"500\",\"chosen_cert_arn\":\"my-chosen-cert-arn\",\"sent_bytes\":455}"
-                ),
-                Arguments.of("%{S3_ACCESS_LOG}",
-                        "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be DOC-EXAMPLE-BUCKET1 [06/Feb/2019:00:00:38 +0000] 192.0.2.3 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE REST.GET.VERSIONING - \"GET /DOC-EXAMPLE-BUCKET1?versioning HTTP/1.1\" 200 - 113 - 7 - \"-\" \"S3Console/0.4\" - s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234= SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader DOC-EXAMPLE-BUCKET1.s3.us-west-1.amazonaws.com TLSV1.2 arn:aws:s3:us-west-1:123456789012:accesspoint/example-AP Yes",
-                        "{\"httpversion\":\"1.1\",\"request\":\"/DOC-EXAMPLE-BUCKET1?versioning\",\"timestamp\":\"06/Feb/2019:00:00:38 +0000\",\"requester\":\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\",\"agent\":\"S3Console/0.4\",\"key\":\"-\",\"clientip\":\"192.0.2.3\",\"response\":200,\"operation\":\"REST.GET.VERSIONING\",\"verb\":\"GET\",\"request_id\":\"3E57427F3EXAMPLE\",\"bucket\":\"DOC-EXAMPLE-BUCKET1\",\"owner\":\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\",\"referrer\":\"-\",\"bytes_sent\":113,\"request_time_ms\":7}"
-                ),
-                Arguments.of("%{ELB_ACCESS_LOG}",
-                        "2020-06-14T17:26:04.805368Z my-clb-1 170.01.01.02:39492 172.31.25.183:5000 0.000032 0.001861 0.000017 200 200 0 13 \"GET http://my-clb-1-1798137604.us-east-2.elb.amazonaws.com:80/ HTTP/1.1\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36\" - -",
-                        "{\"backendport\":5000,\"received_bytes\":0,\"request\":\"http://my-clb-1-1798137604.us-east-2.elb.amazonaws.com:80/\",\"backend_response\":200,\"verb\":\"GET\",\"clientport\":39492,\"request_processing_time\":3.2E-5,\"urihost\":\"my-clb-1-1798137604.us-east-2.elb.amazonaws.com:80\",\"response_processing_time\":1.7E-5,\"path\":\"/\",\"port\":\"80\",\"response\":200,\"bytes\":13,\"clientip\":\"170.01.01.02\",\"proto\":\"http\",\"elb\":\"my-clb-1\",\"httpversion\":\"1.1\",\"backendip\":\"172.31.25.183\",\"backend_processing_time\":0.001861,\"timestamp\":\"2020-06-14T17:26:04.805368Z\"}"
-                )
-        );
+    private static class GrokPatternInputAndOutputArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of("%{VPC_FLOW_LOG}",
+                            "2 123456789010 eni-1235b8ca123456789 203.0.113.12 172.31.16.139 0 0 1 4 336 1432917027 1432917142 ACCEPT OK",
+                            "{\"srcaddr\":\"203.0.113.12\",\"dstport\":0,\"account-id\":\"123456789010\",\"start\":1432917027,\"dstaddr\":\"172.31.16.139\",\"version\":\"2\",\"packets\":4,\"protocol\":1,\"bytes\":336,\"srcport\":0,\"action\":\"ACCEPT\",\"end\":1432917142,\"log-status\":\"OK\",\"interface-id\":\"eni-1235b8ca123456789\"}"
+                    ),
+                    Arguments.of("%{VPC_FLOW_LOG}",
+                            "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA",
+                            "{\"srcaddr\":\"-\",\"account-id\":\"123456789010\",\"start\":1431280876,\"action\":\"-\",\"dstaddr\":\"-\",\"end\":1431280934,\"log-status\":\"NODATA\",\"version\":\"2\",\"interface-id\":\"eni-1235b8ca123456789\"}"
+                    ),
+                    Arguments.of("%{ALB_ACCESS_LOG}",
+                            "https 2017-11-20T22:05:36 long-bill-lb 77.222.19.149:41148 10.168.203.134:23662 0.000201 0.401924 0.772005 500 200 262 455 \"GET https://elmagek.no-ip.org:443/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206 HTTP/1.1\" \"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\" DH-RSA-AES256-GCM-SHA384 TLSv1.2 arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9 \"Root=1-58337364-23a8c76965a2ef7629b185e134\" \"my-domain\" \"my-chosen-cert-arn\" 1000 2018-11-20T22:05:36 \"my-action\" \"my-redirect-url\" \"my-error-reason\" \"target:port1 target:port2\" \"target1 target2\" \"class\" \"reason\"",
+                            "{\"sent_bytes\":455,\"request_processing_time\":\"0.000201\",\"ssl_protocol\":\"TLSv1.2\",\"actions_executed\":\"my-action\",\"trace_id\":\"Root=1-58337364-23a8c76965a2ef7629b185e134\",\"elb\":\"long-bill-lb\",\"received_bytes\":262,\"domain\":\"elmagek.no-ip.org\",\"response_processing_time\":\"0.772005\",\"domain_name\":\"my-domain\",\"classification_reason\":\"reason\",\"ssl_cipher\":\"DH-RSA-AES256-GCM-SHA384\",\"redirect_url\":\"my-redirect-url\",\"target_processing_time\":\"0.401924\",\"target_group_arn\":\"arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9\",\"user_agent\":\"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\",\"target_status_code\":\"200\",\"http_method\":\"GET\",\"matched_rule_priority\":1000,\"http_version\":\"HTTP/1.1\",\"http_port\":\"443\",\"client\":\"77.222.19.149:41148\",\"error_reason\":\"my-error-reason\",\"target_list\":\"target:port1 target:port2\",\"target\":\"10.168.203.134:23662\",\"classification\":\"class\",\"time\":\"2017-11-20T22:05:36\",\"type\":\"https\",\"request_uri\":\"/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206\",\"request_creation_time\":\"2018-11-20T22:05:36\",\"target_status_code_list\":\"target1 target2\",\"protocol\":\"https\",\"elb_status_code\":\"500\",\"chosen_cert_arn\":\"my-chosen-cert-arn\"}"
+                    ),
+                    Arguments.of("%{ALB_ACCESS_LOG_GENERAL_URI}",
+                            "https 2017-11-20T22:05:36 long-bill-lb 77.222.19.149:41148 10.168.203.134:23662 0.000201 0.401924 0.772005 500 200 262 455 \"GET https://elmagek.no-ip.org:443/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206 HTTP/1.1\" \"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\" DH-RSA-AES256-GCM-SHA384 TLSv1.2 arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9 \"Root=1-58337364-23a8c76965a2ef7629b185e134\" \"my-domain\" \"my-chosen-cert-arn\" 1000 2018-11-20T22:05:36 \"my-action\" \"my-redirect-url\" \"my-error-reason\" \"target:port1 target:port2\" \"target1 target2\" \"class\" \"reason\"",
+                            "{\"request_processing_time\":\"0.000201\",\"ssl_protocol\":\"TLSv1.2\",\"actions_executed\":\"my-action\",\"trace_id\":\"Root=1-58337364-23a8c76965a2ef7629b185e134\",\"elb\":\"long-bill-lb\",\"received_bytes\":262,\"response_processing_time\":\"0.772005\",\"domain_name\":\"my-domain\",\"classification_reason\":\"reason\",\"ssl_cipher\":\"DH-RSA-AES256-GCM-SHA384\",\"redirect_url\":\"my-redirect-url\",\"target_processing_time\":\"0.401924\",\"target_group_arn\":\"arn:aws:elasticloadbalancing:us-west-2:104030218370:targetgroup/Prod-frontend/92e3199b1rc814fe9\",\"user_agent\":\"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4\",\"target_status_code\":\"200\",\"http_method\":\"GET\",\"matched_rule_priority\":1000,\"http_version\":\"HTTP/1.1\",\"http_uri\":\"https://elmagek.no-ip.org:443/json/v1/collector/histogram/100105037?startTimestamp=1405571270000&endTimestamp=1405574870000&bucketCount=60&_=1405574870206\",\"client\":\"77.222.19.149:41148\",\"error_reason\":\"my-error-reason\",\"target_list\":\"target:port1 target:port2\",\"target\":\"10.168.203.134:23662\",\"classification\":\"class\",\"time\":\"2017-11-20T22:05:36\",\"type\":\"https\",\"request_creation_time\":\"2018-11-20T22:05:36\",\"target_status_code_list\":\"target1 target2\",\"elb_status_code\":\"500\",\"chosen_cert_arn\":\"my-chosen-cert-arn\",\"sent_bytes\":455}"
+                    ),
+                    Arguments.of("%{S3_ACCESS_LOG}",
+                            "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be DOC-EXAMPLE-BUCKET1 [06/Feb/2019:00:00:38 +0000] 192.0.2.3 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE REST.GET.VERSIONING - \"GET /DOC-EXAMPLE-BUCKET1?versioning HTTP/1.1\" 200 - 113 - 7 - \"-\" \"S3Console/0.4\" - s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234= SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader DOC-EXAMPLE-BUCKET1.s3.us-west-1.amazonaws.com TLSV1.2 arn:aws:s3:us-west-1:123456789012:accesspoint/example-AP Yes",
+                            "{\"httpversion\":\"1.1\",\"request\":\"/DOC-EXAMPLE-BUCKET1?versioning\",\"timestamp\":\"06/Feb/2019:00:00:38 +0000\",\"requester\":\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\",\"agent\":\"S3Console/0.4\",\"key\":\"-\",\"clientip\":\"192.0.2.3\",\"response\":200,\"operation\":\"REST.GET.VERSIONING\",\"verb\":\"GET\",\"request_id\":\"3E57427F3EXAMPLE\",\"bucket\":\"DOC-EXAMPLE-BUCKET1\",\"owner\":\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\",\"referrer\":\"-\",\"bytes_sent\":113,\"request_time_ms\":7}"
+                    ),
+                    Arguments.of("%{ELB_ACCESS_LOG}",
+                            "2020-06-14T17:26:04.805368Z my-clb-1 170.01.01.02:39492 172.31.25.183:5000 0.000032 0.001861 0.000017 200 200 0 13 \"GET http://my-clb-1-1798137604.us-east-2.elb.amazonaws.com:80/ HTTP/1.1\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36\" - -",
+                            "{\"backendport\":5000,\"received_bytes\":0,\"request\":\"http://my-clb-1-1798137604.us-east-2.elb.amazonaws.com:80/\",\"backend_response\":200,\"verb\":\"GET\",\"clientport\":39492,\"request_processing_time\":3.2E-5,\"urihost\":\"my-clb-1-1798137604.us-east-2.elb.amazonaws.com:80\",\"response_processing_time\":1.7E-5,\"path\":\"/\",\"port\":\"80\",\"response\":200,\"bytes\":13,\"clientip\":\"170.01.01.02\",\"proto\":\"http\",\"elb\":\"my-clb-1\",\"httpversion\":\"1.1\",\"backendip\":\"172.31.25.183\",\"backend_processing_time\":0.001861,\"timestamp\":\"2020-06-14T17:26:04.805368Z\"}"
+                    )
+            );
+        }
     }
 }

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_no_captures_with_existing_and_non_existing_key.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_no_captures_with_existing_and_non_existing_key.yaml
@@ -1,0 +1,11 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{SYSLOGBASE}"]
+          bad_key: ["%{SYSLOGBASE}"]
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_keep_empty_captures_true.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_keep_empty_captures_true.yaml
@@ -1,0 +1,11 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{COMMONAPACHELOG}"]
+        keep_empty_captures: true
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_named_captures_only_false.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_named_captures_only_false.yaml
@@ -1,0 +1,11 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{GREEDYDATA} %{IPORHOST:host} %{NUMBER}"]
+        named_captures_only: false
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_named_captures_syntax.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_named_captures_syntax.yaml
@@ -1,0 +1,10 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{GREEDYDATA:greedy_data} (?<mynumber>\\d\\d\\d-\\d\\d\\d-\\d\\d\\d)"]
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_no_captures_and_tags.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/match_with_no_captures_and_tags.yaml
@@ -1,0 +1,13 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{GREEDYDATA:greedy_data} (?<mynumber>\\d\\d\\d-\\d\\d\\d-\\d\\d\\d)"]
+        tags_on_match_failure:
+          - some_test_tag_1
+          - some_test_tag_2
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/multiple_match_with_break_on_match_false.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/multiple_match_with_break_on_match_false.yaml
@@ -1,0 +1,12 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{COMMONAPACHELOG}"]
+          extra_field: ["%{GREEDYDATA} %{IPORHOST:host}"]
+        break_on_match: false
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/pattern_definitions.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/pattern_definitions.yaml
@@ -1,0 +1,12 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{GREEDYDATA:greedy_data} %{CUSTOMPHONENUMBERPATTERN:my_number}"]
+        pattern_definitions:
+          CUSTOMPHONENUMBERPATTERN: "\\d\\d\\d-\\d\\d\\d-\\d\\d\\d"
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/patterns_dir_with_custom_patterns_files_glob.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/patterns_dir_with_custom_patterns_files_glob.yaml
@@ -1,0 +1,14 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message:
+            - "My phone number is %{CUSTOMPHONENUMBERPATTERN:my_number}"
+        patterns_directories:
+          - ./src/test/resources/test_patterns
+        patterns_files_glob: "*1.txt"
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/patterns_dir_with_default_patterns_files_glob.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/patterns_dir_with_default_patterns_files_glob.yaml
@@ -1,0 +1,13 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message:
+            - "My birthday is %{CUSTOMBIRTHDAYPATTERN:my_birthday} and my phone number is %{CUSTOMPHONENUMBERPATTERN:my_number}"
+        patterns_directories:
+          - ./src/test/resources/test_patterns
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/single_match_multiple_pattern_with_break_on_match_false.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/single_match_multiple_pattern_with_break_on_match_false.yaml
@@ -1,0 +1,13 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message:
+            - "%{COMMONAPACHELOG}"
+            - "%{IPORHOST:custom_client_field}"
+        break_on_match: false
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/single_match_single_pattern.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/single_match_single_pattern.yaml
@@ -1,0 +1,10 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message: ["%{COMMONAPACHELOG}"]
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/single_match_type_conversion.yaml
+++ b/data-prepper-plugins/grok-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/grok/single_match_type_conversion.yaml
@@ -1,0 +1,11 @@
+grok-pipeline:
+  source:
+    unused:
+  processor:
+    - grok:
+        match:
+          message:
+            - "\"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response:int} (?:%{NUMBER:bytes:float}|-)"
+
+  sink:
+    - unused:

--- a/data-prepper-plugins/parse-json-processor/build.gradle
+++ b/data-prepper-plugins/parse-json-processor/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation libs.parquet.common
     testImplementation project(':data-prepper-test:test-common')
     testImplementation project(':data-prepper-test:test-event')
+    testImplementation project(':data-prepper-test:plugin-test-framework')
     testImplementation testLibs.slf4j.simple
 }
 

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorIT.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorIT.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.parse.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+import org.opensearch.dataprepper.test.plugins.PluginConfigurationFile;
+import org.opensearch.dataprepper.test.plugins.junit.BaseDataPrepperPluginStandardTestSuite;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@DataPrepperPluginTest(pluginName = "parse_json", pluginType = Processor.class)
+class ParseJsonProcessorIT extends BaseDataPrepperPluginStandardTestSuite {
+    private ObjectMapper objectMapper;
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        random = new Random();
+    }
+
+    @Test
+    void parse_json_with_default_configuration(
+            @PluginConfigurationFile("default.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest,
+            final EventFactory eventFactory) throws JsonProcessingException {
+
+        final List<Event> inputEvents = new LinkedList<>();
+        final List<Map<String, Object>> messageMaps = new LinkedList<>();
+        final List<String> messageStrings = new LinkedList<>();
+        for (int i = 0; i < 5; i++) {
+
+            final Map<String, Object> messageMap = Map.of(
+                    "stringKey", UUID.randomUUID().toString(),
+                    "integerKey", random.nextInt(10_000) + 10,
+                    "objectKey", Map.of(
+                            "nestedKey", UUID.randomUUID().toString()
+                    ),
+                    "arrayKey", List.of(
+                            UUID.randomUUID().toString(),
+                            UUID.randomUUID().toString()
+                    )
+            );
+
+            final String messageString = objectMapper.writeValueAsString(messageMap);
+
+            final Event event = eventFactory.eventBuilder(LogEventBuilder.class)
+                    .withData(Map.of(
+                            "message", messageString
+                            , "some_other_key", UUID.randomUUID().toString()
+                    ))
+                    .build();
+
+            inputEvents.add(event);
+            messageMaps.add(messageMap);
+            messageStrings.add(messageString);
+        }
+
+        final List<Record<Event>> inputRecords = inputEvents.stream()
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        final Collection<Record<Event>> outputRecords = objectUnderTest.execute(inputRecords);
+
+        assertThat(outputRecords, notNullValue());
+
+        final List<Event> outputEvents = outputRecords.stream().map(Record::getData).collect(Collectors.toList());
+
+        assertThat(outputEvents, equalTo(inputEvents));
+
+        assertThat(outputEvents.size(), equalTo(5));
+
+        for (int i = 0; i < outputEvents.size(); i++) {
+            final Event event = outputEvents.get(i);
+            assertThat(event, notNullValue());
+            assertThat(event.get("message", String.class), equalTo(messageStrings.get(i)));
+            assertThat(event.get("stringKey", String.class), equalTo(messageMaps.get(i).get("stringKey")));
+            assertThat(event.get("integerKey", Integer.class), equalTo(messageMaps.get(i).get("integerKey")));
+            assertThat(event.get("objectKey", Map.class), equalTo(messageMaps.get(i).get("objectKey")));
+            assertThat(event.get("arrayKey", List.class), equalTo(messageMaps.get(i).get("arrayKey")));
+        }
+    }
+
+    @Test
+    void parse_json_with_destination(
+            @PluginConfigurationFile("with-destination.yaml") final Processor<Record<Event>, Record<Event>> objectUnderTest,
+            final EventFactory eventFactory) throws JsonProcessingException {
+
+        final List<Event> inputEvents = new LinkedList<>();
+        final List<Map<String, Object>> messageMaps = new LinkedList<>();
+        final List<String> messageStrings = new LinkedList<>();
+        for (int i = 0; i < 5; i++) {
+
+            final Map<String, Object> messageMap = Map.of(
+                    "stringKey", UUID.randomUUID().toString(),
+                    "integerKey", random.nextInt(10_000) + 10,
+                    "objectKey", Map.of(
+                            "nestedKey", UUID.randomUUID().toString()
+                    ),
+                    "arrayKey", List.of(
+                            UUID.randomUUID().toString(),
+                            UUID.randomUUID().toString()
+                    )
+            );
+
+            final String messageString = objectMapper.writeValueAsString(messageMap);
+
+            final Event event = eventFactory.eventBuilder(LogEventBuilder.class)
+                    .withData(Map.of(
+                            "message", messageString
+                            , "some_other_key", UUID.randomUUID().toString()
+                    ))
+                    .build();
+
+            inputEvents.add(event);
+            messageMaps.add(messageMap);
+            messageStrings.add(messageString);
+        }
+
+        final List<Record<Event>> inputRecords = inputEvents.stream()
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        final Collection<Record<Event>> outputRecords = objectUnderTest.execute(inputRecords);
+
+        assertThat(outputRecords, notNullValue());
+
+        final List<Event> outputEvents = outputRecords.stream().map(Record::getData).collect(Collectors.toList());
+
+        assertThat(outputEvents, equalTo(inputEvents));
+
+        assertThat(outputEvents.size(), equalTo(5));
+
+        for (int i = 0; i < outputEvents.size(); i++) {
+            final Event event = outputEvents.get(i);
+            assertThat(event, notNullValue());
+            assertThat(event.get("message", String.class), equalTo(messageStrings.get(i)));
+            assertThat(event.get("parsed_json", Map.class), equalTo(messageMaps.get(i)));
+        }
+    }
+}

--- a/data-prepper-plugins/parse-json-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/parse/json/default.yaml
+++ b/data-prepper-plugins/parse-json-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/parse/json/default.yaml
@@ -1,0 +1,7 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - parse_json:
+  sink:
+    - unused:

--- a/data-prepper-plugins/parse-json-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/parse/json/with-destination.yaml
+++ b/data-prepper-plugins/parse-json-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/parse/json/with-destination.yaml
@@ -1,0 +1,8 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - parse_json:
+        destination: parsed_json
+  sink:
+    - unused:

--- a/data-prepper-test/plugin-test-framework/build.gradle
+++ b/data-prepper-test/plugin-test-framework/build.gradle
@@ -10,9 +10,16 @@
 dependencies {
     implementation testLibs.junit.core
     implementation testLibs.hamcrest
+    implementation testLibs.mockito.core
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugin-framework')
+    implementation project(':data-prepper-pipeline-parser')
+    implementation project(':data-prepper-expression')
+    implementation project(':data-prepper-test:test-event')
     implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 }

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/PluginConfigurationFile.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/PluginConfigurationFile.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface PluginConfigurationFile {
+    String value();
+}

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestFramework.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/DataPrepperPluginTestFramework.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @ExtendWith({
         DataPrepperPluginTestContextParameterResolver.class,
-        PluginProviderParameterResolver.class
+        PluginProviderParameterResolver.class,
+        EventParameterResolver.class,
+        PluginInstanceParameterResolver.class
 })
 public @interface DataPrepperPluginTestFramework {
 }

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/EventParameterResolver.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/EventParameterResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+class EventParameterResolver implements ParameterResolver {
+    private static final Map<Class<?>, Supplier<?>> SUPPORTED_CLASSES = Map.of(
+            EventFactory.class, TestEventFactory::getTestEventFactory,
+            EventKeyFactory.class, TestEventKeyFactory::getTestEventFactory
+    );
+
+    @Override
+    public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+        return SUPPORTED_CLASSES.containsKey(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+        final Class<?> type = parameterContext.getParameter().getType();
+
+        return SUPPORTED_CLASSES.get(type).get();
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/PluginInstanceParameterResolver.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/PluginInstanceParameterResolver.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.opensearch.dataprepper.model.configuration.PipelineModel;
+import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.pipeline.parser.ParseException;
+import org.opensearch.dataprepper.pipeline.parser.PipelinesDataflowModelParser;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+import org.opensearch.dataprepper.test.plugins.PluginConfigurationFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+class PluginInstanceParameterResolver implements ParameterResolver {
+    @Override
+    public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+        final Class<?> testClass = extensionContext.getRequiredTestClass();
+        final DataPrepperPluginTest annotation = testClass.getAnnotation(DataPrepperPluginTest.class);
+        if (annotation == null) {
+            return false;
+        }
+
+        return Objects.equals(annotation.pluginType(), parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+        final Class<?> testClass = extensionContext.getRequiredTestClass();
+        final DataPrepperPluginTest annotation = testClass.getAnnotation(DataPrepperPluginTest.class);
+        if (annotation == null) {
+            throw new ParameterResolutionException("Missing @DataPrepperPluginTest annotation on class: " + testClass.getName());
+        }
+
+        final PluginConfigurationFile configurationFileAnnotation = parameterContext.findAnnotation(PluginConfigurationFile.class)
+                .orElseThrow(() -> new ParameterResolutionException("Parameter resolver used without @PluginConfigurationFile."));
+
+        final String configurationFile = configurationFileAnnotation.value();
+
+        final PluginSetting pluginSetting = generatePluginSetting(testClass, configurationFile);
+
+        final PluginFactory pluginFactory = getOrCreatePluginFactory(extensionContext);
+
+        final Class<?> pluginType = annotation.pluginType();
+
+        return pluginFactory.loadPlugin(pluginType, pluginSetting);
+    }
+
+    private PluginSetting generatePluginSetting(final Class<?> testClass, final String configurationFile) {
+        final PipelinesDataFlowModel pipelinesDataFlowModel = readPipelinesDataFlowModel(testClass, configurationFile);
+        String pipelineName = readSinglePipeline(pipelinesDataFlowModel, configurationFile);
+        final PipelineModel pipelineModel = pipelinesDataFlowModel.getPipelines().get(pipelineName);
+        final PluginModel pluginModel = loadPluginModel(pipelineModel, configurationFile);
+
+        final Map<String, Object> settingsMap = Optional
+                .ofNullable(pluginModel.getPluginSettings())
+                .orElseGet(HashMap::new);
+        final PluginSetting pluginSetting = new PluginSetting(pluginModel.getPluginName(), settingsMap);
+        pluginSetting.setPipelineName(pipelineName);
+
+        return pluginSetting;
+    }
+
+    private static PluginModel loadPluginModel(final PipelineModel pipelineModel, final String configurationFile) {
+        if(pipelineModel.getProcessors() == null || pipelineModel.getProcessors().size() != 1) {
+            throw new ParameterResolutionException("Test configurations must define plugins in the processor section. " + configurationFile);
+        }
+
+        return pipelineModel.getProcessors()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ParameterResolutionException("Test configurations must define plugins in the processor section. " + configurationFile));
+    }
+
+    private static String readSinglePipeline(final PipelinesDataFlowModel pipelinesDataFlowModel, final String configurationFile) {
+        if(pipelinesDataFlowModel.getPipelines().size() != 1) {
+            throw new ParameterResolutionException("Test configurations must have exactly one pipeline. " + configurationFile);
+        }
+
+        return pipelinesDataFlowModel.getPipelines()
+                .keySet()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ParameterResolutionException("Test configurations must have exactly one pipeline. " + configurationFile));
+    }
+
+    private static PipelinesDataFlowModel readPipelinesDataFlowModel(final Class<?> testClass, final String configurationFile) {
+        final PipelinesDataFlowModel pipelinesDataFlowModel;
+        try(final InputStream resourceStream = testClass.getResourceAsStream(configurationFile)) {
+            if(resourceStream == null) {
+                throw new ParameterResolutionException("Unable to find a configuration file " + configurationFile + " in the " + testClass.getPackageName() + " package.");
+            }
+
+            final PipelinesDataflowModelParser pipelinesDataflowModelParser = new PipelinesDataflowModelParser(() -> List.of(resourceStream));
+            try {
+                pipelinesDataFlowModel = pipelinesDataflowModelParser.parseConfiguration();
+            } catch (final ParseException ex) {
+                throw new ParameterResolutionException("Failed to parse configuration file " + configurationFile + ".", ex);
+            }
+        } catch (final IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return pipelinesDataFlowModel;
+    }
+
+    private PluginFactory getOrCreatePluginFactory(final ExtensionContext extensionContext) {
+        return TestApplicationContextProvider.get(extensionContext).getBean(PluginFactory.class);
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/TestApplicationContextProvider.java
+++ b/data-prepper-test/plugin-test-framework/src/main/java/org/opensearch/dataprepper/test/plugins/junit/TestApplicationContextProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opensearch.dataprepper.core.validation.LoggingPluginErrorsHandler;
+import org.opensearch.dataprepper.core.validation.PluginErrorCollector;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDeserializationProblemHandler;
+import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
+import org.opensearch.dataprepper.plugin.ExperimentalConfiguration;
+import org.opensearch.dataprepper.plugin.ExperimentalConfigurationContainer;
+import org.opensearch.dataprepper.plugin.ExtensionsConfiguration;
+import org.opensearch.dataprepper.validation.PluginErrorsHandler;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestApplicationContextProvider {
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(TestApplicationContextProvider.class);
+
+    static ApplicationContext get(final ExtensionContext extensionContext) {
+        final ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
+        return store.getOrComputeIfAbsent("applicationContext",
+                key -> createPluginFactory(), ApplicationContext.class);
+    }
+
+    private static ApplicationContext createPluginFactory() {
+        final AnnotationConfigApplicationContext publicContext = new AnnotationConfigApplicationContext();
+        publicContext.registerBean(EventFactory.class, TestEventFactory::getTestEventFactory);
+        publicContext.registerBean(EventKeyFactory.class, TestEventKeyFactory::getTestEventFactory);
+        publicContext.scan("org.opensearch.dataprepper.expression");
+        publicContext.refresh();
+
+        final AnnotationConfigApplicationContext coreContext = new AnnotationConfigApplicationContext();
+        coreContext.setParent(publicContext);
+
+        final ExperimentalConfigurationContainer experimentalConfigurationContainer = mock(ExperimentalConfigurationContainer.class);
+        final ExperimentalConfiguration experimentalConfiguration = mock(ExperimentalConfiguration.class);
+        when(experimentalConfigurationContainer.getExperimental()).thenReturn(experimentalConfiguration);
+
+        coreContext.scan(DefaultPluginFactory.class.getPackage().getName());
+
+        coreContext.registerBean(DataPrepperDeserializationProblemHandler.class, DataPrepperDeserializationProblemHandler::new);
+        coreContext.registerBean(PluginErrorCollector.class, PluginErrorCollector::new);
+        coreContext.registerBean(PluginErrorsHandler.class, LoggingPluginErrorsHandler::new);
+        coreContext.registerBean(ExtensionsConfiguration.class, () -> mock(ExtensionsConfiguration.class));
+        coreContext.registerBean(PipelinesDataFlowModel.class, () -> mock(PipelinesDataFlowModel.class));
+        coreContext.registerBean(AcknowledgementSetManager.class, () -> mock(AcknowledgementSetManager.class));
+        coreContext.registerBean(ExperimentalConfigurationContainer.class, () -> experimentalConfigurationContainer);
+        coreContext.refresh();
+
+        return coreContext;
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/main/resources/META-INF/services/org.opensearch.dataprepper.plugin.PluginProvider
+++ b/data-prepper-test/plugin-test-framework/src/main/resources/META-INF/services/org.opensearch.dataprepper.plugin.PluginProvider
@@ -1,0 +1,6 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+org.opensearch.dataprepper.plugin.ClasspathPluginProvider

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluggableInterface.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluggableInterface.java
@@ -10,4 +10,5 @@
 package org.opensearch.dataprepper.plugins.test;
 
 public interface TestPluggableInterface {
+    String getOptionAValue();
 }

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPlugin.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPlugin.java
@@ -13,8 +13,16 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 
 @DataPrepperPlugin(name = "test_plugin", pluginType = TestPluggableInterface.class, pluginConfigurationType = TestPluginConfiguration.class)
-public class TestPlugin {
+public class TestPlugin implements TestPluggableInterface {
+    private final TestPluginConfiguration configuration;
+
     @DataPrepperPluginConstructor
     public TestPlugin(final TestPluginConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String getOptionAValue() {
+        return configuration.getOptionA();
     }
 }

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluginConfiguration.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestPluginConfiguration.java
@@ -10,4 +10,9 @@
 package org.opensearch.dataprepper.plugins.test;
 
 public class TestPluginConfiguration {
+    private String optionA;
+
+    public String getOptionA() {
+        return optionA;
+    }
 }

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/DataPrepperPluginIT.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/DataPrepperPluginIT.java
@@ -9,9 +9,30 @@
 
 package org.opensearch.dataprepper.test.plugins;
 
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.plugins.test.TestPluggableInterface;
 import org.opensearch.dataprepper.test.plugins.junit.BaseDataPrepperPluginStandardTestSuite;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 @DataPrepperPluginTest(pluginName = "test_plugin", pluginType = TestPluggableInterface.class)
 class DataPrepperPluginIT extends BaseDataPrepperPluginStandardTestSuite {
+    @Test
+    void parameter_for_plugin_instance_from_configuration_provider_gets_the_correct_plugin_instance(@PluginConfigurationFile("test001.yaml") final TestPluggableInterface testPluggableInterface) {
+        assertThat(testPluggableInterface.getOptionAValue(), equalTo("some-value-for-a"));
+    }
+
+    @Test
+    void parameter_of_EventFactory_gets_an_instance(final EventFactory eventFactory) {
+        assertThat(eventFactory, notNullValue());
+    }
+
+    @Test
+    void parameter_of_EventKeyFactory_gets_an_instance(final EventKeyFactory eventKeyFactory) {
+        assertThat(eventKeyFactory, notNullValue());
+    }
 }

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/PluginInstanceParameterResolverTest.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/PluginInstanceParameterResolverTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+import org.opensearch.dataprepper.test.plugins.PluginConfigurationFile;
+import org.springframework.context.ApplicationContext;
+
+import java.lang.reflect.Parameter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PluginInstanceParameterResolverTest {
+    @Mock
+    private ParameterContext parameterContext;
+
+    @Mock
+    private ExtensionContext extensionContext;
+
+    @DataPrepperPluginTest(pluginName = "test_plugin_annotated", pluginType = Processor.class)
+    private static class AnnotatedClass {
+    }
+
+    private static class UnannotatedClass {
+    }
+
+    private PluginInstanceParameterResolver createObjectUnderTest() {
+        return new PluginInstanceParameterResolver();
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {UnannotatedClass.class, String.class, Processor.class})
+    void supportsParameter_with_unannotated_class_returns_false(final Class<?> unannotatedTestClass) {
+        when(extensionContext.getRequiredTestClass()).thenReturn((Class) unannotatedTestClass);
+
+        assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {UnannotatedClass.class, String.class, Processor.class})
+    void resolveParameter_with_unannotated_class_returns_throws(final Class<?> unannotatedTestClass) {
+        when(extensionContext.getRequiredTestClass()).thenReturn((Class) unannotatedTestClass);
+
+        final PluginInstanceParameterResolver objectUnderTest = createObjectUnderTest();
+
+        final ParameterResolutionException actualException =
+                assertThrows(ParameterResolutionException.class, () -> objectUnderTest.resolveParameter(parameterContext, extensionContext));
+
+        assertThat(actualException.getMessage(), containsString("Missing @DataPrepperPluginTest annotation"));
+        assertThat(actualException.getMessage(), containsString(unannotatedTestClass.getName()));
+    }
+
+    @Nested
+    class WithAnnotatedClass {
+        private Class<?> testClass;
+
+        @Mock
+        private Parameter parameter;
+
+        @BeforeEach
+        void setUp() {
+            testClass = AnnotatedClass.class;
+
+            when(extensionContext.getRequiredTestClass()).thenReturn((Class) testClass);
+        }
+
+        @Test
+        void supportsParameter_returns_true_when_parameterType_is_pluginType() {
+            when(parameterContext.getParameter()).thenReturn(parameter);
+            when(parameter.getType()).thenReturn((Class) Processor.class);
+
+            assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(true));
+
+        }
+
+        @ParameterizedTest
+        @ValueSource(classes = {Sink.class, Source.class, String.class})
+        void supportsParameter_returns_false_when_parameterType_is_different_from_the_pluginType(final Class<?> parameterType) {
+            when(parameterContext.getParameter()).thenReturn(parameter);
+            when(parameter.getType()).thenReturn((Class) parameterType);
+
+            assertThat(createObjectUnderTest().supportsParameter(parameterContext, extensionContext), equalTo(false));
+        }
+
+        @Test
+        void resolveParameter_throws_exception_when_the_parameter_is_not_annotated_with_a_PluginConfigurationFile_annotation() {
+            final PluginInstanceParameterResolver objectUnderTest = createObjectUnderTest();
+
+            when(parameterContext.findAnnotation(PluginConfigurationFile.class)).thenReturn(Optional.empty());
+
+            final ParameterResolutionException actualException = assertThrows(ParameterResolutionException.class, () -> objectUnderTest.resolveParameter(parameterContext, extensionContext));
+
+            assertThat(actualException.getMessage(), containsString("@PluginConfigurationFile"));
+        }
+
+        @Test
+        void resolveParameter_throws_exception_when_the_parameter_is_annotated_with_a_PluginConfigurationFile_annotation_but_no_file_exists() {
+            final PluginInstanceParameterResolver objectUnderTest = createObjectUnderTest();
+
+            final PluginConfigurationFile pluginConfigurationFile = mock(PluginConfigurationFile.class);
+            final String configurationFileName = UUID.randomUUID() + ".yaml";
+            when(pluginConfigurationFile.value()).thenReturn(configurationFileName);
+            when(parameterContext.findAnnotation(PluginConfigurationFile.class)).thenReturn(Optional.of(pluginConfigurationFile));
+
+            final ParameterResolutionException actualException = assertThrows(ParameterResolutionException.class, () -> objectUnderTest.resolveParameter(parameterContext, extensionContext));
+
+            assertThat(actualException.getMessage(), containsString("Unable to find a configuration file"));
+            assertThat(actualException.getMessage(), containsString(configurationFileName));
+            assertThat(actualException.getMessage(), containsString(testClass.getPackageName()));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "empty.yaml,Failed to parse configuration file",
+                "multiple-pipelines.yaml,Test configurations must have exactly one pipeline",
+                "no-processor.yaml,define plugins in the processor",
+                "multiple-processors.yaml,define plugins in the processor"
+        })
+        void resolveParameter_throws_exception_when_the_parameter_file_exists_but_is_invalid(
+                final String configurationFileName, final String expectedExceptionString) {
+            final PluginInstanceParameterResolver objectUnderTest = createObjectUnderTest();
+
+            final PluginConfigurationFile pluginConfigurationFile = mock(PluginConfigurationFile.class);
+            when(pluginConfigurationFile.value()).thenReturn(configurationFileName);
+            when(parameterContext.findAnnotation(PluginConfigurationFile.class)).thenReturn(Optional.of(pluginConfigurationFile));
+
+            final ParameterResolutionException actualException = assertThrows(ParameterResolutionException.class, () -> objectUnderTest.resolveParameter(parameterContext, extensionContext));
+
+            assertThat(actualException.getMessage(), containsString(expectedExceptionString));
+            assertThat(actualException.getMessage(), containsString(configurationFileName));
+        }
+
+        @Test
+        void resolveParameter_with_valid_configuration_returns_plugin_instance() {
+            final PluginInstanceParameterResolver objectUnderTest = createObjectUnderTest();
+
+            final PluginConfigurationFile pluginConfigurationFile = mock(PluginConfigurationFile.class);
+            when(pluginConfigurationFile.value()).thenReturn("valid.yaml");
+            when(parameterContext.findAnnotation(PluginConfigurationFile.class)).thenReturn(Optional.of(pluginConfigurationFile));
+
+            final ApplicationContext applicationContext = mock(ApplicationContext.class);
+            final Object pluginInstance;
+            final PluginFactory pluginFactory = mock(PluginFactory.class);
+            when(applicationContext.getBean(PluginFactory.class)).thenReturn(pluginFactory);
+
+            final Processor expectedPluginInstance = mock(Processor.class);
+            when(pluginFactory.loadPlugin(eq(Processor.class), any(PluginSetting.class)))
+                    .thenReturn(expectedPluginInstance);
+            try (final MockedStatic<TestApplicationContextProvider> mockedContextProvider = mockStatic(TestApplicationContextProvider.class)) {
+                mockedContextProvider.when(() -> TestApplicationContextProvider.get(extensionContext))
+                        .thenReturn(applicationContext);
+                pluginInstance = objectUnderTest.resolveParameter(parameterContext, extensionContext);
+            }
+
+            assertThat(pluginInstance, sameInstance(expectedPluginInstance));
+
+            final ArgumentCaptor<PluginSetting> pluginSettingArgumentCaptor = ArgumentCaptor.forClass(PluginSetting.class);
+            verify(pluginFactory).loadPlugin(eq(Processor.class), pluginSettingArgumentCaptor.capture());
+
+            final PluginSetting actualPluginSetting = pluginSettingArgumentCaptor.getValue();
+
+            assertThat(actualPluginSetting.getName(), equalTo("some_test_plugin"));
+            assertThat(actualPluginSetting.getSettings(), equalTo(
+                    Map.of(
+                            "option_a", "some-value-for-a",
+                            "option_b", "some-value-for-b",
+                            "option_c", "some-value-for-c"
+                    )
+            ));
+
+            assertThat(actualPluginSetting.getPipelineName(), equalTo("test-pipeline"));
+        }
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/TestApplicationContextProviderTest.java
+++ b/data-prepper-test/plugin-test-framework/src/test/java/org/opensearch/dataprepper/test/plugins/junit/TestApplicationContextProviderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.test.plugins.junit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
+import org.springframework.context.ApplicationContext;
+
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestApplicationContextProviderTest {
+    @Mock
+    private ExtensionContext extensionContext;
+
+    @Mock
+    private ExtensionContext.Store store;
+
+    @BeforeEach
+    void setUp() {
+        when(extensionContext.getStore(any(ExtensionContext.Namespace.class)))
+                .thenReturn(store);
+    }
+
+    @Test
+    void get_creates_an_ApplicationContext_with_expected_beans() {
+        when(store.getOrComputeIfAbsent(any(), any(), any())).thenAnswer(a -> {
+            final Function computeFunction = a.getArgument(1, Function.class);
+
+            return computeFunction.apply(null);
+        });
+
+        final ApplicationContext applicationContext = TestApplicationContextProvider.get(extensionContext);
+
+        assertThat(applicationContext, notNullValue());
+        assertThat(applicationContext.getBean(PluginFactory.class), instanceOf(DefaultPluginFactory.class));
+        assertThat(applicationContext.getBean(EventFactory.class), instanceOf(TestEventFactory.class));
+        assertThat(applicationContext.getBean(EventKeyFactory.class), instanceOf(TestEventKeyFactory.class));
+    }
+
+    @Test
+    void get_called_multiple_times_returns_same_instance() {
+        final ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(store.getOrComputeIfAbsent(any(), any(), any())).thenReturn(applicationContext);
+
+        final ApplicationContext applicationContext1 = TestApplicationContextProvider.get(extensionContext);
+        final ApplicationContext applicationContext2 = TestApplicationContextProvider.get(extensionContext);
+
+        assertThat(applicationContext1, sameInstance(applicationContext));
+        assertThat(applicationContext2, sameInstance(applicationContext));
+    }
+}

--- a/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/multiple-pipelines.yaml
+++ b/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/multiple-pipelines.yaml
@@ -1,0 +1,14 @@
+test-pipeline-1:
+  source:
+    unused:
+  processor:
+    - any:
+  sink:
+    - unused:
+test-pipeline-2:
+  source:
+    unused:
+  processor:
+    - any:
+  sink:
+    - unused:

--- a/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/multiple-processors.yaml
+++ b/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/multiple-processors.yaml
@@ -1,0 +1,8 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - one:
+    - two:
+  sink:
+    - unused:

--- a/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/no-processor.yaml
+++ b/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/no-processor.yaml
@@ -1,0 +1,6 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+  sink:
+    - unused:

--- a/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/valid.yaml
+++ b/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/junit/valid.yaml
@@ -1,0 +1,10 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - some_test_plugin:
+        option_a: some-value-for-a
+        option_b: some-value-for-b
+        option_c: some-value-for-c
+  sink:
+    - unused:

--- a/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/test001.yaml
+++ b/data-prepper-test/plugin-test-framework/src/test/resources/org/opensearch/dataprepper/test/plugins/test001.yaml
@@ -1,0 +1,8 @@
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - test_plugin:
+        option_a: some-value-for-a
+  sink:
+    - unused:


### PR DESCRIPTION
### Description

This adds a new feature to the Data Prepper plugin test framework. It provides the ability for plugin authors to write tests that will load plugin instances from a YAML file. The core feature is the addition of the `@PluginConfigurationFile` annotation that can be applied to method parameters. It uses JUnit's support for parameter injection to load the actual plugin and provide it to the plugin author's unit test.

This also provides support for plugin tests to get an injected `EventFactory` or `EventKeyFactory` to help with authoring tests.

This PR also adds plugin test framework support to the `drop_events` and `parse_json` plugins. 

Additionally, I updated the `GrokProcessorIT` to make as many tests as possible use this new approach. These tests are now using the framework to load plugin configurations rather than mutating `PluginSetting` directly. However, there were some tests that I couldn't yet update. These were:

* Negative test cases that result in failures
* Tests that are dynamically generated

I do plan to look into this in a future PR.
 
### Issues Resolved

Resolves #5917
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
