### PR TITLE
Use the STS region for the default AWS configuration when it is provided

### DIFF
--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -81,7 +81,7 @@ class CredentialsProviderFactory {
 
         LOG.debug("Creating new AwsCredentialsProvider with role {}.", stsRoleArn);
 
-        final Region region = credentialsOptions.getRegion() == null ? defaultStsConfiguration.getAwsRegion() : credentialsOptions.getRegion();
+        final Region region = defaultStsConfiguration.getAwsRegion() != null ? defaultStsConfiguration.getAwsRegion() : credentialsOptions.getRegion();
 
         final StsClient stsClient = createStsClient(region);
 


### PR DESCRIPTION
### Description

Use the STS region from the default AWS configuration when it is provided. This effectively changes the behavior to use the default designed region for STS. This allows for improved cross-region support by assuming Data Prepper is running in the default region and allowing per-plugin configuration of the region for the service endpoints while still using the current STS region.
 
### Issues Resolved

Resolves #6068
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
