### PR TITLE
Fix delete_source removing parsed field when writing to root in parse…

### DIFF
--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/AbstractParseProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parse/AbstractParseProcessor.java
@@ -147,13 +147,17 @@ public abstract class AbstractParseProcessor extends AbstractProcessor<Record<Ev
                     parsedValue = parseUsingPointer(event, parsedValue, pointer, doWriteToRoot);
                 }
 
+                if (doWriteToRoot && deleteSourceRequested) {
+                    event.delete(this.source);
+                }
+
                 if (doWriteToRoot) {
                     writeToRoot(event, parsedValue);
                 } else if (overwriteIfDestinationExists || !event.containsKey(destination)) {
                     event.put(destination, parsedValue, normalizeKeys);
                 }
 
-                if(deleteSourceRequested) {
+                if (deleteSourceRequested && !doWriteToRoot) {
                     event.delete(this.source);
                 }
             } catch (Exception e) {

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parse/json/ParseJsonProcessorTest.java
@@ -367,6 +367,24 @@ public class ParseJsonProcessorTest {
     }
 
     @Test
+    void test_when_deleteSourceFlagEnabled_and_parsedJsonContainsSourceFieldName() {
+        when(processorConfig.isDeleteSourceRequested()).thenReturn(true);
+        parseJsonProcessor = createObjectUnderTest();
+
+        // JSON where parsed key "message" matches source field name "message"
+        final String jsonWithMatchingKey = "{\"message\":\"hi\",\"level\":1}";
+        final Event parsedEvent = createAndParseMessageEvent(jsonWithMatchingKey);
+
+        // Source field deleted, but parsed "message" value preserved
+        assertThat(parsedEvent.get("message", String.class), equalTo("hi"));
+        assertThat(parsedEvent.get("level", Integer.class), equalTo(1));
+
+        verifyNoInteractions(processingFailuresCounter);
+        verifyNoInteractions(parseErrorsCounter);
+        verifyNoInteractions(handleFailedEventsOption);
+    }
+
+    @Test
     void test_when_nestedJSONArrayOfJSON_then_parsedIntoArrayAndIndicesAccessible() {
         parseJsonProcessor = createObjectUnderTest();
 


### PR DESCRIPTION
… JSON processor

When source field name matches a key in the parsed JSON and delete_source is true with destination set to root (the default), the source was deleted after writeToRoot(), removing the parsed value instead of the original. Now deletes source before writeToRoot() when writing to root.

### Description
Fixes an oversight in the parse_json processor where if processing a json with a field value matching `source` field and `delete_source` set to true causes the added field to be removed.
 
### Issues Resolved
I haven't opened a ticket, the contribution guide says 'You open an issue to discuss any significant work - we would hate for your time to be wasted.' and I don't consider this a significant change?
 
### Check List
- [X] New functionality includes testing.
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
