### PR TITLE
Adding delete source flag to ListToMapProcessor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -101,6 +101,10 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
                             .log();
                     recordEvent.getMetadata().addTags(config.getTagsOnFailure());
                 }
+
+                if(config.isDeleteSourceRequested()) {
+                    recordEvent.delete(config.getSource());
+                }
             } catch (final Exception e) {
                 LOG.atError()
                         .addMarker(EVENT)

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -65,6 +65,10 @@ public class ListToMapProcessorConfig {
         }
     }
 
+    @JsonProperty
+    @JsonPropertyDescription("If true, the configured <code>source</code> field will be deleted after the JSON data is parsed into separate fields.")
+    private boolean deleteSource = false;
+
     @NotEmpty
     @NotNull
     @JsonProperty("source")
@@ -125,6 +129,10 @@ public class ListToMapProcessorConfig {
         @Example(value = "/some-key == \"test\"", description = "The operation will run when the value of the key is 'test'.")
     })
     private String listToMapWhen;
+
+    public boolean isDeleteSourceRequested() {
+        return deleteSource;
+    }
 
     public String getSource() {
         return source;


### PR DESCRIPTION
Introduced delete source flag for ListToMapProcessor as a memory saving optimization to remove unecessary source keys

### Description
This change allows user to specify a delete source flag in the List To Map processor which will remove the source key after json data is processed into separate fields. This is useful if the user just wants the newly processed data and does not need the original key to be kept.
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

**Documentation issue link:** https://github.com/opensearch-project/documentation-website/issues/11593

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
