### PR TITLE
M365 error type metric names

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClient.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClient.java
@@ -56,7 +56,7 @@ public class Office365CrawlerClient implements CrawlerClient<DimensionalTimeSlic
     private static final String BUFFER_WRITE_RETRY_SUCCESS = "bufferWriteRetrySuccess";
     private static final String BUFFER_WRITE_RETRY_ATTEMPTS = "bufferWriteRetryAttempts";
     private static final String BUFFER_WRITE_FAILURES = "bufferWriteFailures";
-    private static final String TOTAL_FAILURES = "totalFailures";
+    private static final String REQEUEST_ERRORS = "requestErrors";
     private static final int BUFFER_TIMEOUT_IN_SECONDS = 10;
     private static final String CONTENT_ID = "contentId";
     private static final String CONTENT_URI = "contentUri";
@@ -69,7 +69,7 @@ public class Office365CrawlerClient implements CrawlerClient<DimensionalTimeSlic
     private final Counter bufferWriteRetrySuccessCounter;
     private final Counter bufferWriteRetryAttemptsCounter;
     private final Counter bufferWriteFailuresCounter;
-    private final Counter totalFailuresCounter;
+    private final Counter requestErrorsCounter;
     private ObjectMapper objectMapper;
 
     public Office365CrawlerClient(final Office365Service service,
@@ -86,7 +86,7 @@ public class Office365CrawlerClient implements CrawlerClient<DimensionalTimeSlic
         this.bufferWriteRetrySuccessCounter = pluginMetrics.counter(BUFFER_WRITE_RETRY_SUCCESS);
         this.bufferWriteRetryAttemptsCounter = pluginMetrics.counter(BUFFER_WRITE_RETRY_ATTEMPTS);
         this.bufferWriteFailuresCounter = pluginMetrics.counter(BUFFER_WRITE_FAILURES);
-        this.totalFailuresCounter = pluginMetrics.counter(TOTAL_FAILURES);
+        this.requestErrorsCounter = pluginMetrics.counter(REQEUEST_ERRORS);
     }
 
     @VisibleForTesting
@@ -160,7 +160,7 @@ public class Office365CrawlerClient implements CrawlerClient<DimensionalTimeSlic
         } catch (Exception e) {
             log.error(NOISY, "Failed to process partition for log type {} from {} to {}",
                     logType, startTime, endTime, e);
-            totalFailuresCounter.increment();
+            requestErrorsCounter.increment();
             throw e;
         }
     }

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/utils/MetricsHelper.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/utils/MetricsHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.microsoft_office365.utils;
+
+import io.micrometer.core.instrument.Counter;
+import org.springframework.http.HttpStatus;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import java.util.Map;
+import java.util.HashMap;
+/**
+ * The MetricsHelper class.
+ */
+public class MetricsHelper {
+
+    // specific retryable/non-retryable metric names
+    private static final String REQUEST_ACCESS_DENIED  = "requestAccessDenied";
+    private static final String REQUEST_THROTTLED = "requestThrottled";
+    private static final String RESOURCE_NOT_FOUND = "resourceNotFound";
+
+    /**
+     * Get the metric counter map for specific errorType
+     * FORBIDDEN/UNAUTHORIZED = requestAccessDenied
+     * TOO_MANY_REQUESTS = requestThrottled
+     * NOT_FOUND = resourceNotFound
+     * @param pluginMetrics - metric object class to initialize metric counters
+     * 
+     * @return errorTypeMetricCounterMap 
+    */
+    public static Map<String, Counter> getErrorTypeMetricCounterMap(PluginMetrics pluginMetrics) {
+        Map<String, Counter> errorTypeMetricCounterMap = new HashMap<>();
+        errorTypeMetricCounterMap.put(HttpStatus.FORBIDDEN.getReasonPhrase(), pluginMetrics.counter(REQUEST_ACCESS_DENIED));
+        errorTypeMetricCounterMap.put(HttpStatus.UNAUTHORIZED.getReasonPhrase(), pluginMetrics.counter(REQUEST_ACCESS_DENIED));
+        errorTypeMetricCounterMap.put(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(), pluginMetrics.counter(REQUEST_THROTTLED));
+        errorTypeMetricCounterMap.put(HttpStatus.NOT_FOUND.getReasonPhrase(), pluginMetrics.counter(RESOURCE_NOT_FOUND));
+        return errorTypeMetricCounterMap;
+    }
+
+    /**
+     * Increment the errorType metric if it exists in errorTypeMetricCounterMap
+     * Should only be the following: 
+     * FORBIDDEN/UNAUTHORIZED = requestAccessDenied
+     * TOO_MANY_REQUESTS = requestThrottled
+     * NOT_FOUND = resourceNotFound
+     * 
+     * @param errorType - the httpStatusCode string represenation 
+     * @param errorTypeMetricCounterMap - the map of errorType to metric counter
+    */
+    public static void publishErrorTypeMetricCounter(String errorType, Map<String, Counter> errorTypeMetricCounterMap) {
+        if (errorTypeMetricCounterMap != null && errorTypeMetricCounterMap.containsKey(errorType)) {
+            errorTypeMetricCounterMap.get(errorType).increment();
+        }
+    }
+}

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClientTest.java
@@ -153,8 +153,8 @@ class Office365CrawlerClientTest {
         client.injectObjectMapper(mockObjectMapper);
 
          // Mock the total failures counter
-        Counter mockTotalFailuresCounter = mock(Counter.class);
-        when(pluginMetrics.counter("totalFailures")).thenReturn(mockTotalFailuresCounter);
+        Counter mockRequestErrorsCounter = mock(Counter.class);
+        when(pluginMetrics.counter("requestErrors")).thenReturn(mockRequestErrorsCounter);
 
         AuditLogsResponse response = new AuditLogsResponse(
                 Arrays.asList(Map.of(
@@ -181,7 +181,7 @@ class Office365CrawlerClientTest {
         client.executePartition(state, buffer, acknowledgementSet);
 
         verify(buffer).writeAll(argThat(list -> list.isEmpty()), anyInt());
-        verify(mockTotalFailuresCounter, never()).increment();
+        verify(mockRequestErrorsCounter, never()).increment();
     }
 
     @Test
@@ -317,8 +317,8 @@ class Office365CrawlerClientTest {
     @Test
     void testExecutePartitionWithSearchAuditLogsError() throws Exception {
         // Mock the total failures counter before creating the client
-        Counter mockTotalFailuresCounter = mock(Counter.class);
-        when(pluginMetrics.counter("totalFailures")).thenReturn(mockTotalFailuresCounter);
+        Counter mockRequestErrorsCounter = mock(Counter.class);
+        when(pluginMetrics.counter("requestErrors")).thenReturn(mockRequestErrorsCounter);
 
         Office365CrawlerClient client = new Office365CrawlerClient(service, sourceConfig, pluginMetrics);
 
@@ -336,6 +336,6 @@ class Office365CrawlerClientTest {
 
         // Verify exception message and counter increment
         assertEquals("Search audit logs failed", exception.getMessage());
-        verify(mockTotalFailuresCounter).increment();
+        verify(mockRequestErrorsCounter).increment();
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClientTest.java
@@ -30,7 +30,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;


### PR DESCRIPTION
### Description
** What **

Emitting specific metric names for certain httpStatusCode to give us better visibility into the system.

 * FORBIDDEN/UNAUTHORIZED = requestAccessDenied
 * TOO_MANY_REQUESTS = requestThrottled
 * NOT_FOUND = resourceNotFound

### Issues Resolved
N/A
 
### Check List
- [ x ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
