### PR TITLE
Added API metrics to SQS common worker

### DIFF
--- a/data-prepper-plugins/sqs-source/build.gradle
+++ b/data-prepper-plugins/sqs-source/build.gradle
@@ -7,6 +7,22 @@ plugins {
     id 'java'
 }
 
+sourceSets {
+    integrationTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integrationTest/java')
+        }
+        resources.srcDir file('src/integrationTest/resources')
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:buffer-common')
@@ -23,7 +39,20 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
+    integrationTestImplementation 'io.micrometer:micrometer-registry-prometheus'
 }
+
 test {
     useJUnitPlatform()
+}
+
+task integrationTest(type: Test) {
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    useJUnitPlatform()
+
+    filter {
+        includeTestsMatching '*IT'
+    }
 }

--- a/data-prepper-plugins/sqs-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/sqs/SqsMetricsIT.java
+++ b/data-prepper-plugins/sqs-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/sqs/SqsMetricsIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.sqs;
+
+import com.linecorp.armeria.client.retry.Backoff;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.plugins.source.sqs.common.SqsWorkerCommon;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SqsMetricsIT {
+    private SqsClient sqsClient;
+    private SqsWorkerCommon sqsWorkerCommon;
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        Metrics.addRegistry(prometheusMeterRegistry);
+
+        sqsClient = SqsClient.builder()
+                .region(Region.US_EAST_1)
+                .build();
+
+        final Backoff backoff = mock(Backoff.class);
+        final AcknowledgementSetManager acknowledgementSetManager = mock(AcknowledgementSetManager.class);
+        PluginMetrics pluginMetrics = PluginMetrics.fromNames("sqs_source", "test_pipeline");
+        sqsWorkerCommon = new SqsWorkerCommon(backoff, pluginMetrics, acknowledgementSetManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Metrics.removeRegistry(prometheusMeterRegistry);
+        prometheusMeterRegistry.close();
+    }
+
+    @Test
+    void testSqsWorkerFailureEmitsPrometheusMetrics() {
+        String nonExistentQueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789012/non-existent-queue";
+        
+        try {
+            sqsWorkerCommon.pollSqsMessages(nonExistentQueueUrl, sqsClient, 10, null, null);
+        } catch (Exception ignored) {
+        }
+
+        String prometheusMetrics = prometheusMeterRegistry.scrape();
+        
+        // Should increment queue not found metric for non-existent queue
+        assertThat("Queue not found metric should be incremented", 
+                getMetricValue(prometheusMetrics, "test_pipeline_sqs_source_sqsQueueNotFound_total"), equalTo(1.0));
+        assertThat("Access denied metric should be zero", 
+                getMetricValue(prometheusMetrics, "test_pipeline_sqs_source_sqsMessagesAccessDenied_total"), equalTo(0.0));
+        assertThat("Throttled metric should be zero", 
+                getMetricValue(prometheusMetrics, "test_pipeline_sqs_source_sqsMessagesThrottled_total"), equalTo(0.0));
+    }
+
+    private double getMetricValue(String prometheusMetrics, String metricName) {
+        String[] lines = prometheusMetrics.split("\n");
+        for (String line : lines) {
+            if (line.startsWith(metricName + " ")) {
+                return Double.parseDouble(line.split(" ")[1]);
+            }
+        }
+        return 0.0;
+    }
+}


### PR DESCRIPTION
### Description
- Added SQS API metrics to match S3 metrics.
- Added integration tests to ensure values are expected when doing remote calls.
- Reasoning for the differently catch exceptions can be inspected here: https://github.com/aws/api-models-aws/blob/f622f1d5f018e4617cdc14766c3113b6a960703a/models/sqs/service/2012-11-05/sqs-2012-11-05.json

tl;dr; AWS SQS emits some of their exceptions without the matching HTTP code. As we want to generate an aggregate version of these exceptions, we have to explicitly catch the type alongside the status code for the ones that leverage the status code (i.e. InvalidAddressException).
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
- [-] New functionality has a documentation issue. Please link to it in this PR.
  - [-] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
