### PR TITLE
Add thread-safe synchronization to startUpdatingOwnershipForShard

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardAcknowledgementManager.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardAcknowledgementManager.java
@@ -320,7 +320,12 @@ public class ShardAcknowledgementManager {
     }
 
     void startUpdatingOwnershipForShard(final StreamPartition streamPartition) {
-        checkpoints.computeIfAbsent(streamPartition, segment -> new ConcurrentLinkedQueue<>());
+        lock.lock();
+        try {
+            checkpoints.computeIfAbsent(streamPartition, segment -> new ConcurrentLinkedQueue<>());
+        } finally {
+            lock.unlock();
+        }
     }
 
     boolean isStillTrackingShard(final StreamPartition streamPartition) {


### PR DESCRIPTION
### Description
Fixes a race condition in ShardAcknowledgementManager when shards repeatedly receive negative acks.

**The Race Condition:**

When a shard receives a negative ack, the ShardAcknowledgementManager removes it from checkpoints and gives up the partition. The StreamScheduler immediately re-acquires it and creates a new consumer. Without synchronization, the new consumer's`startUpdatingOwnershipForShard()` (adding the shard to checkpoints) can execute concurrently with the ShardAcknowledgementManager `removePartitions()` (removing the shard from checkpoints) causing the shard to go in an inconsistent/zombie state where it might lead to scenarios where the checkPointStatuses queue is empty for the shard

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
