### PR TITLE
Prefer org.lgz4 artifact over at.yawk.lz4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,10 +247,6 @@ subprojects {
                 details.because 'Use the defined JUnit of the Data Prepper project to ensure consistent versions.'
             }
         }
-        resolutionStrategy.capabilitiesResolution.withCapability('org.lz4:lz4-java') {
-            select('org.lz4:lz4-java:0')
-            because 'Prefer the official org.lz4 artifact over the relocated at.yawk.lz4 version'
-        }
     }
 
     test {

--- a/data-prepper-plugins/mapdb-processor-state/build.gradle
+++ b/data-prepper-plugins/mapdb-processor-state/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation('org.mapdb:mapdb:3.1.0') {
         exclude group: 'net.jpountz.lz4', module: 'lz4'
     }
-    implementation 'org.lz4:lz4-java:1.8.1'
+    implementation 'org.lz4:lz4-java:1.8.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.9.23'
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output


### PR DESCRIPTION
### Description

Reverting a change introduced by dependabot that is causing a lot of build failures
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
