### PR TITLE
Add rolling buffer to Prometheus sink

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkBuffer.java
@@ -12,9 +12,9 @@ package org.opensearch.dataprepper.common.sink;
 import java.time.Instant;
 
 public class DefaultSinkBuffer implements SinkBuffer {
-    private final SinkBufferWriter sinkBufferWriter;
-    private final long maxEvents;
-    private final long maxRequestSize;
+    protected final SinkBufferWriter sinkBufferWriter;
+    protected final long maxEvents;
+    protected final long maxRequestSize;
     private final long flushIntervalMs;
     private long lastFlushedTimeMs;
     private long numEvents;

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategy.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategy.java
@@ -33,6 +33,9 @@ public abstract class DefaultSinkOutputStrategy implements SinkBufferEntryProvid
         long startTime = System.nanoTime();
         // getFlushableBuffer() should return the buffer contents
         SinkFlushableBuffer flushableBuffer = sinkBuffer.getFlushableBuffer(sinkFlushContext);
+        if (flushableBuffer == null) {
+            return;
+        }
         List<Event> events = flushableBuffer.getEvents();
         try {      
             SinkFlushResult flushResult = flushableBuffer.flush();

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/SinkBufferWriter.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/SinkBufferWriter.java
@@ -8,4 +8,11 @@ package org.opensearch.dataprepper.common.sink;
 public interface SinkBufferWriter {
     public boolean writeToBuffer(SinkBufferEntry sinkBufferEntry);
     public SinkFlushableBuffer getBuffer(final SinkFlushContext  sinkFlushContext);
+    default boolean isMaxEventsLimitReached(final long maxEvents) {
+        return false;
+    }
+
+    default boolean willExceedMaxRequestSizeBytes(final SinkBufferEntry sinkBufferEntry, final long maxRequestSize) {
+        return false;
+    }
 }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/configuration/PrometheusSinkConfiguration.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/configuration/PrometheusSinkConfiguration.java
@@ -34,6 +34,7 @@ public class PrometheusSinkConfiguration {
     private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration DEFAULT_OUT_OF_ORDER_WINDOW = Duration.ofSeconds(5);
 
     @JsonProperty("aws")
     @NotNull
@@ -43,6 +44,9 @@ public class PrometheusSinkConfiguration {
     @NotNull
     @JsonProperty("url")
     private String url;
+
+    @JsonProperty("out_of_order_window")
+    private Duration outOfOrderWindow = DEFAULT_OUT_OF_ORDER_WINDOW;
 
     @JsonProperty("max_retries")
     private int maxRetries = DEFAULT_MAX_RETRIES;
@@ -106,6 +110,10 @@ public class PrometheusSinkConfiguration {
 
     public String getContentType() {
         return contentType;
+    }
+
+    public Duration getOutOfOrderWindow() {
+        return outOfOrderWindow;
     }
 
     public String getRemoteWriteVersion() {

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBuffer.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBuffer.java
@@ -1,0 +1,34 @@
+ /*
+  * Copyright OpenSearch Contributors
+  * SPDX-License-Identifier: Apache-2.0
+  *
+  * The OpenSearch Contributors require contributions made to
+  * this file be licensed under the Apache-2.0 license or a
+  * compatible open source license.
+  *
+  */
+package org.opensearch.dataprepper.plugins.sink.prometheus.service;
+
+import org.opensearch.dataprepper.common.sink.DefaultSinkBuffer;
+import org.opensearch.dataprepper.common.sink.SinkBufferWriter;
+import org.opensearch.dataprepper.common.sink.SinkBufferEntry;
+
+public class PrometheusSinkBuffer extends DefaultSinkBuffer {
+
+    public PrometheusSinkBuffer(final long maxEvents, final long maxRequestSize, 
+        final long flushIntervalMs, final SinkBufferWriter sinkBufferWriter) {
+
+        super(maxEvents, maxRequestSize, flushIntervalMs, sinkBufferWriter);
+    }
+     
+    @Override
+    public boolean isMaxEventsLimitReached() {
+        return sinkBufferWriter.isMaxEventsLimitReached(maxEvents);
+    }
+
+    @Override
+    public boolean willExceedMaxRequestSizeBytes(final SinkBufferEntry sinkBufferEntry) {
+        return sinkBufferWriter.willExceedMaxRequestSizeBytes(sinkBufferEntry, maxRequestSize);
+    }
+
+}

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferEntry.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferEntry.java
@@ -13,12 +13,7 @@ package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 import org.opensearch.dataprepper.common.sink.SinkBufferEntry;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventType;
-import org.opensearch.dataprepper.model.metric.ExponentialHistogram;
-import org.opensearch.dataprepper.model.metric.Gauge;
 import org.opensearch.dataprepper.model.metric.Metric;
-import org.opensearch.dataprepper.model.metric.Histogram;
-import org.opensearch.dataprepper.model.metric.Sum;
-import org.opensearch.dataprepper.model.metric.Summary;
 
 public class PrometheusSinkBufferEntry implements SinkBufferEntry {
 
@@ -51,30 +46,7 @@ public class PrometheusSinkBufferEntry implements SinkBufferEntry {
 
     private PrometheusTimeSeries getTimeSeriesForEvent(final boolean sanitizeNames) throws Exception {
         if (event.getMetadata().getEventType().equals(EventType.METRIC.toString())) {
-            try {
-                PrometheusTimeSeries timeSeries = new PrometheusTimeSeries((Metric)event, sanitizeNames);
-                if (event instanceof Gauge) {
-                    final Gauge gauge = (Gauge) event;
-                    timeSeries.addGaugeMetric(gauge);
-                } else if (event instanceof Sum) {
-                    final Sum sum = (Sum) event;
-                    timeSeries.addSumMetric(sum);
-                } else if (event instanceof Summary) {
-                    final Summary summary = (Summary) event;
-                    timeSeries.addSummaryMetric(summary);
-                } else if (event instanceof Histogram) {
-                    final Histogram histogram = (Histogram) event;
-                    timeSeries.addHistogramMetric(histogram);
-                } else if (event instanceof ExponentialHistogram) {
-                    final ExponentialHistogram exponentialHistogram = (ExponentialHistogram) event;
-                    timeSeries.addExponentialHistogramMetric(exponentialHistogram);
-                } else {
-                    throw new RuntimeException("Unknown metric type");
-                }
-                return timeSeries;
-            } catch (Exception e) {
-                throw e;
-            }
+            return new PrometheusTimeSeries((Metric)event, sanitizeNames);
         }
         throw new RuntimeException("Not metric type");
     }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriter.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriter.java
@@ -9,51 +9,104 @@
   */
 package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.opensearch.dataprepper.common.sink.SinkBufferEntry;
 import org.opensearch.dataprepper.common.sink.SinkBufferWriter;
 import org.opensearch.dataprepper.common.sink.SinkFlushableBuffer;
 import org.opensearch.dataprepper.common.sink.SinkFlushContext;
 import org.opensearch.dataprepper.common.sink.SinkMetrics;
+import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.PrometheusSinkConfiguration;
+import software.amazon.awssdk.utils.Pair;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PrometheusSinkBufferWriter implements SinkBufferWriter {
 
+    private static final int MAX_EVENTS_PER_SERIES = 1000;
     // Each buffer entry is a metric.
     // Duplicate entries for the same metric at the same time is not allowed
     // If there are multiple entries in the buffer for the same metric (with different time stamps),
     // They must be sorted by time before sending to Prometheus
-    private final Map<String, Map<Long, SinkBufferEntry>> buffer;
+    private final Map<String, PrometheusSinkBufferWriterEntry> buffer;
     private final SinkMetrics sinkMetrics;
+    private final long outOfOrderWindowMillis;
+    private final long maxEvents;
+    private final long maxRequestSize;
 
-    public PrometheusSinkBufferWriter(SinkMetrics sinkMetrics) {
+    public PrometheusSinkBufferWriter(final PrometheusSinkConfiguration sinkConfig, final SinkMetrics sinkMetrics) {
         this.buffer = new HashMap<>();
         this.sinkMetrics = sinkMetrics;
+        this.outOfOrderWindowMillis = sinkConfig.getOutOfOrderWindow().toMillis();
+        this.maxEvents = sinkConfig.getThresholdConfig().getMaxEvents();
+        this.maxRequestSize = sinkConfig.getThresholdConfig().getMaxRequestSizeBytes();
     }
 
-    public boolean writeToBuffer(SinkBufferEntry bufferEntry) {
-        PrometheusTimeSeries timeSeries = ((PrometheusSinkBufferEntry)bufferEntry).getTimeSeries();
-        if (timeSeries == null) {
+    private String getSeriesKey(PrometheusSinkBufferEntry bufferEntry) {
+        return bufferEntry.getTimeSeries().getMetricKey();
+    }
+
+    @Override
+    public boolean isMaxEventsLimitReached(final long maxEvents) {
+        return buffer.values().stream()
+             .mapToLong(PrometheusSinkBufferWriterEntry::getNumberOfEntriesReadyToFlush)
+             .sum() >= maxEvents;
+    }
+
+    @Override
+    public boolean willExceedMaxRequestSizeBytes(final SinkBufferEntry sinkBufferEntry, final long maxRequestSize) {
+        return buffer.values().stream()
+             .mapToLong(PrometheusSinkBufferWriterEntry::getSizeOfEntriesReadyToFlush)
+             .sum() >= maxRequestSize;
+    }
+
+    public boolean writeToBuffer(final SinkBufferEntry bufferEntry) {
+        PrometheusSinkBufferEntry entry = (PrometheusSinkBufferEntry)bufferEntry;
+        if (entry.getTimeSeries() == null || entry.getTimeSeries().getSize() >= maxRequestSize) {
             return false;
         }
+        final String seriesKey = getSeriesKey(entry);
 
-        buffer.computeIfAbsent(timeSeries.getMetricName(), k -> new HashMap<>())
-              .put(timeSeries.getTimeStamp(), bufferEntry);
-        return true;
+        boolean result = buffer.computeIfAbsent(seriesKey,
+            k -> new PrometheusSinkBufferWriterEntry(this.outOfOrderWindowMillis, MAX_EVENTS_PER_SERIES)).add(entry);
+        if (!result) {
+            sinkMetrics.incrementEventsDroppedCounter(1);
+        }
+        return result;
+    }
+
+    @VisibleForTesting
+    long getBufferSize() {
+        return buffer.size();
     }
 
     @Override
     public SinkFlushableBuffer getBuffer(final SinkFlushContext sinkFlushContext) {
-        List<SinkBufferEntry> bufferList = buffer.values().stream()
-            .flatMap(timeSeriesMap -> timeSeriesMap.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .map(Map.Entry::getValue))
-            .collect(Collectors.toList());
+        List<SinkBufferEntry> bufferList = new ArrayList<>();
+        long curMaxEvents = maxEvents;
+        long curMaxSize = maxRequestSize;
+        long reqSize = 0L;
+        for (Map.Entry<String, PrometheusSinkBufferWriterEntry> entry : buffer.entrySet()) {
+            if (curMaxEvents == 0 || curMaxSize == 0) {
+                break;
+            }
+            Pair<List<PrometheusSinkBufferEntry>, Long> result = entry.getValue().getEntriesReadyToFlush(curMaxEvents, curMaxSize);
+            if (!result.left().isEmpty()) {
+                curMaxEvents -= result.left().size();
+                curMaxSize -= result.right();
+                reqSize += result.right();
+                bufferList.addAll(result.left());
+            }
+        }
+        if (bufferList.isEmpty()) {
+            return null;
+        }
+        sinkMetrics.recordRequestSize(reqSize);
+        buffer.entrySet().removeIf(entry -> entry.getValue().getSize() == 0);
 
-        buffer.clear();
         return new PrometheusSinkFlushableBuffer(bufferList, sinkMetrics, sinkFlushContext);
     }
 }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterEntry.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterEntry.java
@@ -1,0 +1,119 @@
+ /*
+  * Copyright OpenSearch Contributors
+  * SPDX-License-Identifier: Apache-2.0
+  *
+  * The OpenSearch Contributors require contributions made to
+  * this file be licensed under the Apache-2.0 license or a
+  * compatible open source license.
+  *
+  */
+package org.opensearch.dataprepper.plugins.sink.prometheus.service;
+
+import com.google.common.annotations.VisibleForTesting;
+import software.amazon.awssdk.utils.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class PrometheusSinkBufferWriterEntry {
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusSinkBufferWriterEntry.class);
+    private long lastSentTimestamp = -1L;
+    private final int maxEntries;
+    private final long windowMillis;
+    private long seriesMaxTimestamp = -1L;
+    private long realtimeSeriesMax;
+    private final TreeMap<Long, PrometheusSinkBufferEntry> entries;
+
+    public PrometheusSinkBufferWriterEntry(final long windowMillis, final int maxEntries) {
+        this.maxEntries = maxEntries;
+        this.windowMillis = windowMillis;
+        this.entries = new TreeMap<>();
+        this.realtimeSeriesMax = Instant.now().toEpochMilli();
+    }
+    
+    public boolean add(final PrometheusSinkBufferEntry bufferEntry) {
+        long time = bufferEntry.getTimeSeries().getTimestamp();
+        if (time <= lastSentTimestamp) {
+            return false; 
+        }
+
+        if (time > seriesMaxTimestamp) {
+            seriesMaxTimestamp = time;
+            realtimeSeriesMax = Instant.now().toEpochMilli();
+        }
+
+        entries.put(time, bufferEntry);
+        if (entries.size() > maxEntries) {
+            LOG.warn("Number of entries exceeded maxEntries");
+            return false;
+        }
+        return true;
+    }
+
+    public long getSize() {
+        return entries.size();
+    }
+
+    @VisibleForTesting
+    long windowSize() {
+        long timeOffset = Instant.now().toEpochMilli() - realtimeSeriesMax;
+        return (seriesMaxTimestamp - windowMillis + timeOffset + 1);
+    }
+
+    public long getNumberOfEntriesReadyToFlush() {
+        SortedMap<Long, PrometheusSinkBufferEntry> readyToFlush = entries.headMap(windowSize());
+        return readyToFlush.size();
+    }
+
+    public long getSizeOfEntriesReadyToFlush() {
+        return entries.headMap(windowSize())
+              .values()
+              .stream()
+              .mapToLong(entry -> entry.getTimeSeries().getSize())
+              .sum();
+    }
+
+    public Pair<List<PrometheusSinkBufferEntry>, Long> getEntriesReadyToFlush(final long maxEvents, final long maxSize) {
+        if (entries.isEmpty()) {
+            return Pair.of(Collections.emptyList(), 0L);
+        }
+
+        final long cutoff = windowSize();
+        List<PrometheusSinkBufferEntry> toFlush = new ArrayList<>();
+
+        SortedMap<Long, PrometheusSinkBufferEntry> readyToFlush = entries.headMap(cutoff);
+        long numEntries = 0L;
+        long curSize = 0L;
+        if (!readyToFlush.isEmpty()) {
+            Iterator<Map.Entry<Long, PrometheusSinkBufferEntry>> iterator = readyToFlush.entrySet().iterator();
+
+            while (iterator.hasNext() && numEntries < maxEvents ) {
+                Map.Entry<Long, PrometheusSinkBufferEntry> entry = iterator.next();
+                long entrySize = entry.getValue().getTimeSeries().getSize();
+    
+                if (curSize + entrySize > maxSize) {
+                    break;
+                }
+                curSize += entrySize;
+                toFlush.add(entry.getValue());
+                iterator.remove();
+                numEntries++;
+            }
+        }
+        
+        if (!toFlush.isEmpty()) {
+            toFlush.sort(Comparator.comparing(bufferEntry -> bufferEntry.getTimeSeries().getTimestamp()));
+            this.lastSentTimestamp = toFlush.get(toFlush.size() - 1).getTimeSeries().getTimestamp();
+        }
+        return Pair.of(toFlush, curSize);
+    }
+}

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
@@ -13,7 +13,6 @@ package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.opensearch.dataprepper.common.sink.DefaultSinkOutputStrategy;
-import org.opensearch.dataprepper.common.sink.DefaultSinkBuffer;
 import org.opensearch.dataprepper.common.sink.SinkMetrics;
 import org.opensearch.dataprepper.common.sink.SinkBufferEntry;
 import org.opensearch.dataprepper.common.sink.ReentrantLockStrategy;
@@ -29,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 
 public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     static final String PLUGIN_NAME = "prometheus";
@@ -51,10 +49,10 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
                                  final HeadlessPipeline dlqPipeline,
                                  final PipelineDescription pipelineDescription) {
         super(new ReentrantLockStrategy(),
-              new DefaultSinkBuffer(prometheusSinkConfiguration.getThresholdConfig().getMaxEvents(),
+              new PrometheusSinkBuffer(prometheusSinkConfiguration.getThresholdConfig().getMaxEvents(),
                   prometheusSinkConfiguration.getThresholdConfig().getMaxRequestSizeBytes(),
                   prometheusSinkConfiguration.getThresholdConfig().getFlushIntervalMs(),
-                  new PrometheusSinkBufferWriter(sinkMetrics)),
+                  new PrometheusSinkBufferWriter(prometheusSinkConfiguration, sinkMetrics)),
               new PrometheusSinkFlushContext(httpSender),
               sinkMetrics);
         sanitizeNames = prometheusSinkConfiguration.getSanitizeNames();
@@ -81,7 +79,7 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     }
 
     public void flushDlqList() {
-        if (dlqRecords.size() == 0) {
+        if (dlqRecords.isEmpty()) {
             return;
         }
         if (dlqPipeline != null) {

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterEntryTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterEntryTest.java
@@ -1,0 +1,132 @@
+ /*
+  * Copyright OpenSearch Contributors
+  * SPDX-License-Identifier: Apache-2.0
+  *
+  * The OpenSearch Contributors require contributions made to
+  * this file be licensed under the Apache-2.0 license or a
+  * compatible open source license.
+  *
+  */
+
+package org.opensearch.dataprepper.plugins.sink.prometheus.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import software.amazon.awssdk.utils.Pair;
+
+import java.util.List;
+
+public class PrometheusSinkBufferWriterEntryTest {
+    static final long TEST_WINDOW_MS = 2000;
+    static final int TEST_MAX_ENTRIES = 100;
+    static final int TEST_NUM_ENTRIES = 10;
+
+    private PrometheusSinkBufferWriterEntry sinkBufferWriterEntry;
+    private long timeStamp;
+    
+
+    private PrometheusSinkBufferWriterEntry createObjectUnderTest() {
+        return new PrometheusSinkBufferWriterEntry(TEST_WINDOW_MS, TEST_MAX_ENTRIES);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 5, 8, 10})
+    public void testBufferEntryWriterMaxEvents(final int maxEvents) {
+        sinkBufferWriterEntry = createObjectUnderTest();
+        assertThat(sinkBufferWriterEntry.getNumberOfEntriesReadyToFlush(), equalTo(0L));
+        assertThat(sinkBufferWriterEntry.getSizeOfEntriesReadyToFlush(), equalTo(0L));
+        Pair<List<PrometheusSinkBufferEntry>, Long> result = sinkBufferWriterEntry.getEntriesReadyToFlush(1, 100L);
+        assertTrue(result.left().isEmpty());
+        assertThat(result.right(), equalTo(0L));
+        for (int i = 0; i < TEST_NUM_ENTRIES; i++) {
+            long timeStamp = (i+1)*1000L;
+            PrometheusTimeSeries timeSeries = mock(PrometheusTimeSeries.class);
+            when(timeSeries.getTimestamp()).thenReturn(timeStamp);
+            when(timeSeries.getSize()).thenReturn(100);
+            PrometheusSinkBufferEntry bufferEntry = mock(PrometheusSinkBufferEntry.class);
+            when(bufferEntry.getTimeSeries()).thenReturn(timeSeries);
+            assertThat(sinkBufferWriterEntry.add(bufferEntry), equalTo(true));
+        }
+        assertThat(sinkBufferWriterEntry.getSize(), equalTo(10L));
+
+        try {
+            Thread.sleep(3000);
+        } catch (Exception e) {}
+
+        int remainingEvents = TEST_NUM_ENTRIES;
+        while (remainingEvents > 0) {
+            int expectedEvents = Math.min(maxEvents, remainingEvents);
+            result = sinkBufferWriterEntry.getEntriesReadyToFlush(maxEvents, 2000L);
+            assertThat(result.left().size(), equalTo(expectedEvents));
+            remainingEvents -= result.left().size();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {100L, 200L, 500L, 800L, 1000L})
+    public void testBufferEntryWriterMaxSize(final long maxSize) {
+        sinkBufferWriterEntry = createObjectUnderTest();
+        assertThat(sinkBufferWriterEntry.getNumberOfEntriesReadyToFlush(), equalTo(0L));
+        assertThat(sinkBufferWriterEntry.getSizeOfEntriesReadyToFlush(), equalTo(0L));
+        Pair<List<PrometheusSinkBufferEntry>, Long> result = sinkBufferWriterEntry.getEntriesReadyToFlush(1, 100L);
+        assertTrue(result.left().isEmpty());
+        assertThat(result.right(), equalTo(0L));
+        for (int i = 0; i < TEST_NUM_ENTRIES; i++) {
+            long timeStamp = (i+1)*1000L;
+            PrometheusTimeSeries timeSeries = mock(PrometheusTimeSeries.class);
+            when(timeSeries.getTimestamp()).thenReturn(timeStamp);
+            when(timeSeries.getSize()).thenReturn(100);
+            PrometheusSinkBufferEntry bufferEntry = mock(PrometheusSinkBufferEntry.class);
+            when(bufferEntry.getTimeSeries()).thenReturn(timeSeries);
+            assertThat(sinkBufferWriterEntry.add(bufferEntry), equalTo(true));
+        }
+        assertThat(sinkBufferWriterEntry.getSize(), equalTo(10L));
+
+        try {
+            Thread.sleep(3000);
+        } catch (Exception e) {}
+
+        int remainingEvents = TEST_NUM_ENTRIES;
+        while (remainingEvents > 0) {
+            long expectedSize = Math.min(maxSize, remainingEvents * 100L);
+            result = sinkBufferWriterEntry.getEntriesReadyToFlush(20, maxSize);
+            assertThat(result.right(), equalTo(expectedSize));
+            remainingEvents -= result.left().size();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 5, 8, 10})
+    public void testAddingOldEventsGetRejected(final int numEvents) {
+        long timeStamp = 0;
+        sinkBufferWriterEntry = createObjectUnderTest();
+        for (int i = 0; i < numEvents; i++) {
+            timeStamp = (i+1)*1000L;
+            PrometheusTimeSeries timeSeries = mock(PrometheusTimeSeries.class);
+            when(timeSeries.getTimestamp()).thenReturn(timeStamp);
+            when(timeSeries.getSize()).thenReturn(100);
+            PrometheusSinkBufferEntry bufferEntry = mock(PrometheusSinkBufferEntry.class);
+            when(bufferEntry.getTimeSeries()).thenReturn(timeSeries);
+            assertThat(sinkBufferWriterEntry.add(bufferEntry), equalTo(true));
+        }
+        try {
+            Thread.sleep(3000);
+        } catch (Exception e) {}
+        Pair<List<PrometheusSinkBufferEntry>, Long> result = sinkBufferWriterEntry.getEntriesReadyToFlush(20, 2000L);
+        assertThat(result.left().size(), equalTo(numEvents));
+        PrometheusTimeSeries timeSeries = mock(PrometheusTimeSeries.class);
+        when(timeSeries.getTimestamp()).thenReturn(timeStamp - 100L);
+        when(timeSeries.getSize()).thenReturn(100);
+        PrometheusSinkBufferEntry bufferEntry = mock(PrometheusSinkBufferEntry.class);
+        when(bufferEntry.getTimeSeries()).thenReturn(timeSeries);
+        assertThat(sinkBufferWriterEntry.add(bufferEntry), equalTo(false));
+        assertThat(sinkBufferWriterEntry.getSize(), equalTo(0L));
+    }
+}


### PR DESCRIPTION
### Description
Add rolling buffer to Prometheus sink
1. A time based window can be configured using "out_of_order_window" config parameter which is used to keep last few milli seconds ( defined in out_of_order_window with default value of 5 seconds) of buffer as rolling buffer. Any events before this time are flushed and after flushing them, older events are rejected. 
2. This rolling buffer is maintained for each metric separately. Time window of metric1 doesn't interfere with time window of metric2
3. for a given metric, samples are returned in time sorted way
4. for a given metric, labels are sorted by the name
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
