### PR TITLE
Enable cross-region writes in the S3 sink.

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ClientFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ClientFactory.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.s3;
@@ -16,33 +20,23 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
-import software.amazon.awssdk.services.s3.S3Client;
 
 public final class ClientFactory {
     private ClientFactory() { }
-
-    static S3Client createS3Client(final S3SinkConfig s3SinkConfig, final AwsCredentialsSupplier awsCredentialsSupplier) {
-        final AwsCredentialsOptions awsCredentialsOptions = convertToCredentialsOptions(s3SinkConfig.getAwsAuthenticationOptions());
-        final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
-
-        return S3Client.builder()
-                .region(s3SinkConfig.getAwsAuthenticationOptions().getAwsRegion())
-                .credentialsProvider(awsCredentialsProvider)
-                .overrideConfiguration(createOverrideConfiguration(s3SinkConfig)).build();
-    }
 
     static S3AsyncClient createS3AsyncClient(final S3SinkConfig s3SinkConfig, final AwsCredentialsSupplier awsCredentialsSupplier) {
         final AwsCredentialsOptions awsCredentialsOptions = convertToCredentialsOptions(s3SinkConfig.getAwsAuthenticationOptions());
         final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
 
-        S3AsyncClientBuilder s3AsyncClientBuilder = S3AsyncClient.builder()
+        final S3AsyncClientBuilder s3AsyncClientBuilder = S3AsyncClient.builder()
                 .region(s3SinkConfig.getAwsAuthenticationOptions().getAwsRegion())
+                .crossRegionAccessEnabled(true)
                 .credentialsProvider(awsCredentialsProvider)
                 .overrideConfiguration(createOverrideConfiguration(s3SinkConfig));
 
         if (s3SinkConfig.getClientOptions() != null) {
             final ClientOptions clientOptions = s3SinkConfig.getClientOptions();
-            SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder()
+            final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder()
                     .connectionAcquisitionTimeout(clientOptions.getAcquireTimeout())
                     .maxConcurrency(clientOptions.getMaxConnections())
                     .build();


### PR DESCRIPTION
### Description

This enables cross-region writes in the S3 sink. This is similar to what we did for the S3 source in #6083, but now works for the sink.

Additionally, we only use the `S3AsyncClient`, so I removed the old code for the sync client and merged the tests. I also updated the copyright headers since I was modifying this file.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
