### PR TITLE
Eclipse Temurin by default in the tarball smoke test and documentation

### DIFF
--- a/release/smoke-tests/README.md
+++ b/release/smoke-tests/README.md
@@ -38,8 +38,8 @@ You can also customize what it tests against. The `-i` parameter specifies a bas
 The values for `-t` are `opensearch-data-prepper` or `opensearch-data-prepper-jdk`.
 
 ```shell
-./release/smoke-tests/run-tarball-files-smoke-tests.sh -i openjdk:11 -t opensearch-data-prepper
-./release/smoke-tests/run-tarball-files-smoke-tests.sh -i openjdk:17 -t opensearch-data-prepper
+./release/smoke-tests/run-tarball-files-smoke-tests.sh -i eclipse-temurin:11 -t opensearch-data-prepper
+./release/smoke-tests/run-tarball-files-smoke-tests.sh -i eclipse-temurin:17 -t opensearch-data-prepper
 ./release/smoke-tests/run-tarball-files-smoke-tests.sh -i ubuntu:latest -t opensearch-data-prepper-jdk
 ```
 

--- a/release/smoke-tests/run-tarball-files-smoke-tests.sh
+++ b/release/smoke-tests/run-tarball-files-smoke-tests.sh
@@ -193,7 +193,7 @@ fi
 
 if ! is_defined "${FROM_IMAGE}"
 then
-    export FROM_IMAGE="openjdk:11"
+    export FROM_IMAGE="eclipse-temurin:11"
 fi
 
 if ! is_defined "${TAR_NAME}"


### PR DESCRIPTION
### Description

Following on #6293, this PR makes two changes to move from OpenJDK Docker images to Eclipse Temurin:

* Use Eclipse Temurin by default
* Update the documentation to suggest using Temurin when running the CLI.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
