### PR TITLE
Implement handling strategy for retryable vs non-retryable exceptons in workerPartition

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365SourceConfigTest.java
@@ -101,4 +101,10 @@ class Office365SourceConfigTest {
 
         assertEquals(0, config.getLookBackHours());
     }
+
+    @Test
+    void testDefaultDurationValues() {
+        assertEquals(Duration.ofDays(30), config.getDurationToGiveUpRetry());
+        assertEquals(Duration.ofDays(1), config.getDurationToDelayRetry());
+    }
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourceConfig.java
@@ -1,11 +1,20 @@
 package org.opensearch.dataprepper.plugins.source.source_crawler.base;
 
+import java.time.Duration;
+
 /**
  * Marker interface to all the SAAS connectors configuration
  */
 public interface CrawlerSourceConfig {
 
     int DEFAULT_NUMBER_OF_WORKERS = 1;
+
+    /*
+     * Retry settings for non-retrayble exceptions in workerPartition
+     * default to 30 days to giveup retry; and 1 day to delay retry
+     */
+    Duration DEFAULT_MAX_DURATION_TO_GIVEUP_RETRY = Duration.ofDays(30);
+    Duration DEFAULT_MAX_DURATION_TO_DELAY_RETRY = Duration.ofDays(1);
 
     /**
      * Number of worker threads enabled for this source
@@ -20,4 +29,20 @@ public interface CrawlerSourceConfig {
      * @return boolean indicating acknowledgement state
      */
     boolean isAcknowledgments();
+
+    /**
+     * Duration to give up retrying workerPartition's work on non-retrayble exceptions
+     * @return Duration indicating max duration to give up retrying 
+     */
+    default Duration getDurationToGiveUpRetry() {
+        return DEFAULT_MAX_DURATION_TO_GIVEUP_RETRY;
+    }
+
+    /**
+     * Duration to retry workerPartition's work on non-retrayble exceptions
+     * @return Duration indicating max duration to delay retrying
+     */
+    default Duration getDurationToDelayRetry() {
+        return DEFAULT_MAX_DURATION_TO_DELAY_RETRY;
+    }
 }


### PR DESCRIPTION
### Description

This is second part of the change to handle retryable vs non-retryable excpetions. 

First part PR for more context: https://github.com/opensearch-project/data-prepper/pull/6255

### How

We are adding a new generic exception class `SaaSCrawlerException` to be shared by all connectors. This class is similar to previous API specific exception class (e.g `Office365Exception`). 

CrawlerException will have two criterias:
* Any REST API calls failures will be considered retryable. Additionally, writing to buffer will be considered retryable too. 
* Other exceptions (e.g internal failures) will be considered non-retryable

We will utilize CrawlerException, and throw this up all the way to `WorkerSchedule` where in the followup PR:

* If the exception is flagged as "retryable = true", we will continue with current behaviour of backoff retry every 5ms
* Otherwise, we will delay the retry by 1 day by calling `sourceCoordinator.saveProgressStateForPartition(workerPartition, DURATION_TO_DELAY_RETRY)`. If it continues to fail up to 30 days (using partitionCreationTime field to confirm), we will give up the worker partition. 

### Is this change backward compatible? 

Yes. We ensure to keep the catch block on generic "Exception" so all other connectors will still use the default behaviour of backoff retry every 5ms for all exception types.

### Testing

Unit tests, ran the below successfully:

```
./gradlew :data-prepper-plugins:saas-source-plugins:microsoft-office365-source:test \
--tests "org.opensearch.dataprepper.plugins.source.microsoft_office365.Office365SourceConfigTest"


./gradlew :data-prepper-plugins:saas-source-plugins:source-crawler:test \
--tests "org.opensearch.dataprepper.plugins.source.source_crawler.coordination.scheduler.WorkerSchedulerTest"

./gradlew :data-prepper-plugins:saas-source-plugins:microsoft-office365-source:checkstyleTest  
./gradlew :data-prepper-plugins:saas-source-plugins:source-crawler:checkstyleTest  
```
 
### Issues Resolved

N/A 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
