### PR TITLE
Add metric tracking total number of open shards, stop setting ending sequence number once open shards are discovered

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
@@ -77,7 +77,7 @@ public class DynamoDBService {
         s3Client = clientFactory.buildS3Client();
 
         // A shard manager is responsible to retrieve the shard information from streams.
-        shardManager = new ShardManager(dynamoDbStreamsClient, dynamoDBSourceAggregateMetrics);
+        shardManager = new ShardManager(dynamoDbStreamsClient, dynamoDBSourceAggregateMetrics, pluginMetrics);
         tableConfigs = sourceConfig.getTableConfigs();
         executor = Executors.newFixedThreadPool(4);
     }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
@@ -406,9 +406,9 @@ public class ShardConsumer implements Runnable {
         if (lastShardIterator != null && !lastShardIterator.isEmpty()) {
             GetRecordsResponse response = callGetRecords(lastShardIterator);
             if (response.records().isEmpty()) {
-                // Empty shard
-                LOG.info("LastShardIterator is provided, but there is no Last Event Time, skip processing");
-                return true;
+                // There is no guarantee that the shard is empty just because there is no record at the endingSequenceNumber
+                LOG.info("LastShardIterator is provided, but there is no Last Event Time, paginating through for documents");
+                return false;
             }
 
             Instant lastEventTime = response.records().get(response.records().size() - 1).dynamodb().approximateCreationDateTime();


### PR DESCRIPTION

### Description
Adds a metric `totalOpenShards` as a DistributionSummary that will be reported roughly every 10 minutes. This will show how many shards without an `endingSequenceNumber` are contained in the DynamoDB streams, and is useful to track due to the limitation of each Data Prepper instance only being able to process 150 open shards in parallel.

This change also fixes a data loss scenario where shards could be skipped if there were no records returned in a call to GetRecords using the `endingSequenceNumber` of the shard to check AT_SHARD_ITERATOR if there were any records in the shard, and was incorrectly assuming this meant that shards are 100% empty in this case. Now, instead of assuming the shard is empty, we will paginate fully through it to look for records, and filter out records from before the export or start time. This could result on some extra pagination through shards during and right after the export, but it will not result in duplicate processing due to the filtering based on timestamp.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
