### PR TITLE
Add metric tracking time between poll calls for kafka consumer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -210,6 +210,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
     }
 
     <T> ConsumerRecords<String, T> doPoll() throws Exception {
+            topicMetrics.recordTimeBetweenPolls();
             ConsumerRecords<String, T> records =
                     consumer.poll(Duration.ofMillis(topicConfig.getThreadWaitingTime().toMillis()/2));
             return records;

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -327,6 +328,8 @@ public class KafkaCustomConsumerTest {
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
+
+        verify(topicMetrics).recordTimeBetweenPolls();
     }
 
     @Test
@@ -377,6 +380,8 @@ public class KafkaCustomConsumerTest {
         });
         // This counter should not be incremented with acknowledgements
         Assertions.assertEquals(consumer.getNumRecordsCommitted(), 0L);
+
+        verify(topicMetrics).recordTimeBetweenPolls();
     }
 
     @Test
@@ -420,6 +425,8 @@ public class KafkaCustomConsumerTest {
         consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
         Assertions.assertEquals(offsetsToCommit.size(), 0);
+
+        verify(topicMetrics).recordTimeBetweenPolls();
     }
 
     @Test
@@ -458,6 +465,8 @@ public class KafkaCustomConsumerTest {
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
+
+        verify(topicMetrics).recordTimeBetweenPolls();
     }
 
     @Test


### PR DESCRIPTION
### Description
This change adds a metric to the KafkaCustomerConsumer `actualPollInterval` that tracks how often the consumers are calling poll. This metric is useful because if poll is not called often enough based on the `max.poll.interval.ms` setting, there will be Rebalances on the kafka topic.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
