### PR TITLE
Add EMF config that enables adding extra properties to the EMF record

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/meter/EMFLoggingMeterRegistry.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/meter/EMFLoggingMeterRegistry.java
@@ -65,12 +65,8 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
     private final Environment environment;
     private static final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(EMFLoggingMeterRegistry.class);
 
-    public EMFLoggingMeterRegistry() {
-        this(new EnvironmentProvider().resolveEnvironment().join());
-    }
-
-    public EMFLoggingMeterRegistry(final Environment environment) {
-        this(EMFLoggingRegistryConfig.DEFAULT, environment, Clock.SYSTEM);
+    public EMFLoggingMeterRegistry(final EMFLoggingRegistryConfig config) {
+        this(config, new EnvironmentProvider().resolveEnvironment().join(), Clock.SYSTEM);
     }
 
     public EMFLoggingMeterRegistry(final EMFLoggingRegistryConfig config, final Environment environment, final Clock clock) {
@@ -124,11 +120,16 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
                 .setNamespace(NAMESPACE)
                 .setTimestamp(timestamp);
         addDimensionSet(tags, metricsLogger);
+        addAdditionalProperties(metricsLogger);
         return metricsLogger;
     }
 
     private void addDimensionSet(final List<Tag> tags, final MetricsLogger metricsLogger) {
         metricsLogger.setDimensions(toDimensionSet(tags));
+    }
+
+    private void addAdditionalProperties(final MetricsLogger metricsLogger) {
+        config.additionalProperties().forEach(metricsLogger::putProperty);
     }
 
     private DimensionSet toDimensionSet(final List<Tag> tags) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/meter/EMFLoggingRegistryConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/meter/EMFLoggingRegistryConfig.java
@@ -7,11 +7,17 @@ package org.opensearch.dataprepper.core.meter;
 
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 
+import java.util.Collections;
+import java.util.Map;
+
 public interface EMFLoggingRegistryConfig extends StepRegistryConfig {
-    EMFLoggingRegistryConfig DEFAULT = k -> null;
 
     @Override
     default String prefix() {
         return "emf";
+    }
+
+    default Map<String, String> additionalProperties() {
+        return Collections.emptyMap();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/config/MetricsConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/config/MetricsConfig.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.opensearch.dataprepper.core.meter.EMFLoggingMeterRegistry;
+import org.opensearch.dataprepper.core.meter.EMFLoggingRegistryConfig;
 import org.opensearch.dataprepper.core.meter.JvmMemoryAggregateMetrics;
 import org.opensearch.dataprepper.core.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.core.parser.model.MetricRegistryType;
@@ -28,10 +29,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+
+import java.util.Map;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -149,7 +153,8 @@ public class MetricsConfig {
     @Bean
     public EMFLoggingMeterRegistry emfLoggingMeterRegistry(final DataPrepperConfiguration dataPrepperConfiguration) {
         if (dataPrepperConfiguration.getMetricRegistryTypes().contains(MetricRegistryType.EmbeddedMetricsFormat)) {
-            final EMFLoggingMeterRegistry meterRegistry = new EMFLoggingMeterRegistry();
+            final EMFLoggingRegistryConfig config = createEMFLoggingRegistryConfig(dataPrepperConfiguration);
+            final EMFLoggingMeterRegistry meterRegistry = new EMFLoggingMeterRegistry(config);
             configureMetricRegistry(
                     dataPrepperConfiguration.getMetricTags(), dataPrepperConfiguration.getMetricTagFilters(),
                     dataPrepperConfiguration.getDisabledMetrics(), meterRegistry
@@ -182,6 +187,20 @@ public class MetricsConfig {
         meterBinders.forEach(binder -> binder.bindTo(compositeMeterRegistry));
 
         return compositeMeterRegistry;
+    }
+
+    private EMFLoggingRegistryConfig createEMFLoggingRegistryConfig(final DataPrepperConfiguration dataPrepperConfiguration) {
+        return new EMFLoggingRegistryConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> additionalProperties() {
+                return Collections.unmodifiableMap(dataPrepperConfiguration.getEmfAdditionalProperties());
+            }
+        };
     }
 
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfiguration.java
@@ -56,6 +56,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
     private Map<String, String> metricTags = new HashMap<>();
     private List<MetricTagFilter> metricTagFilters = new LinkedList<>();
     private List<String> disabledMetrics = new LinkedList<>();
+    private EmfConfig emf = new EmfConfig();
     private PeerForwarderConfiguration peerForwarderConfiguration;
     private Duration processorShutdownTimeout;
     private Duration sinkShutdownTimeout;
@@ -93,6 +94,8 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
             final List<MetricTagFilter> metricTagFilters,
             @JsonProperty("disabled_metrics")
             final List<String> disabledMetrics,
+            @JsonProperty("emf_metrics")
+            final EmfConfig emf,
             @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration,
             @JsonProperty("processor_shutdown_timeout")
             @JsonAlias("processorShutdownTimeout")
@@ -126,6 +129,7 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
         setServerPort(serverPort);
         this.peerForwarderConfiguration = peerForwarderConfiguration;
         this.disabledMetrics = disabledMetrics;
+        this.emf = emf != null ? emf : new EmfConfig();
 
         this.processorShutdownTimeout = processorShutdownTimeout != null ? processorShutdownTimeout : DEFAULT_SHUTDOWN_DURATION;
         if (this.processorShutdownTimeout.isNegative()) {
@@ -179,6 +183,10 @@ public class DataPrepperConfiguration implements ExtensionsConfiguration, EventC
 
     public List<String> getDisabledMetrics() {
         return disabledMetrics != null ? disabledMetrics : Collections.emptyList();
+    }
+
+    public Map<String, String> getEmfAdditionalProperties() {
+        return emf.getAdditionalProperties();
     }
 
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/EmfConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/parser/model/EmfConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.core.parser.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EmfConfig {
+    @JsonProperty("additional_properties")
+    private Map<String, String> additionalProperties = new HashMap<>();
+
+    public Map<String, String> getAdditionalProperties() {
+        return additionalProperties;
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/meter/EMFLoggingRegistryConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/meter/EMFLoggingRegistryConfigTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class EMFLoggingRegistryConfigTest {
     @Test
     void testDefault() {
-        final EMFLoggingRegistryConfig objectUnderTest = EMFLoggingRegistryConfig.DEFAULT;
+        final EMFLoggingRegistryConfig objectUnderTest = k -> null;
         assertThat(objectUnderTest.prefix(), equalTo("emf"));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/model/DataPrepperConfigurationTests.java
@@ -275,4 +275,11 @@ public class DataPrepperConfigurationTests {
                 Map.of("test_extension", Map.of("test_attribute", "test_string"))
         ));
     }
+
+    @Test
+    public void testGetEmfAdditionalPropertiesDefault() {
+        final DataPrepperConfiguration dataPrepperConfiguration = new DataPrepperConfiguration();
+        assertThat(dataPrepperConfiguration.getEmfAdditionalProperties(), notNullValue());
+        assertThat(dataPrepperConfiguration.getEmfAdditionalProperties().isEmpty(), equalTo(true));
+    }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/model/EmfConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/model/EmfConfigTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.core.parser.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EmfConfigTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        final EmfConfig emfConfiguration = new EmfConfig();
+        assertThat(emfConfiguration.getAdditionalProperties(), equalTo(Collections.emptyMap()));
+    }
+}


### PR DESCRIPTION
### Description
Adds EMF configuration to the DataPrepper config schema. This config supports adding additional properties to the EMF record by specifying the following in the config:

```yaml
emf:
    additional_properties: 
        test_property: "test_value"
        environment": "integration_test"
```

This will generate an EMF record with the following:

```json
{
  "_aws": {
    "Timestamp": 1762919187031,
    "CloudWatchMetrics": [
      {
        "Namespace": "DataPrepper",
        "Metrics": [
          {"Name": "test-pipeline.s3-source.s3ObjectsFailed.count", "Unit": "Count"},
          // ... other metrics
        ],
        "Dimensions": [[]]
      }
    ]
  },
  "test_property": "test_value",           // ✅ OUR ADDITIONAL PROPERTY!
  "environment": "integration_test",       // ✅ OUR ADDITIONAL PROPERTY!
  "test-pipeline.s3-source.s3ObjectsFailed.count": 1.0,
  "test-pipeline.s3-source.s3ObjectsSucceeded.count": 0.0,
  // ... other metric values
}
```

 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [-] New functionality has a documentation issue. Please link to it in this PR.
  - [-] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
