### PR TITLE
allow custom name pattern prefix for S3 sink

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/configuration/ObjectKeyOptions.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/configuration/ObjectKeyOptions.java
@@ -6,18 +6,20 @@
 package org.opensearch.dataprepper.plugins.sink.s3.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 
 /**
  * An implementation class of path prefix and file pattern configuration Options
  */
 public class ObjectKeyOptions {
     private static final String DEFAULT_OBJECT_NAME_PATTERN = "events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}";
+    private static final String DEFAULT_TIME_PATTERN = "%{yyyy-MM-dd'T'HH-mm-ss'Z'}";
 
     @JsonProperty("path_prefix")
     private String pathPrefix;
 
-    @JsonProperty("name_pattern")
-    private String namePattern;
+    @JsonProperty("name_pattern_prefix")
+    private String namePatternPrefix;
 
     /**
      * S3 index path configuration Option
@@ -28,13 +30,28 @@ public class ObjectKeyOptions {
     }
 
     /**
+     * S3 object name configuration Option
+     * @return  S3 object prefix.
+     */
+    public String getNamePatternPrefix() {return namePatternPrefix;}
+
+    /**
      * Read s3 object index file pattern configuration.
-     * @return default object name pattern if namePattern is null, empty, or blank; otherwise returns the configured pattern.
+     * @return default object name pattern if namePatternPrefix is null, empty, or blank; otherwise returns the configured namePatternPrefix with default TimePattern.
      */
     public String getNamePattern() {
-        if (namePattern == null || namePattern.trim().isEmpty()) {
+        if (namePatternPrefix == null || namePatternPrefix.trim().isEmpty()) {
             return DEFAULT_OBJECT_NAME_PATTERN;
         }
-        return namePattern;
+        return namePatternPrefix + "-" + DEFAULT_TIME_PATTERN;
     }
+
+    @AssertTrue(message = "Custom time pattern is not allowed in the name pattern prefix since the default time pattern will be appended.")
+    boolean isTimePatternExcludedFromNamePatternPrefix() {
+        if (namePatternPrefix == null || namePatternPrefix.trim().isEmpty()) {
+            return true;
+        }
+        return !namePatternPrefix.contains("%{");
+    }
+
 }


### PR DESCRIPTION
### Description
Allow custom name_pattern_prefix for the S3 sink. This is needed to support merging ml inference job output file with the original S3 inputs.

To use it in the S3 sink config:
```
  sink:
    - s3:
        object_key:
          path_prefix: bedrockbatch/batch-input
          name_pattern_prefix: test-batch
```
It would generate the S3 files with the object path/name in the key which includes the configured prefix: 
```
bedrockbatch/batch-input/test_batch-2025-10-24T21-51-09Z-1761342669629351000-5afa362f-ad79-4910-9543-f65edcf5b10d.jsonl
```

By default, if no name_pattern_prefix is provided, it would generate the S3 keys using the default key pattern
```
bedrockbatch/batch-input/events-2025-10-24T21-51-09Z-1761342669629351000-5afa362f-ad79-4910-9543-f65edcf5b10d.jsonl
```

### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
