### PR TITLE
Some refactoring to how we determine the Data Prepper version and log it

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'data-prepper.publish'
 }
 
+def dataPrepperVersion = version
 def generatedSourcesDir = "${project.buildDir}/generated/sources/version/java"
 
 sourceSets {
@@ -87,7 +88,7 @@ configurations {
 }
 
 task generateVersionProvider {
-    inputs.property('version', version)
+    inputs.property('version', dataPrepperVersion)
     inputs.file('src/main/java/org/opensearch/dataprepper/core/CoreVersionProvider.java.template')
     outputs.dir(generatedSourcesDir)
 
@@ -97,7 +98,7 @@ task generateVersionProvider {
 
         def templateFile = file('src/main/java/org/opensearch/dataprepper/core/CoreVersionProvider.java.template')
         def versionProviderFile = file("$outputDir/CoreVersionProvider.java")
-        versionProviderFile.text = templateFile.text.replace('${version}', version)
+        versionProviderFile.text = templateFile.text.replace('${version}', dataPrepperVersion)
     }
 }
 

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper;
 
 import org.opensearch.dataprepper.core.DataPrepper;
+import org.opensearch.dataprepper.model.configuration.DataPrepperVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
@@ -20,6 +21,7 @@ public class DataPrepperExecute {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperExecute.class);
 
     public static void main(final String ... args) {
+        LOG.info("Data Prepper {}", DataPrepperVersion.getCurrentVersion());
         java.security.Security.setProperty("networkaddress.cache.ttl", "60");
         System.setProperty("software.amazon.awssdk.http.service.impl", "software.amazon.awssdk.http.apache.ApacheSdkHttpService");
 


### PR DESCRIPTION
### Description

In order to support easier modification of the Data Prepper version by custom builds, I moved the dataPrepperVersion into a Gradle variable. 

Additionally print the Data Prepper version on start up.

Example:

```
2025-10-22T23:24:12,373 [main] INFO  org.opensearch.dataprepper.DataPrepperExecute - Data Prepper 2.13
```
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
