### PR TITLE
Do not wait for export to exit ShardConsumer for shards that have no records to write to buffer

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
@@ -340,10 +340,6 @@ public class ShardConsumer implements Runnable {
             LOG.warn("Processing for shard {} was interrupted by a shutdown signal, giving up shard", shardId);
             throw new RuntimeException("Consuming shard was interrupted from shutdown");
         }
-
-        if (waitForExport) {
-            waitForExport();
-        }
     }
 
     /**


### PR DESCRIPTION


### Description
This change removes the wait for export that blocks the ShardConsumer from exiting for shards that do not have any records to be written to buffer. Shards that are processed during the export with data to process (data from after the export time) will still block and wait for the export to complete before processing.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
