### PR TITLE
Fix consecutive hyphens in export id

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportTaskManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportTaskManager.java
@@ -76,7 +76,10 @@ public class ExportTaskManager {
 
     private String generateExportTaskId(String snapshotArn) {
         String snapshotId = Arn.fromString(snapshotArn).resource().resource();
-        return truncateString(snapshotId, EXPORT_TASK_ID_MAX_LENGTH - 16) + "-export-" + UUID.randomUUID().toString().substring(0, 8);
+        String truncatedSnapshotId = truncateString(snapshotId, EXPORT_TASK_ID_MAX_LENGTH - 16);
+        // Remove trailing hyphens to prevent consecutive hyphens in the export task identifier
+        truncatedSnapshotId = truncatedSnapshotId.replaceAll("-+$", "");
+        return truncatedSnapshotId + "-export-" + UUID.randomUUID().toString().substring(0, 8);
     }
 
     private String truncateString(String originalString, int maxLength) {


### PR DESCRIPTION
### Description
Fixed the RDS export task ID generation to prevent consecutive hyphens in export task identifiers that cause RDS validation failures.
 
### Issues Resolved
Resolves #6186 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
