### PR TITLE
Migrate Bitnami Zookeeper and Kafka Docker Images

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/kraft/docker-compose.yml
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/kraft/docker-compose.yml
@@ -6,7 +6,7 @@ version: "2"
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:3.5.1
+    image: docker.io/bitnamilegacy/kafka:3.5.1
     ports:
       - "9092:9092"
     volumes:

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/kraft/sasl-scram/docker-compose.yml
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/kraft/sasl-scram/docker-compose.yml
@@ -6,7 +6,7 @@ version: "2"
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: docker.io/bitnamilegacy/kafka:${KAFKA_VERSION}
     ports:
       - "9092:9092"
     environment:

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/zookeeper/docker-compose.yml
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/zookeeper/docker-compose.yml
@@ -6,14 +6,14 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.9
+    image: docker.io/bitnamilegacy/zookeeper:3.9
     ports:
       - "2181:2181"
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: docker.io/bitnamilegacy/kafka:${KAFKA_VERSION}
     ports:
       - "9092:9092"
     environment:

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/zookeeper/sasl-plaintext/docker-compose.yml
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/resources/kafka/zookeeper/sasl-plaintext/docker-compose.yml
@@ -6,14 +6,14 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.9
+    image: docker.io/bitnamilegacy/zookeeper:3.9
     ports:
       - "2181:2181"
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: docker.io/bitnamilegacy/kafka:${KAFKA_VERSION}
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
### Description
Broadcom discontinued support of non-secured Docker images used in the integration tests. They were moved to the bitnamilegacy repository. This PR changes the images accordingly.

Eventually the images should be replaced by supported images as there is no further updates on the images. The images were not changed to avoid conflicts that might arise using other images.
 
### Issues Resolved
#6057 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
