### PR TITLE
Adding Subscription Metrics to Metric Recorder and Onboarding M365 to Auth Metrics from Metrics Recorder

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/configuration/Office365Configuration.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/configuration/Office365Configuration.java
@@ -11,23 +11,26 @@ package org.opensearch.dataprepper.plugins.source.microsoft_office365.configurat
 
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.source.microsoft_office365.Office365RestClient;
+import org.opensearch.dataprepper.plugins.source.microsoft_office365.Office365SourceConfig;
 import org.opensearch.dataprepper.plugins.source.microsoft_office365.auth.Office365AuthenticationInterface;
+import org.opensearch.dataprepper.plugins.source.microsoft_office365.auth.Office365AuthenticationProvider;
 import org.opensearch.dataprepper.plugins.source.source_crawler.metrics.VendorAPIMetricsRecorder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Spring configuration for Microsoft Office 365 RestClient.
+ * Spring configuration for Microsoft Office 365 components.
  * 
- * This configuration class creates the Office365RestClient with the required dependencies:
- * 1. Office365AuthenticationInterface for authentication
- * 2. PluginMetrics for unified metrics recording
+ * This configuration class creates all Office 365 related beans with their dependencies:
+ * 1. VendorAPIMetricsRecorder for unified metrics across all operations
+ * 2. Office365AuthenticationProvider with authentication metrics support
+ * 3. Office365RestClient with VendorAPIMetricsRecorder
  * 
- * The Office365RestClient internally creates VendorAPIMetricsRecorder instances 
- * for different operation types (GET, SEARCH, AUTH) from the provided PluginMetrics.
+ * This provides comprehensive metrics coverage for authentication, API calls, 
+ * and subscription management operations.
  */
 @Configuration
