### PR TITLE
Fixes a false reporting bug for the invalidEventHandles counter

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/router/RouterFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/router/RouterFactory.java
@@ -1,17 +1,24 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.core.pipeline.router;
 
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
+import org.opensearch.dataprepper.model.event.Event;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class RouterFactory {
+    private static final Consumer<Event> RELEASE_EVENT_ON_NO_ROUTE = event -> event.getEventHandle().release(true);
     private final ExpressionEvaluator expressionEvaluator;
     private final DataFlowComponentRouter dataFlowComponentRouter;
 
@@ -23,6 +30,6 @@ public class RouterFactory {
     public Router createRouter(final Set<ConditionalRoute> routes) {
         final RouteEventEvaluator routeEventEvaluator = new RouteEventEvaluator(expressionEvaluator, routes);
         return new Router(routeEventEvaluator, dataFlowComponentRouter,
-                event -> event.getEventHandle().release(true));
+                    RELEASE_EVENT_ON_NO_ROUTE);
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroup.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroup.java
@@ -28,7 +28,7 @@ class AggregateGroup implements AggregateActionInput {
     private final Lock handleEventForGroupLock;
     private final Map<Object, Object> identificationKeys;
     private Function<Duration, Boolean> customShouldConclude;
-    private EventHandle eventHandle;
+    private EventHandle groupEventHandle;
 
     AggregateGroup(final Map<Object, Object> identificationKeys) {
         this.groupState = new DefaultGroupState();
@@ -36,19 +36,18 @@ class AggregateGroup implements AggregateActionInput {
         this.groupStart = Instant.now();
         this.concludeGroupLock = new ReentrantLock();
         this.handleEventForGroupLock = new ReentrantLock();
-        this.eventHandle = new AggregateEventHandle(Instant.now());
+        this.groupEventHandle = new AggregateEventHandle(Instant.now());
     }
 
     @Override
     public EventHandle getEventHandle() {
-        return eventHandle;
+        return groupEventHandle;
     }
 
-    public void attachToEventAcknowledgementSet(Event event) {
-        InternalEventHandle internalEventHandle;
-        EventHandle handle = event.getEventHandle();
-        internalEventHandle = (InternalEventHandle)(handle);
-        internalEventHandle.addEventHandle(eventHandle);
+    public void attachToEventAcknowledgementSet(final Event event) {
+        final EventHandle handle = event.getEventHandle();
+        final InternalEventHandle internalEventHandle = (InternalEventHandle) (handle);
+        internalEventHandle.addEventHandle(groupEventHandle);
     }
 
     public GroupState getGroupState() {
@@ -86,6 +85,6 @@ class AggregateGroup implements AggregateActionInput {
     void resetGroup() {
         groupStart = Instant.now();
         groupState.clear();
-        this.eventHandle = new AggregateEventHandle(groupStart);
+        this.groupEventHandle = new AggregateEventHandle(groupStart);
     }
 }


### PR DESCRIPTION
### Description

Fixes a bug with the invalidEventHandles counter in the PipelineRunner. This metric was being counted for any event that is not a default event (ie. for aggregate events). This would happen even if there is no need to discard the event. This change should count this when aggregate events should be released but are not. We probably need some deeper investigation into how we can properly release aggregate events. But, for now this metric will be more accurate.

Also improves some code to reduce unnecessary variables, use final modifiers, and better legibility.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
