### PR TITLE
Add configurable range parameter to Office 365 source plugin

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/build.gradle
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'javax.inject:javax.inject:1'
     implementation 'org.jsoup:jsoup:1.18.3'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 
     implementation 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365Source.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365Source.java
@@ -49,7 +49,6 @@ public class Office365Source extends CrawlerSourcePlugin {
     private final Office365AuthenticationInterface office365AuthProvider;
     private final Office365Service office365Service;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
-    private static final int OFFICE365_LOOKBACK_HOURS = 0;
 
     @DataPrepperPluginConstructor
     public Office365Source(final PluginMetrics pluginMetrics,
@@ -89,7 +88,7 @@ public class Office365Source extends CrawlerSourcePlugin {
 
     @Override
     protected LeaderProgressState createLeaderProgressState() {
-        return new DimensionalTimeSliceLeaderProgressState(Instant.now(), OFFICE365_LOOKBACK_HOURS);
+        return new DimensionalTimeSliceLeaderProgressState(Instant.now(), office365SourceConfig.getLookBackHours());
     }
 
     @Override

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfig.java
@@ -13,8 +13,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import org.hibernate.validator.constraints.time.DurationMax;
 import org.opensearch.dataprepper.plugins.source.microsoft_office365.auth.AuthenticationConfiguration;
 import org.opensearch.dataprepper.plugins.source.source_crawler.base.CrawlerSourceConfig;
+
+import java.time.Duration;
 
 /**
  * Configuration class for Office 365 source plugin.
@@ -45,6 +48,28 @@ public class Office365SourceConfig implements CrawlerSourceConfig {
      */
     @JsonProperty("acknowledgments")
     private boolean acknowledgments = false;
+
+    /**
+     * Time range for lookback data collection using ISO 8601 duration format.
+     * Specifies how far back in time to collect data from the current time.
+     * Default: null (no lookback, only incremental data)
+     * Maximum: P7D (7 days due to Office 365 API limitation)
+     */
+    @JsonProperty("range")
+    @DurationMax(days = 7, message = "Range cannot exceed 7 days due to Office 365 API limitation")
+    private Duration range;
+
+    /**
+     * Gets the look back range as hours for compatibility with existing crawler framework.
+     *
+     * @return the number of hours to look back, or 0 if no range is specified
+     */
+    public int getLookBackHours() {
+        if (range == null || range.toHours() <= 0) {
+            return 0;
+        }
+        return (int) range.toHours();
+    }
 
     @Override
     public int getNumberOfWorkers() {

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.plugins.source.microsoft_office365.auth.Authen
 import org.opensearch.dataprepper.plugins.source.microsoft_office365.auth.Oauth2Config;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -78,6 +79,7 @@ class Office365SourceConfigTest {
     void testDefaultValues() {
         assertFalse(config.isAcknowledgments());
         assertEquals(4, config.getNumberOfWorkers());
+        assertEquals(0, config.getLookBackHours());
     }
 
     @Test
@@ -90,5 +92,13 @@ class Office365SourceConfigTest {
     void testGetClientSecretValue() {
         String actualClientSecret = (String) config.getAuthenticationConfiguration().getOauth2().getClientSecret().getValue();
         assertEquals(clientSecret, actualClientSecret);
+    }
+
+    @Test
+    void testNegativeDurationRange() throws Exception {
+        Duration negativeDuration = Duration.ofDays(-1);
+        setField(config, "range", negativeDuration);
+
+        assertEquals(0, config.getLookBackHours());
     }
 }


### PR DESCRIPTION
Signed-off-by: Alekhya Parisha <aparisha@amazon.com>

### Description
- Added a new 'range' configuration parameter to the Office 365 source plugin
- The range parameter allows users to specify how far back in time to collect data using ISO 8601 duration format

Example configuration:
```
source:
  office365:
    tenant_id: "your-tenant-id"
    authentication:
      client_id: "your-client-id"
      client_secret: "your-client-secret"
    range: "P4D"  # Collect 4 days of historical data
```
- Aligns with existing patterns in other source plugins (e.g., Okta SSO)

 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
