### PR TITLE
Update sample app urlib3 from 2.6.0 to 2.6.3 to fix CVE-2026-21441

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -8,6 +8,6 @@ opentelemetry-sdk==1.25.0
 protobuf==4.25.8
 requests==2.32.4
 setuptools==78.1.1
-urllib3==2.6.0
+urllib3==2.6.3
 werkzeug==3.0.6
 zipp==3.19.1


### PR DESCRIPTION
### Description
Fixes CVE-2026-21441
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
