### PR TITLE
remove usage of buffer accumulator from Kafka custom consumer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -17,13 +17,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.errors.RebalanceInProgressException;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RecordDeserializationException;
-import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -70,8 +69,8 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaCustomConsumer.class);
     private static final Long COMMIT_OFFSET_INTERVAL_MS = 300000L;
-    private static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 1;
     private static final int RETRY_ON_EXCEPTION_SLEEP_MS = 1000;
+    private static final int BUFFER_WRITE_TIMEOUT = 2000;
     static final String DEFAULT_KEY = "message";
 
     private volatile long lastCommitTime;
@@ -81,7 +80,6 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
     private final TopicConsumerConfig topicConfig;
     private MessageFormat schema;
     private boolean paused;
-    private final BufferAccumulator<Record<Event>> bufferAccumulator;
     private final Buffer<Record<Event>> buffer;
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final JsonFactory jsonFactory = new JsonFactory();
@@ -123,7 +121,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         this.paused = false;
         this.byteDecoder = byteDecoder;
         this.topicMetrics = topicMetrics;
-        this.maxRetriesOnException = topicConfig.getMaxPollInterval().toMillis() / (2 * RETRY_ON_EXCEPTION_SLEEP_MS);
+        this.maxRetriesOnException = topicConfig.getMaxPollInterval().toMillis() / (2 * (RETRY_ON_EXCEPTION_SLEEP_MS + BUFFER_WRITE_TIMEOUT));
         this.pauseConsumePredicate = pauseConsumePredicate;
         this.topicMetrics.register(consumer);
         this.offsetsToCommit = new HashMap<>();
@@ -137,8 +135,6 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         this.partitionCommitTrackerMap = new HashMap<>();
         this.partitionsToReset = Collections.synchronizedSet(new HashSet<>());
         this.schema = MessageFormat.getByMessageFormatByName(schemaType);
-        Duration bufferTimeout = Duration.ofSeconds(1);
-        this.bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE, bufferTimeout);
         this.lastCommitTime = System.currentTimeMillis();
         this.numberOfAcksPending = new AtomicInteger(0);
         this.errLogRateLimiter = new LogRateLimiter(2, System.currentTimeMillis());
@@ -492,23 +488,19 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         return new Record<Event>(event);
     }
 
-    private void processRecord(final AcknowledgementSet acknowledgementSet, final Record<Event> record) {
+    private void processRecords(final AcknowledgementSet acknowledgementSet, final List<Record<Event>> eventRecords) {
         // Always add record to acknowledgementSet before adding to
         // buffer because another thread may take and process
         // buffer contents before the event record is added
         // to acknowledgement set
         if (acknowledgementSet != null) {
-            acknowledgementSet.add(record.getData());
+            eventRecords.forEach(record -> acknowledgementSet.add(record.getData()));
         }
         long numRetries = 0;
         while (true) {
             LOG.debug("In while loop for processing records, paused = {}", paused);
             try {
-                if (numRetries == 0) {
-                    bufferAccumulator.add(record);
-                } else {
-                    bufferAccumulator.flush();
-                }
+                buffer.writeAll(eventRecords, BUFFER_WRITE_TIMEOUT);
                 break;
             } catch (Exception e) {
                 if (!paused && numRetries++ > maxRetriesOnException) {
@@ -559,6 +551,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             }
 
             List<ConsumerRecord<String, T>> partitionRecords = records.records(topicPartition);
+            final List<Record<Event>> eventRecords = new ArrayList<>();
             for (ConsumerRecord<String, T> consumerRecord : partitionRecords) {
                 if (schema == MessageFormat.BYTES) {
                     InputStream byteInputStream = new ByteArrayInputStream((byte[])consumerRecord.value());
@@ -567,23 +560,23 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                     if(byteDecoder != null) {
                         final long receivedTimeStamp = getRecordTimeStamp(consumerRecord, Instant.now().toEpochMilli());
 
-                        byteDecoder.parse(decompressedInputStream, Instant.ofEpochMilli(receivedTimeStamp), (record) -> {
-                            processRecord(acknowledgementSet, record);
-                        });
+                        byteDecoder.parse(decompressedInputStream, Instant.ofEpochMilli(receivedTimeStamp), eventRecords::add);
                     } else {
                         JsonNode jsonNode = objectMapper.readValue(decompressedInputStream, JsonNode.class);
 
                         Event event = JacksonLog.builder().withData(jsonNode).build();
                         Record<Event> record = new Record<>(event);
-                        processRecord(acknowledgementSet, record);
+                        eventRecords.add(record);
                     }
                 } else {
                     Record<Event> record = getRecord(consumerRecord, topicPartition.partition());
                     if (record != null) {
-                        processRecord(acknowledgementSet, record);
+                        eventRecords.add(record);
                     }
                 }
             }
+
+            processRecords(acknowledgementSet, eventRecords);
 
             long lastOffset = partitionRecords.get(partitionRecords.size() - 1).offset();
             long firstOffset = partitionRecords.get(0).offset();


### PR DESCRIPTION
### Description
This change removes the buffer accumulator in favor of directly calling `buffer.writeAll`. This is because BufferAccumulator does not throw TimeoutException, and instead will do infinite back off and retry to write to the buffer during TimeoutExceptions. This causes the consumer thread processing the records to get blocked, which stops `poll` from getting called on the consumer, which can result in the consumer being removed from the group after the `max.poll.interval.ms` expires, which leads to Kafka rebalances. 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
