### PR TITLE
Add Pattern API with opt-in Re2J support

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation libs.parquet.common
     implementation libs.commons.lang3
     implementation 'jakarta.validation:jakarta.validation-api:3.1.1'
+    implementation 'com.google.re2j:re2j:1.8'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-test:test-common')
     testImplementation 'org.skyscreamer:jsonassert:1.5.3'

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/JavaPatternProvider.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/JavaPatternProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.pattern;
+
+/**
+ * Default pattern provider using Java SDK Pattern.
+ */
+class JavaPatternProvider implements PatternProvider {
+    @Override
+    public String getName() {
+        return "java";
+    }
+    
+    @Override
+    public Pattern compile(String regex) throws PatternSyntaxException {
+        try {
+            return new JavaPattern(java.util.regex.Pattern.compile(regex));
+        } catch (java.util.regex.PatternSyntaxException e) {
+            throw new PatternSyntaxException(e.getMessage(), regex, e);
+        }
+    }
+    
+    private static class JavaPattern implements Pattern {
+        private final java.util.regex.Pattern pattern;
+        
+        JavaPattern(java.util.regex.Pattern pattern) {
+            this.pattern = pattern;
+        }
+        
+        @Override
+        public Matcher matcher(CharSequence input) {
+            return new JavaMatcher(pattern.matcher(input));
+        }
+    }
+    
+    private static class JavaMatcher implements Matcher {
+        private final java.util.regex.Matcher matcher;
+        
+        JavaMatcher(java.util.regex.Matcher matcher) {
+            this.matcher = matcher;
+        }
+        
+        @Override
+        public boolean matches() {
+            return matcher.matches();
+        }
+        
+        @Override
+        public boolean find() {
+            return matcher.find();
+        }
+        
+        @Override
+        public String group() {
+            return matcher.group();
+        }
+        
+        @Override
+        public String group(int group) {
+            return matcher.group(group);
+        }
+        
+        @Override
+        public String replaceAll(String replacement) {
+            return matcher.replaceAll(replacement);
+        }
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/Matcher.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/Matcher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.pattern;
+
+/**
+ * Interface for regex matcher operations.
+ */
+public interface Matcher {
+    /**
+     * Attempts to match the entire region against the pattern.
+     *
+     * @return true if, and only if, the entire region sequence matches this matcher's pattern
+     */
+    boolean matches();
+    
+    /**
+     * Attempts to find the next subsequence of the input sequence that matches the pattern.
+     *
+     * @return true if, and only if, a subsequence of the input sequence matches this matcher's pattern
+     */
+    boolean find();
+    
+    /**
+     * Returns the input subsequence matched by the previous match.
+     *
+     * @return The (possibly empty) subsequence matched by the previous match, in string form
+     */
+    String group();
+    
+    /**
+     * Returns the input subsequence captured by the given group during the previous match operation.
+     *
+     * @param group The index of a capturing group in this matcher's pattern
+     * @return The (possibly empty) subsequence captured by the group during the previous match, or null if the group failed to match part of the input
+     */
+    String group(int group);
+    
+    /**
+     * Replaces every subsequence of the input sequence that matches the pattern with the given replacement string.
+     *
+     * @param replacement The replacement string
+     * @return The string constructed by replacing each matching subsequence by the replacement string
+     */
+    String replaceAll(String replacement);
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/Pattern.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/Pattern.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.pattern;
+
+/**
+ * Interface for regex pattern matching operations.
+ * Implementations can use different regex engines (Java SDK, Re2J, etc.)
+ */
+public interface Pattern {
+    /**
+     * Creates a matcher that will match the given input against this pattern.
+     *
+     * @param input The character sequence to be matched
+     * @return A new matcher for this pattern
+     */
+    Matcher matcher(CharSequence input);
+    
+    /**
+     * Compiles the given regular expression into a pattern.
+     *
+     * @param regex The expression to be compiled
+     * @return the compiled pattern
+     * @throws PatternSyntaxException if the expression's syntax is invalid
+     */
+    static Pattern compile(String regex) throws PatternSyntaxException {
+        return PatternProvider.getProvider().compile(regex);
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/PatternProvider.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/PatternProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.pattern;
+
+import java.util.ServiceLoader;
+
+/**
+ * Service provider interface for Pattern implementations.
+ * Implementations should be registered via Java ServiceLoader mechanism.
+ */
+public interface PatternProvider {
+    /**
+     * Compiles the given regular expression into a pattern.
+     *
+     * @param regex The expression to be compiled
+     * @return the compiled pattern
+     * @throws PatternSyntaxException if the expression's syntax is invalid
+     */
+    Pattern compile(String regex) throws PatternSyntaxException;
+    
+    /**
+     * Returns the name of this provider (e.g., "java", "re2j").
+     */
+    String getName();
+    
+    /**
+     * Gets the pattern provider instance based on system property.
+     * Uses "dataprepper.pattern.provider" system property to select implementation.
+     * Defaults to Java SDK Pattern if property not set or provider not found.
+     *
+     * @return the pattern provider
+     */
+    static PatternProvider getProvider() {
+        String providerName = System.getProperty("dataprepper.pattern.provider", "java");
+        
+        ServiceLoader<PatternProvider> loader = ServiceLoader.load(PatternProvider.class);
+        for (PatternProvider provider : loader) {
+            if (provider.getName().equalsIgnoreCase(providerName)) {
+                return provider;
+            }
+        }
+        
+        // Default to Java SDK Pattern
+        return new JavaPatternProvider();
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/PatternSyntaxException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/PatternSyntaxException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.pattern;
+
+/**
+ * Exception thrown when a syntax error is encountered in a pattern.
+ */
+public class PatternSyntaxException extends RuntimeException {
+    private final String pattern;
+    
+    public PatternSyntaxException(String message, String pattern) {
+        super(message);
+        this.pattern = pattern;
+    }
+    
+    public PatternSyntaxException(String message, String pattern, Throwable cause) {
+        super(message, cause);
+        this.pattern = pattern;
+    }
+    
+    public String getPattern() {
+        return pattern;
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/Re2JPatternProvider.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/pattern/Re2JPatternProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.pattern;
+
+/**
+ * Pattern provider using Re2J regex engine for protection against catastrophic backtracking.
+ */
+class Re2JPatternProvider implements PatternProvider {
+    @Override
+    public String getName() {
+        return "re2j";
+    }
+    
+    @Override
+    public Pattern compile(String regex) throws PatternSyntaxException {
+        try {
+            return new Re2JPattern(com.google.re2j.Pattern.compile(regex));
+        } catch (com.google.re2j.PatternSyntaxException e) {
+            throw new PatternSyntaxException(e.getMessage(), regex, e);
+        }
+    }
+    
+    private static class Re2JPattern implements Pattern {
+        private final com.google.re2j.Pattern pattern;
+        
+        Re2JPattern(com.google.re2j.Pattern pattern) {
+            this.pattern = pattern;
+        }
+        
+        @Override
+        public Matcher matcher(CharSequence input) {
+            return new Re2JMatcher(pattern.matcher(input));
+        }
+    }
+    
+    private static class Re2JMatcher implements Matcher {
+        private final com.google.re2j.Matcher matcher;
+        
+        Re2JMatcher(com.google.re2j.Matcher matcher) {
+            this.matcher = matcher;
+        }
+        
+        @Override
+        public boolean matches() {
+            return matcher.matches();
+        }
+        
+        @Override
+        public boolean find() {
+            return matcher.find();
+        }
+        
+        @Override
+        public String group() {
+            return matcher.group();
+        }
+        
+        @Override
+        public String group(int group) {
+            return matcher.group(group);
+        }
+        
+        @Override
+        public String replaceAll(String replacement) {
+            return matcher.replaceAll(replacement);
+        }
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
@@ -7,9 +7,9 @@ package org.opensearch.dataprepper.expression;
 
 import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+import org.opensearch.dataprepper.model.pattern.PatternSyntaxException;
 
 import java.util.function.BiPredicate;
-import java.util.regex.PatternSyntaxException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorConfiguration.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorConfiguration.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import org.opensearch.dataprepper.model.event.DataType;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 import org.springframework.context.annotation.Bean;
 
 import javax.inject.Named;
@@ -20,7 +21,7 @@ import java.util.function.Function;
 
 @Named
 class OperatorConfiguration {
-    public final BiPredicate<Object, Object> regexEquals = (x, y) -> ((String) x).matches((String) y);
+    public final BiPredicate<Object, Object> regexEquals = (x, y) -> Pattern.compile((String) y).matcher((String) x).matches();
     public final BiPredicate<Object, Object> equals = Objects::equals;
     public final BiPredicate<Object, Object> inSet = (x, y) -> ((Set<?>) y).contains(x);
     public final BiPredicate<Object, Object> typeOf = (x, y) -> DataType.isSameType(x, (String)y);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexEqualOperatorTest.java
@@ -71,4 +71,17 @@ class RegexEqualOperatorTest {
     void evaluate_with_null_lhs_returns_false() {
         assertThat(objectUnderTest.evaluate(null, "a*"), equalTo(false));
     }
+    
+    @Test
+    void testEvalAdversarialArgsWithRe2j() {
+        System.setProperty("dataprepper.pattern.provider", "re2j");
+        try {
+            Boolean result = Assertions.assertTimeoutPreemptively(Duration.ofMillis(1000), () -> {
+                return objectUnderTest.evaluate("a".repeat(1000) + "X", "(a+)+");
+            });
+            assertThat(result, is(false));
+        } finally {
+            System.clearProperty("dataprepper.pattern.provider");
+        }
+    }
 }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -32,11 +32,11 @@ import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import java.util.regex.Matcher;
 import java.util.Stack;
 import java.util.ArrayList;
+import org.opensearch.dataprepper.model.pattern.Pattern;
+import org.opensearch.dataprepper.model.pattern.PatternSyntaxException;
+import org.opensearch.dataprepper.model.pattern.Matcher;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -32,7 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.PatternSyntaxException;
+import org.opensearch.dataprepper.model.pattern.PatternSyntaxException;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -1009,7 +1009,24 @@ public class KeyValueProcessorTests {
     void testShutdownIsReady() {
         assertThat(createObjectUnderTest().isReadyForShutdown(), is(true));
     }
-
+        
+    @Test
+    void testKeyValueProcessorWithRe2j() {
+        System.setProperty("dataprepper.pattern.provider", "re2j");
+        try {
+            when(mockConfig.getFieldDelimiterRegex()).thenReturn("&");
+            when(mockConfig.getKeyValueDelimiterRegex()).thenReturn("=");
+            KeyValueProcessor processor = createObjectUnderTest();
+            
+            final Record<Event> record = getMessage("key1=value1&key2=value2");
+            final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+            
+            assertThat(editedRecords.size(), equalTo(1));
+        } finally {
+            System.clearProperty("dataprepper.pattern.provider");
+        }
+    }
+    
     private Record<Event> getMessage(String message) {
         final Map<String, Object> testData = new HashMap();
         testData.put("message", message);

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 import java.util.stream.Collectors;
 
 @DataPrepperPlugin(name = "delete_entries", pluginType = Processor.class, pluginConfigurationType = DeleteEntryProcessorConfig.class)

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -26,8 +26,8 @@ import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import org.opensearch.dataprepper.model.pattern.Pattern;
+import org.opensearch.dataprepper.model.pattern.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 @ConditionalRequired(value = {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessor.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 @DataPrepperPlugin(name = "rename_keys", pluginType = Processor.class, pluginConfigurationType = RenameKeyProcessorConfig.class)
 public class RenameKeyProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -24,7 +24,7 @@ import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
 import java.util.List;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 @JsonPropertyOrder
 @JsonClassDescription("The <code>rename_keys</code> processor renames keys in an event.")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 @DataPrepperPlugin(name = "select_entries", pluginType = Processor.class, pluginConfigurationType = SelectEntriesProcessorConfig.class)
 public class SelectEntriesProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
@@ -15,8 +15,8 @@ import org.opensearch.dataprepper.model.annotations.ExampleValues;
 import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import org.opensearch.dataprepper.model.pattern.Pattern;
+import org.opensearch.dataprepper.model.pattern.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 @JsonPropertyOrder

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorTests.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessor.java
@@ -17,7 +17,7 @@ import org.opensearch.dataprepper.model.processor.Processor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 @DataPrepperPlugin(name = "split_string", pluginType = Processor.class, pluginConfigurationType = SplitStringProcessorConfig.class)
 public class SplitStringProcessor extends AbstractStringProcessor<SplitStringProcessorConfig.Entry> {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessor.java
@@ -17,8 +17,8 @@ import org.opensearch.dataprepper.model.processor.Processor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Matcher;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 /**
  * This processor takes in a key and changes its value by searching for a pattern and replacing the matches with a string.

--- a/data-prepper-plugins/mutate-string-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorTests.java
+++ b/data-prepper-plugins/mutate-string-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorTests.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.PatternSyntaxException;
+import org.opensearch.dataprepper.model.pattern.PatternSyntaxException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Matcher;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 @DataPrepperPlugin(name = "obfuscate", pluginType = Processor.class, pluginConfigurationType = ObfuscationProcessorConfig.class)
 public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskAction.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskAction.java
@@ -11,7 +11,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.List;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 @DataPrepperPlugin(name = "mask", pluginType = ObfuscationAction.class, pluginConfigurationType = MaskActionConfig.class)
 public class MaskAction implements ObfuscationAction {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/ObfuscationAction.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/ObfuscationAction.java
@@ -6,7 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.obfuscation.action;
 
 import java.util.List;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashAction.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashAction.java
@@ -12,8 +12,8 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Matcher;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;

--- a/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskActionTest.java
+++ b/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/MaskActionTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionTest.java
+++ b/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/action/OneWayHashActionTest.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;

--- a/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessor.java
+++ b/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessor.java
@@ -23,7 +23,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.function.Function;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 
 @DataPrepperPlugin(name = "split_event", pluginType = Processor.class, pluginConfigurationType = SplitEventProcessorConfig.class)

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorEnhancedTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorEnhancedTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Pattern;
+import org.opensearch.dataprepper.model.pattern.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -378,5 +378,22 @@ class TranslateProcessorEnhancedTest {
                 .withData(data)
                 .withEventType("event")
                 .build());
+    }
+    
+    @Test
+    void testTranslateProcessorWithRe2j() {
+        System.setProperty("dataprepper.pattern.provider", "re2j");
+        try {
+            when(mockConfig.getSource()).thenReturn("sourceField");
+            when(mockConfig.getTargets()).thenReturn(List.of());
+            TranslateProcessor processor = createObjectUnderTest();
+            
+            final Record<Event> record = getEvent("testValue");
+            final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+            
+            assertThat(editedRecords.size(), equalTo(1));
+        } finally {
+            System.clearProperty("dataprepper.pattern.provider");
+        }
     }
 }


### PR DESCRIPTION
### Description

Creates an overridable Pattern interface in data-prepper-api that allows consumers to set the Pattern library used for regex evaluation through System environment field `dataprepper.pattern.provider`. By default, it will fallback to the Java SDK regex library (the current one), unless set in the system. Updates the corresponding modules that leverage Pattern to use the new Pattern interface.

Additionally, this CR creates a Pattern Provider leveraging the Re2j library, which works to minimize the risk of adversarial regex's directly resolving #6279 

 
### Issues Resolved
Resolves #6279 
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR -> #6477 
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
