### PR TITLE
Increase m365 worker thread count from 2 to 4

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
@@ -21,7 +21,7 @@ import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSour
  */
 @Getter
 public class Office365SourceConfig implements CrawlerSourceConfig {
-    private static final int NUMBER_OF_WORKERS = 2;
+    private static final int NUMBER_OF_WORKERS = 4;
 
     /**
      * The Office 365 tenant ID that uniquely identifies the Microsoft Entra organization.

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
@@ -77,7 +77,7 @@ class Office365SourceConfigTest {
     @Test
     void testDefaultValues() {
         assertFalse(config.isAcknowledgments());
-        assertEquals(2, config.getNumberOfWorkers());
+        assertEquals(4, config.getNumberOfWorkers());
     }
 
     @Test


### PR DESCRIPTION
This commit increases the m365 connector worker thread count from 2 to 4. This is because the worker thread is per host and we need to ensure there are not too many threads in total to avoid api throttling.

We had alignment between different teams that 3pE connector will be fixed at 2 OCU. The performance test confirms a total of 8 threads cross all fleet. Changing to 4 would fit 2 OCU.

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
