### PR TITLE
remove json creator annotation from no-arg constructor in SinkForward…

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfig.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfig.java
@@ -26,7 +26,6 @@ public class SinkForwardConfig {
     @JsonProperty("with_data")
     Map<String, Object> withData;
 
-    @JsonCreator
     public SinkForwardConfig() {
     }
 


### PR DESCRIPTION
…Config

### Description
Removes the Json creator annotation from no-arg constructor to fix invalid definition exception caused by conflicting property-based creators
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
