### PR TITLE
Pass sts header overrides to awscredentialssupplier in otlp sink

### DIFF
--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfig.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfig.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.regions.Region;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -111,6 +112,14 @@ public class OtlpSinkConfig {
         }
 
         return awsConfig.getAwsStsExternalId();
+    }
+
+    public Map<String, String> getStsHeaderOverrides() {
+        if (awsConfig == null || awsConfig.getAwsStsHeaderOverrides() == null) {
+            return null;
+        }
+
+        return awsConfig.getAwsStsHeaderOverrides();
     }
 
     /**

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4Signer.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4Signer.java
@@ -45,6 +45,7 @@ class SigV4Signer {
                 .withRegion(region)
                 .withStsRoleArn(config.getStsRoleArn())
                 .withStsExternalId(config.getStsExternalId())
+                .withStsHeaderOverrides(config.getStsHeaderOverrides())
                 .build());
 
         this.endpointUri = config.getEndpoint() != null

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfigTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfigTest.java
@@ -145,6 +145,7 @@ class OtlpSinkConfigTest {
 
         assertThat(config.getStsRoleArn(), nullValue());
         assertThat(config.getStsExternalId(), nullValue());
+        assertThat(config.getStsHeaderOverrides(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
### Description
Passes sts_header_overrides from the otlp sink configuration to the aws credentials supplier

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
