### PR TITLE
Update Armeria to 1.32.6

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/meter/EMFLoggingMeterRegistry.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/meter/EMFLoggingMeterRegistry.java
@@ -24,7 +24,6 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.instrument.util.StringUtils;
-import io.micrometer.core.lang.Nullable;
 import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 import software.amazon.cloudwatchlogs.emf.environment.Environment;
 import software.amazon.cloudwatchlogs.emf.environment.EnvironmentProvider;
@@ -32,6 +31,7 @@ import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,7 +34,7 @@ dependencyResolutionManagement {
         libs {
             version('slf4j', '2.0.6')
             library('slf4j-api', 'org.slf4j', 'slf4j-api').versionRef('slf4j')
-            version('armeria', '1.32.5')
+            version('armeria', '1.32.6')
             library('armeria-core', 'com.linecorp.armeria', 'armeria').versionRef('armeria')
             library('armeria-grpc', 'com.linecorp.armeria', 'armeria-grpc').versionRef('armeria')
             library('armeria-junit', 'com.linecorp.armeria', 'armeria-junit5').versionRef('armeria')


### PR DESCRIPTION
### Description

Fixes https://github.com/opensearch-project/data-prepper/issues/6271 since the current Armeria version is affected by a couple
of bugs (see comment https://github.com/opensearch-project/data-prepper/issues/6271#issuecomment-3627395389).

This Armeria patch version was requested explicitly: https://github.com/line/armeria/issues/6733

Furthermore, replace io.micrometer.core.lang annotation which is going
to be removed in Micrometer 1.16.0 - see release notes:
https://github.com/micrometer-metrics/micrometer/releases/tag/v1.16.0.
> Remove deprecated io.micrometer.core.lang annotations https://github.com/micrometer-metrics/micrometer/issues/6407
 
### Issues Resolved
Resolves #6271
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
