### PR TITLE
Increment Office365 request failure metrics on retry

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClient.java
@@ -182,11 +182,11 @@ public class Office365RestClient {
 
                             return new AuditLogsResponse(response.getBody(), nextPageUri);
                         },
-                        authConfig::renewCredentials
+                        authConfig::renewCredentials,
+                        searchRequestsFailedCounter
                 );
             } catch (Exception e) {
                 log.error(NOISY, "Error while fetching audit logs for content type {}", contentType, e);
-                searchRequestsFailedCounter.increment();
                 throw new RuntimeException("Failed to fetch audit logs", e);
             }
         });
@@ -216,12 +216,11 @@ public class Office365RestClient {
                             new HttpEntity<>(headers),
                             String.class
                     ).getBody();
-                }, authConfig::renewCredentials);
+                }, authConfig::renewCredentials, auditLogRequestsFailedCounter);
                 auditLogRequestsSuccessCounter.increment();
                 return response;
             } catch (Exception e) {
                 log.error(NOISY, "Error while fetching audit log content from URI: {}", contentUri, e);
-                auditLogRequestsFailedCounter.increment();
                 throw new RuntimeException("Failed to fetch audit log", e);
             }
         });


### PR DESCRIPTION
### Description
Increment Office365 request failure count metrics on retry.

This will give users better visibility into the total number of request failures, rather than incrementing once after 6 retries
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
