### PR TITLE
Fix multiple javadoc warnings to reduce build log clutter

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/OutputCodec.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/OutputCodec.java
@@ -121,6 +121,7 @@ public interface OutputCodec {
      * this method get called from {@link Sink} to estimate size of event in {@link OutputStream}
      *
      * @param event        event Record event
+     * @param codecContext the output codec context for configuration and metadata
      * @return long        size of the serialized event
      * @throws IOException throws IOException when invalid input is received or not able to create wrapping
      */

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/EncryptionEnvelope.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/EncryptionEnvelope.java
@@ -12,11 +12,13 @@ package org.opensearch.dataprepper.model.encryption;
 public interface EncryptionEnvelope {
     /**
      * The encrypted data.
+     * @return the encrypted data as a byte array
      */
     byte[] getEncryptedData();
 
     /**
      * The encrypted data key.
+     * @return the encrypted data key as a String
      */
     String getEncryptedDataKey();
 }

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/util/LambdaRetryStrategy.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/util/LambdaRetryStrategy.java
@@ -82,6 +82,8 @@ public final class LambdaRetryStrategy {
 
     /**
      * Determines if this is definitely NOT retryable (client error or permanent failure).
+     * @param response the Lambda invoke response to check
+     * @return true if the response indicates a non-retryable error, false otherwise
      */
     public static boolean isNonRetryable(final InvokeResponse response) {
         if(response == null) return false;
@@ -95,10 +97,11 @@ public final class LambdaRetryStrategy {
     /**
      * For convenience, you can create more fine-grained checks or
      * direct set membership checks (e.g. isBadRequest(...), isTimeout(...)) if you want.
+     * @param response the Lambda invoke response to check
+     * @return true if the response indicates a timeout error, false otherwise
      */
     public static boolean isTimeoutError(final InvokeResponse response) {
         return TIMEOUT_ERRORS.contains(response.statusCode());
     }
 
 }
-

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/utils/RetryUtil.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/utils/RetryUtil.java
@@ -37,6 +37,9 @@ public class RetryUtil {
 
     /**
      * Retry with exponential backoff, using default values.
+     * @param task The runnable task to execute with retry logic
+     * @param log The logger instance for logging retry attempts and failures
+     * @return true if the task succeeded within the retry attempts, false otherwise
      */
     public static boolean retryWithBackoff(Runnable task, Logger log) {
         return retryWithBackoff(task, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_DELAY_MS, DEFAULT_MAX_RETRIES, log);
@@ -44,6 +47,12 @@ public class RetryUtil {
 
     /**
      * Retry with exponential backoff, allowing custom delay and retry values.
+     * @param task The runnable task to execute with retry logic
+     * @param baseDelayMs The base delay in milliseconds for the first retry
+     * @param maxDelayMs The maximum delay in milliseconds between retries
+     * @param maxRetries The maximum number of retry attempts
+     * @param log The logger instance for logging retry attempts and failures
+     * @return true if the task succeeded within the retry attempts, false otherwise
      */
     public static boolean retryWithBackoff(Runnable task, long baseDelayMs, long maxDelayMs, int maxRetries, Logger log) {
         RetryResult result = retryWithBackoffInternal(task, baseDelayMs, maxDelayMs, maxRetries, e -> true, log);
@@ -52,6 +61,9 @@ public class RetryUtil {
 
     /**
      * Retry with exponential backoff, returning detailed result.
+     * @param task The runnable task to execute with retry logic
+     * @param log The logger instance for logging retry attempts and failures
+     * @return RetryResult containing success status, last exception, and number of attempts made
      */
     public static RetryResult retryWithBackoffWithResult(Runnable task, Logger log) {
         return retryWithBackoffInternal(task, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_DELAY_MS, DEFAULT_MAX_RETRIES, e -> true, log);

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -134,6 +134,7 @@ public class ShardConsumerFactory {
      * @param streamArn      Stream Arn
      * @param shardId        Shard Id
      * @param sequenceNumber The last Sequence Number processed if any
+     * @param shardIteratorType The type of shard iterator to retrieve
      * @return A shard iterator.
      */
     public String getShardIterator(String streamArn, String shardId, String sequenceNumber, ShardIteratorType shardIteratorType) {

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptedDataKeySupplier.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptedDataKeySupplier.java
@@ -11,6 +11,7 @@ package org.opensearch.dataprepper.plugins.encryption;
 public interface EncryptedDataKeySupplier {
     /**
      * Retrieve the current encrypted data key.
+     * @return the current encrypted data key as a String
      */
     String retrieveValue();
 

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptedDataKeyWriter.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptedDataKeyWriter.java
@@ -11,6 +11,8 @@ package org.opensearch.dataprepper.plugins.encryption;
 public interface EncryptedDataKeyWriter {
     /**
      * Writes encrypted data key into storage.
+     * @param encryptedDataKey the encrypted data key to write to storage
+     * @throws Exception if an error occurs while writing the encrypted data key
      */
     void writeEncryptedDataKey(String encryptedDataKey) throws Exception;
 }

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionEngineConfiguration.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionEngineConfiguration.java
@@ -22,16 +22,19 @@ import java.time.Duration;
 public interface EncryptionEngineConfiguration {
     /**
      * Represents the type of the encryption engine.
+     * @return the name of the encryption engine type
      */
     String name();
 
     /**
      * Whether encrypted data key rotation is enabled.
+     * @return true if rotation is enabled, false otherwise
      */
     boolean rotationEnabled();
 
     /**
      * Retrieves the rotation interval.
+     * @return the rotation interval as a Duration
      */
     Duration getRotationInterval();
 }

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionRotationHandler.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionRotationHandler.java
@@ -11,6 +11,7 @@ package org.opensearch.dataprepper.plugins.encryption;
 public interface EncryptionRotationHandler {
     /**
      * Retrieves encryption configuration ID.
+     * @return the encryption configuration ID
      */
     String getEncryptionId();
 

--- a/data-prepper-plugins/http-common/src/main/java/org/opensearch/dataprepper/plugins/server/CreateServer.java
+++ b/data-prepper-plugins/http-common/src/main/java/org/opensearch/dataprepper/plugins/server/CreateServer.java
@@ -205,6 +205,8 @@ public class CreateServer {
 
     /**
      * Creates a GRPC server with a single service
+     * @param <K> Request type parameter
+     * @param <V> Response type parameter
      * @param authenticationProvider Provider for authentication
      * @param grpcService Service to be added
      * @param certificateProvider Provider for SSL/TLS certificates

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferSerializationFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferSerializationFactory.java
@@ -27,6 +27,7 @@ public class BufferSerializationFactory implements SerializationFactory {
      * the {@link org.opensearch.dataprepper.plugins.kafka.common.serialization.CommonSerializationFactory}.
      *
      * @param innerSerializationFactory The serialization factory for the inner data.
+     * @param encryptionSupplier The encryption supplier for handling encryption engines
      */
     public BufferSerializationFactory(final SerializationFactory innerSerializationFactory,
                                       final EncryptionSupplier encryptionSupplier) {

--- a/data-prepper-plugins/otlp-source/src/main/java/org/opensearch/dataprepper/plugins/source/otlp/OTLPSourceConfig.java
+++ b/data-prepper-plugins/otlp-source/src/main/java/org/opensearch/dataprepper/plugins/source/otlp/OTLPSourceConfig.java
@@ -208,6 +208,7 @@ public class OTLPSourceConfig {
    * Validation via @DurationMax ensures this is safe.
    * Casting to int is necessary because ServerConfiguration method signature
    * requires it.
+   * @return the request timeout in milliseconds as an integer
    */
   public int getRequestTimeoutInMillis() {
     return (int) requestTimeout.toMillis();

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusHttpSender.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusHttpSender.java
@@ -65,6 +65,7 @@ public class PrometheusHttpSender {
      *
      * @param awsCredentialsSupplier the AWS credentials supplier
      * @param config The configuration for the Prometheus sink plugin.
+     * @param sinkMetrics The sink metrics for recording request information
      */
     public PrometheusHttpSender(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier, @Nonnull final PrometheusSinkConfiguration config, @Nonnull final SinkMetrics sinkMetrics) {
         this(awsCredentialsSupplier, buildWebClient(config), config, sinkMetrics);
@@ -121,6 +122,7 @@ public class PrometheusHttpSender {
      * Sends the provided OTLP Protobuf payload to the OTLP endpoint asynchronously.
      *
      * @param payload - batch the batch of spans to send
+     * @return PrometheusPushResult containing the success status and response code
      */
     public PrometheusPushResult pushToEndpoint(final byte[] payload) {
         PrometheusPushResult result;

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectHandler.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectHandler.java
@@ -18,6 +18,7 @@ public interface S3ObjectHandler {
     /**
      * Process S3 object content using S3 object reference and pushing to buffer
      * @param s3ObjectReference Contains bucket and s3 object details
+     * @param dataSelection Data selection configuration for filtering S3 objects
      * @param acknowledgementSet acknowledgement set for the object
      * @param sourceCoordinator source coordinator
      * @param partitionKey partition key


### PR DESCRIPTION
### Description
This PR fixes multiple javadoc warnings that were cluttering the build logs when building Data Prepper. Several method javadoc comments have been updated to adhere to javadoc best practices, including proper parameter documentation, return value descriptions, and formatting conventions.
 
### Issues Resolved
Fixing warnings cluttering logs during build. 
 
### Check List
- [N/A] New functionality includes testing.
- [N/A] New functionality has a documentation issue. Please link to it in this PR.
  - [N/A] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
