### PR TITLE
Optimized RestClient Tests using customized Retry Handler

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClientTest.java
@@ -22,6 +22,9 @@ import org.opensearch.dataprepper.plugins.source.microsoft_office365.auth.Office
 import org.opensearch.dataprepper.plugins.source.microsoft_office365.models.AuditLogsResponse;
 import org.opensearch.dataprepper.plugins.source.source_crawler.exception.SaaSCrawlerException;
 import org.opensearch.dataprepper.plugins.source.source_crawler.metrics.VendorAPIMetricsRecorder;
+import org.opensearch.dataprepper.plugins.source.source_crawler.utils.retry.DefaultRetryStrategy;
+import org.opensearch.dataprepper.plugins.source.source_crawler.utils.retry.DefaultStatusCodeHandler;
+import org.opensearch.dataprepper.plugins.source.source_crawler.utils.retry.RetryHandler;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -79,6 +82,8 @@ class Office365RestClientTest {
 
     private Office365RestClient office365RestClient;
 
+    private static final int CUSTOM_MAX_RETRIES = 1;
+
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
         // Setup VendorAPIMetricsRecorder method mocks - use lenient to avoid unnecessary stubbing errors
@@ -112,6 +117,12 @@ class Office365RestClientTest {
 
         office365RestClient = new Office365RestClient(authConfig, pluginMetrics, metricsRecorder);
         ReflectivelySetField.setField(Office365RestClient.class, office365RestClient, "restTemplate", restTemplate);
+
+        // Optionally replace RetryHandler with custom one (1 retry) for faster test execution
+        RetryHandler customRetryHandler = new RetryHandler(
+                new DefaultRetryStrategy(CUSTOM_MAX_RETRIES),
+                new DefaultStatusCodeHandler());
+        ReflectivelySetField.setField(Office365RestClient.class, office365RestClient, "retryHandler", customRetryHandler);
     }
 
     /**
@@ -365,10 +376,17 @@ class Office365RestClientTest {
      * Verifies that failed authentication triggers credential renewal and retry succeeds.
      */
     @Test
-    void testTokenRenewal() {
+    void testTokenRenewal() throws NoSuchFieldException, IllegalAccessException {
         // Setup
         Instant startTime = Instant.now().minus(1, ChronoUnit.HOURS);
         Instant endTime = Instant.now();
+
+        // Override retry handler to allow at least 2 attempts for token renewal test
+        RetryHandler tokenRenewalRetryHandler = new RetryHandler(
+                new DefaultRetryStrategy(2), // Need at least 2 attempts for token renewal scenario
+                new DefaultStatusCodeHandler());
+        ReflectivelySetField.setField(Office365RestClient.class, office365RestClient, "retryHandler",
+                tokenRenewalRetryHandler);
 
         List<String> tokensUsed = new ArrayList<>();
         List<String> requestTokens = new ArrayList<>();


### PR DESCRIPTION
## Description

Refactored Office365RestClient Tests using New RetryHandler, reducing test execution time from 17 minutes to 50 seconds.

## Performance Summary

- **Total test duration:** 17m 3.8s → 49.5s (**95.2% faster**)
- **Office365RestClientTest:** 16m 18s → 6.2s (**99.4% faster**)

## Test Report Details

## Old Test Report(6 Retries for tests):

<img width="751" height="415" alt="{0C68270F-187F-4D7F-A03D-14202CEFF697}" src="https://github.com/user-attachments/assets/60f2c88b-86fc-4f37-aa2d-0f04b67933bb" />

## New Test Report(1 Retries for tests):

<img width="832" height="412" alt="{AA6E813F-C46E-4533-8F3B-38248A0620E2}" src="https://github.com/user-attachments/assets/f90af632-96c6-43e5-aaf0-9304232f8da7" />



## How

Introduced configurable retry strategies and set `maxRetries = 1` for unit tests to eliminate unnecessary exponential backoff waits.


### Check List

- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).