### PR TITLE
Add read timeout configuration for AWS Lambda plugin

### DIFF
--- a/data-prepper-plugins/aws-lambda/README.md
+++ b/data-prepper-plugins/aws-lambda/README.md
@@ -16,6 +16,11 @@ lambda-pipeline:
         max_retries: 3
         invocation_type: "RequestResponse"
         payload_model: "batch_event"
+        client:
+            connection_timeout: 60s
+            read_timeout: 60s
+            api_call_timeout: 60s
+            max_retries: 3
         batch:
             key_name: "osi_key"
             threshold:
@@ -96,6 +101,11 @@ lambda-pipeline:
             sts_role_arn: "<arn>"
         function_name: "uploadToS3Lambda"
         max_retries: 3
+        client:
+            connection_timeout: 60s
+            read_timeout: 60s
+            api_call_timeout: 60s
+            max_retries: 3
         batch:
             key_name: "osi_key"
             threshold:

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/client/LambdaClientFactory.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/client/LambdaClientFactory.java
@@ -34,7 +34,8 @@ public final class LambdaClientFactory {
                     createOverrideConfiguration(clientOptions, awsSdkMetrics))
             .httpClient(NettyNioAsyncHttpClient.builder()
                     .maxConcurrency(clientOptions.getMaxConcurrency())
-                    .connectionTimeout(clientOptions.getConnectionTimeout()).build())
+                    .connectionTimeout(clientOptions.getConnectionTimeout())
+                    .readTimeout(clientOptions.getReadTimeout()).build())
             .build();
   }
 

--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/config/ClientOptions.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/common/config/ClientOptions.java
@@ -11,6 +11,7 @@ public class ClientOptions {
     public static final int DEFAULT_CONNECTION_RETRIES = 3;
     public static final int DEFAULT_MAXIMUM_CONCURRENCY = 200;
     public static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
+    public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60);
     public static final Duration DEFAULT_API_TIMEOUT = Duration.ofSeconds(60);
     public static final Duration DEFAULT_BASE_DELAY = Duration.ofMillis(100);
     public static final Duration DEFAULT_MAX_BACKOFF = Duration.ofSeconds(20);
@@ -26,6 +27,10 @@ public class ClientOptions {
     @JsonPropertyDescription("sdk timeout defines the time sdk maintains the connection to the client before timing out")
     @JsonProperty("connection_timeout")
     private Duration connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+
+    @JsonPropertyDescription("read timeout defines the time sdk waits for data to be read from an established connection")
+    @JsonProperty("read_timeout")
+    private Duration readTimeout = DEFAULT_READ_TIMEOUT;
 
     @JsonPropertyDescription("max concurrency defined from the client side")
     @JsonProperty("max_concurrency")


### PR DESCRIPTION
- Add read_timeout field to ClientOptions with default 60s
- Configure NettyNioAsyncHttpClient with read timeout
- Update README with client configuration examples
- Enables configurable read timeout for Lambda function calls

### Description

Adds configurable read timeout support for AWS Lambda plugin HTTP client. This enhancement allows users to configure how long the
HTTP client waits for data to be read from an established connection when invoking Lambda functions, providing better control over
timeout behavior for long-running Lambda operations.

### Changes include:
• Added read_timeout configuration option to ClientOptions with 60-second default
• Updated LambdaClientFactory to apply read timeout to NettyNioAsyncHttpClient
Issues Resolved

Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/data-prepper/issues/6257

### Check List

[]New functionality includes testing.

[]New functionality has a documentation issue. Please link to it in this PR.
[yes ] New functionality has javadoc added
[ yes] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).