### PR TITLE
Use standard TLS when downloading the database from an HTTP URL.

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/DBSource.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/DBSource.java
@@ -5,50 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.geoip.extension.databasedownload;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-
 public interface DBSource {
     String MAXMIND_DATABASE_EXTENSION = ".mmdb";
     void initiateDownload() throws Exception;
-
-    /**
-     * initiateSSL
-     * @throws NoSuchAlgorithmException NoSuchAlgorithmException
-     * @throws KeyManagementException KeyManagementException
-     */
-    default void initiateSSL() throws NoSuchAlgorithmException, KeyManagementException {
-        final TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager() {
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return null;
-                    }
-                    public void checkServerTrusted(X509Certificate[] certs, String authType) throws CertificateException {
-                        return;
-                    }
-                    public void checkClientTrusted(X509Certificate[] certs, String authType) throws CertificateException {
-                        return;
-                    }
-                }
-        };
-
-        final SSLContext sc = SSLContext.getInstance("TLS");
-        sc.init(null, trustAllCerts, new SecureRandom());
-        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        final HostnameVerifier hostnameVerifier = new HostnameVerifier() {
-            public boolean verify(String urlHostName, SSLSession session) {
-                return true;
-            }
-        };
-        HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
-    }
 }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/HttpDBDownloadService.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/HttpDBDownloadService.java
@@ -53,7 +53,6 @@ public class HttpDBDownloadService implements DBSource {
         for (final String key: databasePaths) {
             geoIPFileManager.createDirectoryIfNotExist(tarDir);
             try {
-                initiateSSL();
                 buildRequestAndDownloadFile(maxMindDatabaseConfig.getDatabasePaths().get(key), downloadTarFilepath);
                 final File tarFile = decompressAndgetTarFile(tarDir, downloadTarFilepath);
                 unTarFile(tarFile, new File(destinationDirectory), key);


### PR DESCRIPTION
### Description

Use standard TLS when downloading the database from an HTTP URL.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
