### PR TITLE
Add derived server-side attributes to OTel trace raw processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,13 @@ data-prepper-main/src/test/resources/logstash-conf/logstash-filter.yaml
 *.iml
 .kiro
 .vscode
+
+# Manual testing files (should not be committed)
+MANUAL_TEST.md
+data-prepper-config.yaml
+pipelines.yaml
+run-dataprepper.sh
+trace-tester.py
+
+# Claude session notes
+claude.md

--- a/.whitesource
+++ b/.whitesource
@@ -26,7 +26,6 @@
     "issueType": "DEPENDENCY"
   },
   "remediateSettings": {
-    "enableRenovate": true,
     "workflowRules": {
       "enabled": true
     }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/otel/common/utils/OTelSpanDerivationUtil.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/otel/common/utils/OTelSpanDerivationUtil.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.otel.common.utils;
+
+import org.opensearch.dataprepper.model.trace.Span;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.dataprepper.model.metric.JacksonMetric.ATTRIBUTES_KEY;
+
+/**
+ * Utility class for deriving fault, error, operation, and environment attributes from OpenTelemetry spans.
+ * This class provides shared logic that can be used by multiple processors for consistent attribute derivation.
+ *
+ * Originally extracted from SpanStateData in otel-apm-service-map-processor to ensure
+ * consistent behavior across different processors.
+ */
+public class OTelSpanDerivationUtil {
+    // Attribute keys for derived values
+    public static final String DERIVED_FAULT_ATTRIBUTE = "derived.fault";
+    public static final String DERIVED_ERROR_ATTRIBUTE = "derived.error";
+    public static final String DERIVED_OPERATION_ATTRIBUTE = "derived.operation";
+    public static final String DERIVED_ENVIRONMENT_ATTRIBUTE = "derived.environment";
+    private static final Logger LOG = LoggerFactory.getLogger(OTelSpanDerivationUtil.class);
+    private static final String SPAN_KIND_SERVER = "SPAN_KIND_SERVER";
+
+    /**
+     * Derives fault, error, operation, and environment attributes for SERVER spans in the provided list.
+     * Only SERVER spans (kind == SERVER) will be decorated with derived attributes.
+     *
+     * @param spans List of spans to process
+     */
+    public static void deriveServerSpanAttributes(final List<Span> spans) {
+        if (spans == null) {
+            return;
+        }
+
+        for (final Span span : spans) {
+            if (span != null && SPAN_KIND_SERVER.equals(span.getKind())) {
+                deriveAttributesForSpan(span);
+            }
+        }
+    }
+
+
+    /**
+     * Adds an attribute to the span. This method just delegates to span.putAttribute()
+     * since JacksonSpan already handles null/immutable maps correctly.
+     *
+     * @param span The span to add the attribute to
+     * @param key The attribute key
+     * @param value The attribute value
+     */
+    private static void putAttribute(final Span span, final String key, final Object value) {
+        Map<String, Object> attributes = span.getAttributes();
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        } else {
+            attributes = new HashMap<>(attributes);
+        }
+        attributes.put(key, value);
+        span.put(ATTRIBUTES_KEY ,attributes);
+    }
+
+    /**
+     * Derive attributes for a single span and add them to the span's attributes
+     *
+     * @param span The span to derive attributes for
+     */
+    public static void deriveAttributesForSpan(final Span span) {
+        try {
+            final Map<String, Object> spanAttributes = span.getAttributes();
+
+            final ErrorFaultResult errorFault = computeErrorAndFault(span.getStatus(), spanAttributes);
+
+            final String operationName = computeOperationName(span.getName(), spanAttributes);
+
+            final String environment = computeEnvironment(spanAttributes);
+
+            // Add derived attributes using our safe attribute setting method
+            putAttribute(span, DERIVED_FAULT_ATTRIBUTE, String.valueOf(errorFault.fault));
+            putAttribute(span, DERIVED_ERROR_ATTRIBUTE, String.valueOf(errorFault.error));
+            putAttribute(span, DERIVED_OPERATION_ATTRIBUTE, operationName);
+            putAttribute(span, DERIVED_ENVIRONMENT_ATTRIBUTE, environment);
+
+            LOG.debug("Derived attributes for SERVER span {}: fault={}, error={}, operation={}, environment={}",
+                    span.getSpanId(), errorFault.fault, errorFault.error, operationName, environment);
+
+        } catch (Exception e) {
+            LOG.warn("Failed to derive attributes for span {}: {}", span.getSpanId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Compute error and fault indicators based on span status and HTTP status codes.
+     * Package-private for testing purposes only.
+     *
+     * @param spanStatus     The span status (Map with "code" or String like "ERROR")
+     * @param spanAttributes The span attributes containing HTTP status codes
+     * @return ErrorFaultResult containing error and fault indicators
+     */
+    static ErrorFaultResult computeErrorAndFault(final Object spanStatus, final Map<String, Object> spanAttributes) {
+        // Check HTTP status first (highest priority)
+        if (spanAttributes != null) {
+            Object httpStatusObj = spanAttributes.get("http.response.status_code");
+            if (httpStatusObj == null) {
+                httpStatusObj = spanAttributes.get("http.status_code");
+            }
+
+            if (httpStatusObj != null) {
+                Integer httpStatusCode = parseHttpStatusCode(httpStatusObj);
+                if (httpStatusCode != null) {
+                    if (httpStatusCode >= 500) return new ErrorFaultResult(0, 1); // 5xx = fault
+                    if (httpStatusCode >= 400) return new ErrorFaultResult(1, 0); // 4xx = error
+                    return new ErrorFaultResult(0, 0); // 2xx/3xx = success
+                }
+            }
+        }
+
+        // No HTTP status, check span status for error
+        if (isSpanStatusError(spanStatus)) {
+            return new ErrorFaultResult(0, 1); // span error = fault
+        }
+
+        return new ErrorFaultResult(0, 0); // no error/fault
+    }
+
+    /**
+     * Parse HTTP status code from various object types.
+     * Package-private for testing purposes only.
+     *
+     * @param statusCodeObject The status code object (Integer, String, etc.)
+     * @return Parsed integer status code, or null if invalid
+     */
+    static Integer parseHttpStatusCode(final Object statusCodeObject) {
+        if (statusCodeObject == null) {
+            return null;
+        }
+
+        try {
+            if (statusCodeObject instanceof Integer) {
+                return (Integer) statusCodeObject;
+            } else if (statusCodeObject instanceof Long) {
+                return ((Long) statusCodeObject).intValue();
+            } else {
+                return Integer.parseInt(statusCodeObject.toString());
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Check if span status indicates an error.
+     * Package-private for testing purposes only.
+     *
+     * @param spanStatus The span status (Map with "code" key or String like "ERROR"/"2")
+     * @return true if status indicates error
+     */
+    private static boolean isSpanStatusError(final Object spanStatus) {
+        if (spanStatus == null) return false;
+
+        String statusString;
+        if (spanStatus instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> statusMap = (Map<String, Object>) spanStatus;
+            final Object code = statusMap.get("code");
+            if (code == null) return false;
+            statusString = code.toString();
+        } else {
+            statusString = spanStatus.toString();
+        }
+
+        return "ERROR".equalsIgnoreCase(statusString) ||
+               "2".equals(statusString) ||
+               statusString.toLowerCase().contains("error");
+    }
+
+    /**
+     * Compute operation name using HTTP-aware derivation rules.
+     * Package-private for testing purposes only.
+     *
+     * @param spanName       The span name from the span
+     * @param spanAttributes The span attributes containing HTTP method and URL information
+     * @return Computed operation name
+     */
+    static String computeOperationName(final String spanName, final Map<String, Object> spanAttributes) {
+        // Get HTTP method (try new standard first, then legacy)
+        String method = getStringAttribute(spanAttributes, "http.request.method");
+        if (method == null) {
+            method = getStringAttribute(spanAttributes, "http.method");
+        }
+
+        // Get HTTP path (try multiple attributes)
+        String path = getStringAttribute(spanAttributes, "http.path");
+        if (path == null) path = getStringAttribute(spanAttributes, "http.target");
+        if (path == null) path = getStringAttribute(spanAttributes, "http.url");
+        if (path == null) path = getStringAttribute(spanAttributes, "url.full");
+
+        // Use HTTP method + first path section when available
+        if (method != null && path != null && !path.isEmpty() &&
+            (spanName == null || "UnknownOperation".equals(spanName) || spanName.equals(method))) {
+
+            // Extract first path section
+            String cleanPath = path.split("[?#]")[0]; // Remove query/fragment
+            if (!cleanPath.startsWith("/")) cleanPath = "/" + cleanPath;
+            int secondSlash = cleanPath.indexOf('/', 1);
+            String firstPath = (secondSlash > 0) ? cleanPath.substring(0, secondSlash) : cleanPath;
+
+            return method + " " + firstPath;
+        }
+
+        // If span name equals method but no path available, return UnknownOperation
+        if (method != null && spanName != null && spanName.equals(method)) {
+            return "UnknownOperation";
+        }
+
+        // Fall back to span name or default
+        return spanName != null ? spanName : "UnknownOperation";
+    }
+
+    /**
+     * Compute environment from resource attributes.
+     * Package-private for testing purposes only.
+     *
+     * @param spanAttributes The span attributes containing resource information
+     * @return Computed environment string
+     */
+    static String computeEnvironment(final Map<String, Object> spanAttributes) {
+        try {
+            // Navigate: spanAttributes -> "resource" -> "attributes" -> deployment keys
+            @SuppressWarnings("unchecked")
+            Map<String, Object> resourceAttrs = (Map<String, Object>)
+                ((Map<String, Object>) spanAttributes.get("resource")).get("attributes");
+
+            // Extract from resource.attributes.deployment.environment.name
+            String env = getStringAttribute(resourceAttrs, "deployment.environment.name");
+            if (env != null && !env.trim().isEmpty()) {
+                return env;
+            }
+
+            // Fall back to resource.attributes.deployment.environment
+            env = getStringAttribute(resourceAttrs, "deployment.environment");
+            if (env != null && !env.trim().isEmpty()) {
+                return env;
+            }
+        } catch (Exception ignored) {
+            // Any navigation failure falls through to default
+        }
+
+        // Default: 'generic:default'
+        return "generic:default";
+    }
+
+    /**
+     * Get string attribute from a map safely.
+     * Package-private for testing purposes only.
+     *
+     * @param map The map to get value from
+     * @param key The attribute key
+     * @return String value or null if not present/not a string
+     */
+    static String getStringAttribute(final Map<String, Object> map, final String key) {
+        if (map == null) {
+            return null;
+        }
+
+        final Object value = map.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * @deprecated Use {@link #getStringAttribute(Map, String)} instead.
+     * This method is kept for backward compatibility.
+     */
+    @Deprecated
+    static String getStringAttributeFromMap(final Map<String, Object> map, final String key) {
+        return getStringAttribute(map, key);
+    }
+
+
+    /**
+     * Simple data class to hold error and fault computation results.
+     * Package-private for testing purposes only.
+     */
+    static class ErrorFaultResult {
+        public final int error;
+        public final int fault;
+
+        public ErrorFaultResult(final int error, final int fault) {
+            this.error = error;
+            this.fault = fault;
+        }
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/utils/OTelSpanDerivationUtilTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/utils/OTelSpanDerivationUtilTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.otel.common.utils;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.otel.common.utils.OTelSpanDerivationUtil.ErrorFaultResult;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OTelSpanDerivationUtilTest {
+
+    @Test
+    void testComputeErrorAndFault_Http500() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("http.response.status_code", 500);
+
+        ErrorFaultResult result = OTelSpanDerivationUtil.computeErrorAndFault((String) null, spanAttributes);
+
+        assertEquals(1, result.fault);
+        assertEquals(0, result.error);
+    }
+
+    @Test
+    void testComputeErrorAndFault_Http404() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("http.response.status_code", 404);
+
+        ErrorFaultResult result = OTelSpanDerivationUtil.computeErrorAndFault((String) null, spanAttributes);
+
+        assertEquals(0, result.fault);
+        assertEquals(1, result.error);
+    }
+
+    @Test
+    void testComputeErrorAndFault_Http200() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("http.response.status_code", 200);
+
+        ErrorFaultResult result = OTelSpanDerivationUtil.computeErrorAndFault((String) null, spanAttributes);
+
+        assertEquals(0, result.fault);
+        assertEquals(0, result.error);
+    }
+
+    @Test
+    void testComputeErrorAndFault_SpanStatusError() {
+        ErrorFaultResult result = OTelSpanDerivationUtil.computeErrorAndFault("ERROR", null);
+
+        assertEquals(1, result.fault);
+        assertEquals(0, result.error);
+    }
+
+    @Test
+    void testComputeErrorAndFault_MapVersion() {
+        Map<String, Object> spanStatus = new HashMap<>();
+        spanStatus.put("code", "ERROR");
+
+        ErrorFaultResult result = OTelSpanDerivationUtil.computeErrorAndFault(spanStatus, null);
+
+        assertEquals(1, result.fault);
+        assertEquals(0, result.error);
+    }
+
+    @Test
+    void testComputeOperationName_HttpDerivation() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("http.request.method", "GET");
+        spanAttributes.put("http.path", "/payment/123");
+
+        String result = OTelSpanDerivationUtil.computeOperationName("GET", spanAttributes);
+
+        assertEquals("GET /payment", result);
+    }
+
+    @Test
+    void testComputeOperationName_NoHttpDerivation() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+
+        String result = OTelSpanDerivationUtil.computeOperationName("CustomOperation", spanAttributes);
+
+        assertEquals("CustomOperation", result);
+    }
+
+    @Test
+    void testComputeOperationName_FallbackToHttpMethod() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("http.method", "POST");
+        spanAttributes.put("http.path", "/api/users");
+
+        String result = OTelSpanDerivationUtil.computeOperationName("POST", spanAttributes);
+
+        assertEquals("POST /api", result);
+    }
+
+    @Test
+    void testComputeOperationName_UnknownOperation() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("http.request.method", "GET");
+
+        String result = OTelSpanDerivationUtil.computeOperationName("GET", spanAttributes);
+
+        assertEquals("UnknownOperation", result);
+    }
+
+    @Test
+    void testComputeEnvironment_DeploymentEnvironmentName() {
+        Map<String, Object> resourceAttributes = new HashMap<>();
+        resourceAttributes.put("deployment.environment.name", "production");
+
+        Map<String, Object> resource = new HashMap<>();
+        resource.put("attributes", resourceAttributes);
+
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("resource", resource);
+
+        String result = OTelSpanDerivationUtil.computeEnvironment(spanAttributes);
+
+        assertEquals("production", result);
+    }
+
+    @Test
+    void testComputeEnvironment_DeploymentEnvironment() {
+        Map<String, Object> resourceAttributes = new HashMap<>();
+        resourceAttributes.put("deployment.environment", "staging");
+
+        Map<String, Object> resource = new HashMap<>();
+        resource.put("attributes", resourceAttributes);
+
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("resource", resource);
+
+        String result = OTelSpanDerivationUtil.computeEnvironment(spanAttributes);
+
+        assertEquals("staging", result);
+    }
+
+    @Test
+    void testComputeEnvironment_Default() {
+        String result = OTelSpanDerivationUtil.computeEnvironment(null);
+
+        assertEquals("generic:default", result);
+    }
+
+    @Test
+    void testComputeEnvironment_NoResourceAttributes() {
+        Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("resource", new HashMap<>());
+
+        String result = OTelSpanDerivationUtil.computeEnvironment(spanAttributes);
+
+        assertEquals("generic:default", result);
+    }
+
+
+    @Test
+    void testParseHttpStatusCode() {
+        assertEquals(Integer.valueOf(200), OTelSpanDerivationUtil.parseHttpStatusCode(200));
+        assertEquals(Integer.valueOf(404), OTelSpanDerivationUtil.parseHttpStatusCode("404"));
+        assertEquals(Integer.valueOf(500), OTelSpanDerivationUtil.parseHttpStatusCode(500L));
+        assertNull(OTelSpanDerivationUtil.parseHttpStatusCode("invalid"));
+        assertNull(OTelSpanDerivationUtil.parseHttpStatusCode(null));
+    }
+
+
+    @Test
+    void testGetStringAttribute() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("key1", "value1");
+        attributes.put("key2", 123);
+        attributes.put("key3", null);
+
+        assertEquals("value1", OTelSpanDerivationUtil.getStringAttribute(attributes, "key1"));
+        assertEquals("123", OTelSpanDerivationUtil.getStringAttribute(attributes, "key2"));
+        assertNull(OTelSpanDerivationUtil.getStringAttribute(attributes, "key3"));
+        assertNull(OTelSpanDerivationUtil.getStringAttribute(attributes, "nonexistent"));
+        assertNull(OTelSpanDerivationUtil.getStringAttribute(null, "key1"));
+    }
+
+    @Test
+    void testGetStringAttributeFromMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", 123);
+
+        assertEquals("value1", OTelSpanDerivationUtil.getStringAttributeFromMap(map, "key1"));
+        assertEquals("123", OTelSpanDerivationUtil.getStringAttributeFromMap(map, "key2"));
+        assertNull(OTelSpanDerivationUtil.getStringAttributeFromMap(null, "key1"));
+    }
+
+
+    @Test
+    void testErrorFaultResult() {
+        ErrorFaultResult result = new ErrorFaultResult(1, 0);
+        assertEquals(1, result.error);
+        assertEquals(0, result.fault);
+    }
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace;
@@ -19,6 +24,7 @@ import org.opensearch.dataprepper.model.trace.Span;
 import io.micrometer.core.instrument.util.StringUtils;
 import org.opensearch.dataprepper.plugins.processor.oteltrace.model.SpanSet;
 import org.opensearch.dataprepper.plugins.processor.oteltrace.model.TraceGroup;
+import org.opensearch.dataprepper.plugins.otel.common.utils.OTelSpanDerivationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +98,9 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
         }
 
         processedSpans.addAll(getTracesToFlushByGarbageCollection());
+
+        // Derive server span attributes (fault, error, operation, environment)
+        OTelSpanDerivationUtil.deriveServerSpanAttributes(processedSpans);
 
         return processedSpans.stream().map(Record::new).collect(Collectors.toList());
     }

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace;

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/SpanSet.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/SpanSet.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace.model;

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroup.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroup.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace.model;

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroupTest.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroupTest.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace.model;

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/custom-env-child-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/custom-env-child-span.json
@@ -1,0 +1,28 @@
+{
+  "traceId": "CUSTOM_ENV_TRACE_ID",
+  "spanId": "CUSTOM_ENV_CHILD_SPAN_ID",
+  "traceState": "CUSTOM_ENV_TRACE_STATE",
+  "kind": "SPAN_KIND_SERVER",
+  "name": "HEALTH_CHECK",
+  "startTime": "2020-08-20T05:40:43.178010200Z",
+  "durationInNanos": 29160000,
+  "endTime": "2020-08-20T05:40:43.207170200Z",
+  "parentSpanId": "CUSTOM_ENV_ROOT_SPAN_ID",
+  "attributes": {
+    "http.response.status_code": 200,
+    "http.request.method": "GET",
+    "http.path": "/api/health",
+    "resource": {
+      "attributes": {
+        "deployment.environment.name": "production",
+        "service.name": "user-service",
+        "service.version": "1.2.3"
+      }
+    }
+  },
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/custom-env-root-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/custom-env-root-span.json
@@ -1,0 +1,22 @@
+{
+  "traceId": "CUSTOM_ENV_TRACE_ID",
+  "spanId": "CUSTOM_ENV_ROOT_SPAN_ID",
+  "traceState": "CUSTOM_ENV_TRACE_STATE",
+  "kind": "SPAN_KIND_CLIENT",
+  "traceGroupFields": {
+    "endTime": "2020-08-20T05:40:43.217170200Z",
+    "durationInNanos": 49160000,
+    "statusCode": 1
+  },
+  "name": "CUSTOM_ENV_ROOT_SPAN",
+  "traceGroup": "CUSTOM_ENV_ROOT_SPAN",
+  "startTime": "2020-08-20T05:40:43.168010200Z",
+  "durationInNanos": 49160000,
+  "endTime": "2020-08-20T05:40:43.217170200Z",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/error-status-child-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/error-status-child-span.json
@@ -1,0 +1,21 @@
+{
+  "traceId": "ERROR_TRACE_ID",
+  "spanId": "ERROR_CHILD_SPAN_ID",
+  "traceState": "ERROR_TRACE_STATE",
+  "kind": "SPAN_KIND_SERVER",
+  "name": "ERROR_OPERATION",
+  "startTime": "2020-08-20T05:40:43.178010200Z",
+  "durationInNanos": 29160000,
+  "endTime": "2020-08-20T05:40:43.207170200Z",
+  "parentSpanId": "ERROR_ROOT_SPAN_ID",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0,
+  "status": {
+    "code": "2",
+    "message": "Something went wrong"
+  }
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/error-status-root-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/error-status-root-span.json
@@ -1,0 +1,22 @@
+{
+  "traceId": "ERROR_TRACE_ID",
+  "spanId": "ERROR_ROOT_SPAN_ID",
+  "traceState": "ERROR_TRACE_STATE",
+  "kind": "SPAN_KIND_CLIENT",
+  "traceGroupFields": {
+    "endTime": "2020-08-20T05:40:43.217170200Z",
+    "durationInNanos": 49160000,
+    "statusCode": 1
+  },
+  "name": "ERROR_ROOT_SPAN",
+  "traceGroup": "ERROR_ROOT_SPAN",
+  "startTime": "2020-08-20T05:40:43.168010200Z",
+  "durationInNanos": 49160000,
+  "endTime": "2020-08-20T05:40:43.217170200Z",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/generic-name-child-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/generic-name-child-span.json
@@ -1,0 +1,21 @@
+{
+  "traceId": "GENERIC_NAME_TRACE_ID",
+  "spanId": "GENERIC_NAME_CHILD_SPAN_ID",
+  "traceState": "GENERIC_NAME_TRACE_STATE",
+  "kind": "SPAN_KIND_SERVER",
+  "name": "GET",
+  "startTime": "2020-08-20T05:40:43.178010200Z",
+  "durationInNanos": 29160000,
+  "endTime": "2020-08-20T05:40:43.207170200Z",
+  "parentSpanId": "GENERIC_NAME_ROOT_SPAN_ID",
+  "attributes": {
+    "http.response.status_code": 200,
+    "http.request.method": "GET",
+    "http.path": "/api/users/123"
+  },
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/generic-name-root-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/generic-name-root-span.json
@@ -1,0 +1,22 @@
+{
+  "traceId": "GENERIC_NAME_TRACE_ID",
+  "spanId": "GENERIC_NAME_ROOT_SPAN_ID",
+  "traceState": "GENERIC_NAME_TRACE_STATE",
+  "kind": "SPAN_KIND_CLIENT",
+  "traceGroupFields": {
+    "endTime": "2020-08-20T05:40:43.217170200Z",
+    "durationInNanos": 49160000,
+    "statusCode": 1
+  },
+  "name": "GENERIC_NAME_ROOT_SPAN",
+  "traceGroup": "GENERIC_NAME_ROOT_SPAN",
+  "startTime": "2020-08-20T05:40:43.168010200Z",
+  "durationInNanos": 49160000,
+  "endTime": "2020-08-20T05:40:43.217170200Z",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-4xx-child-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-4xx-child-span.json
@@ -1,0 +1,21 @@
+{
+  "traceId": "HTTP_4XX_TRACE_ID",
+  "spanId": "HTTP_4XX_CHILD_SPAN_ID",
+  "traceState": "HTTP_4XX_TRACE_STATE",
+  "kind": "SPAN_KIND_SERVER",
+  "name": "USER_LOOKUP",
+  "startTime": "2020-08-20T05:40:43.178010200Z",
+  "durationInNanos": 29160000,
+  "endTime": "2020-08-20T05:40:43.207170200Z",
+  "parentSpanId": "HTTP_4XX_ROOT_SPAN_ID",
+  "attributes": {
+    "http.response.status_code": 404,
+    "http.request.method": "GET",
+    "http.path": "/api/users/999"
+  },
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-4xx-root-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-4xx-root-span.json
@@ -1,0 +1,22 @@
+{
+  "traceId": "HTTP_4XX_TRACE_ID",
+  "spanId": "HTTP_4XX_ROOT_SPAN_ID",
+  "traceState": "HTTP_4XX_TRACE_STATE",
+  "kind": "SPAN_KIND_CLIENT",
+  "traceGroupFields": {
+    "endTime": "2020-08-20T05:40:43.217170200Z",
+    "durationInNanos": 49160000,
+    "statusCode": 1
+  },
+  "name": "HTTP_4XX_ROOT_SPAN",
+  "traceGroup": "HTTP_4XX_ROOT_SPAN",
+  "startTime": "2020-08-20T05:40:43.168010200Z",
+  "durationInNanos": 49160000,
+  "endTime": "2020-08-20T05:40:43.217170200Z",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-5xx-child-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-5xx-child-span.json
@@ -1,0 +1,21 @@
+{
+  "traceId": "HTTP_5XX_TRACE_ID",
+  "spanId": "HTTP_5XX_CHILD_SPAN_ID",
+  "traceState": "HTTP_5XX_TRACE_STATE",
+  "kind": "SPAN_KIND_SERVER",
+  "name": "ORDER_CREATE",
+  "startTime": "2020-08-20T05:40:43.178010200Z",
+  "durationInNanos": 29160000,
+  "endTime": "2020-08-20T05:40:43.207170200Z",
+  "parentSpanId": "HTTP_5XX_ROOT_SPAN_ID",
+  "attributes": {
+    "http.response.status_code": 500,
+    "http.request.method": "POST",
+    "http.path": "/api/orders/create"
+  },
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-5xx-root-span.json
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/resources/http-5xx-root-span.json
@@ -1,0 +1,22 @@
+{
+  "traceId": "HTTP_5XX_TRACE_ID",
+  "spanId": "HTTP_5XX_ROOT_SPAN_ID",
+  "traceState": "HTTP_5XX_TRACE_STATE",
+  "kind": "SPAN_KIND_CLIENT",
+  "traceGroupFields": {
+    "endTime": "2020-08-20T05:40:43.217170200Z",
+    "durationInNanos": 49160000,
+    "statusCode": 1
+  },
+  "name": "HTTP_5XX_ROOT_SPAN",
+  "traceGroup": "HTTP_5XX_ROOT_SPAN",
+  "startTime": "2020-08-20T05:40:43.168010200Z",
+  "durationInNanos": 49160000,
+  "endTime": "2020-08-20T05:40:43.217170200Z",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}


### PR DESCRIPTION
## Summary

Adds 4 derived attributes to SERVER spans to simplify UI visualization layer queries without complex conditional logic.

### New Derived Attributes

**Added to all SERVER spans:**
- `derived.fault` - "0" or "1" 
- `derived.error` - "0" or "1"
- `derived.operation` - Operation name string
- `derived.environment` - Environment string

### Extraction Logic

**Error/Fault:**
- HTTP 5xx status codes → `fault=1, error=0`
- HTTP 4xx status codes → `fault=0, error=1` 
- Span status ERROR → `fault=1, error=0`
- Otherwise → `fault=0, error=0`

**Operation:**
- Uses HTTP method + first URL path section when available: `"GET /payment"`
- Falls back to span name
- Default: `"UnknownOperation"`

**Environment:**
- Extracts from `resource.attributes.deployment.environment.name`
- Falls back to `resource.attributes.deployment.environment` 
- Default: `"generic:default"`

### Implementation

- `OTelSpanDerivationUtil` in common module for reusability
- Single method call added to `OTelTraceRawProcessor.doExecute()`
- Only processes spans where `kind == "SERVER"`

### Test Coverage

- **Unit tests:** 21 test methods covering all derivation scenarios
- **Processor tests:** Updated to verify derived attributes are added
- **Edge cases:** Null handling, invalid data, missing attributes

### Files Changed

**Added:**
- `data-prepper-plugins/common/src/main/java/.../OTelSpanDerivationUtil.java`
- `data-prepper-plugins/common/src/test/java/.../OTelSpanDerivationUtilTest.java`

**Modified:** 
- `OTelTraceRawProcessor.java` - Added derivation call
- `OTelTraceRawProcessorTest.java` - Updated for derived attributes