### PR TITLE
Prometheus Sink: Fix setting DLQ pipeline, add NOISY marker for logs

### DIFF
--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusHttpSender.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusHttpSender.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.prometheus;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.PrometheusSinkConfiguration;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.retry.Backoff;
@@ -145,12 +146,12 @@ public class PrometheusHttpSender {
                     return new PrometheusPushResult(handleResponse(statusCode, responseBytes), statusCode);
                 })
                 .exceptionally(throwable -> {
-                    LOG.error("Request failed", throwable);
+                    LOG.error(NOISY, "Request failed", throwable);
                     return new PrometheusPushResult(false, 0);
                 })
                 .join();  // Wait for completion
         } catch (Exception e) {
-            LOG.error("Failed to execute request", e);
+            LOG.error(NOISY, "Failed to execute request", e);
             result = new PrometheusPushResult(false, 0);
         }
         return result;
@@ -210,7 +211,7 @@ public class PrometheusHttpSender {
                 ? new String(responseBytes, StandardCharsets.UTF_8)
                 : "<no body>";
 
-        LOG.error("Non-successful Prometheus server response. Status: {}, Response: {}",
+        LOG.error(NOISY, "Non-successful Prometheus server response. Status: {}, Response: {}",
                     statusCode, responseBody);
         return false;
     }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSink.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSink.java
@@ -66,7 +66,6 @@ public class PrometheusSink extends AbstractSink<Record<Event>> {
                 prometheusSinkConfiguration,
                 sinkMetrics,
                 httpSender,
-                getFailurePipeline(),
                 pipelineDescription);
     }
 
@@ -87,6 +86,7 @@ public class PrometheusSink extends AbstractSink<Record<Event>> {
     @Override
     public void doInitialize() {
         sinkInitialized = Boolean.TRUE;
+        prometheusSinkService.setDlqPipeline(getFailurePipeline());
     }
 
     @VisibleForTesting

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterEntry.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterEntry.java
@@ -9,6 +9,7 @@
   */
 package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.utils.Pair;
 import org.slf4j.Logger;
@@ -53,7 +54,7 @@ public class PrometheusSinkBufferWriterEntry {
 
         entries.put(time, bufferEntry);
         if (entries.size() > maxEntries) {
-            LOG.warn("Number of entries exceeded maxEntries");
+            LOG.warn(NOISY, "Number of entries exceeded maxEntries");
             return false;
         }
         return true;

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
@@ -10,8 +10,6 @@
 
 package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import org.opensearch.dataprepper.common.sink.DefaultSinkOutputStrategy;
 import org.opensearch.dataprepper.common.sink.SinkMetrics;
 import org.opensearch.dataprepper.common.sink.SinkBufferEntry;
@@ -22,8 +20,6 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.PrometheusSinkConfiguration;
 import org.opensearch.dataprepper.plugins.sink.prometheus.PrometheusHttpSender;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,7 +27,6 @@ import java.util.List;
 
 public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     static final String PLUGIN_NAME = "prometheus";
-    private static final Logger LOG = LoggerFactory.getLogger(PrometheusSinkService.class);
     public static final String PROMETHEUS_SINK_RECORDS_SUCCESS_COUNTER = "prometheusSinkRecordsNumberOfSuccessful";
 
     public static final String PROMETHEUS_SINK_RECORDS_FAILED_COUNTER = "prometheusSinkRecordsNumberOfFailed";
@@ -46,7 +41,6 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     public PrometheusSinkService(final PrometheusSinkConfiguration prometheusSinkConfiguration,
                                  final SinkMetrics sinkMetrics,
                                  final PrometheusHttpSender httpSender,
-                                 final HeadlessPipeline dlqPipeline,
                                  final PipelineDescription pipelineDescription) {
         super(new ReentrantLockStrategy(),
               new PrometheusSinkBuffer(prometheusSinkConfiguration.getThresholdConfig().getMaxEvents(),
@@ -57,7 +51,6 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
               sinkMetrics);
         sanitizeNames = prometheusSinkConfiguration.getSanitizeNames();
         this.dropIfNoDLQConfigured = false;
-        this.dlqPipeline = dlqPipeline;
         this.dlqRecords = new ArrayList<>();
         this.httpSender = httpSender;
         this.pipelineDescription = pipelineDescription;
@@ -73,7 +66,6 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
         return new PrometheusSinkBufferEntry(event, sanitizeNames);
     }
 
-    @VisibleForTesting
     public void setDlqPipeline(HeadlessPipeline pipeline) {
         this.dlqPipeline = pipeline;
     }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusTimeSeries.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusTimeSeries.java
@@ -10,6 +10,8 @@
 
 package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
 import com.arpnetworking.metrics.prometheus.Types.Label;
 import com.arpnetworking.metrics.prometheus.Types.Sample;
 import com.arpnetworking.metrics.prometheus.Types.TimeSeries;
@@ -161,7 +163,7 @@ public class PrometheusTimeSeries {
                 size += processAttributes(scopeAttributes, SCOPE_PREFIX);
             }
         } catch (Exception e) {
-            LOG.warn("Failed to get resource/scope attributes", e);
+            LOG.warn(NOISY, "Failed to get resource/scope attributes", e);
         }
         return size;
     }

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkServiceTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkServiceTest.java
@@ -109,19 +109,18 @@ public class PrometheusSinkServiceTest {
 
     }
 
-    PrometheusSinkService createObjectUnderTest(final PrometheusSinkConfiguration prometheusSinkConfig, final HeadlessPipeline dlqPipeline) {
+    PrometheusSinkService createObjectUnderTest(final PrometheusSinkConfiguration prometheusSinkConfig) {
         return new PrometheusSinkService(
                 prometheusSinkConfig,
                 sinkMetrics,
                 httpSender,
-                dlqPipeline,
                 pipelineDescription);
     }
 
     @Test
     void prometheusSinkServiceTestSuccessfulOutput() throws NoSuchFieldException, IllegalAccessException {
         when(httpSender.pushToEndpoint(any())).thenReturn(new PrometheusPushResult(true, 0));
-        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration, null);
+        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration);
         JacksonGauge gauge1 = createGaugeMetric("gauge1", null);
         JacksonGauge gauge2 = createGaugeMetric("gauge2", null);
         Collection<Record<Event>> records = List.of(new Record<>(gauge1), new Record<>(gauge2));
@@ -136,7 +135,7 @@ public class PrometheusSinkServiceTest {
         String newYaml = SINK_YAML.replace("out_of_order_window: 0", "out_of_order_window: 1");
         this.prometheusSinkConfiguration = objectMapper.readValue(newYaml,PrometheusSinkConfiguration.class);
         when(httpSender.pushToEndpoint(any())).thenReturn(new PrometheusPushResult(true, 0));
-        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration, null);
+        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration);
         Instant t = Instant.now();
         JacksonGauge gauge1 = createGaugeMetric("gauge1", t);
         JacksonGauge gauge2 = createGaugeMetric("gauge1", t.plusMillis(100));
