### PR TITLE
Integration test the OpenSearch sink against 2.12.0 and 2.19.3.

### DIFF
--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.14, 2.0.1, 2.1.0, 2.3.0, 2.5.0, 2.7.0, 2.9.0, 2.11.1]
+        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.14, 2.0.1, 2.1.0, 2.3.0, 2.5.0, 2.7.0, 2.9.0, 2.11.1, 2.12.0, 2.19.3]
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -32,15 +32,22 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set password for OpenSearch version
+        run: |
+          if [[ "${{ matrix.opensearch }}" =~ ^2\.(1[2-9]|[2-9][0-9]) ]]; then
+            echo "PASSWORD=yourStrongPassword123!" >> $GITHUB_ENV
+          else
+            echo "PASSWORD=admin" >> $GITHUB_ENV
+          fi
       - name: Run OpenSearch docker
         run: |
           docker pull opensearchproject/opensearch:${{ matrix.opensearch }}
-          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchproject/opensearch:${{ matrix.opensearch }}
+          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!" -d opensearchproject/opensearch:${{ matrix.opensearch }}
           sleep 90
       - name: Run OpenSearch tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin -Dtests.opensearch.bundle=true -Dtests.opensearch.version=opensearch:${{ matrix.opensearch }}
+          ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password="$PASSWORD"
+          ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password="$PASSWORD" -Dtests.opensearch.bundle=true -Dtests.opensearch.version=opensearch:${{ matrix.opensearch }}
       - name: Upload Unit Test Results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Description

Integration test the OpenSearch sink against 2.12.0 and 2.19.3.

Because OpenSearch 2.12.0 and above require a strong password, this has some additional logic to determine whether to use the old password or the new password.
 
I tested this on my fork and see all the tests passing: https://github.com/dlvenable/data-prepper/actions/runs/18510858757/job/52751160930

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
