### PR TITLE
Update the aggregate processor to log errors at the error level.

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -65,7 +65,7 @@ class AggregateActionSynchronizer {
                     aggregateGroupManager.closeGroup(hash, aggregateGroup);
                 }
             } catch (final Exception e) {
-                LOG.debug("Error while concluding group: ", e);
+                LOG.error("Error while concluding group: ", e);
                 actionConcludeGroupEventsProcessingErrors.increment();
             } finally {
                 handleEventForGroupLock.unlock();
@@ -89,7 +89,7 @@ class AggregateActionSynchronizer {
             handleEventResponse = aggregateAction.handleEvent(event, aggregateGroup);
             aggregateGroupManager.putGroupWithHash(hash, aggregateGroup);
         } catch (final Exception e) {
-            LOG.debug("Error while handling event, event will be processed by remainder of the pipeline: ", e);
+            LOG.error("Error while handling event, event will be processed by remainder of the pipeline: ", e);
             actionHandleEventsProcessingErrors.increment();
             handleEventResponse = new AggregateActionResponse(event);
         } finally {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -15,6 +15,8 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.locks.Lock;
 import java.util.Collections;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
 /**
  * An {@link AggregateAction} contains two functons, {@link AggregateAction#concludeGroup(AggregateActionInput)} and {@link AggregateAction#handleEvent(Event, AggregateActionInput)},
  * that potentially modify a shared state that needs to be synchronized between multiple worker threads. These two functions should not be called on the same {@link AggregateGroup} at the same time,
@@ -65,7 +67,7 @@ class AggregateActionSynchronizer {
                     aggregateGroupManager.closeGroup(hash, aggregateGroup);
                 }
             } catch (final Exception e) {
-                LOG.error("Error while concluding group: ", e);
+                LOG.error(NOISY, "Error while concluding group: ", e);
                 actionConcludeGroupEventsProcessingErrors.increment();
             } finally {
                 handleEventForGroupLock.unlock();
@@ -89,7 +91,7 @@ class AggregateActionSynchronizer {
             handleEventResponse = aggregateAction.handleEvent(event, aggregateGroup);
             aggregateGroupManager.putGroupWithHash(hash, aggregateGroup);
         } catch (final Exception e) {
-            LOG.error("Error while handling event, event will be processed by remainder of the pipeline: ", e);
+            LOG.error(NOISY, "Error while handling event, event will be processed by remainder of the pipeline: ", e);
             actionHandleEventsProcessingErrors.increment();
             handleEventResponse = new AggregateActionResponse(event);
         } finally {


### PR DESCRIPTION
### Description

The `aggregate` processor logs errors at the `DEBUG` level. This PR logs them at the `ERROR` level.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
