### PR TITLE
Give the license header check GitHub Action permissions to write to pull requests

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -16,6 +16,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   license-header-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Give the license header check GitHub Action permissions to write to issues and pull requests. The check is running fine, but the comments are failing to actually post.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