@@ -163,7 +162,7 @@ public class PrometheusSinkServiceTest {
             }
             return null;
         }).when(dlqPipeline).sendEvents(any(Collection.class));
-        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration, null);
+        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration);
         objectUnderTest.setDlqPipeline(dlqPipeline);
         JacksonGauge gauge1 = createGaugeMetric("gauge1", null);
         JacksonGauge gauge2 = createGaugeMetric("gauge2", null);
@@ -177,7 +176,7 @@ public class PrometheusSinkServiceTest {
     @Test
     void prometheusSinkServiceTestFailedOutputWithNoDLQ() throws NoSuchFieldException, IllegalAccessException {
         when(httpSender.pushToEndpoint(any())).thenReturn(new PrometheusPushResult(false, 410));
-        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration, null);
+        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration);
         JacksonGauge gauge1 = createGaugeMetric("gauge1", null);
         JacksonGauge gauge2 = createGaugeMetric("gauge2", null);
         Collection<Record<Event>> records = List.of(new Record<>(gauge1), new Record<>(gauge2));
@@ -190,7 +189,7 @@ public class PrometheusSinkServiceTest {
     @Test
     void prometheusSinkServiceTestWithExceptionInHttpSender() throws NoSuchFieldException, IllegalAccessException {
         when(httpSender.pushToEndpoint(any())).thenThrow(new RuntimeException("exception"));
-        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration, null);
+        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration);
         JacksonGauge gauge1 = createGaugeMetric("gauge1", null);
         JacksonGauge gauge2 = createGaugeMetric("gauge2", null);
         Collection<Record<Event>> records = List.of(new Record<>(gauge1), new Record<>(gauge2));
@@ -204,7 +203,7 @@ public class PrometheusSinkServiceTest {
 
     @Test
     void prometheus_sink_service_test_output_with_zero_record() throws NoSuchFieldException, IllegalAccessException {
-        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration, null);
+        final PrometheusSinkService objectUnderTest = createObjectUnderTest(prometheusSinkConfiguration);
         Collection<Record<Event>> records = List.of();
         objectUnderTest.output(records);
     }


### PR DESCRIPTION
### Description
Fix Prometheus Sink -
1. Add NOISY markers to LOG messages
2. Fix setting of DLQ pipeline by setting it during sink initialization and not during sink object construction
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
