### PR TITLE
Address typo and improve publishErrorTypeMetricCounter function

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClient.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClient.java
@@ -42,7 +42,7 @@ import java.util.Iterator;
 import java.util.concurrent.TimeoutException;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
-import static org.opensearch.dataprepper.plugins.source.source_crawler.utils.MetricsHelper.REQEUEST_ERRORS;
+import static org.opensearch.dataprepper.plugins.source.source_crawler.utils.MetricsHelper.REQUEST_ERRORS;
 
 /**
  * Implementation of CrawlerClient for Office 365 audit logs.
@@ -86,7 +86,7 @@ public class Office365CrawlerClient implements CrawlerClient<DimensionalTimeSlic
         this.bufferWriteRetrySuccessCounter = pluginMetrics.counter(BUFFER_WRITE_RETRY_SUCCESS);
         this.bufferWriteRetryAttemptsCounter = pluginMetrics.counter(BUFFER_WRITE_RETRY_ATTEMPTS);
         this.bufferWriteFailuresCounter = pluginMetrics.counter(BUFFER_WRITE_FAILURES);
-        this.requestErrorsCounter = pluginMetrics.counter(REQEUEST_ERRORS);
+        this.requestErrorsCounter = pluginMetrics.counter(REQUEST_ERRORS);
     }
 
     @VisibleForTesting

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClient.java
@@ -26,7 +26,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.http.HttpStatus;
 
 import javax.inject.Named;
 import java.nio.charset.StandardCharsets;
@@ -142,17 +141,8 @@ public class Office365RestClient {
                     }
                 }, authConfig::renewCredentials);
             }
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            HttpStatus statusCode = e.getStatusCode();
-            publishErrorTypeMetricCounter(statusCode.getReasonPhrase(), this.errorTypeMetricCounterMap);
-            log.error(NOISY, "Failed to initialize subscriptions with status code {}: {}",
-                    statusCode, e.getMessage());
-            throw new RuntimeException("Failed to initialize subscriptions: " + e.getMessage(), e);
         } catch (Exception e) {
-            // FORBIDDEN throws SecurityException in RetryHandler
-            if (e instanceof SecurityException) {
-                publishErrorTypeMetricCounter(HttpStatus.FORBIDDEN.getReasonPhrase(), this.errorTypeMetricCounterMap);
-            }
+            publishErrorTypeMetricCounter(e, this.errorTypeMetricCounterMap);
             log.error(NOISY, "Failed to initialize subscriptions", e);
             throw new RuntimeException("Failed to initialize subscriptions: " + e.getMessage(), e);
         }
@@ -214,16 +204,8 @@ public class Office365RestClient {
                         authConfig::renewCredentials,
                         searchRequestsFailedCounter
                 );
-            } catch (HttpClientErrorException | HttpServerErrorException e) {
-                HttpStatus statusCode = e.getStatusCode();
-                publishErrorTypeMetricCounter(statusCode.getReasonPhrase(), this.errorTypeMetricCounterMap);
-                log.error(NOISY, "Error while fetching audit logs for content type {}", contentType, e);
-                throw new RuntimeException("Failed to fetch audit logs", e);
             } catch (Exception e) {
-                // FORBIDDEN throws SecurityException in RetryHandler
-                if (e instanceof SecurityException) {
-                    publishErrorTypeMetricCounter(HttpStatus.FORBIDDEN.getReasonPhrase(), this.errorTypeMetricCounterMap);
-                }
+                publishErrorTypeMetricCounter(e, this.errorTypeMetricCounterMap);
                 log.error(NOISY, "Error while fetching audit logs for content type {}", contentType, e);
                 throw new RuntimeException("Failed to fetch audit logs", e);
             }
@@ -265,16 +247,8 @@ public class Office365RestClient {
                 }, authConfig::renewCredentials, auditLogRequestsFailedCounter);
                 auditLogRequestsSuccessCounter.increment();
                 return response;
-            } catch (HttpClientErrorException | HttpServerErrorException e) {
-                HttpStatus statusCode = e.getStatusCode();
-                publishErrorTypeMetricCounter(statusCode.getReasonPhrase(), this.errorTypeMetricCounterMap);
-                log.error(NOISY, "Error while fetching audit log content from URI: {}", contentUri, e);
-                throw new RuntimeException("Failed to fetch audit log", e);
             } catch (Exception e) {
-                // FORBIDDEN throws SecurityException in RetryHandler
-                if (e instanceof SecurityException) {
-                    publishErrorTypeMetricCounter(HttpStatus.FORBIDDEN.getReasonPhrase(), this.errorTypeMetricCounterMap);
-                }
+                publishErrorTypeMetricCounter(e, this.errorTypeMetricCounterMap);
                 log.error(NOISY, "Error while fetching audit log content from URI: {}", contentUri, e);
                 throw new RuntimeException("Failed to fetch audit log", e);
             }

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365CrawlerClientTest.java
@@ -57,6 +57,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 
+import static org.opensearch.dataprepper.plugins.source.source_crawler.utils.MetricsHelper.REQUEST_ERRORS;
+
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class Office365CrawlerClientTest {
@@ -154,7 +156,7 @@ class Office365CrawlerClientTest {
 
          // Mock the total failures counter
         Counter mockRequestErrorsCounter = mock(Counter.class);
-        when(pluginMetrics.counter("requestErrors")).thenReturn(mockRequestErrorsCounter);
+        when(pluginMetrics.counter(REQUEST_ERRORS)).thenReturn(mockRequestErrorsCounter);
 
         AuditLogsResponse response = new AuditLogsResponse(
                 Arrays.asList(Map.of(
@@ -318,7 +320,7 @@ class Office365CrawlerClientTest {
     void testExecutePartitionWithSearchAuditLogsError() throws Exception {
         // Mock the total failures counter before creating the client
         Counter mockRequestErrorsCounter = mock(Counter.class);
-        when(pluginMetrics.counter("requestErrors")).thenReturn(mockRequestErrorsCounter);
+        when(pluginMetrics.counter(REQUEST_ERRORS)).thenReturn(mockRequestErrorsCounter);
 
         Office365CrawlerClient client = new Office365CrawlerClient(service, sourceConfig, pluginMetrics);
 

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/MetricsHelper.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/MetricsHelper.java
@@ -13,8 +13,11 @@ package org.opensearch.dataprepper.plugins.source.source_crawler.utils;
 import io.micrometer.core.instrument.Counter;
 import org.springframework.http.HttpStatus;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.HashMap;
 /**
  * The MetricsHelper class.
@@ -27,7 +30,7 @@ public class MetricsHelper {
     private static final String RESOURCE_NOT_FOUND = "resourceNotFound";
 
     // other errors in crawlerClient
-    public static final String REQEUEST_ERRORS = "requestErrors";
+    public static final String REQUEST_ERRORS = "requestErrors";
 
     /**
      * Get the metric counter map for specific errorType
@@ -54,12 +57,27 @@ public class MetricsHelper {
      * TOO_MANY_REQUESTS = requestThrottled
      * NOT_FOUND = resourceNotFound
      * 
-     * @param errorType - the httpStatusCode string represenation 
+     * @param ex - exception from RestClient
      * @param errorTypeMetricCounterMap - the map of errorType to metric counter
     */
