### PR TITLE
Adding functionality to read from specific timestamps for KDS source

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/InitialPositionInStreamConfig.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/InitialPositionInStreamConfig.java
@@ -20,7 +20,8 @@ import java.util.stream.Collectors;
 @Getter
 public enum InitialPositionInStreamConfig {
     LATEST("latest", InitialPositionInStream.LATEST),
-    EARLIEST("earliest", InitialPositionInStream.TRIM_HORIZON);
+    EARLIEST("earliest", InitialPositionInStream.TRIM_HORIZON),
+    AT_TIMESTAMP("at_timestamp", InitialPositionInStream.AT_TIMESTAMP);
 
     private final String position;
 

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisStreamConfig.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisStreamConfig.java
@@ -11,6 +11,8 @@
 package org.opensearch.dataprepper.plugins.kinesis.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import jakarta.validation.Valid;
 import lombok.Getter;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
@@ -18,6 +20,7 @@ import software.amazon.awssdk.arns.Arn;
 import software.amazon.kinesis.common.InitialPositionInStream;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
@@ -43,6 +46,13 @@ public class KinesisStreamConfig {
 
     @JsonProperty("checkpoint_interval")
     private Duration checkPointInterval = MINIMAL_CHECKPOINT_INTERVAL;
+
+    @JsonProperty("range")
+    private Duration range;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonProperty("initial_timestamp")
+    private LocalDateTime initialTimestamp;
 
     public InitialPositionInStream getInitialPosition() {
         return initialPosition.getPositionInStream();

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/InitialPositionInStreamConfigTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/InitialPositionInStreamConfigTest.java
@@ -35,4 +35,13 @@ public class InitialPositionInStreamConfigTest {
         assertEquals(initialPositionInStreamConfig.getPositionInStream(), InitialPositionInStream.TRIM_HORIZON);
     }
 
+    @Test
+    void testInitialPositionGetByNameAtTimestamp() {
+        final InitialPositionInStreamConfig initialPositionInStreamConfig = InitialPositionInStreamConfig.fromPositionValue("at_timestamp");
+        assertEquals(initialPositionInStreamConfig, InitialPositionInStreamConfig.AT_TIMESTAMP);
+        assertEquals(initialPositionInStreamConfig.toString(), "at_timestamp");
+        assertEquals(initialPositionInStreamConfig.getPosition(), "at_timestamp");
+        assertEquals(initialPositionInStreamConfig.getPositionInStream(), InitialPositionInStream.AT_TIMESTAMP);
+    }
+
 }

--- a/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfigTest.java
+++ b/data-prepper-plugins/kinesis-source/src/test/java/org/opensearch/dataprepper/plugins/kinesis/source/configuration/KinesisSourceConfigTest.java
@@ -28,9 +28,11 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -46,6 +48,7 @@ public class KinesisSourceConfigTest {
     private static final String PIPELINE_CONFIG_CHECKPOINT_ENABLED = "pipeline_with_checkpoint_enabled.yaml";
     private static final String PIPELINE_CONFIG_STREAM_ARN_ENABLED = "pipeline_with_stream_arn_config.yaml";
     private static final String PIPELINE_CONFIG_STREAM_ARN_CONSUMER_ARN_ENABLED = "pipeline_with_stream_arn_consumer_arn_config.yaml";
+    private static final String PIPELINE_CONFIG_WITH_INITIAL_POSITION_AT_TIMESTAMP = "pipeline_with_initial_position_at_timestamp_config.yaml";
     private static final Duration MINIMAL_CHECKPOINT_INTERVAL = Duration.ofMillis(2 * 60 * 1000); // 2 minute
 
     KinesisSourceConfig kinesisSourceConfig;
@@ -234,4 +237,49 @@ public class KinesisSourceConfigTest {
             assertEquals(kinesisStreamConfig.getCheckPointInterval(), MINIMAL_CHECKPOINT_INTERVAL);
         }
     }
+
+    @Test
+    @Tag(PIPELINE_CONFIG_WITH_INITIAL_POSITION_AT_TIMESTAMP)
+    void testSourceConfigWithInitialPositionAtTimestamp() {
+
+        assertThat(kinesisSourceConfig, notNullValue());
+        assertEquals(KinesisSourceConfig.DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE, kinesisSourceConfig.getNumberOfRecordsToAccumulate());
+        assertEquals(KinesisSourceConfig.DEFAULT_TIME_OUT_IN_MILLIS, kinesisSourceConfig.getBufferTimeout());
+        assertEquals(KinesisSourceConfig.DEFAULT_MAX_INITIALIZATION_ATTEMPTS, kinesisSourceConfig.getMaxInitializationAttempts());
+        assertEquals(KinesisSourceConfig.DEFAULT_INITIALIZATION_BACKOFF_TIME, kinesisSourceConfig.getInitializationBackoffTime());
+        assertFalse(kinesisSourceConfig.isAcknowledgments());
+        assertEquals(KinesisSourceConfig.DEFAULT_SHARD_ACKNOWLEDGEMENT_TIMEOUT, kinesisSourceConfig.getShardAcknowledgmentTimeout());
+        assertThat(kinesisSourceConfig.getAwsAuthenticationConfig(), notNullValue());
+        assertEquals(kinesisSourceConfig.getAwsAuthenticationConfig().getAwsRegion(), Region.US_EAST_1);
+        assertEquals(kinesisSourceConfig.getAwsAuthenticationConfig().getAwsStsRoleArn(), "arn:aws:iam::123456789012:role/OSI-PipelineRole");
+        assertNull(kinesisSourceConfig.getAwsAuthenticationConfig().getAwsStsExternalId());
+        assertNull(kinesisSourceConfig.getAwsAuthenticationConfig().getAwsStsHeaderOverrides());
+        assertNotNull(kinesisSourceConfig.getCodec());
+        List<KinesisStreamConfig> streamConfigs = kinesisSourceConfig.getStreams();
+        assertEquals(kinesisSourceConfig.getConsumerStrategy(), ConsumerStrategy.ENHANCED_FAN_OUT);
+
+        assertEquals(streamConfigs.size(), 2);
+
+        Map<String, KinesisStreamConfig> streamConfigMap = streamConfigs.stream()
+                .collect(Collectors.toMap(KinesisStreamConfig::getName, config -> config));
+
+        assertEquals(2, streamConfigMap.size());
+
+        KinesisStreamConfig stream1 = streamConfigMap.get("stream-1");
+        assertNotNull(stream1);
+        assertNull(stream1.getStreamArn());
+        assertNull(stream1.getConsumerArn());
+        assertEquals(InitialPositionInStream.AT_TIMESTAMP, stream1.getInitialPosition());
+        assertEquals(Duration.parse("P3DT12H"), stream1.getRange());
+        assertNull(stream1.getInitialTimestamp());
+
+        KinesisStreamConfig stream2 = streamConfigMap.get("stream-2");
+        assertNotNull(stream2);
+        assertNull(stream2.getStreamArn());
+        assertNull(stream2.getConsumerArn());
+        assertEquals(InitialPositionInStream.AT_TIMESTAMP, stream2.getInitialPosition());
+        assertNull(stream2.getRange());
+        assertEquals(LocalDateTime.parse("2024-01-15T10:30:00"), stream2.getInitialTimestamp());
+    }
+
 }

--- a/data-prepper-plugins/kinesis-source/src/test/resources/pipeline_with_initial_position_at_timestamp_config.yaml
+++ b/data-prepper-plugins/kinesis-source/src/test/resources/pipeline_with_initial_position_at_timestamp_config.yaml
@@ -1,0 +1,14 @@
+source:
+  kinesis:
+    streams:
+      - stream_name: "stream-1"
+        initial_position: "AT_TIMESTAMP"
+        range: "P3DT12H"
+      - stream_name: "stream-2"
+        initial_position: "AT_TIMESTAMP"
+        initial_timestamp: "2024-01-15T10:30:00"
+    codec:
+      ndjson:
+    aws:
+      sts_role_arn: "arn:aws:iam::123456789012:role/OSI-PipelineRole"
+      region: "us-east-1"


### PR DESCRIPTION
### Description
Adds support for starting Kinesis stream reads from a specific timestamp, configurable via relative duration (lookback) or absolute timestamp. Users can specify the timestamps in two ways:

1. Relative duration(lookback) - Specify how far back from the current time to start reading

```
kinesis-pipeline:
  source:
    kinesis:
      streams:
        - stream_name: my-stream
          initial_position: AT_TIMESTAMP
          lookback_duration: "P3DT12H"  # Start from 3 days 12 hours ago
```
2. Absolute timestamp - Specify an exact timestamp to start reading from
```
kinesis-pipeline:
  source:
    kinesis:
      streams:
        - stream_name: my-stream
          initial_position: AT_TIMESTAMP
          initial_timestamp: "2024-01-15T10:30:00Z" #Specified in UTC timezone format
```
 
### Issues Resolved
Resolves #6366 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
