### PR TITLE
feat: Add configurable lease interval for crawler source

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourceConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourceConfig.java
@@ -45,4 +45,14 @@ public interface CrawlerSourceConfig {
     default Duration getDurationToDelayRetry() {
         return DEFAULT_MAX_DURATION_TO_DELAY_RETRY;
     }
+
+    /**
+     * Gets the lease interval for the leader scheduler.
+     * Defaults to 1 minute if not overridden.
+     *
+     * @return Duration for lease interval
+     */
+    default Duration getLeaseInterval() {
+        return Duration.ofMinutes(1);
+    }
 }

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourcePlugin.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/CrawlerSourcePlugin.java
@@ -70,7 +70,8 @@ public abstract class CrawlerSourcePlugin implements Source<Record<Event>>, Uses
         boolean isPartitionCreated = coordinator.createPartition(leaderPartition);
         log.debug("Leader partition creation status: {}", isPartitionCreated);
 
-        Runnable leaderScheduler = new LeaderScheduler(coordinator, crawler);
+        LeaderScheduler leaderScheduler = new LeaderScheduler(coordinator, crawler);
+        leaderScheduler.setLeaseInterval(sourceConfig.getLeaseInterval());
         this.executorService.submit(leaderScheduler);
         //Register worker threaders
         for (int i = 0; i < sourceConfig.getNumberOfWorkers(); i++) {


### PR DESCRIPTION
## Description

This PR adds support for configurable lease interval in the crawler source plugin, allowing users to customize the leader scheduler's lease interval instead of using a hardcoded value.

## Changes
- Added `getLeaseInterval()` method to `CrawlerSourceConfig` interface with default value of 1 minute
- Modified `CrawlerSourcePlugin` to use the configurable lease interval from the source configuration

## Testing
- [x] Unit tests pass
- [x] Confirmed M365 maintained 1 minute lease interval. 

Signed-off-by: Alexander Christensen <alchrisk@amazon.com>