### PR TITLE
Minor update to the release notes for 2.11.0 for a breaking change.

### DIFF
--- a/release/release-notes/data-prepper.release-notes-2.11.0.md
+++ b/release/release-notes/data-prepper.release-notes-2.11.0.md
@@ -2,6 +2,10 @@
 
 ---
 
+### Breaking Changes
+
+* The Docker task no longer runs as root. This may break existing Docker compose configurations. For example, mapping the `.aws` directory to the `/root/.aws` directory should map it to `/.aws` instead.
+
 ### Features
 
 * Support AWS Aurora/RDS PostgreSQL as source ([#5309](https://github.com/opensearch-project/data-prepper/issues/5309))


### PR DESCRIPTION
### Description

Data Prepper 2.11.0 had a minor breaking change related to how it runs in Docker. I'm updating the release notes for this version to help see the difference.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