-public class Office365RestClientConfiguration {
+public class Office365Configuration {
 
     /**
      * Creates VendorAPIMetricsRecorder with unified metrics for all operations.
@@ -41,18 +44,31 @@ public class Office365RestClientConfiguration {
     }
 
     /**
+     * Creates Office365AuthenticationProvider with metrics recording capabilities.
+     *
+     * @param config The Office 365 source configuration
+     * @param metricsRecorder The metrics recorder for authentication operations
+     * @return Configured Office365AuthenticationProvider with metrics support
+     */
+    @Bean
+    public Office365AuthenticationProvider office365AuthenticationProvider(
+            Office365SourceConfig config,
+            VendorAPIMetricsRecorder metricsRecorder) {
+        return new Office365AuthenticationProvider(config, metricsRecorder);
+    }
+
+
+    /**
      * Creates Office365RestClient with unified metrics recorder.
      * 
      * @param authConfig The Office 365 authentication provider
-     * @param pluginMetrics The system plugin metrics instance
      * @param vendorAPIMetricsRecorder The unified metrics recorder
      * @return Configured Office365RestClient
      */
     @Bean
     public Office365RestClient office365RestClient(
             Office365AuthenticationInterface authConfig,
-            PluginMetrics pluginMetrics,
             VendorAPIMetricsRecorder vendorAPIMetricsRecorder) {
-        return new Office365RestClient(authConfig, pluginMetrics, vendorAPIMetricsRecorder);
+        return new Office365RestClient(authConfig, vendorAPIMetricsRecorder);
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/metrics/VendorAPIMetricsRecorder.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/metrics/VendorAPIMetricsRecorder.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
  * - Search operations: latency, success/failure rates, and response sizes
  * - Get/retrieval operations: latency, success/failure rates, and response sizes  
  * - Authentication operations: latency, success/failure rates
+ * - Subscription operations: latency, success/failure rates, and call counts
  * - General API operations: request counts, logs requested, error categorization
  * 
  * Most methods return void for efficient standalone usage. The error() method supports chaining for error handling scenarios.
@@ -45,6 +46,12 @@ public class VendorAPIMetricsRecorder {
     private final Counter authSuccessCounter;
     private final Counter authFailureCounter;
     private final Timer authLatencyTimer;
+
+    // Subscription operation metrics
+    private final Counter subscriptionSuccessCounter;
+    private final Counter subscriptionFailureCounter;
+    private final Timer subscriptionLatencyTimer;
+    private final Counter subscriptionCallsCounter;
 
     // Shared metrics
     private final Counter totalDataApiRequestsCounter;
@@ -81,6 +88,12 @@ public class VendorAPIMetricsRecorder {
         this.authSuccessCounter = pluginMetrics.counter("authenticationRequestsSuccess");
         this.authFailureCounter = pluginMetrics.counter("authenticationRequestsFailed");
         this.authLatencyTimer = pluginMetrics.timer("authenticationRequestLatency");
+
+        // Subscription metrics
+        this.subscriptionSuccessCounter = pluginMetrics.counter("startSubscriptionRequestsSuccess");
+        this.subscriptionFailureCounter = pluginMetrics.counter("startSubscriptionRequestsFailed");
+        this.subscriptionLatencyTimer = pluginMetrics.timer("startSubscriptionRequestLatency");
+        this.subscriptionCallsCounter = pluginMetrics.counter("startSubscriptionApiCalls");
 
         // Shared metrics
         this.totalDataApiRequestsCounter = pluginMetrics.counter("totalDataApiRequests");
@@ -202,6 +215,31 @@ public class VendorAPIMetricsRecorder {
 
     public void recordAuthLatency(Duration duration) {
         authLatencyTimer.record(duration);
+    }
+
+    // Subscription operation methods
+    public void recordSubscriptionSuccess() {
+        subscriptionSuccessCounter.increment();
+    }
+
+    public void recordSubscriptionFailure() {
+        subscriptionFailureCounter.increment();
+    }
+
+    public <T> T recordSubscriptionLatency(Supplier<T> operation) {
+        return subscriptionLatencyTimer.record(operation);
+    }
+
+    public void recordSubscriptionLatency(Runnable operation) {
+        subscriptionLatencyTimer.record(operation);
+    }
+
+    public void recordSubscriptionLatency(Duration duration) {
+        subscriptionLatencyTimer.record(duration);
+    }
+
+    public void recordSubscriptionCall() {
+        subscriptionCallsCounter.increment();
     }
 
     // Shared operation methods


### PR DESCRIPTION
### Description
This PR introduces comprehensive metrics tracking for Microsoft Office 365 API operations in the Data Prepper M365 source plugin by extending the VendorAPIMetricsRecorder to support both start subscription APIs and authentication APIs, maintaining centralized vendor API metrics while adding M365-specific operation tracking.

### Changes
#### New Metrics in VendorAPIMetricsRecorder
- Start Subscription Metrics: Extended VendorAPIMetricsRecorder to support Office 365 start subscription operations
    - Tracks start subscription operations (success/failure/latency/call counts)
    - Provides multiple overloaded methods for latency recording (Supplier, Runnable, Duration)
    - Maintains centralized vendor API metrics while supporting M365-specific operations

#### Modified Components
- Office365RestClient: Updated to use VendorAPIMetricsRecorder for subscription metrics
   - Integrated VendorAPIMetricsRecorder for start subscription operations
   - Wrapped start subscription logic with latency tracking
   - Removed generic apiCallsCounter in favor of specific start subscription metrics
- Office365Configuration (formerly Office365RestClientConfiguration): Updated dependency injection
   - Updated Office365RestClient bean to inject VendorAPIMetricsRecorder for subscription metrics
   - Added VendorAPIMetricsRecorder bean injection for Office365AuthenticationProvider
   - Renamed from Office365RestClientConfiguration to reflect broader configuration scope

#### Test Coverage
- VendorAPIMetricsRecorderTest: Updated/added unit tests
    - Tests subscription metric recording methods
    - Validates success/failure tracking for start subscription operations
    - Tests latency recording with multiple overloads
    - Includes edge cases and error scenarios
- Office365RestClientTest: Updated integration tests
    - Added tests for metrics recording during start subscription operations
    - Validates failure metric recording
    - Tests AF20024 error handling with metrics
- Office365AuthenticationProviderTest: Updated unit tests
    - Added tests for VendorAPIMetricsRecorder injection
    - Validates authentication metrics recording
    - Tests success and failure scenarios for authentication metrics

#### Metrics Added
- Start Subscription Metrics(via VendorAPIMetricsRecorder):
   - startSubscriptionRequestsSuccess: Count of successful start subscription operations
   - startSubscriptionRequestsFailed: Count of failed start subscription operations
   - startSubscriptionRequestLatency: Timer for start subscription operation duration
   - startSubscriptionApiCalls: Count of individual API calls during start subscription operations
- Authentication Metrics (via VendorAPIMetricsRecorder):
   - authenticationRequestsSuccess: Count of successful authentication requests
   - authenticationRequestsFailed: Count of failed authentication requests
   - authenticationRequestLatency: Timer for authentication request duration
### Testing: 
- Spun up local M365 pipeline and confirmed that all metrics (subscription and authentication) were generated successfully.
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
