### PR TITLE
Add read failure metric to S3 source

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectPluginMetrics.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectPluginMetrics.java
@@ -13,6 +13,7 @@ public class S3ObjectPluginMetrics {
     static final String S3_OBJECTS_SIZE_PROCESSED = "s3ObjectProcessedBytes";
     static final String S3_OBJECTS_FAILED_METRIC_NAME = "s3ObjectsFailed";
     static final String S3_OBJECTS_DELETE_FAILED_METRIC_NAME = "s3ObjectsDeleteFailed";
+    static final String S3_OBJECTS_READ_FAILED_METRIC_NAME = "s3ObjectReadFailed";
     static final String S3_OBJECTS_SUCCEEDED_METRIC_NAME = "s3ObjectsSucceeded";
     static final String S3_OBJECTS_EVENTS = "s3ObjectsEvents";
     static final String S3_OBJECTS_FAILED_NOT_FOUND_METRIC_NAME = "s3ObjectsNotFound";
@@ -33,6 +34,7 @@ public class S3ObjectPluginMetrics {
     private final Counter s3ObjectNoRecordsFound;
 
     private final Counter s3ObjectsDeleteFailed;
+    private final Counter s3ObjectReadFailedCounter;
 
     public S3ObjectPluginMetrics(final PluginMetrics pluginMetrics){
         s3ObjectsFailedCounter = pluginMetrics.counter(S3_OBJECTS_FAILED_METRIC_NAME);
@@ -46,6 +48,7 @@ public class S3ObjectPluginMetrics {
         s3ObjectEventsSummary = pluginMetrics.summary(S3_OBJECTS_EVENTS);
         s3ObjectNoRecordsFound = pluginMetrics.counter(S3_OBJECTS_NO_RECORDS_FOUND);
         s3ObjectsDeleteFailed = pluginMetrics.counter(S3_OBJECTS_DELETE_FAILED_METRIC_NAME);
+        s3ObjectReadFailedCounter = pluginMetrics.counter(S3_OBJECTS_READ_FAILED_METRIC_NAME);
     }
 
     public Counter getS3ObjectsFailedCounter() {
@@ -89,4 +92,6 @@ public class S3ObjectPluginMetrics {
     }
 
     public Counter getS3ObjectsDeleteFailed() { return s3ObjectsDeleteFailed; }
+
+    public Counter getS3ObjectReadFailedCounter() { return s3ObjectReadFailedCounter; }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
@@ -155,10 +155,15 @@ class S3ObjectWorker implements S3ObjectHandler {
             final CompressionOption fileCompressionOption = compressionOption != CompressionOption.AUTOMATIC ?
                     compressionOption : CompressionOption.fromFileName(s3ObjectReference.getKey());
 
-            codec.parse(inputFile, fileCompressionOption.getDecompressionEngine(), record -> {
-                consumer.accept(record, dataSelection);
-            });
-            return inputFile.getLength();
+            try {
+                codec.parse(inputFile, fileCompressionOption.getDecompressionEngine(), record -> {
+                    consumer.accept(record, dataSelection);
+                });
+                return inputFile.getLength();
+            } catch (final Exception e) {
+                s3ObjectPluginMetrics.getS3ObjectReadFailedCounter().increment();
+                throw new S3ReadFailedException(e);
+            }
         }
     }
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ReadFailedException.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ReadFailedException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.s3;
+
+/**
+ * Exception thrown when there is a failure reading from S3 objects.
+ * This is used to distinguish actual S3 read failures from other processing failures.
+ */
+public class S3ReadFailedException extends RuntimeException {
+    public S3ReadFailedException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectPluginMetricsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectPluginMetricsTest.java
@@ -46,5 +46,6 @@ public class S3ObjectPluginMetricsTest {
         assertThat(metrics.getS3ObjectsFailedAccessDeniedCounter(),sameInstance(counter));
         assertThat(metrics.getS3ObjectsFailedNotFoundCounter(),sameInstance(counter));
         assertThat(metrics.getS3ObjectsThrottledCounter(),sameInstance(counter));
+        assertThat(metrics.getS3ObjectReadFailedCounter(),sameInstance(counter));
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3SelectObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3SelectObjectWorkerTest.java
@@ -152,6 +152,7 @@ class S3SelectObjectWorkerTest {
         lenient().when(selectJsonOption.getType()).thenReturn(JSON_LINES_TYPE);
 
         given(s3ObjectRequest.getS3ObjectPluginMetrics()).willReturn(s3ObjectPluginMetrics);
+        lenient().when(s3ObjectPluginMetrics.getS3ObjectReadFailedCounter()).thenReturn(mock(Counter.class));
         bucketOwnerProvider = mock(BucketOwnerProvider.class);
         given(bucketOwnerProvider.getBucketOwner(any(String.class))).willReturn(Optional.of("my-bucket-1"));
         given(s3ObjectRequest.getBucketOwnerProvider()).willReturn(bucketOwnerProvider);


### PR DESCRIPTION
### Description
Adding read failure metric to S3 source for SQS notification and Select scan modes. This metric attempts to catch codec, compression and stream failures that act against the S3 payload retrieved from GetObject.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [-] New functionality has a documentation issue. Please link to it in this PR.
  - [-] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
