### PR TITLE
feat: Add ConfigurableIntervalDimensionalTimeSliceCrawler for per-dim…

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/ConfigurableIntervalDimensionalTimeSliceCrawler.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/ConfigurableIntervalDimensionalTimeSliceCrawler.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.source_crawler.base;
+
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.SaasSourcePartition;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.ConfigurableIntervalLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.DimensionalTimeSliceLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.DimensionalTimeSliceWorkerProgressState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import static org.opensearch.dataprepper.plugins.source.source_crawler.coordination.scheduler.LeaderScheduler.DEFAULT_EXTEND_LEASE_MINUTES;
+
+/**
+ * An enhanced dimensional time slice crawler that supports configurable partition creation
+ * intervals per dimension type. This allows different event types to have different
+ * partition creation frequencies (e.g., some every 5 minutes, others daily).
+ * 
+ * Extends DimensionalTimeSliceCrawler to maintain backward compatibility while adding
+ * the ability to configure partition schedules per dimension type.
+ */
+@Named
+public class ConfigurableIntervalDimensionalTimeSliceCrawler extends DimensionalTimeSliceCrawler {
+    private static final Logger log = LoggerFactory.getLogger(ConfigurableIntervalDimensionalTimeSliceCrawler.class);
+    private static final String CONFIGURABLE_INTERVAL_PARTITIONS_CREATED = "configurableIntervalPartitionsCreated";
+    private static final String CONFIGURABLE_INTERVAL_PARTITIONS_SKIPPED = "configurableIntervalPartitionsSkipped";
+    private static final String LAST_UPDATED_KEY = "last_updated|";
+
+    private final Counter configurablePartitionsCreatedCounter;
+    private final Counter configurablePartitionsSkippedCounter;
+    private final AtomicLong partitionCreationCount = new AtomicLong(0);
+    private Function<String, Duration> partitionScheduleProvider;
+    private List<String> dimensionTypes;
+
+    public ConfigurableIntervalDimensionalTimeSliceCrawler(CrawlerClient client,
+                                                          PluginMetrics pluginMetrics) {
+        super(client, pluginMetrics);
+        this.configurablePartitionsCreatedCounter = pluginMetrics.counter(CONFIGURABLE_INTERVAL_PARTITIONS_CREATED);
+        this.configurablePartitionsSkippedCounter = pluginMetrics.counter(CONFIGURABLE_INTERVAL_PARTITIONS_SKIPPED);
+    }
+
+    /**
+     * Sets the partition schedule provider function.
+     * 
+     * @param partitionScheduleProvider Function that returns the Duration for partition
+     *                                creation interval given a dimension type
+     */
+    public void setPartitionScheduleProvider(Function<String, Duration> partitionScheduleProvider) {
+        this.partitionScheduleProvider = partitionScheduleProvider;
+    }
+
+    /**
+     * Sets the dimension types for this crawler.
+     * 
+     * @param dimensionTypes List of dimension types to process
+     */
+    public void setDimensionTypes(List<String> dimensionTypes) {
+        this.dimensionTypes = dimensionTypes;
+    }
+
+    /**
+     * Gets the dimension types for this crawler.
+     * 
+     * @return List of dimension types
+     */
+    protected List<String> getDimensionTypes() {
+        return this.dimensionTypes;
+    }
+
+    /**
+     * Creates partitions using configurable intervals per dimension type.
+     * Only creates partitions for dimension types whose schedule interval has elapsed.
+     */
+    @Override
+    public Instant crawl(LeaderPartition leaderPartition, EnhancedSourceCoordinator coordinator) {
+        if (partitionScheduleProvider == null) {
+            log.warn("No partition schedule provider configured, falling back to default behavior");
+            return super.crawl(leaderPartition, coordinator);
+        }
+
+        long startCount = partitionCreationCount.get();
+        Instant latestModifiedTime = createPartitionsWithConfigurableIntervals(leaderPartition, coordinator);
+        long partitionsInThisCrawl = partitionCreationCount.get() - startCount;
+        
+        log.info("Total configurable interval partitions created in this crawl: {}", partitionsInThisCrawl);
+        return latestModifiedTime;
+    }
+
+    private Instant createPartitionsWithConfigurableIntervals(LeaderPartition leaderPartition,
+                                                             EnhancedSourceCoordinator coordinator) {
+        ConfigurableIntervalLeaderProgressState leaderProgressState =
+                (ConfigurableIntervalLeaderProgressState) leaderPartition.getProgressState().get();
+
+        if (leaderProgressState.getRemainingHours() == 0) {
+            return createPartitionsForIncrementalSyncWithSchedules(leaderPartition, coordinator);
+        } else {
+            return createPartitionsForHistoricalPullWithSchedules(leaderPartition, coordinator);
+        }
+    }
+
+    /**
+     * Creates partitions for historical data pull with schedule awareness.
+     * Falls back to parent behavior as historical pulls typically need all data.
+     */
+    private Instant createPartitionsForHistoricalPullWithSchedules(LeaderPartition leaderPartition,
+                                                                  EnhancedSourceCoordinator coordinator) {
+        log.info("Historical pull mode - creating partitions for all dimension types");
+        
+        // For historical pulls, we need all data regardless of schedules
+        // For historical pulls, convert the configurable state to standard state
+        ConfigurableIntervalLeaderProgressState configurableState = 
+            (ConfigurableIntervalLeaderProgressState) leaderPartition.getProgressState().get();
+        
+        DimensionalTimeSliceLeaderProgressState standardState = 
+            new DimensionalTimeSliceLeaderProgressState(
+                configurableState.getLastPollTime(),
+                configurableState.getRemainingHours());
+        
+        LeaderPartition standardLeaderPartition = new LeaderPartition(standardState);
+        
+        // Call parent's crawl method which will handle historical pulls
+        return super.crawl(standardLeaderPartition, coordinator);
+    }
+
+    /**
+     * Creates partitions for incremental sync with per-dimension-type scheduling.
+     * Only creates partitions for dimension types whose schedule interval has elapsed.
+     */
+    private Instant createPartitionsForIncrementalSyncWithSchedules(LeaderPartition leaderPartition,
+                                                                   EnhancedSourceCoordinator coordinator) {
+        Instant currentTime = Instant.now().minusSeconds(WAIT_SECONDS_BEFORE_PARTITION_CREATION);
+        ConfigurableIntervalLeaderProgressState leaderProgressState =
+                (ConfigurableIntervalLeaderProgressState) leaderPartition.getProgressState().get();
+        
+        Instant globalLastPollTime = leaderProgressState.getLastPollTime();
+        Map<String, Instant> lastPartitionTimes = leaderProgressState.getLastPartitionTimePerDimensionType();
+        
+        // Initialize partition count for this crawl
+        long crawlStartCount = partitionCreationCount.get();
+        
+        // Initialize missing dimension types with original baseline to prevent state corruption
+        // This ensures each dimension type maintains its own stable timing, preventing 5-minute events
+        // from corrupting the scheduling of 10-minute events by updating the global baseline
+        for (String dimensionType : getDimensionTypes()) {
+            if (!lastPartitionTimes.containsKey(dimensionType)) {
+                lastPartitionTimes.put(dimensionType, globalLastPollTime);
+            }
+        }
+        
+        boolean anyPartitionsCreated = false;
+        Instant latestPartitionTime = globalLastPollTime;
+
+        for (String dimensionType : getDimensionTypes()) {
+            Duration scheduleInterval = partitionScheduleProvider.apply(dimensionType);
+            Instant lastPartitionTime = lastPartitionTimes.getOrDefault(dimensionType, globalLastPollTime);
+            Instant nextScheduledTime = lastPartitionTime.plus(scheduleInterval);
+
+            if (currentTime.isAfter(nextScheduledTime)) {
+                log.info("Creating partition for dimension type '{}' (schedule: {}, last partition: {})",
+                        dimensionType, scheduleInterval, lastPartitionTime);
+                
+                createWorkerPartitionForDimensionType(lastPartitionTime, currentTime, dimensionType, coordinator);
+                
+                // Update last partition time for this dimension type
+                lastPartitionTimes.put(dimensionType, currentTime);
+                anyPartitionsCreated = true;
+                
+                if (currentTime.isAfter(latestPartitionTime)) {
+                    latestPartitionTime = currentTime;
+                }
+                
+                // Increment both counters for reliability
+                configurablePartitionsCreatedCounter.increment();
+                partitionCreationCount.incrementAndGet();
+            } else {
+                log.debug("Skipping partition creation for dimension type '{}' - next scheduled time: {}",
+                         dimensionType, nextScheduledTime);
+                configurablePartitionsSkippedCounter.increment();
+            }
+        }
+
+        if (anyPartitionsCreated) {
+            updateConfigurableIntervalLeaderProgressState(leaderPartition, 0, latestPartitionTime, 
+                                                         lastPartitionTimes, coordinator);
+            return latestPartitionTime;
+        }
+
+        return globalLastPollTime;
+    }
+
+    /**
+     * Creates a worker partition for a specific dimension type.
+     */
+    private void createWorkerPartitionForDimensionType(Instant startTime, Instant endTime,
+                                                      String dimensionType, EnhancedSourceCoordinator coordinator) {
+        DimensionalTimeSliceWorkerProgressState workerState = new DimensionalTimeSliceWorkerProgressState();
+        workerState.setPartitionCreationTime(Instant.now());
+        workerState.setStartTime(startTime);
+        workerState.setEndTime(endTime);
+        workerState.setDimensionType(dimensionType);
+
+        SaasSourcePartition partition = new SaasSourcePartition(workerState, LAST_UPDATED_KEY + UUID.randomUUID());
+        coordinator.createPartition(partition);
+    }
+
+    /**
+     * Updates the configurable interval leader progress state.
+     */
+    private void updateConfigurableIntervalLeaderProgressState(LeaderPartition leaderPartition,
+                                                              int remainingHours,
+                                                              Instant updatedPollTime,
+                                                              Map<String, Instant> lastPartitionTimes,
+                                                              EnhancedSourceCoordinator coordinator) {
+        ConfigurableIntervalLeaderProgressState state =
+                (ConfigurableIntervalLeaderProgressState) leaderPartition.getProgressState().get();
+        
+        state.setRemainingHours(remainingHours);
+        state.setLastPollTime(updatedPollTime);
+        state.setLastPartitionTimePerDimensionType(lastPartitionTimes);
+        
+        leaderPartition.setLeaderProgressState(state);
+        coordinator.saveProgressStateForPartition(leaderPartition, DEFAULT_EXTEND_LEASE_MINUTES);
+    }
+}

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/ConfigurableIntervalLeaderProgressState.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/ConfigurableIntervalLeaderProgressState.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enhanced leader progress state that tracks last partition creation time
+ * per dimension type, enabling configurable partition creation intervals.
+ */
+public class ConfigurableIntervalLeaderProgressState extends DimensionalTimeSliceLeaderProgressState {
+
+    /**
+     * Map tracking the last partition creation time for each dimension type.
+     * This allows each dimension type to have independent partition creation schedules.
+     */
+    @JsonProperty("lastPartitionTimePerDimensionType")
+    private Map<String, Instant> lastPartitionTimePerDimensionType;
+
+    /**
+     * Default constructor for Jackson deserialization.
+     */
+    public ConfigurableIntervalLeaderProgressState() {
+        super(Instant.now(), 0);
+        this.lastPartitionTimePerDimensionType = new HashMap<>();
+    }
+
+    /**
+     * Constructor with initial values.
+     *
+     * @param lastPollTime   the last poll time for general progress tracking
+     * @param remainingHours the number of remaining hours for historical data processing
+     */
+    public ConfigurableIntervalLeaderProgressState(Instant lastPollTime, int remainingHours) {
+        super(lastPollTime, remainingHours);
+        this.lastPartitionTimePerDimensionType = new HashMap<>();
+    }
+
+    /**
+     * Gets the map of last partition creation times per dimension type.
+     *
+     * @return Map of dimension type to last partition creation time
+     */
+    public Map<String, Instant> getLastPartitionTimePerDimensionType() {
+        if (lastPartitionTimePerDimensionType == null) {
+            lastPartitionTimePerDimensionType = new HashMap<>();
+        }
+        return lastPartitionTimePerDimensionType;
+    }
+
+    /**
+     * Sets the map of last partition creation times per dimension type.
+     *
+     * @param lastPartitionTimePerDimensionType Map of dimension type to last partition creation time
+     */
+    public void setLastPartitionTimePerDimensionType(Map<String, Instant> lastPartitionTimePerDimensionType) {
+        this.lastPartitionTimePerDimensionType = lastPartitionTimePerDimensionType;
+    }
+
+    /**
+     * Gets the last partition creation time for a specific dimension type.
+     *
+     * @param dimensionType the dimension type
+     * @return the last partition creation time, or the global last poll time if not tracked
+     */
+    public Instant getLastPartitionTimeForDimension(String dimensionType) {
+        return getLastPartitionTimePerDimensionType().getOrDefault(dimensionType, getLastPollTime());
+    }
+
+    /**
+     * Sets the last partition creation time for a specific dimension type.
+     *
+     * @param dimensionType the dimension type
+     * @param partitionTime the last partition creation time
+     */
+    public void setLastPartitionTimeForDimension(String dimensionType, Instant partitionTime) {
+        getLastPartitionTimePerDimensionType().put(dimensionType, partitionTime);
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigurableIntervalLeaderProgressState{" +
+                "lastPartitionTimePerDimensionType=" + lastPartitionTimePerDimensionType +
+                ", lastPollTime=" + getLastPollTime() +
+                ", remainingHours=" + getRemainingHours() +
+                '}';
+    }
+}

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/ConfigurableIntervalDimensionalTimeSliceCrawlerTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/base/ConfigurableIntervalDimensionalTimeSliceCrawlerTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.source_crawler.base;
+
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.ConfigurableIntervalLeaderProgressState;
+import org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state.DimensionalTimeSliceWorkerProgressState;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurableIntervalDimensionalTimeSliceCrawlerTest {
+
+    @Mock
+    private CrawlerClient crawlerClient;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Counter partitionsCreatedCounter;
+
+    @Mock
+    private Counter partitionsSkippedCounter;
+
+    @Mock
+    private EnhancedSourceCoordinator coordinator;
+
+    @Mock
+    private LeaderPartition leaderPartition;
+
+    @Mock
+    private ConfigurableIntervalLeaderProgressState leaderProgressState;
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    @Mock
+    private AcknowledgementSet acknowledgementSet;
+
+    private ConfigurableIntervalDimensionalTimeSliceCrawler crawler;
+    private Function<String, Duration> scheduleProvider;
+
+    @BeforeEach
+    void setUp() {
+        when(pluginMetrics.counter(anyString())).thenReturn(partitionsCreatedCounter);
+        
+        crawler = new ConfigurableIntervalDimensionalTimeSliceCrawler(crawlerClient, pluginMetrics);
+        
+        // Set up schedule provider: 5 minutes for some types, 10 minutes for others
+        scheduleProvider = dimensionType -> {
+            switch (dimensionType) {
+                case "auditLogEntries":
+                case "detections":
+                    return Duration.ofMinutes(5);
+                case "issues":
+                case "vulnerabilityFindings":
+                case "configurationFindings":
+                    return Duration.ofMinutes(10);
+                default:
+                    return Duration.ofMinutes(5);
+            }
+        };
+        
+        crawler.setPartitionScheduleProvider(scheduleProvider);
+        crawler.setDimensionTypes(Arrays.asList("auditLogEntries", "detections", "issues", 
+                "vulnerabilityFindings", "configurationFindings"));
+    }
+
+    @Test
+    void testCrawlWithNullScheduleProvider() {
+        ConfigurableIntervalDimensionalTimeSliceCrawler crawlerWithoutSchedule = 
+                new ConfigurableIntervalDimensionalTimeSliceCrawler(crawlerClient, pluginMetrics);
+        
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        
+        // Should fall back to parent behavior
+        Instant result = crawlerWithoutSchedule.crawl(leaderPartition, coordinator);
+        
+        // Verify warning was logged (would need log capture for full verification)
+        assertNotNull(result);
+    }
+
+    @Test
+    void testCrawlIncrementalSyncWithMixedIntervals() {
+        Instant now = Instant.now();
+        Instant lastPollTime = now.minus(Duration.ofMinutes(11)); // 11 minutes ago
+        
+        Map<String, Instant> lastPartitionTimes = new HashMap<>();
+        lastPartitionTimes.put("auditLogEntries", now.minus(Duration.ofMinutes(6))); // Should create (5min schedule)
+        lastPartitionTimes.put("detections", now.minus(Duration.ofMinutes(4))); // Should skip (5min schedule)
+        lastPartitionTimes.put("issues", now.minus(Duration.ofMinutes(11))); // Should create (10min schedule)
+        
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        when(leaderProgressState.getRemainingHours()).thenReturn(0); // Incremental sync
+        when(leaderProgressState.getLastPollTime()).thenReturn(lastPollTime);
+        when(leaderProgressState.getLastPartitionTimePerDimensionType()).thenReturn(lastPartitionTimes);
+        
+        Instant result = crawler.crawl(leaderPartition, coordinator);
+        
+        // Should create partitions for auditLogEntries and issues (3 total including uninitialized types)
+        verify(coordinator, atLeastOnce()).createPartition(any());
+        verify(partitionsCreatedCounter, atLeastOnce()).increment();
+        assertNotNull(result);
+    }
+
+    @Test
+    void testCrawlHistoricalPull() {
+        Instant now = Instant.now();
+        
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        when(leaderProgressState.getRemainingHours()).thenReturn(5); // Historical pull
+        when(leaderProgressState.getLastPollTime()).thenReturn(now);
+        
+        Instant result = crawler.crawl(leaderPartition, coordinator);
+        
+        // Should handle historical pull (exact behavior depends on parent implementation)
+        assertNotNull(result);
+    }
+
+    @Test
+    void testExecutePartition() {
+        DimensionalTimeSliceWorkerProgressState workerState = new DimensionalTimeSliceWorkerProgressState();
+        workerState.setDimensionType("testType");
+        workerState.setStartTime(Instant.now().minus(Duration.ofMinutes(10)));
+        workerState.setEndTime(Instant.now());
+        workerState.setPartitionCreationTime(Instant.now().minus(Duration.ofMinutes(1)));
+        
+        crawler.executePartition(workerState, buffer, acknowledgementSet);
+        
+        verify(crawlerClient).executePartition(workerState, buffer, acknowledgementSet);
+    }
+
+    @Test
+    void testStateInitializationPreventsCorruption() {
+        Instant baseTime = Instant.now().minus(Duration.ofMinutes(20));
+        Map<String, Instant> lastPartitionTimes = new HashMap<>();
+        // Only initialize some dimension types
+        lastPartitionTimes.put("auditLogEntries", baseTime.minus(Duration.ofMinutes(6)));
+        // Leave others uninitialized to test initialization logic
+        
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        when(leaderProgressState.getRemainingHours()).thenReturn(0);
+        when(leaderProgressState.getLastPollTime()).thenReturn(baseTime);
+        when(leaderProgressState.getLastPartitionTimePerDimensionType()).thenReturn(lastPartitionTimes);
+        
+        crawler.crawl(leaderPartition, coordinator);
+        
+        // Verify that uninitialized dimension types were initialized with base time
+        assertEquals(5, lastPartitionTimes.size()); // All dimension types should be initialized
+        assertTrue(lastPartitionTimes.containsKey("issues"));
+        assertTrue(lastPartitionTimes.containsKey("vulnerabilityFindings"));
+        assertEquals(baseTime, lastPartitionTimes.get("issues")); // Should be initialized with base time
+    }
+
+    @Test
+    void testGetDimensionTypes() {
+        assertEquals(5, crawler.getDimensionTypes().size());
+        assertTrue(crawler.getDimensionTypes().contains("auditLogEntries"));
+        assertTrue(crawler.getDimensionTypes().contains("issues"));
+    }
+
+    @Test
+    void testSetPartitionScheduleProvider() {
+        Function<String, Duration> newProvider = type -> Duration.ofHours(1);
+        crawler.setPartitionScheduleProvider(newProvider);
+        
+        // Verify the provider was set (indirect test through behavior)
+        assertNotNull(crawler);
+    }
+
+    @Test
+    void testSetDimensionTypes() {
+        crawler.setDimensionTypes(Arrays.asList("newType1", "newType2"));
+        
+        assertEquals(2, crawler.getDimensionTypes().size());
+        assertTrue(crawler.getDimensionTypes().contains("newType1"));
+        assertTrue(crawler.getDimensionTypes().contains("newType2"));
+    }
+
+    @Test 
+    void testPartitionCountReliability() {
+        // Test that the AtomicLong counter provides consistent counts
+        Instant now = Instant.now();
+        Instant lastPollTime = now.minus(Duration.ofMinutes(11));
+        
+        Map<String, Instant> lastPartitionTimes = new HashMap<>();
+        // Set up all types to be eligible for partition creation
+        lastPartitionTimes.put("auditLogEntries", now.minus(Duration.ofMinutes(6)));
+        lastPartitionTimes.put("detections", now.minus(Duration.ofMinutes(6)));
+        lastPartitionTimes.put("issues", now.minus(Duration.ofMinutes(11)));
+        lastPartitionTimes.put("vulnerabilityFindings", now.minus(Duration.ofMinutes(11)));
+        lastPartitionTimes.put("configurationFindings", now.minus(Duration.ofMinutes(11)));
+        
+        when(leaderPartition.getProgressState()).thenReturn(Optional.of(leaderProgressState));
+        when(leaderProgressState.getRemainingHours()).thenReturn(0);
+        when(leaderProgressState.getLastPollTime()).thenReturn(lastPollTime);
+        when(leaderProgressState.getLastPartitionTimePerDimensionType()).thenReturn(lastPartitionTimes);
+        
+        Instant result = crawler.crawl(leaderPartition, coordinator);
+        
+        // All 5 dimension types should create partitions
+        verify(coordinator, times(5)).createPartition(any());
+        verify(partitionsCreatedCounter, times(5)).increment();
+        assertNotNull(result);
+    }
+}

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/ConfigurableIntervalLeaderProgressStateTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/coordination/state/ConfigurableIntervalLeaderProgressStateTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.source_crawler.coordination.state;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigurableIntervalLeaderProgressStateTest {
+
+    private ConfigurableIntervalLeaderProgressState progressState;
+    private Instant testTime;
+    private int testRemainingHours;
+
+    @BeforeEach
+    void setUp() {
+        testTime = Instant.now();
+        testRemainingHours = 24;
+        progressState = new ConfigurableIntervalLeaderProgressState(testTime, testRemainingHours);
+    }
+
+    @Test
+    void testConstructorWithLastPollTimeAndRemainingHours() {
+        assertEquals(testTime, progressState.getLastPollTime());
+        assertEquals(testRemainingHours, progressState.getRemainingHours());
+        assertNotNull(progressState.getLastPartitionTimePerDimensionType());
+        assertTrue(progressState.getLastPartitionTimePerDimensionType().isEmpty());
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        ConfigurableIntervalLeaderProgressState defaultState = new ConfigurableIntervalLeaderProgressState();
+        
+        assertNull(defaultState.getLastPollTime());
+        assertEquals(0, defaultState.getRemainingHours());
+        assertNotNull(defaultState.getLastPartitionTimePerDimensionType());
+        assertTrue(defaultState.getLastPartitionTimePerDimensionType().isEmpty());
+    }
+
+    @Test
+    void testGetAndSetLastPartitionTimePerDimensionType() {
+        Map<String, Instant> partitionTimes = new HashMap<>();
+        Instant auditLogTime = testTime.minus(Duration.ofMinutes(5));
+        Instant issueTime = testTime.minus(Duration.ofMinutes(10));
+        
+        partitionTimes.put("auditLogEntries", auditLogTime);
+        partitionTimes.put("issues", issueTime);
+        
+        progressState.setLastPartitionTimePerDimensionType(partitionTimes);
+        
+        Map<String, Instant> retrieved = progressState.getLastPartitionTimePerDimensionType();
+        assertEquals(2, retrieved.size());
+        assertEquals(auditLogTime, retrieved.get("auditLogEntries"));
+        assertEquals(issueTime, retrieved.get("issues"));
+    }
+
+    @Test
+    void testSetLastPartitionTimePerDimensionTypeWithNull() {
+        progressState.setLastPartitionTimePerDimensionType(null);
+        
+        Map<String, Instant> retrieved = progressState.getLastPartitionTimePerDimensionType();
+        assertNotNull(retrieved);
+        assertTrue(retrieved.isEmpty());
+    }
+
+    @Test
+    void testMapIsModifiable() {
+        Map<String, Instant> partitionTimes = progressState.getLastPartitionTimePerDimensionType();
+        
+        // Should be able to modify the returned map
+        Instant testInstant = Instant.now();
+        partitionTimes.put("testType", testInstant);
+        
+        assertEquals(testInstant, progressState.getLastPartitionTimePerDimensionType().get("testType"));
+    }
+
+    @Test
+    void testInheritedFunctionality() {
+        // Test that it properly inherits from DimensionalTimeSliceLeaderProgressState
+        Instant newTime = testTime.plus(Duration.ofHours(1));
+        int newHours = 12;
+        
+        progressState.setLastPollTime(newTime);
+        progressState.setRemainingHours(newHours);
+        
+        assertEquals(newTime, progressState.getLastPollTime());
+        assertEquals(newHours, progressState.getRemainingHours());
+    }
+
+    @Test
+    void testStateIndependenceFromParent() {
+        // Ensure that the configurable interval specific functionality doesn't interfere
+        // with the parent class functionality
+        
+        Map<String, Instant> partitionTimes = new HashMap<>();
+        partitionTimes.put("type1", testTime);
+        progressState.setLastPartitionTimePerDimensionType(partitionTimes);
+        
+        // Change parent state
+        Instant newLastPoll = testTime.plus(Duration.ofMinutes(30));
+        progressState.setLastPollTime(newLastPoll);
+        
+        // Both should be independent
+        assertEquals(newLastPoll, progressState.getLastPollTime());
+        assertEquals(testTime, progressState.getLastPartitionTimePerDimensionType().get("type1"));
+    }
+
+    @Test
+    void testMultipleTimeUpdates() {
+        Map<String, Instant> partitionTimes = new HashMap<>();
+        
+        // Initial setup
+        Instant time1 = testTime.minus(Duration.ofMinutes(10));
+        Instant time2 = testTime.minus(Duration.ofMinutes(5));
+        partitionTimes.put("auditLogEntries", time1);
+        partitionTimes.put("detections", time2);
+        progressState.setLastPartitionTimePerDimensionType(partitionTimes);
+        
+        // Update one dimension type
+        partitionTimes.put("auditLogEntries", testTime);
+        
+        Map<String, Instant> retrieved = progressState.getLastPartitionTimePerDimensionType();
+        assertEquals(testTime, retrieved.get("auditLogEntries"));
+        assertEquals(time2, retrieved.get("detections")); // Should remain unchanged
+    }
+
+    @Test
+    void testEmptyMapHandling() {
+        Map<String, Instant> emptyMap = new HashMap<>();
+        progressState.setLastPartitionTimePerDimensionType(emptyMap);
+        
+        Map<String, Instant> retrieved = progressState.getLastPartitionTimePerDimensionType();
+        assertNotNull(retrieved);
+        assertTrue(retrieved.isEmpty());
+        
+        // Should be able to add to it
+        retrieved.put("newType", testTime);
+        assertEquals(1, progressState.getLastPartitionTimePerDimensionType().size());
+    }
+
+    @Test
+    void testPartitionTimeRetrieval() {
+        Map<String, Instant> partitionTimes = new HashMap<>();
+        Instant auditTime = testTime.minus(Duration.ofMinutes(15));
+        Instant issueTime = testTime.minus(Duration.ofMinutes(30));
+        Instant detectionTime = testTime.minus(Duration.ofMinutes(2));
+        
+        partitionTimes.put("auditLogEntries", auditTime);
+        partitionTimes.put("issues", issueTime);
+        partitionTimes.put("detections", detectionTime);
+        
+        progressState.setLastPartitionTimePerDimensionType(partitionTimes);
+        
+        // Verify individual retrievals
+        Map<String, Instant> all = progressState.getLastPartitionTimePerDimensionType();
+        assertEquals(auditTime, all.get("auditLogEntries"));
+        assertEquals(issueTime, all.get("issues"));  
+        assertEquals(detectionTime, all.get("detections"));
+        assertNull(all.get("nonExistentType"));
+    }
+
+    @Test
+    void testStateConsistency() {
+        // Test that the state remains consistent when both parent and child properties are modified
+        Instant parentTime = testTime.plus(Duration.ofHours(2));
+        int parentHours = 48;
+        
+        Map<String, Instant> childMap = new HashMap<>();
+        childMap.put("type1", testTime.minus(Duration.ofMinutes(5)));
+        childMap.put("type2", testTime.minus(Duration.ofMinutes(10)));
+        
+        // Set both parent and child properties
+        progressState.setLastPollTime(parentTime);
+        progressState.setRemainingHours(parentHours);
+        progressState.setLastPartitionTimePerDimensionType(childMap);
+        
+        // Verify both are maintained correctly
+        assertEquals(parentTime, progressState.getLastPollTime());
+        assertEquals(parentHours, progressState.getRemainingHours());
+        assertEquals(2, progressState.getLastPartitionTimePerDimensionType().size());
+        assertEquals(testTime.minus(Duration.ofMinutes(5)), 
+                     progressState.getLastPartitionTimePerDimensionType().get("type1"));
+    }
+}


### PR DESCRIPTION
### Description
* **Target Class**: ConfigurableIntervalDimensionalTimeSliceCrawler (extends DimensionalTimeSliceCrawler)
* **State Independence**: Each dimension type now maintains independent partition timing

### Testing Results
* **Data Ingestion**: Verified data ingestion from source. 
* **Mixed Intervals Confirmed**: 
  - 2 events process every 5 minutes (auditLogEntries, detections)
  - 3 events process every 10 minutes (issues, vulnerabilityFindings, configurationFindings)
* **Accurate Counting**: Partition counts now show correct values (2, 5, etc.) instead of always 0.0
* **State Persistence**: Per-dimension timing properly survives across crawl cycles
* **Extended Testing**: Stable performance over multiple crawl cycles

### Sample Use Case: Security Monitoring Plugin with Multi-Interval API Polling
#### Background

A security monitoring plugin integrates with a vendor's API that exposes multiple endpoints, each with different data characteristics and recommended polling frequencies.

**API Endpoints**
- Detections/Alerts API (/api/v1/detections)
   - Returns security alerts and threat detections
   - High volatility: New detections appear frequently
   - Vendor recommendation: Poll every 5 minutes
   - Business requirement: Timely threat response

- Configuration Snapshot API (/api/v1/configurations)
   - Returns system configuration state
   - Low volatility: Changes occur infrequently
   - Vendor recommendation: Poll every 30 minutes
   - Business requirement: Audit trail and compliance

- Audit Logs API (/api/v1/audit-logs)
   - Returns user activity logs
   - Medium volatility: Regular but not urgent updates
   - Vendor recommendation: Poll every 15 minutes
   - Business requirement: Security monitoring and compliance

#### Problem Statement

The existing framework enforces a single polling interval per plugin. This creates a trade-off:
- Setting a 5-minute interval for all APIs results in unnecessary load on low-volatility endpoints
- Setting a 30-minute interval for all APIs results in stale detection data and delayed threat response

#### Solution

Implement per-API configurable intervals within a single plugin:

Plugin: SecurityMonitoringPlugin
├── DetectionsAPI (interval: 5 minutes)
├── ConfigurationAPI (interval: 30 minutes)
└── AuditLogsAPI (interval: 15 minutes)

#### Expected Behavior
- Detections are polled every 5 minutes, ensuring timely threat detection
- Configuration snapshots are polled every 30 minutes, reducing unnecessary API calls
- Audit logs are polled every 15 minutes, balancing freshness with efficiency

#### Benefits
- Optimized API usage: Respects vendor rate limits and recommendations
- Reduced data staleness: Critical data is refreshed more frequently
- Cost efficiency: Avoids over-polling low-volatility endpoints
- Vendor compliance: Aligns with vendor-specified best practices

### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
