### PR TITLE
Makes ByteCount Comparable to make it easier to write validations.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  *
  * @since 2.1
  */
-public class ByteCount {
+public class ByteCount implements Comparable<ByteCount> {
     private static final Pattern BYTE_PATTERN = Pattern.compile("^(?<value>\\d+\\.?\\d*)(?<unit>[a-z]+)?\\z");
     private static final ByteCount ZERO_BYTES = new ByteCount(0);
     private final long bytes;
@@ -166,5 +166,10 @@ public class ByteCount {
     @Override
     public String toString() {
         return bytes + Unit.BYTE.unitString;
+    }
+
+    @Override
+    public int compareTo(final ByteCount otherByteCount) {
+        return Long.compare(this.bytes, otherByteCount.bytes);
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/types/ByteCountTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/types/ByteCountTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Random;
-
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -21,8 +19,6 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ByteCountTest {
-    private final Random random = new Random();
-
     @ParameterizedTest
     @ValueSource(strings = {
             ".1b",
@@ -261,5 +257,25 @@ class ByteCountTest {
         final ByteCount parsedByteCount = ByteCount.parse(objectUnderTest.toString());
         assertThat(parsedByteCount, equalTo(objectUnderTest));
         assertThat(parsedByteCount.hashCode(), equalTo(objectUnderTest.hashCode()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0b, 0b, 0",
+            "1b, 1b, 0",
+            "0b, 1b, -1",
+            "1b, 0b, 1",
+            "1kb, 1024b, 0",
+            "512b, 1kb, -1",
+            "2kb, 1kb, 1",
+            "1mb, 1kb, 1",
+            "1kb, 1mb, -1",
+            "1gb, 1mb, 1",
+            "500mb, 1gb, -1"
+    })
+    void compareTo_returns_expected_comparison_result(final String firstByteString, final String secondByteString, final int expectedResult) {
+        final ByteCount first = ByteCount.parse(firstByteString);
+        final ByteCount second = ByteCount.parse(secondByteString);
+        assertThat(first.compareTo(second), equalTo(expectedResult));
     }
 }


### PR DESCRIPTION
### Description

Makes ByteCount a Java `Comparable` to make it easier to write validations.

This can simplify work similar to what we have in #6154.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
