### PR TITLE
Fix unsatisfied dependency issue in leaderOnlyTokenCrawler

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/LeaderOnlyTokenCrawlerClient.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/LeaderOnlyTokenCrawlerClient.java
@@ -14,7 +14,7 @@ import java.util.List;
  * This interface adds additional method for direct buffer writing,
  * optimized for single-leader processing without worker partitions.
  */
-public interface LeaderOnlyTokenCrawlerClient extends TokenCrawlerClient<PaginationCrawlerWorkerProgressState> {
+public interface LeaderOnlyTokenCrawlerClient<T extends SaasWorkerProgressState> extends TokenCrawlerClient<PaginationCrawlerWorkerProgressState> {
     /**
      * Writes a batch of items directly to the buffer.
      *


### PR DESCRIPTION
### Description
Crawler plugins are failing to startup due to autowiring setup:
```
2025-11-01T18:08:01.350 [main] ERROR org.opensearch.dataprepper.core.validation.LoggingPluginErrorsHandler - 1. pipeline.source.microsoft_office365: caused by: Error creating bean with name 'leaderOnlyTokenCrawler' defined in URL [jar:file:/opt/amazon/lib/source-crawler-2.x.893.jar!/org/opensearch/dataprepper/plugins/source/source_crawler/base/LeaderOnlyTokenCrawler.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.opensearch.dataprepper.plugins.source.source_crawler.base.LeaderOnlyTokenCrawlerClient' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: 
{}
 caused by: No qualifying bean of type 'org.opensearch.dataprepper.plugins.source.source_crawler.base.LeaderOnlyTokenCrawlerClient' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: 
{}
```

CrawlerSourcePlugin uses the packagesToScan annotation which includes CrawlerApplicationContextMarker.class. This likely causes Spring to scan and try to autowire beans like  LeaderOnlyTokenCrawlerClient from the source_crawler package even when there is no bean instantiated

Casting as LeaderOnlyTokenCrawlerClient will prevent Spring from autowiring LeaderOnlyTokenCrawlerClient as a dependency of crawler plugins which do not require it
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
