### PR TITLE
Add Jackson deserialization test for SinkForwardConfig

### DIFF
--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfigTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkForwardConfigTest.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.dataprepper.model.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +54,15 @@ public class SinkForwardConfigTest {
     @Test
     void empty_pipelines_list_throws_exception() {
         assertThrows(InvalidPluginConfigurationException.class, ()->new SinkForwardConfig(List.of(), Map.of(), Map.of()));
+    }
+
+    @Test
+    void jackson_deserialization_succeeds() throws Exception {
+        String json = "{\"pipelines\":[\"pipeline1\"],\"with_data\":{\"key\":\"value\"},\"with_metadata\":{\"meta\":\"data\"}}";
+        ObjectMapper mapper = new ObjectMapper();
+        SinkForwardConfig config = mapper.readValue(json, SinkForwardConfig.class);
+        assertThat(config.getPipelineNames().size(), equalTo(1));
+        assertThat(config.getPipelineNames().get(0), equalTo("pipeline1"));
     }
 }
 


### PR DESCRIPTION
### Description
Adds test to validate Jackson deserialization works correctly with the single @JsonCreator annotation. This test ensures the fix for the "Conflicting property-based creators" error (caused by duplicate  @JsonCreator annotations) doesn't regress when using Jackson 2.21+. 

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
