### PR TITLE
Disabling a DDB source coordination integration test

### DIFF
--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreIT.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreIT.java
@@ -14,6 +14,7 @@ import com.amazonaws.services.dynamodbv2.local.shared.access.AmazonDynamoDBLocal
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +43,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -263,6 +263,7 @@ class DynamoDbSourceCoordinationStoreIT {
         assertThat(getItem.getExpirationTime(), lessThanOrEqualTo(Instant.now().getEpochSecond()));
     }
 
+    @Disabled("This test is flaky on the current version of DynamoDB Local. However, newer versions require JDK 17+.")
     @Test
     void tryAcquireAvailablePartition_gets_first_unassigned_partition() throws InterruptedException {
         final DynamoDbSourceCoordinationStore objectUnderTest = createObjectUnderTest();


### PR DESCRIPTION
### Description

One of our new DDB source coordination integration tests is failing on GitHub. 

I originally tried to fix this by: 1) including a sleep between writing events to ensure that they have different timestamps; and 2) waiting for the GSI to reach eventual consistency.

This is more consistent, but still fails some. Instead, I'm disabling these tests.

I found that these tests are much more consistent on newer versions of AmazonDBLocal. But, these require JDK 17+. This will be good to correct after updating to Java 21.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
