### PR TITLE
Enable Mend Renovate in Whitesource settings

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -26,6 +26,7 @@
     "issueType": "DEPENDENCY"
   },
   "remediateSettings": {
+    "enableRenovate": true,
     "workflowRules": {
       "enabled": true
     }


### PR DESCRIPTION
### Description

Attempting to allow whitesource to automatically create PRs when finding dependencies with known CVEs.
 
This is borrowing settings from repos where mend is seen creating PRs like https://github.com/opensearch-project/opensearch-sdk-java/blob/654a735d0ae17862e147eb7c1831d666f1fcb802/.whitesource#L18

Example mend PR: https://github.com/opensearch-project/opensearch-sdk-java/pull/1035
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
