### PR TITLE
Add regex-based key selection for delete_entries processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
@@ -62,11 +62,14 @@ public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Recor
                             ".org/docs/latest/data-prepper/pipelines/expression-syntax/ for valid expression syntax", deleteWhen));
         }
 
-        if (!this.withKeys.isEmpty()) {
-            DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(this.withKeys, null, null, this.deleteWhen, config.getIterateOn(), config.getDeleteFromElementWhen());
-            this.entries = List.of(entry);
-        } else if (!this.withKeysRegex.isEmpty()) {
-            DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(null, this.withKeysRegex, this.excludeFromDelete, this.deleteWhen, config.getIterateOn(), config.getDeleteFromElementWhen());
+        if (!this.withKeys.isEmpty() || !this.withKeysRegex.isEmpty()) {
+            DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(
+                    this.withKeys,
+                    this.withKeysRegex,
+                    this.excludeFromDelete,
+                    this.deleteWhen,
+                    config.getIterateOn(),
+                    config.getDeleteFromElementWhen());
             this.entries = List.of(entry);
         } else {
             this.entries = config.getEntries();

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -85,10 +85,7 @@ public class DeleteEntryProcessorConfig {
 
         @AssertTrue(message = "exclude_from_delete only applies when with_keys_regex is configured.")
         boolean isExcludeFromDeleteValid() {
-            if (excludeFromDelete == null || excludeFromDelete.isEmpty()) {
-                return true;
-            }
-            return withKeysRegex != null && !withKeysRegex.isEmpty();
+            return excludeFromDelete != null && !excludeFromDelete.isEmpty() && withKeysRegex != null && !withKeysRegex.isEmpty();
         }
 
         @JsonIgnore
@@ -197,10 +194,7 @@ public class DeleteEntryProcessorConfig {
 
     @AssertTrue(message = "exclude_from_delete only applies when with_keys_regex is configured.")
     boolean isExcludeFromDeleteValid() {
-        if (excludeFromDelete == null || excludeFromDelete.isEmpty()) {
-            return true;
-        }
-        return withKeysRegex != null && !withKeysRegex.isEmpty();
+        return excludeFromDelete != null && !excludeFromDelete.isEmpty() && withKeysRegex != null && !withKeysRegex.isEmpty();
     }
 
     @JsonIgnore

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfigTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfigTests.java
@@ -1,12 +1,15 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.EventKey;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class DeleteEntryProcessorConfigTests {
 
@@ -26,5 +29,27 @@ public class DeleteEntryProcessorConfigTests {
         ReflectivelySetField.setField(DeleteEntryProcessorConfig.class, objectUnderTest, "withKeysRegex", invalidPatterns);
 
         assertThat(objectUnderTest.isValidWithKeysRegexPattern(), equalTo(false));
+    }
+    
+    @Test
+    void testisExcludeFromDeleteValid_with_valid_config() throws NoSuchFieldException, IllegalAccessException{
+        final DeleteEntryProcessorConfig objectUnderTest = new DeleteEntryProcessorConfig();
+        final List<String> regexKeys = List.of("test.*");
+        final Set<EventKey> excludeKeys = Set.of(mock(EventKey.class));
+        ReflectivelySetField.setField(DeleteEntryProcessorConfig.class, objectUnderTest, "withKeysRegex", regexKeys);
+        ReflectivelySetField.setField(DeleteEntryProcessorConfig.class, objectUnderTest, "excludeFromDelete", excludeKeys);
+
+        assertThat(objectUnderTest.isExcludeFromDeleteValid(), equalTo(true));
+    }
+
+    @Test
+    void testisExcludeFromDeleteValid_with_invalid_config() throws NoSuchFieldException, IllegalAccessException{
+        final DeleteEntryProcessorConfig objectUnderTest = new DeleteEntryProcessorConfig();
+        final List<EventKey> testKeys = List.of(mock(EventKey.class));
+        final Set<EventKey> excludeKeys = Set.of(mock(EventKey.class));
+        ReflectivelySetField.setField(DeleteEntryProcessorConfig.class, objectUnderTest, "withKeys", testKeys);
+        ReflectivelySetField.setField(DeleteEntryProcessorConfig.class, objectUnderTest, "excludeFromDelete", excludeKeys);
+
+        assertThat(objectUnderTest.isExcludeFromDeleteValid(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
@@ -310,10 +310,12 @@ public class DeleteEntryProcessorTests {
 
     @Test
     public void test_multiple_entries_with_different_delete_when_conditions() {
-        final DeleteEntryProcessorConfig.Entry entry1 = new DeleteEntryProcessorConfig.Entry(List.of(eventKeyFactory.createEventKey("key1"
-                , EventKeyFactory.EventAction.DELETE)), null, null, "condition1", null, null);
-        final DeleteEntryProcessorConfig.Entry entry2 = new DeleteEntryProcessorConfig.Entry(List.of(eventKeyFactory.createEventKey("key2"
-                , EventKeyFactory.EventAction.DELETE)), null, null, "condition2", null, null);
+        final DeleteEntryProcessorConfig.Entry entry1 = new DeleteEntryProcessorConfig.Entry(
+                List.of(eventKeyFactory.createEventKey("key1", EventKeyFactory.EventAction.DELETE)),
+                null, null, "condition1", null, null);
+        final DeleteEntryProcessorConfig.Entry entry2 = new DeleteEntryProcessorConfig.Entry(
+                List.of(eventKeyFactory.createEventKey("key2", EventKeyFactory.EventAction.DELETE)),
+                null, null, "condition2", null, null);
 
         when(mockConfig.getEntries()).thenReturn(List.of(entry1, entry2));
         when(expressionEvaluator.isValidExpressionStatement("condition1")).thenReturn(true);
@@ -351,8 +353,9 @@ public class DeleteEntryProcessorTests {
 
     @Test
     public void invalid_delete_when_with_entries_format_throws_InvalidPluginConfigurationException() {
-        DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(List.of(eventKeyFactory.createEventKey("key1",
-                EventKeyFactory.EventAction.DELETE)), null, null, "invalid_condition", null, null);
+        DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(
+                List.of(eventKeyFactory.createEventKey("key1", EventKeyFactory.EventAction.DELETE)),
+                null, null, "invalid_condition", null, null);
 
         when(mockConfig.getEntries()).thenReturn(List.of(entry));
         when(expressionEvaluator.isValidExpressionStatement("invalid_condition")).thenReturn(false);
@@ -363,8 +366,9 @@ public class DeleteEntryProcessorTests {
     @Test
     public void test_both_configurations_used_together() {
         final DeleteEntryProcessorConfig configObjectUnderTest = new DeleteEntryProcessorConfig();
-        final DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(List.of(eventKeyFactory.createEventKey("key1"
-                , EventKeyFactory.EventAction.DELETE)), null, null, "condition", null, null);
+        final DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(
+                List.of(eventKeyFactory.createEventKey("key1", EventKeyFactory.EventAction.DELETE)),
+                null, null, "condition", null, null);
 
         ReflectionTestUtils.setField(configObjectUnderTest, "withKeys", List.of(eventKeyFactory.createEventKey("message",
                 EventKeyFactory.EventAction.DELETE)));
@@ -388,7 +392,8 @@ public class DeleteEntryProcessorTests {
     @Test
     public void test_has_only_one_config_returns_false_when_entries_and_with_keys_regex_used_together() {
         final DeleteEntryProcessorConfig configObjectUnderTest = new DeleteEntryProcessorConfig();
-        final DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(null, List.of("^ran.*"), null, "condition", null, null);
+        final DeleteEntryProcessorConfig.Entry entry = new DeleteEntryProcessorConfig.Entry(
+                null, List.of("^ran.*"), null, "condition", null, null);
 
         ReflectionTestUtils.setField(configObjectUnderTest, "withKeysRegex", List.of("^test.*"));
         ReflectionTestUtils.setField(configObjectUnderTest, "entries", List.of(entry));
@@ -400,8 +405,8 @@ public class DeleteEntryProcessorTests {
     public void test_has_only_one_config_returns_false_when_with_keys_and_with_keys_regex_used_together() {
         final DeleteEntryProcessorConfig configObjectUnderTest = new DeleteEntryProcessorConfig();
 
-        ReflectionTestUtils.setField(configObjectUnderTest, "withKeys", List.of(eventKeyFactory.createEventKey("key1"
-                , EventKeyFactory.EventAction.DELETE)));
+        ReflectionTestUtils.setField(configObjectUnderTest, "withKeys", List.of(
+                eventKeyFactory.createEventKey("key1",EventKeyFactory.EventAction.DELETE)));
         ReflectionTestUtils.setField(configObjectUnderTest, "withKeysRegex", List.of("^test.*"));
 
         assertThat(configObjectUnderTest.hasOnlyOneConfiguration(), is(false));
@@ -411,9 +416,10 @@ public class DeleteEntryProcessorTests {
     public void test_exclude_from_delete_without_with_key_regex() {
         final DeleteEntryProcessorConfig configObjectUnderTest = new DeleteEntryProcessorConfig();
 
-        ReflectionTestUtils.setField(configObjectUnderTest, "withKeys", List.of(eventKeyFactory.createEventKey("key1"
-                , EventKeyFactory.EventAction.DELETE)));
-        ReflectionTestUtils.setField(configObjectUnderTest, "excludeFromDelete", Set.of(eventKeyFactory.createEventKey("excludeKey")));
+        ReflectionTestUtils.setField(configObjectUnderTest, "withKeys", List.of(
+                eventKeyFactory.createEventKey("key1", EventKeyFactory.EventAction.DELETE)));
+        ReflectionTestUtils.setField(configObjectUnderTest, "excludeFromDelete", Set.of(
+                eventKeyFactory.createEventKey("excludeKey")));
 
         assertThat(configObjectUnderTest.isExcludeFromDeleteValid(), is(false));
     }


### PR DESCRIPTION
### Description
This change adds new configuration parameters to the <i>delete_entries</i> processor.

* <b>`with_keys_regex`</b> -> A list of regex patterns to match keys to delete from the event. Can be used alongside `with_keys`, and by default will only check keys at the root of the event.
* <b>`exclude_from_delete`</b> -> A list of event keys to skip over when deleting entries. Can be used only alongside `with_keys_regex`

#### Note:
`with_keys` was previously required in this processor, and now at least one of `with_keys` or `with_keys_regex` is required.
 
### Issues Resolved
Related to issue #6087
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