-    public static void publishErrorTypeMetricCounter(String errorType, Map<String, Counter> errorTypeMetricCounterMap) {
-        if (errorTypeMetricCounterMap != null && errorTypeMetricCounterMap.containsKey(errorType)) {
-            errorTypeMetricCounterMap.get(errorType).increment();
+    public static void publishErrorTypeMetricCounter(Exception ex, Map<String, Counter> errorTypeMetricCounterMap) {
+        Optional<String> statusCode = Optional.empty();
+        if (ex instanceof HttpClientErrorException) {
+            HttpClientErrorException httpE = (HttpClientErrorException) ex;
+            statusCode = Optional.ofNullable(httpE.getStatusCode().getReasonPhrase());
+        } else if (ex instanceof HttpServerErrorException) {
+            HttpServerErrorException httpE = (HttpServerErrorException) ex;
+            statusCode = Optional.ofNullable(httpE.getStatusCode().getReasonPhrase());
+        } else if (ex instanceof SecurityException) { // FORBIDDEN throws SecurityException in RetryHandler
+            statusCode = Optional.ofNullable(HttpStatus.FORBIDDEN.getReasonPhrase());
+        } // ignore for others
+
+        if (statusCode.isPresent()) {
+            String errorType = statusCode.get();
+            if (errorTypeMetricCounterMap != null && errorTypeMetricCounterMap.containsKey(errorType)) {
+                errorTypeMetricCounterMap.get(errorType).increment();
+            }
         }
+
     }
 }


### PR DESCRIPTION
### Description
Address typo and improve publishErrorTypeMetricCounter function.

* Typo in REQEUEST_ERRORS -> REQUEST_ERRORS
* Update `publishErrorTypeMetricCounter` to take exception directly and determine if metric should be emitted or not. Saves us one catch block in RestClient class.

### Testing

```
./gradlew :data-prepper-plugins:saas-source-plugins:microsoft-office365-source:test \
--tests "org.opensearch.dataprepper.plugins.source.microsoft_office365.Office365CrawlerClientTest"

./gradlew :data-prepper-plugins:saas-source-plugins:microsoft-office365-source:test \
--tests "org.opensearch.dataprepper.plugins.source.microsoft_office365.Office365RestClientTest"

./gradlew :data-prepper-plugins:saas-source-plugins:microsoft-office365-source:checkstyleTest  

```
 
### Issues Resolved
N/A
 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
