### PR TITLE
Adjust CWL Sink Threshold to allow minimal 10 second flush interval

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ThresholdConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/ThresholdConfig.java
@@ -44,7 +44,7 @@ public class ThresholdConfig {
     private ByteCount maxRequestSize = DEFAULT_MAX_REQUEST_SIZE;
 
     @JsonProperty("flush_interval")
-    @DurationMin(seconds = 60)
+    @DurationMin(seconds = 10)
     @DurationMax(seconds = 3600)
     private Duration flushInterval = Duration.ofSeconds(DEFAULT_FLUSH_INTERVAL);
 


### PR DESCRIPTION
### Description

**What?**

This commit updates CWL sink minimal allowed flush interval from 60s to 10s.

**Why?**

CWL is a high TPS dataplane service with small batch of events. It is reasonable to allow shorter flush interval to improve the ingestion latency
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [] New functionality includes testing.
- [] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
