### PR TITLE
fix: Update Werkzeug to 3.1.5 to fix CVE-2026-21860 and CVE-2025-66221

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -5,7 +5,7 @@ opentelemetry-instrumentation-flask==0.46b0
 opentelemetry-instrumentation-mysql==0.46b0
 opentelemetry-instrumentation-requests==0.46b0
 opentelemetry-sdk==1.25.0
-protobuf==4.25.8
+protobuf>=5.29.4
 requests==2.32.4
 setuptools==78.1.1
 urllib3==2.6.3


### PR DESCRIPTION
Updates werkzeug from 3.0.6 to 3.1.5 in the trace analytics sample app to address two medium-severity security vulnerabilities related to the safe_join function allowing path segments with Windows device names.

 
### Issues Resolved
Resolves #6326
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
