### PR TITLE
Fix delete_entries incorrect validation

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -194,7 +194,7 @@ public class DeleteEntryProcessorConfig {
 
     @AssertTrue(message = "exclude_from_delete only applies when with_keys_regex is configured.")
     boolean isExcludeFromDeleteValid() {
-        return excludeFromDelete != null && !excludeFromDelete.isEmpty() && withKeysRegex != null && !withKeysRegex.isEmpty();
+        return !((excludeFromDelete != null && !excludeFromDelete.isEmpty()) && (withKeysRegex == null || withKeysRegex.isEmpty()));
     }
 
     @JsonIgnore

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfigTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfigTests.java
@@ -43,6 +43,15 @@ public class DeleteEntryProcessorConfigTests {
     }
 
     @Test
+    void test_with_keys_valid_config() throws NoSuchFieldException, IllegalAccessException{
+        final DeleteEntryProcessorConfig objectUnderTest = new DeleteEntryProcessorConfig();
+        final List<String> regexKeys = List.of("test.*");
+        ReflectivelySetField.setField(DeleteEntryProcessorConfig.class, objectUnderTest, "withKeys", regexKeys);
+
+        assertThat(objectUnderTest.isExcludeFromDeleteValid(), equalTo(true));
+    }
+
+    @Test
     void testisExcludeFromDeleteValid_with_invalid_config() throws NoSuchFieldException, IllegalAccessException{
         final DeleteEntryProcessorConfig objectUnderTest = new DeleteEntryProcessorConfig();
         final List<EventKey> testKeys = List.of(mock(EventKey.class));


### PR DESCRIPTION
### Description
Fixes incorrect validation that would throw when only `with_keys` was used
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
