### PR TITLE
Fixes the license headers in all files in data-prepper-api.

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 plugins {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluationException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluationException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionParsingException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionParsingException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.logging;
 
 import org.slf4j.Marker;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/MetricNames.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.metrics;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/PluginMetrics.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.metrics;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/CheckpointState.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/CheckpointState.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.acknowledgements;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.acknowledgements;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/ProgressCheck.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/ProgressCheck.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.acknowledgements;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/AlsoRequired.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/AlsoRequired.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.annotations;
 
 import java.lang.annotation.Documented;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ConditionalRequired.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ConditionalRequired.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.annotations;
 
 import java.lang.annotation.ElementType;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperExtensionPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperExtensionPlugin.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.annotations;
 
 import java.lang.annotation.Documented;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPluginConstructor.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPluginConstructor.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ExampleValues.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ExampleValues.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ExtensionDependsOn.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ExtensionDependsOn.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ExtensionProvides.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ExtensionProvides.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/SingleThread.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/SingleThread.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/SkipTestCoverageGenerated.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/SkipTestCoverageGenerated.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/UsesDataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/UsesDataPrepperPlugin.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.annotations;
 
 import java.lang.annotation.Documented;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ValidRegex.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/ValidRegex.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.annotations;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/breaker/CircuitBreaker.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/breaker/CircuitBreaker.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.breaker;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/DelegatingBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/DelegatingBuffer.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/SizeOverflowException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/SizeOverflowException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/CompressionEngine.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/CompressionEngine.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/DecompressionEngine.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/DecompressionEngine.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.codec;
 
 import java.io.IOException;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/HasByteDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/HasByteDecoder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/InputCodec.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/InputCodec.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonObjectDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonObjectDecoder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/OutputCodec.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/OutputCodec.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/ConditionalRoute.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/ConditionalRoute.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineDescription.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineDescription.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineExtensions.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineExtensions.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.configuration;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineModel.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModel.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfig.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfig.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/document/Document.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/document/Document.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.document;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/document/JacksonDocument.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/document/JacksonDocument.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.document;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/EncryptionEngine.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/EncryptionEngine.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.encryption;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/EncryptionEnvelope.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/EncryptionEnvelope.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.encryption;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/KeyProvider.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/encryption/KeyProvider.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.encryption;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/AbstractEventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/AbstractEventHandle.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/AggregateEventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/AggregateEventHandle.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/BaseEventBuilder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/BaseEventBuilder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventHandle.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventBuilder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventBuilder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFactory.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFailureMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFailureMetadata.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventHandle.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKey.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKeyConfiguration.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKeyConfiguration.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKeyFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKeyFactory.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventType.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOption.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOption.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/InternalEventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/InternalEventHandle.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/LogEventBuilder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/LogEventBuilder.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/exceptions/EventKeyNotFoundException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/exceptions/EventKeyNotFoundException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event.exceptions;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.failures;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/io/InputFile.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/io/InputFile.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.io;
 
 public interface InputFile extends org.apache.parquet.io.InputFile {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/io/OutputFile.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/io/OutputFile.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.io;
 
 public interface OutputFile extends org.apache.parquet.io.OutputFile {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonLog.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonStandardOTelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonStandardOTelLog.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/Log.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/Log.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Bucket.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Bucket.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/DefaultBucket.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/DefaultBucket.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/DefaultExemplar.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/DefaultExemplar.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/DefaultQuantile.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/DefaultQuantile.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Exemplar.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Exemplar.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/ExponentialHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/ExponentialHistogram.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Gauge.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Gauge.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Histogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Histogram.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonGauge.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonGauge.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardExponentialHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardExponentialHistogram.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardGauge.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardGauge.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardHistogram.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardSum.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardSum.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardSummary.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonStandardSummary.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSum.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSum.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSummary.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSummary.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Metric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Metric.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Quantile.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Quantile.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Sum.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Sum.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Summary.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Summary.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActions.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActions.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.opensearch;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.peerforwarder;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pipeline/HeadlessPipeline.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pipeline/HeadlessPipeline.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.pipeline;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/ExtensionPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/ExtensionPlugin.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/ExtensionPoints.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/ExtensionPoints.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/ExtensionProvider.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/ExtensionProvider.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/FailedToUpdatePluginConfigValueException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/FailedToUpdatePluginConfigValueException.java
@@ -5,7 +5,6 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
  */
 package org.opensearch.dataprepper.model.plugin;
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/InvalidPluginConfigurationException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/InvalidPluginConfigurationException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/InvalidPluginDefinitionException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/InvalidPluginDefinitionException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/NoPluginFoundException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/NoPluginFoundException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginComponentRefresher.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginComponentRefresher.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.plugin;
 
 /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigObservable.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigObservable.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.plugin;
 
 /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigObserver.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigObserver.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.plugin;
 
 /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigPublisher.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigPublisher.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.plugin;
 
 /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigValueTranslator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigValueTranslator.java
@@ -5,7 +5,6 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
  */
 package org.opensearch.dataprepper.model.plugin;
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigVariable.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigVariable.java
@@ -5,7 +5,6 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
  */
 package org.opensearch.dataprepper.model.plugin;
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginInvocationException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginInvocationException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.processor;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/Processor.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/Processor.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.processor;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/Record.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/Record.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.record;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/RecordMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/RecordMetadata.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.record;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/OutputCodecContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/OutputCodecContext.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/Sink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/Sink.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContext.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkLatencyMetrics.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkLatencyMetrics.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkThread.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkThread.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifier.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifier.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartition.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartition.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionStatus.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionStatus.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionStoreItem.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionStoreItem.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/UsesSourceCoordination.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/UsesSourceCoordination.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedPartition.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedPartition.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourceCoordinator.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourcePartition.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourcePartition.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/UsesEnhancedSourceCoordination.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/UsesEnhancedSourceCoordination.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotFoundException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotFoundException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.exceptions;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotOwnedException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotOwnedException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.exceptions;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionUpdateException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionUpdateException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.exceptions;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/UninitializedSourceCoordinatorException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/UninitializedSourceCoordinatorException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.exceptions;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/s3/S3ScanEnvironmentVariables.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/s3/S3ScanEnvironmentVariables.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.source.s3;
 
 import org.opensearch.dataprepper.model.annotations.SkipTestCoverageGenerated;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultLink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultLink.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultSpanEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultSpanEvent.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFields.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFields.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpan.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Link.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Link.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/SpanEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/SpanEvent.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/TraceGroupFields.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/TraceGroupFields.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.types;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCountInvalidInputException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCountInvalidInputException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.types;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCountParseException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCountParseException.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.types;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/validation/ParameterValidator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/validation/ParameterValidator.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.validation;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/validation/RegexValueValidator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/validation/RegexValueValidator.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.validation;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/processor/state/ProcessorState.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/processor/state/ProcessorState.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.processor.state;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
  package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/ConverterArguments.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/ConverterArguments.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.typeconverter;
 
 /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/DoubleConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/DoubleConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/IntegerConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/IntegerConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/LongConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/LongConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
  package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/StringConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/StringConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/TypeConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/TypeConverter.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluationExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluationExceptionTest.java
@@ -1,8 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionParsingExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionParsingExceptionTest.java
@@ -1,8 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.logging;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/MetricsTestUtil.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.metrics;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/PluginMetricsTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.metrics;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/CheckpointStateTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/CheckpointStateTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.acknowledgements;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/AbstractBufferTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/DelegatingBufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/DelegatingBufferTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.buffer;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/CompressionEngineTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/CompressionEngineTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/HasByteDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/HasByteDecoderTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/InputCodecTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/InputCodecTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.codec;
 
 import org.apache.parquet.io.SeekableInputStream;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.codec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonObjectDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonObjectDecoderTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.codec;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/OutputCodecTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/OutputCodecTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.codec;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/ConditionalRouteTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/ConditionalRouteTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelineModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelineModelTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginModelTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginModelTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginSettingsTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginSettingsTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfigTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfigTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.configuration;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/document/JacksonDocumentTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/document/JacksonDocumentTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.document;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/AggregateEventHandleTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/AggregateEventHandleTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventHandleTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventHandleTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventActionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventActionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventKeyFactoryTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventKeyFactoryTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventTypeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventTypeTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/HandleFailedEventsOptionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEvent_JavaSerializationTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEvent_JavaSerializationTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/TestObject.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/TestObject.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.failures;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonLogTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonStandardOTelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonStandardOTelLogTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.log;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonHistogramTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardExponentialHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardExponentialHistogramTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardGaugeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardGaugeTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardHistogramTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardSumTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardSumTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardSummaryTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonStandardSummaryTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSumTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSumTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSummaryTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSummaryTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.metric;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActionsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActionsTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.opensearch;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.peerforwarder;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/ExtensionPluginTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/ExtensionPluginTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.model.plugin;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/FailedToUpdatePluginConfigValueExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/FailedToUpdatePluginConfigValueExceptionTest.java
@@ -5,7 +5,6 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
  */
 package org.opensearch.dataprepper.model.plugin;
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/InvalidPluginConfigurationExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/InvalidPluginConfigurationExceptionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/InvalidPluginDefinitionExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/InvalidPluginDefinitionExceptionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/NoPluginFoundExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/NoPluginFoundExceptionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/PluginInvocationExceptionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/plugin/PluginInvocationExceptionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.plugin;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/processor/AbstractProcessorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/processor/AbstractProcessorTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.processor;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/processor/ProcessorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/processor/ProcessorTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.processor;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordMetadataTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.record;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.record;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/OutputCodecContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/OutputCodecContextTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkForwardRecordsContextTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkLatencyMetricsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkLatencyMetricsTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkThreadTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkThreadTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.sink;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/SourceTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/SourceTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifierTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifierTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourcePartitionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourcePartitionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestInstantTypeProgressState.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestInstantTypeProgressState.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestInvalidPartitionProgressState.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestInvalidPartitionProgressState.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestPartitionProgressState.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/TestPartitionProgressState.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.source.coordinator.enhanced;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultLinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultLinkTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultSpanEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultSpanEventTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonStandardSpanTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.trace;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/types/ByteCountTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/types/ByteCountTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.types;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/validation/RegexValueValidatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/validation/RegexValueValidatorTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.model.validation;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BooleanConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BooleanConverterTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/DoubleConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/DoubleConverterTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/IntegerConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/IntegerConverterTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/LongConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/LongConverterTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/StringConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/StringConverterTests.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.typeconverter;


### PR DESCRIPTION
### Description

This PR updates or adds license headers to files in the data-prepper-api project. Mostly, they needed the update header.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
