### PR TITLE
Some clean up on the PrometheusSink class

### DIFF
--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSink.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSink.java
@@ -13,10 +13,6 @@ package org.opensearch.dataprepper.plugins.sink.prometheus;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
-import org.opensearch.dataprepper.aws.api.AwsConfig;
-import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
-import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.PrometheusSinkThresholdConfig;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import org.opensearch.dataprepper.model.annotations.Experimental;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -32,7 +28,6 @@ import org.opensearch.dataprepper.common.sink.SinkMetrics;
 import org.opensearch.dataprepper.common.sink.DefaultSinkMetrics;
 import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.PrometheusSinkConfiguration;
 import org.opensearch.dataprepper.plugins.sink.prometheus.service.PrometheusSinkService;
-import software.amazon.awssdk.regions.Region;
 
 import java.util.Collection;
 
@@ -42,8 +37,8 @@ public class PrometheusSink extends AbstractSink<Record<Event>> {
 
     private volatile boolean sinkInitialized;
     private final PrometheusSinkService prometheusSinkService;
-    private PrometheusHttpSender httpSender;
-    private SinkMetrics sinkMetrics;
+    private final PrometheusHttpSender httpSender;
+    private final SinkMetrics sinkMetrics;
 
     @DataPrepperPluginConstructor
     public PrometheusSink(final PluginSetting pluginSetting,
@@ -52,30 +47,16 @@ public class PrometheusSink extends AbstractSink<Record<Event>> {
                     final PrometheusSinkConfiguration prometheusSinkConfiguration,
                     final AwsCredentialsSupplier awsCredentialsSupplier) {
         super(pluginSetting);
-        this.sinkInitialized = Boolean.FALSE;
-        AwsConfig awsConfig = prometheusSinkConfiguration.getAwsConfig();
-        final AwsCredentialsProvider awsCredentialsProvider = (awsConfig != null) ? awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig)) : awsCredentialsSupplier.getProvider(AwsCredentialsOptions.builder().build());
-        Region region = (awsConfig != null) ? awsConfig.getAwsRegion() : awsCredentialsSupplier.getDefaultRegion().get();
-      
+        this.sinkInitialized = false;
+
         sinkMetrics = new DefaultSinkMetrics(pluginMetrics, "Metric");
         httpSender = new PrometheusHttpSender(awsCredentialsSupplier, prometheusSinkConfiguration, sinkMetrics);
-
-        PrometheusSinkThresholdConfig thresholdConfig = prometheusSinkConfiguration.getThresholdConfig();
 
         this.prometheusSinkService = new PrometheusSinkService(
                 prometheusSinkConfiguration,
                 sinkMetrics,
                 httpSender,
                 pipelineDescription);
-    }
-
-    private static AwsCredentialsOptions convertToCredentialOptions(final AwsConfig awsConfig) {
-        return AwsCredentialsOptions.builder()
-                .withRegion(awsConfig.getAwsRegion())
-                .withStsRoleArn(awsConfig.getAwsStsRoleArn())
-                .withStsExternalId(awsConfig.getAwsStsExternalId())
-                .withStsHeaderOverrides(awsConfig.getAwsStsHeaderOverrides())
-                .build();
     }
 
     @Override
@@ -85,12 +66,12 @@ public class PrometheusSink extends AbstractSink<Record<Event>> {
 
     @Override
     public void doInitialize() {
-        sinkInitialized = Boolean.TRUE;
+        sinkInitialized = true;
         prometheusSinkService.setDlqPipeline(getFailurePipeline());
     }
 
     @VisibleForTesting
-    void setDlqPipeline(HeadlessPipeline dlqPipeline) {
+    void setDlqPipeline(final HeadlessPipeline dlqPipeline) {
         prometheusSinkService.setDlqPipeline(dlqPipeline);
     }
 


### PR DESCRIPTION
### Description

I was looking at the behavior of the Prometheus sink for the AWS config and found that there were some unused code paths. This PR cleans them up. Additionally, this makes some improvements to using `final` and boolean primitives instead of objects.
 
It is actually used here:

https://github.com/opensearch-project/data-prepper/blob/63b2c43ddd0fde12290cb2579e3c0577e012d3ce/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSigV4Signer.java#L50-L60

Not in the code removed.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
