### PR TITLE
refactor: make s3 sqs shutdown configurable

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsService.java
@@ -25,7 +25,6 @@ import java.util.stream.IntStream;
 
 public class SqsService {
     private static final Logger LOG = LoggerFactory.getLogger(SqsService.class);
-    static final long SHUTDOWN_TIMEOUT = 30L;
     private final S3SourceConfig s3SourceConfig;
     private final S3Service s3Accessor;
     private final SqsClient sqsClient;
@@ -60,7 +59,7 @@ public class SqsService {
         executorService.shutdown();
         sqsWorkers.forEach(SqsWorker::stop);
         try {
-            if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT, TimeUnit.SECONDS)) {
+            if (!executorService.awaitTermination(s3SourceConfig.getSqsOptions().getShutdownTimeout().getSeconds(), TimeUnit.SECONDS)) {
                 LOG.warn("Failed to terminate SqsWorkers");
                 executorService.shutdownNow();
             }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/SqsOptions.java
@@ -22,6 +22,7 @@ public class SqsOptions {
     private static final Duration DEFAULT_VISIBILITY_DUPLICATE_PROTECTION_TIMEOUT = Duration.ofHours(2);
     private static final Duration DEFAULT_WAIT_TIME_SECONDS = Duration.ofSeconds(20);
     private static final Duration DEFAULT_POLL_DELAY_SECONDS = Duration.ofSeconds(0);
+    private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
 
     @JsonProperty("queue_url")
     @NotBlank(message = "SQS URL cannot be null or empty")
@@ -59,6 +60,10 @@ public class SqsOptions {
     @Min(1)
     private Integer maxReceiveAttempts;
 
+    @JsonProperty("shutdown_timeout")
+    @DurationMin(seconds = 30)
+    private Duration shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
+
     public String getSqsUrl() {
         return sqsUrl;
     }
@@ -87,5 +92,11 @@ public class SqsOptions {
         return pollDelay;
     }
 
-    public Integer getMaxReceiveAttempts() { return maxReceiveAttempts; }
+    public Integer getMaxReceiveAttempts() {
+        return maxReceiveAttempts;
+    }
+
+    public Duration getShutdownTimeout() {
+        return shutdownTimeout;
+    }
 }


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Replace hardcoded s3 SQS shutdown timeout with configurable property.
 
### Issues Resolved
Resolves #6442
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
