### PR TITLE
Log the error message from SQS when failing to send a message

### DIFF
--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatch.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatch.java
@@ -6,6 +6,8 @@
 package org.opensearch.dataprepper.plugins.sink.sqs;
 
 import org.opensearch.dataprepper.model.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
@@ -30,7 +32,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
 public class SqsSinkBatch {
+    private static final Logger LOG = LoggerFactory.getLogger(SqsSinkBatch.class);
     public static final int MAX_MESSAGES_PER_BATCH = 10;
     public static final int MAX_BATCH_SIZE_BYTES = 256*1024;
     private static final String SQS_FIFO_SUFFIX = ".fifo";
@@ -227,6 +232,7 @@ public class SqsSinkBatch {
             sinkMetrics.recordRequestSize((double)requestSize);
 
         } catch (SqsException e) {
+            LOG.error(NOISY, "Failed to send messages to SQS: {}", e.getMessage());
             sinkMetrics.incrementRequestsFailedCounter(1);
             sinkMetrics.incrementEventsFailedCounter(entries.size());
             if (!isRetryableException(e)) {


### PR DESCRIPTION
### Description

The SQS sink is giving no indication in the logs when it fails to write to SQS. This leaves pipeline authors at a loss of what to do.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
