### PR TITLE
Adding Partition Execution Logging for DimensionalTimeSliceCrawler 

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/DimensionalTimeSliceCrawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/DimensionalTimeSliceCrawler.java
@@ -87,6 +87,8 @@ public class DimensionalTimeSliceCrawler implements Crawler<DimensionalTimeSlice
 
     @Override
     public void executePartition(DimensionalTimeSliceWorkerProgressState state, Buffer<Record<Event>> buffer, AcknowledgementSet acknowledgementSet) {
+        log.info("Processing partition - DimensionType: {}, TimeRange: {} to {}", 
+                 state.getDimensionType(), state.getStartTime(), state.getEndTime());
         partitionWaitTimeTimer.record(Duration.between(state.getPartitionCreationTime(), Instant.now()));
         partitionProcessLatencyTimer.record(() -> client.executePartition(state, buffer, acknowledgementSet));
     }


### PR DESCRIPTION
### Description
Implemented enhanced partition logging to facilitate debugging and observability of partition processing workflows in DimensionalTimeSliceCrawler and added a 2 minute limitter for partition batch processing.

### Testing
#### M365 Pipeline Validation 
- Successfully deployed and validated the M365 pipeline with the following observations:
```
2026-01-06T10:13:04,117 [pool-7-thread-4] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.Exchange, TimeRange: 2026-01-06T18:08:03.989022Z to 2026-01-06T18:08:04.036494Z
2026-01-06T10:13:04,117 [pool-7-thread-3] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.AzureActiveDirectory, TimeRange: 2026-01-06T18:08:03.989022Z to 2026-01-06T18:08:04.036494Z
2026-01-06T10:13:04,119 [pool-7-thread-2] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.SharePoint, TimeRange: 2026-01-06T18:08:03.989022Z to 2026-01-06T18:08:04.036494Z
2026-01-06T10:13:04,119 [pool-7-thread-5] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.General, TimeRange: 2026-01-06T18:08:03.989022Z to 2026-01-06T18:08:04.036494Z
2026-01-06T10:14:04,052 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:15:04,061 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:15:04,123 [pool-7-thread-3] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: DLP.All, TimeRange: 2026-01-06T18:08:03.989022Z to 2026-01-06T18:08:04.036494Z
2026-01-06T10:15:04,123 [pool-7-thread-4] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.AzureActiveDirectory, TimeRange: 2026-01-06T18:08:04.036494Z to 2026-01-06T18:09:04.051336Z
2026-01-06T10:15:04,125 [pool-7-thread-5] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.SharePoint, TimeRange: 2026-01-06T18:08:04.036494Z to 2026-01-06T18:09:04.051336Z
2026-01-06T10:15:04,125 [pool-7-thread-2] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.Exchange, TimeRange: 2026-01-06T18:08:04.036494Z to 2026-01-06T18:09:04.051336Z
2026-01-06T10:16:04,070 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:17:04,075 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:17:04,128 [pool-7-thread-5] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.General, TimeRange: 2026-01-06T18:08:04.036494Z to 2026-01-06T18:09:04.051336Z
2026-01-06T10:17:04,129 [pool-7-thread-4] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: DLP.All, TimeRange: 2026-01-06T18:08:04.036494Z to 2026-01-06T18:09:04.051336Z
2026-01-06T10:17:04,129 [pool-7-thread-3] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.AzureActiveDirectory, TimeRange: 2026-01-06T18:09:04.051336Z to 2026-01-06T18:10:04.057166Z
2026-01-06T10:17:04,131 [pool-7-thread-2] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.Exchange, TimeRange: 2026-01-06T18:09:04.051336Z to 2026-01-06T18:10:04.057166Z
2026-01-06T10:18:04,086 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:19:04,094 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:19:04,134 [pool-7-thread-5] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.SharePoint, TimeRange: 2026-01-06T18:09:04.051336Z to 2026-01-06T18:10:04.057166Z
2026-01-06T10:19:04,134 [pool-7-thread-3] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.General, TimeRange: 2026-01-06T18:09:04.051336Z to 2026-01-06T18:10:04.057166Z
2026-01-06T10:19:04,135 [pool-7-thread-4] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: DLP.All, TimeRange: 2026-01-06T18:09:04.051336Z to 2026-01-06T18:10:04.057166Z
2026-01-06T10:19:04,137 [pool-7-thread-2] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.AzureActiveDirectory, TimeRange: 2026-01-06T18:10:04.057166Z to 2026-01-06T18:11:04.067885Z
2026-01-06T10:20:04,107 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:21:04,117 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:21:04,139 [pool-7-thread-3] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.SharePoint, TimeRange: 2026-01-06T18:10:04.057166Z to 2026-01-06T18:11:04.067885Z
2026-01-06T10:21:04,139 [pool-7-thread-5] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.Exchange, TimeRange: 2026-01-06T18:10:04.057166Z to 2026-01-06T18:11:04.067885Z
2026-01-06T10:21:04,142 [pool-7-thread-4] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: DLP.All, TimeRange: 2026-01-06T18:10:04.057166Z to 2026-01-06T18:11:04.067885Z
2026-01-06T10:21:04,142 [pool-7-thread-2] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.General, TimeRange: 2026-01-06T18:10:04.057166Z to 2026-01-06T18:11:04.067885Z
2026-01-06T10:22:04,126 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:23:04,133 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
2026-01-06T10:23:04,145 [pool-7-thread-5] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.AzureActiveDirectory, TimeRange: 2026-01-06T18:11:04.067885Z to 2026-01-06T18:12:04.073043Z
2026-01-06T10:23:04,146 [pool-7-thread-3] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.Exchange, TimeRange: 2026-01-06T18:11:04.067885Z to 2026-01-06T18:12:04.073043Z
2026-01-06T10:23:04,146 [pool-7-thread-2] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.SharePoint, TimeRange: 2026-01-06T18:11:04.067885Z to 2026-01-06T18:12:04.073043Z
2026-01-06T10:23:04,147 [pool-7-thread-4] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Processing partition - DimensionType: Audit.General, TimeRange: 2026-01-06T18:11:04.067885Z to 2026-01-06T18:12:04.073043Z
2026-01-06T10:24:04,142 [pool-7-thread-1] INFO  org.opensearch.dataprepper.plugins.source.source_crawler.base.DimensionalTimeSliceCrawler - Total partitions created in this crawl: 5.0
```
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
