### PR TITLE
Fixes the AWS Secrets end-to-end test

### DIFF
--- a/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
+++ b/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
@@ -29,20 +29,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: configure aws credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.TEST_IAM_ROLE_ARN }}
           aws-region: ${{ secrets.TEST_REGION }}
           output-credentials: true
-      - name: get caller identity 1
-        run: |
-          aws sts get-caller-identity
       - name: Configure AWS Credentials file
         run: |
           aws configure set default.region ${{ secrets.TEST_REGION }}
           aws configure set default.aws_access_key_id ${{ steps.creds.outputs.aws-access-key-id }}
           aws configure set default.aws_secret_access_key ${{ steps.creds.outputs.aws-secret-access-key }}
           aws configure set default.aws_session_token ${{ steps.creds.outputs.aws-session-token }}
+      - name: Fix AWS credentials permissions for Docker
+        run: |
+          chmod 644 ~/.aws/credentials ~/.aws/config
+          ls -la ~/.aws/
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/kinesis-source-integration-tests.yml
+++ b/.github/workflows/kinesis-source-integration-tests.yml
@@ -30,15 +30,12 @@ jobs:
 
       - name: configure aws credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.TEST_IAM_ROLE_ARN }}
           aws-region: ${{ secrets.TEST_REGION }}
           output-credentials: true
 
-      - name: get caller identity 1
-        run: |
-          aws sts get-caller-identity
       - name: Configure AWS Credentials file
         run: |
           aws configure set default.region ${{ secrets.TEST_REGION }}

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -79,7 +79,7 @@ logTestConfigurations.each { testConfiguration ->
         exposePorts('tcp', [2021, 4900])
         hostConfig.portBindings = ['2021:2021', '4900:4900']
         hostConfig.binds = [
-                "${System.getProperty('user.home')}/.aws" : '/.aws',
+                ("${System.getProperty('user.home')}/.aws".toString()) : '/.aws',
                 (project.file("src/integrationTest/resources/${testConfiguration.pipelineConfiguration}").toString())   : '/usr/share/data-prepper/pipelines/log-pipeline.yaml',
                 (project.file("src/integrationTest/resources/${testConfiguration.dataPrepperConfiguration}").toString()): '/usr/share/data-prepper/config/data-prepper-config.yaml'
         ]


### PR DESCRIPTION
### Description

Fixes the AWS Secrets end-to-end test by setting permissions for the `.aws` directory.

The root problem was that the `.aws` directory had user permissions for the GitHub Actions users (UID 1001). This prevented Data Prepper from having access when running in the Docker container. This worked previously because Data Prepper ran as root. To solve this, I made these files readable to other users.

Additionally:

* Removes getting the STS caller. 
* Updates the `configure-aws-credentials` GHA action to v5. 
* Use a String for the binds map rather than a GString.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
