### PR TITLE
Support building and releasing Docker multi-architecture images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,6 @@ jobs:
     - name: Build Maven Artifacts
       run: ./gradlew publishAllPublicationsToMavenRepository
 
-    - name: Build Docker Image
-      run: ./gradlew :release:docker:docker
-
     - name: Upload Archives to Archives Bucket
       run: ./gradlew :release:archives:uploadArchives -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
 
@@ -63,10 +60,8 @@ jobs:
         registry: public.ecr.aws
       env:
         AWS_REGION: us-east-1
-    - name: Push Image to Staging ECR
-      run: |
-        docker tag opensearch-data-prepper:${{ env.version }} ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
-        docker push ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
+    - name: Build and Push Multi-Architecture Docker Image to Staging ECR
+      run: ./gradlew :release:docker:dockerMultiArchitecture -PdockerRepository=${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
 
   validate-docker:
     runs-on: ubuntu-latest

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,9 +1,19 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
+
+ARG TARGETARCH
+
+RUN dnf -y install tar gzip
+
+# Copy all archives and extract only the correct one
+COPY *.tar.gz /tmp/
+RUN tar -xzf /tmp/*-linux-${TARGETARCH}.tar.gz -C /tmp && \
+    rm -f /tmp/*.tar.gz && \
+    mv /tmp/opensearch-data-prepper-* /tmp/data-prepper
+
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 ARG PIPELINE_FILEPATH
 ARG CONFIG_FILEPATH
-ARG ARCHIVE_FILE
-ARG ARCHIVE_FILE_UNPACKED
 
 ENV DATA_PREPPER_PATH=/usr/share/data-prepper
 ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
@@ -22,8 +32,9 @@ ADD adoptium.repo /etc/yum.repos.d/adoptium.repo
 RUN dnf -y install temurin-17-jdk
 
 RUN mkdir -p /var/log/data-prepper
-ADD $ARCHIVE_FILE /usr/share
-RUN mv /usr/share/$ARCHIVE_FILE_UNPACKED /usr/share/data-prepper
+
+# Copy extracted data-prepper from builder stage
+COPY --from=builder /tmp/data-prepper /usr/share/data-prepper
 
 COPY default-data-prepper-config.yaml $ENV_CONFIG_FILEPATH
 COPY default-keystore.p12 /usr/share/data-prepper/keystore.p12

--- a/release/docker/build.gradle
+++ b/release/docker/build.gradle
@@ -1,25 +1,117 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
-plugins {
-    id 'com.palantir.docker' version '0.35.0'
+def supportedArchitectures = architectures.get('linux') as String[]
+
+class DockerBuildxTask extends Exec {
+    @Input
+    String platform
+    
+    @Input
+    String tag
+    
+    @Input
+    boolean push = false
+    
+    @TaskAction
+    @Override
+    protected void exec() {
+        def args = [
+            'docker', 'buildx', 'build',
+            '--platform', platform,
+            '--build-arg', 'CONFIG_FILEPATH=/usr/share/data-prepper/config/data-prepper-config.yaml',
+            '--build-arg', 'PIPELINE_FILEPATH=/usr/share/data-prepper/pipelines/pipelines.yaml',
+            '-t', tag
+        ]
+        
+        if (push) {
+            args << '--push'
+        } else if (!platform.contains(',')) {
+            // Only use --load for single-arch builds
+            args << '--load'
+        }
+        
+        args << '.'
+        
+        commandLine args
+        super.exec()
+    }
 }
 
-docker {
-    name "${project.rootProject.name}:${project.version}"
-    tag "${project.rootProject.name}", "${project.version}"
-    files project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFile.get().asFile
-    files "${project.projectDir}/config/default-data-prepper-config.yaml", "${project.projectDir}/config/default-keystore.p12"
-    files 'adoptium.repo'
-    buildArgs(['ARCHIVE_FILE' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get(),
-               'ARCHIVE_FILE_UNPACKED' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get().replace('.tar.gz', ''),
-               'CONFIG_FILEPATH' : '/usr/share/data-prepper/config/data-prepper-config.yaml',
-               'PIPELINE_FILEPATH' : '/usr/share/data-prepper/pipelines/pipelines.yaml'])
-    dockerfile file('Dockerfile')
+tasks.register('dockerBuildxSetup', Exec) {
+    commandLine 'docker', 'buildx', 'create', '--name', 'data-prepper-builder', '--use'
+    ignoreExitValue = true
 }
 
-dockerPrepare.dependsOn ':release:releasePrerequisites'
-dockerPrepare.dependsOn ':release:archives:linux:linuxx64DistTar'
-dockerPush.dependsOn docker
+tasks.register('dockerPrepare') {
+    dependsOn ':release:releasePrerequisites'
+    supportedArchitectures.each { arch ->
+        dependsOn ":release:archives:linux:linux${arch}DistTar"
+    }
+
+    doLast {
+        supportedArchitectures.each { arch ->
+            def archiveTask = project(':release:archives:linux').tasks.getByName("linux${arch}DistTar")
+            def dockerArch = arch == 'x64' ? 'amd64' : arch
+            def sourceFile = archiveTask.archiveFile.get().asFile
+            def targetFile = new File("${buildDir}/docker", sourceFile.name.replace("-linux-${arch}", "-linux-${dockerArch}"))
+
+            copy {
+                from sourceFile
+                into "${buildDir}/docker"
+                rename { targetFile.name }
+            }
+        }
+        copy {
+            from "${project.projectDir}/config/default-data-prepper-config.yaml",
+                    "${project.projectDir}/config/default-keystore.p12",
+                    'adoptium.repo',
+                    'Dockerfile'
+            into "${buildDir}/docker"
+        }
+    }
+}
+
+tasks.register('docker', DockerBuildxTask) {
+    dependsOn dockerPrepare
+    workingDir "${buildDir}/docker"
+
+    def currentArch = System.getProperty("os.arch")
+    platform = currentArch == 'aarch64' ? 'linux/arm64' : 'linux/amd64'
+    tag = "${project.rootProject.name}:${project.version}"
+    push = false
+}
+
+tasks.register('dockerMultiArchitecture', DockerBuildxTask) {
+    dependsOn dockerPrepare, dockerBuildxSetup
+    workingDir "${buildDir}/docker"
+
+    platform = supportedArchitectures.collect { arch ->
+        arch == 'x64' ? 'linux/amd64' : "linux/${arch}"
+    }.join(',')
+    tag = "${project.rootProject.name}:${project.version}"
+    push = false
+}
+
+tasks.register('dockerPush', Exec) {
+    dependsOn docker
+
+    commandLine 'docker', 'push', "${project.rootProject.name}:${project.version}"
+}
+
+tasks.register('dockerMultiArchitecturePush', DockerBuildxTask) {
+    dependsOn dockerPrepare, dockerBuildxSetup
+    workingDir "${buildDir}/docker"
+
+    platform = supportedArchitectures.collect { arch ->
+        arch == 'x64' ? 'linux/amd64' : "linux/${arch}"
+    }.join(',')
+    tag = project.findProperty('dockerRepository') ?: "${project.rootProject.name}:${project.version}"
+    push = true
+}


### PR DESCRIPTION
### Description

Support building Docker multi-architecture images and releasing these in the GitHub Actions release project. These are built using Docker buildx. This adds new tasks:

* `dockerMultiArchitecture` - Builds a multi-architecture Docker image locally
* `dockerMultiArchitecturePush` - Builds and pushes the multi-architecture image

This required changing how the release process works. Now we don't build the Docker image and then push. We do it in one step. This is because only the current architecture is loaded.

The `docker` task still builds for the current architecture only to facilitate easy development.

Additionally, this stops using the Palatir Docker plugin entirely. Now it uses Docker buildx directly.
 
### Issues Resolved

Resolves #6405.
Resolves #6410.
Resolves #5313.

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
