### PR TITLE
Add support for IAM authentication in connection string for DocumentDB source

### DIFF
--- a/data-prepper-plugins/mongodb/build.gradle
+++ b/data-prepper-plugins/mongodb/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'software.amazon.awssdk:s3'
 
     implementation project(path: ':data-prepper-plugins:aws-plugin-api')

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Size;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class MongoDBSourceConfig {
     private static final int DEFAULT_PORT = 27017;
@@ -162,5 +163,19 @@ public class MongoDBSourceConfig {
             return password;
         }
 
+    }
+
+    public void validateAwsConfigWithUsernameAndPassword() {
+        final boolean hasUsernamePassword = Objects.nonNull(authenticationConfig) &&
+                (Objects.nonNull(authenticationConfig.getUsername()) || Objects.nonNull(authenticationConfig.getPassword()));
+        final boolean hasAwsAuth = Objects.nonNull(awsConfig) && Objects.nonNull(awsConfig.getAwsStsRoleArn());
+
+        if (hasUsernamePassword && hasAwsAuth) {
+            throw new IllegalArgumentException("Either username and password, or aws sts_role_arn must be specified. Both cannot be set at once.");
+        }
+
+        if (!hasUsernamePassword && !hasAwsAuth) {
+            throw new IllegalArgumentException("Either username and password, or aws sts_role_arn must be specified.");
+        }
     }
 }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/documentdb/DocumentDBSource.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/documentdb/DocumentDBSource.java
@@ -47,6 +47,8 @@ public class DocumentDBSource implements Source<Record<Event>>, UsesEnhancedSour
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginConfigObservable = pluginConfigObservable;
         this.acknowledgementsEnabled = sourceConfig.isAcknowledgmentsEnabled();
+
+        sourceConfig.validateAwsConfigWithUsernameAndPassword();
     }
 
     @Override

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfigTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.mongo.configuration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MongoDBSourceConfigTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
+
+    @Test
+    void username_password_only() throws JsonProcessingException {
+        final String configYaml =
+                "host: \"localhost\"\n" +
+                "authentication:\n" +
+                "  username: test\n" +
+                "  password: test\n" +
+                "collections:\n" +
+                "  - collection: test\n";
+
+        final MongoDBSourceConfig config = objectMapper.readValue(configYaml, MongoDBSourceConfig.class);
+
+        config.validateAwsConfigWithUsernameAndPassword();
+        assertThat(config.getAuthenticationConfig(), notNullValue());
+        assertThat(config.getAuthenticationConfig().getUsername(), equalTo("test"));
+        assertThat(config.getAuthenticationConfig().getPassword(), equalTo("test"));
+        assertThat(config.getAwsConfig(), nullValue());
+    }
+
+    @Test
+    void aws_sts_role_arn_only() throws JsonProcessingException {
+        final String configYaml =
+                "host: \"localhost\"\n" +
+                "aws:\n" +
+                "  sts_role_arn: \"arn:aws:iam::123456789012:role/test-role\"\n" +
+                "collections:\n" +
+                "  - collection: test\n";
+
+        final MongoDBSourceConfig config = objectMapper.readValue(configYaml, MongoDBSourceConfig.class);
+
+        config.validateAwsConfigWithUsernameAndPassword();
+        assertThat(config.getAwsConfig(), notNullValue());
+        assertThat(config.getAwsConfig().getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/test-role"));
+        assertThat(config.getAuthenticationConfig(), nullValue());
+    }
+
+    @Test
+    void both_username_password_and_aws_is_invalid() throws JsonProcessingException {
+        final String configYaml =
+                "host: \"localhost\"\n" +
+                "authentication:\n" +
+                "  username: test\n" +
+                "  password: test\n" +
+                "aws:\n" +
+                "  sts_role_arn: \"arn:aws:iam::123456789012:role/test-role\"\n" +
+                "collections:\n" +
+                "  - collection: test\n";
+
+        final MongoDBSourceConfig config = objectMapper.readValue(configYaml, MongoDBSourceConfig.class);
+        assertThrows(IllegalArgumentException.class, config::validateAwsConfigWithUsernameAndPassword);
+    }
+
+    @Test
+    void neither_username_password_nor_aws_is_invalid() throws JsonProcessingException {
+        final String configYaml =
+                "host: \"localhost\"\n" +
+                "collections:\n" +
+                "  - collection: test\n";
+
+        final MongoDBSourceConfig config = objectMapper.readValue(configYaml, MongoDBSourceConfig.class);
+        assertThrows(IllegalArgumentException.class, config::validateAwsConfigWithUsernameAndPassword);
+    }
+}

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfigTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfigTest.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 package org.opensearch.dataprepper.plugins.mongo.configuration;
 


### PR DESCRIPTION
### Description
Add support for IAM authentication in connection string for DocumentDB source ([AWS docs link](https://docs.aws.amazon.com/documentdb/latest/developerguide/iam-identity-auth.html)) –
* Adds validation for either providing `authentication.username/password` OR `aws.sts_role_arn` in `documentdb` source configuration
* Adds new test class for `MongoDBSourceConfigTest.java`
* In `MongoDBConnection.java`, detects authentication mode and creates the required connection string and credential for the `MongoClientSettings.Builder` during connection creation
 
### Issues Resolved
Resolves [#5983](https://github.com/opensearch-project/data-prepper/issues/5983)
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has [a documentation issue](https://github.com/opensearch-project/documentation-website/issues/11804). Please link to it in this PR.
  - [x] New functionality has javadoc added (n/a, change to existing functions)
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
