### PR TITLE
Synchronization fix for aggregate processor and aggregate event handles on groups

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -92,6 +92,7 @@ class AggregateActionSynchronizer {
         handleEventForGroupLock.lock();
         try {
             LOG.debug("Start critical section in handleEventForGroup");
+            aggregateGroup.attachToEventAcknowledgementSet(event);
             handleEventResponse = aggregateAction.handleEvent(event, aggregateGroup);
             aggregateGroupManager.putGroupWithHash(hash, aggregateGroup);
         } catch (final Exception e) {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -97,10 +97,8 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         return pluginFactory.loadPlugin(AggregateAction.class, actionPluginSetting);
     }
 
-    AggregateGroup getAggregateGroupForEvent(final IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap, final Event event) {
-        AggregateGroup aggregateGroup = aggregateGroupManager.getAggregateGroup(identificationKeysMap);
-        aggregateGroup.attachToEventAcknowledgementSet(event);
-        return aggregateGroup;
+    private AggregateGroup getAggregateGroupForEvent(final IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap) {
+        return aggregateGroupManager.getAggregateGroup(identificationKeysMap);
     }
 
     @Override
@@ -134,7 +132,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
                 continue;
             }
             final IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
-            final AggregateGroup aggregateGroupForEvent = getAggregateGroupForEvent(identificationKeysMap, event);
+            final AggregateGroup aggregateGroupForEvent = getAggregateGroupForEvent(identificationKeysMap);
 
             final AggregateActionResponse handleEventResponse = aggregateActionSynchronizer.handleEventForGroup(event, identificationKeysMap, aggregateGroupForEvent);
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
@@ -158,10 +158,11 @@ public class AggregateActionSynchronizerTest {
 
         final AggregateActionResponse handleEventResponse = objectUnderTest.handleEventForGroup(event, identificationKeysMap, aggregateGroup);
 
-        final InOrder inOrder = Mockito.inOrder(concludeGroupLock, handleEventForGroupLock, aggregateAction, aggregateGroupManager);
+        final InOrder inOrder = Mockito.inOrder(concludeGroupLock, handleEventForGroupLock, aggregateGroup, aggregateAction, aggregateGroupManager);
         inOrder.verify(concludeGroupLock).lock();
         inOrder.verify(concludeGroupLock).unlock();
         inOrder.verify(handleEventForGroupLock).lock();
+        inOrder.verify(aggregateGroup).attachToEventAcknowledgementSet(event);
         inOrder.verify(aggregateAction).handleEvent(event, aggregateGroup);
         inOrder.verify(aggregateGroupManager).putGroupWithHash(identificationKeysMap, aggregateGroup);
         inOrder.verify(handleEventForGroupLock).unlock();

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate;
 
+import org.junit.jupiter.api.AfterEach;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -156,6 +158,11 @@ public class AggregateProcessorTest {
         when(pluginMetrics.counter(MetricNames.RECORDS_IN)).thenReturn(recordsIn);
         when(pluginMetrics.counter(MetricNames.RECORDS_OUT)).thenReturn(recordsOut);
         when(pluginMetrics.timer(MetricNames.TIME_ELAPSED)).thenReturn(timeElapsed);
+    }
+
+    @AfterEach
+    void processorDoesNotAttachEventsDirectly() {
+        verify(aggregateGroup, never()).attachToEventAcknowledgementSet(any());
     }
 
     @Test


### PR DESCRIPTION
### Description

There is a possible synchronization issue in the aggregate processor. It currently calls `attachToEventAcknowledgementSet` on the aggregate group outside of any locks.

Possible scenario in time order:

1. Threat 1 gets an `AggregateGroup` from the map. The get from the map is synchronized, but not necessarily what happens afterward.
2. Thread 1 begins using the aggregate event from this thread
3. Thread 2 closes and resets the `AggregateGroup`. This creates a new aggregate event handle for the group going forward.
4. Thread 1 finishes attachment for the aggregate event it had from step 2. But, this is not the one that the group will use later.

The end result is that we may have two aggregate events for one group. Both are holding the acknowledgement set, but only one will leave the aggregate processor.

The solution is to attach the event within the locks.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
