### PR TITLE
Update the AWS credentials directory in the end-to-end tests

### DIFF
--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -79,7 +79,7 @@ logTestConfigurations.each { testConfiguration ->
         exposePorts('tcp', [2021, 4900])
         hostConfig.portBindings = ['2021:2021', '4900:4900']
         hostConfig.binds = [
-                "${System.getProperty('user.home')}/.aws" : '/root/.aws',
+                "${System.getProperty('user.home')}/.aws" : '/.aws',
                 (project.file("src/integrationTest/resources/${testConfiguration.pipelineConfiguration}").toString())   : '/usr/share/data-prepper/pipelines/log-pipeline.yaml',
                 (project.file("src/integrationTest/resources/${testConfiguration.dataPrepperConfiguration}").toString()): '/usr/share/data-prepper/config/data-prepper-config.yaml'
         ]


### PR DESCRIPTION
### Description

Mount the AWS credentials in the `/.aws` directory instead of the `/root/.aws` directory for the end-to-end tests.
 
### Issues Resolved

None, but should fix failing AWS Secrets end-to-end tests.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
