### PR TITLE
Test the opensearch sink against OpenSearch 3.

### DIFF
--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -1,7 +1,13 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
 
-name: Data Prepper OpenSearchSink integration tests with Open Distro
+name: Integration Tests - OpenSearch sink against Open Distro
 
 on:
   push:
@@ -27,19 +33,24 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          java-version:  ${{ matrix.java }}
+
       - name: Checkout Data Prepper
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+
       - name: Run Open Distro docker
         run: |
           docker pull amazon/opendistro-for-elasticsearch:${{ matrix.opendistro }}
           docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d amazon/opendistro-for-elasticsearch:${{ matrix.opendistro }}
-          sleep 90
-      - name: Run Open Distro tests
+          sleep 1
+      - name: Wait for Open Distro to be available
         run: |
           ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
+      - name: Run Open Distro tests
+        run: |
           ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin -Dtests.opensearch.bundle=true -Dtests.opensearch.version=opendistro:${{ matrix.opendistro }}
       - name: Upload Unit Test Results
         if: always()

--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -1,7 +1,13 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
 
-name: Data Prepper OpenSearchSink integration tests with OpenSearch
+name: Integration Tests - OpenSearch sink against OpenSearch
 
 on:
   push:
@@ -20,21 +26,39 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.14, 2.0.1, 2.1.0, 2.3.0, 2.5.0, 2.7.0, 2.9.0, 2.11.1, 2.12.0, 2.19.3]
+        opensearch:
+          - 1.0.1
+          - 1.1.0
+          - 1.2.4
+          - 1.3.14
+          - 2.0.1
+          - 2.1.0
+          - 2.3.0
+          - 2.5.0
+          - 2.7.0
+          - 2.9.0
+          - 2.11.1
+          - 2.12.0
+          - 2.19.3
+          - 3.0.0
+          - 3.4.0
       fail-fast: false
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          java-version:  ${{ matrix.java }}
+
       - name: Checkout Data Prepper
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+
       - name: Set password for OpenSearch version
         run: |
-          if [[ "${{ matrix.opensearch }}" =~ ^2\.(1[2-9]|[2-9][0-9]) ]]; then
+          if [[ "${{ matrix.opensearch }}" =~ ^(2\.(1[2-9]|[2-9][0-9])|[3-9]\.) ]]; then
             echo "PASSWORD=yourStrongPassword123!" >> $GITHUB_ENV
           else
             echo "PASSWORD=admin" >> $GITHUB_ENV
@@ -42,11 +66,13 @@ jobs:
       - name: Run OpenSearch docker
         run: |
           docker pull opensearchproject/opensearch:${{ matrix.opensearch }}
-          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!" -d opensearchproject/opensearch:${{ matrix.opensearch }}
-          sleep 90
-      - name: Run OpenSearch tests
+          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!' -d opensearchproject/opensearch:${{ matrix.opensearch }}
+          sleep 1
+      - name: Wait for OpenSearch to be available
         run: |
           ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password="$PASSWORD"
+      - name: Run OpenSearch tests
+        run: |
           ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password="$PASSWORD" -Dtests.opensearch.bundle=true -Dtests.opensearch.version=opensearch:${{ matrix.opensearch }}
       - name: Upload Unit Test Results
         if: always()

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersion.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersion.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersionTest.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchIT.java
@@ -1,27 +1,32 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.rest.RestStatus;
 
-import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class OpenSearchIT {
+class OpenSearchIT {
     @Test
-    public void testOpenSearchConnection() throws IOException {
+    void waitOnOpenSearchConnection() {
         final String host = System.getProperty("tests.opensearch.host");
         final String hostUrl = "https://" + host;
         final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(
@@ -40,12 +45,17 @@ public class OpenSearchIT {
         // does not work with ODFE
         // https://github.com/opensearch-project/OpenSearch/issues/922
         final Request request = new Request("GET", "_cluster/health");
-        request.addParameter("master_timeout", "30s");
+        request.addParameter("master_timeout", "10s");
         request.addParameter("level", "cluster");
-        request.addParameter("timeout", "30s");
+        request.addParameter("timeout", "10s");
         request.addParameter("wait_for_status", "yellow");
 
-        final Response response = client.getLowLevelClient().performRequest(request);
-        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        await().atMost(3, TimeUnit.MINUTES)
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+            final Response response = client.getLowLevelClient().performRequest(request);
+            client.close();
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        });
     }
 }

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSecurityAccessor.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSecurityAccessor.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
@@ -716,7 +720,9 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   public void shutdown() {
     super.shutdown();
     closeFiles();
-    openSearchClient.shutdown();
+    if (openSearchClient != null) {
+      openSearchClient.shutdown();
+    }
     if (queryExecutorService != null && existingDocumentQueryManager != null) {
       existingDocumentQueryManager.stop();
       queryExecutorService.shutdown();


### PR DESCRIPTION
### Description

Data Prepper currently doesn't test against OpenSearch 3. This PR adds OpenSearch 3.0.0 and 3.4.0 as test targets in our GitHub Actions.

Some of the changes to support this:

* Use complicated password for OpenSearch 3.x and beyond.
* Addresses some issues found during testing where test would fail or get stuck by closing resources better and adding test timeouts. 
* Move waiting on the OpenSearch cluster into the OpenSearchIT class.
* Use more Awaitility in tests and increased some waits. This was critical for getting the tests to run against OpenSearch 3.

Some other improvements to the GitHub Actions affected.

* Updated the test names for the GitHub Actions. 
* Clarified the steps with a wait period. 
* Updated some actions versions.

### Issues Resolved

Resolves #6485.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
