### PR TITLE
Fixes bug where DataPrepperVersion can support invalid versions

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
@@ -18,8 +18,8 @@ import java.util.regex.Pattern;
 public class DataPrepperVersion {
     private static final String FULL_FORMAT = "%d.%d";
     private static final String SHORTHAND_FORMAT = "%d";
-    private static final String VERSION_PATTERN_STRING = "^((\\d+)(\\.(\\d+))?(\\.(\\d+))?)(-SNAPSHOT)?$";
-    private static final Pattern VERSION_PATTERN = Pattern.compile(VERSION_PATTERN_STRING);
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^((\\d+)(\\.(\\d+))?)$");
+    private static final Pattern VERSION_FULL_PATTERN = Pattern.compile("^((\\d+)(\\.(\\d+))?(\\.(\\d+))?)(-SNAPSHOT)?$");
     private static final int MAJOR_VERSION_PATTERN_POSITION = 2;
     private static final int MINOR_VERSION_PATTERN_POSITION = 4;
 
@@ -38,14 +38,17 @@ public class DataPrepperVersion {
             final String versionString = ServiceLoader.load(VersionProvider.class).findFirst()
                     .orElseThrow(() -> new RuntimeException("No Data Prepper version available."))
                     .getVersionString();
-            instance = parse(versionString);
+            instance = parse(versionString, VERSION_FULL_PATTERN);
         }
         return instance;
     }
 
     public static DataPrepperVersion parse(final String version) {
+        return parse(version, VERSION_PATTERN);
+    }
 
-        final Matcher result = VERSION_PATTERN.matcher(version);
+    private static DataPrepperVersion parse(final String version, final Pattern versionPattern) {
+        final Matcher result = versionPattern.matcher(version);
         if(result.find()) {
             String major = result.group(MAJOR_VERSION_PATTERN_POSITION);
             final int foundMajorVersion = Integer.parseInt(major);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionIT.java
@@ -19,11 +19,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class DataPrepperVersionIT {
     @Test
     void getCurrentVersion_returns_expected_value_using_Java_SPI() {
-        final String fullDataPrepperVersion = System.getProperty("project.version");
-
         final DataPrepperVersion currentVersion = DataPrepperVersion.getCurrentVersion();
         assertThat(currentVersion, notNullValue());
+
+        final String fullDataPrepperVersion = System.getProperty("project.version");
+        final String[] majorMinorPair = fullDataPrepperVersion.split("\\.");
         assertThat(fullDataPrepperVersion, containsString(currentVersion.toString()));
-        assertThat(currentVersion, equalTo(DataPrepperVersion.parse(fullDataPrepperVersion)));
+        assertThat(currentVersion, equalTo(DataPrepperVersion.parse(majorMinorPair[0] + "." + majorMinorPair[1])));
     }
 }


### PR DESCRIPTION
### Description

A recent commit to parse the version from the Gradle project updated the public `parse()` method to support a full version string. However, this is not an allowable version to parse for the purposes of pipeline configurations. This change fixes that by bringing back the restriction on the public `parse()` method to support only major or major.minor patterns. Only when reading from the version string from the `VersionProvider` do we now allow reading the full version string.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
