### PR TITLE
Create a data_prepper_test user in the end-to-end tests for Java.

### DIFF
--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -66,9 +66,12 @@ subprojects {
         destFile = project.file('build/docker/Dockerfile')
 
         from(dataPrepperBaseImage)
+        runCommand('useradd -u 1012 -M -U -d / -s /sbin/nologin -c "Data Prepper Test" data_prepper_test')
         runCommand('mkdir -p /var/log/data-prepper')
         addFile(project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get(), '/usr/share')
         runCommand("mv /usr/share/${project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get().replace('.tar.gz', '')} /usr/share/data-prepper")
+        runCommand('chown -R 1012:1012 /usr/share/data-prepper /var/log/data-prepper')
+        user('data_prepper_test')
         workingDir('/usr/share/data-prepper')
         defaultCommand('bin/data-prepper')
     }


### PR DESCRIPTION
### Description

Create a `data_prepper_test` user in the Docker image created for end-to-end tests that test Java versions. This approach allows the tests to map the `.aws` volume to `/.aws` for all test scenarios.
 
I tested this locally and it works for both Java 21 and Docker.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
