### PR TITLE
Add lookback time adjustment for Office 365 source plugin partition e…

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/service/Office365Service.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/service/Office365Service.java
@@ -63,11 +63,11 @@ public class Office365Service {
                 return office365RestClient.searchAuditLogs(logType, startTime, endTime, nextPageUri);
             }
 
-            // Check and adjust start time for 7-day limit
+            // Adjust start time based on configured lookback hours
             Instant adjustedStartTime = startTime;
-            Instant sevenDaysAgo = Instant.now().minus(SEVEN_DAYS);
-            if (startTime.isBefore(sevenDaysAgo)) {
-                adjustedStartTime = sevenDaysAgo;
+            Instant lookBackHoursAgo = Instant.now().minus(Duration.ofHours(office365SourceConfig.getLookBackHours()));
+            if (startTime.isBefore(lookBackHoursAgo) && lookBackHoursAgo.isBefore(endTime)) {
+                adjustedStartTime = lookBackHoursAgo;
             }
 
             AuditLogsResponse response =


### PR DESCRIPTION
…xecution

What:
- Added time window adjustment logic in Office365Service to correctly handle configured range parameter
- Ensures exact time window compliance when fetching audit logs

Example time window adjustment:
If current time is 9:30 AM and range is 4 days:
- Crawler creates partition with startTime = 9:00 AM (4 days ago)
- Service adjusts to exact 9:30 AM (4 days ago)
→ Ensures we fetch exactly 4 days of data, not 4 days + 30 minutes

Why:
- The dimensional time slice crawler creates hourly partitions starting from truncated hours
- Without adjustment, we would fetch extra data beyond the configured range
- For example, if current time is 9:30 AM:
  - Crawler starts from 9:00 AM (extra 30 minutes)
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
