### PR TITLE
Add negative tests to sqs and cloudwatch logs sink

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
@@ -549,6 +549,7 @@ public class CloudWatchLogsIT {
         when(thresholdConfig.getBatchSize()).thenReturn(1);
         when(thresholdConfig.getMaxEventSizeBytes()).thenReturn(1000L);
         when(thresholdConfig.getMaxRequestSizeBytes()).thenReturn(1000L);
+        lenient().when(thresholdConfig.getFlushInterval()).thenReturn(1L);
         AwsCredentialsProvider provider = mock(AwsCredentialsProvider.class);
         when(awsCredentialsSupplier.getProvider(any())).thenReturn(provider);
 
@@ -556,7 +557,7 @@ public class CloudWatchLogsIT {
         Collection<Record<Event>> records = getRecordList(NUM_RECORDS);
         sink.doOutput(records);
 
-        assertThrows( org.awaitility.core.ConditionTimeoutException.class, () ->  await().atMost(Duration.ofSeconds(30))
+        assertThrows( org.awaitility.core.ConditionTimeoutException.class, () ->  await().atMost(Duration.ofSeconds(2))
                 .untilAsserted(() -> {
                     long endTime = Instant.now().toEpochMilli();
                     GetLogEventsRequest getRequest = GetLogEventsRequest

--- a/data-prepper-plugins/sqs-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkIT.java
+++ b/data-prepper-plugins/sqs-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkIT.java
@@ -677,11 +677,12 @@ public class SqsSinkIT {
         AwsCredentialsProvider provider = mock(AwsCredentialsProvider.class);
         when(awsCredentialsSupplier.getProvider(any())).thenReturn(provider);
         when(thresholdConfig.getMaxEventsPerMessage()).thenReturn(1);
+        lenient().when(thresholdConfig.getFlushInterval()).thenReturn(1L);
         sink = createObjectUnderTest();
         int numRecords = 2;
         Collection<Record<Event>> records = getRecordList(numRecords, false);
         sink.doOutput(records);
-        assertThrows( org.awaitility.core.ConditionTimeoutException.class, () ->  await().atMost(Duration.ofSeconds(60))
+        assertThrows( org.awaitility.core.ConditionTimeoutException.class, () ->  await().atMost(Duration.ofSeconds(2))
                 .untilAsserted(() -> {
                     final Map<String, Object> expectedMap = new HashMap<>();
                     for (int i = 0; i < numRecords; i++) {


### PR DESCRIPTION
### Description
Add negative tests to sqs and cloudwatch logs sink to verify that when correct credentials were not passed, Data Prepper cannot communicate with the sqs/cloudwatch service.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
