### PR TITLE
Run the smoke tests against Eclipse Temurin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - image : "openjdk:11"
+          - image : "eclipse-temurin:11"
             archive: opensearch-data-prepper
-          - image : "openjdk:17"
+          - image : "eclipse-temurin:17"
             archive: opensearch-data-prepper
           - image : "ubuntu:latest"
             archive: opensearch-data-prepper-jdk


### PR DESCRIPTION
### Description

The release process was smoke testing against OpenJDK builds. This has been deprecated. This PR builds against Eclipse Temurin instead.
 
### Issues Resolved

N/A

Fixes the 2.13 release build. https://github.com/opensearch-project/data-prepper/actions/runs/19651508923
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
