### PR TITLE
Get last shard iterator at sequence number for closed shards

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/state/LeaderProgressState.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/state/LeaderProgressState.java
@@ -27,4 +27,5 @@ public class LeaderProgressState {
     public void setStreamArns(List<String> streamArns) {
         this.streamArns = streamArns;
     }
+
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
@@ -362,5 +362,4 @@ public class LeaderScheduler implements Runnable {
         ExportPartition exportPartition = new ExportPartition(tableArn, exportTime, Optional.of(exportProgressState));
         coordinator.createPartition(exportPartition);
     }
-
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -86,11 +86,11 @@ public class ShardConsumerFactory {
             // If ending sequence number is present, get the shardIterator for last record
             String endingSequenceNumber = progressState.get().getEndingSequenceNumber();
             if (endingSequenceNumber != null && !endingSequenceNumber.isEmpty()) {
-                lastShardIterator = getShardIterator(streamPartition.getStreamArn(), streamPartition.getShardId(), endingSequenceNumber);
+                lastShardIterator = getShardIterator(streamPartition.getStreamArn(), streamPartition.getShardId(), endingSequenceNumber, ShardIteratorType.AT_SEQUENCE_NUMBER);
             }
         }
 
-        String shardIterator = getShardIterator(streamPartition.getStreamArn(), streamPartition.getShardId(), sequenceNumber);
+        String shardIterator = getShardIterator(streamPartition.getStreamArn(), streamPartition.getShardId(), sequenceNumber, ShardIteratorType.AFTER_SEQUENCE_NUMBER);
         if (shardIterator == null) {
             LOG.error("Failed to start consuming shard '{}'. Unable to get a shard iterator for this shard, this shard may have expired", streamPartition.getShardId());
             return null;
@@ -136,7 +136,7 @@ public class ShardConsumerFactory {
      * @param sequenceNumber The last Sequence Number processed if any
      * @return A shard iterator.
      */
-    public String getShardIterator(String streamArn, String shardId, String sequenceNumber) {
+    public String getShardIterator(String streamArn, String shardId, String sequenceNumber, ShardIteratorType shardIteratorType) {
         LOG.debug("Get Initial Shard Iter for {}", shardId);
         GetShardIteratorRequest getShardIteratorRequest;
 
@@ -145,7 +145,7 @@ public class ShardConsumerFactory {
             getShardIteratorRequest = GetShardIteratorRequest.builder()
                     .shardId(shardId)
                     .streamArn(streamArn)
-                    .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
+                    .shardIteratorType(shardIteratorType)
                     .sequenceNumber(sequenceNumber)
                     .build();
         } else {


### PR DESCRIPTION
### Description
This change fixes a potential data loss scenario where shards can be skipped completely on this condition in ShardConsumer (https://github.com/opensearch-project/data-prepper/blob/4b4febc810097aab82c7effe224ab96f212ab928/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java#L410). This data loss can happen if the partitions for the shards are created in source coordination after the shard has already closed (in the case that a child shard is already closed by the time data prepper fully processes the parent shard).
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
