### PR TITLE
[Backport 2.13] Confluence and CloudWatch and multiple other failing tests fix

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorValidationIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorValidationIT.java
@@ -211,6 +211,12 @@ class ProcessorValidationIT {
     }
 
     private static void verifySingleThreadUsage() {
+        // Wait for all processor instances to be registered (one per worker)
+        await().atMost(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(
+                        SingleThreadEventsTrackingTestProcessor.getProcessors().size(),
+                        equalTo(4)));
+
         List<SingleThreadEventsTrackingTestProcessor> singleThreadProcessors = SingleThreadEventsTrackingTestProcessor.getProcessors();
         assertThat(singleThreadProcessors.size(), equalTo(4));
         assertAll(

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactory.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.AwsConfig;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClientBuilder;
@@ -64,8 +65,12 @@ public final class CloudWatchLogsClientFactory {
     }
 
     private static ClientOverrideConfiguration createOverrideConfiguration(final Map<String, String> customHeaders) {
+        final RetryPolicy retryPolicy = RetryPolicy.builder()
+                .numRetries(AwsConfig.DEFAULT_CONNECTION_ATTEMPTS)
+                .build();
+
         final ClientOverrideConfiguration.Builder configBuilder = ClientOverrideConfiguration.builder()
-                .retryPolicy(r -> r.numRetries(AwsConfig.DEFAULT_CONNECTION_ATTEMPTS));
+                .retryPolicy(retryPolicy);
 
         customHeaders.forEach(configBuilder::putHeader);
 

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsServiceTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsServiceTest.java
@@ -12,7 +12,9 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.log.JacksonLog;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.Buffer;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.InMemoryBuffer;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.InMemoryBufferFactory;
@@ -20,8 +22,6 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatch
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.ThresholdConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
-import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
-import org.opensearch.dataprepper.model.log.JacksonLog;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,13 +31,13 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CloudWatchLogsServiceTest {
     private static final int LARGE_THREAD_COUNT = 1000;
@@ -95,8 +95,10 @@ class CloudWatchLogsServiceTest {
 
     Collection<Record<Event>> getSampleRecordsOfLargerSize() {
         final ArrayList<Record<Event>> returnCollection = new ArrayList<>();
+        int messageSize = (int) (thresholdConfig.getMaxRequestSizeBytes() / 24);
         for (int i = 0; i < thresholdConfig.getBatchSize() * 2; i++) {
-            JacksonEvent mockJacksonEvent = (JacksonEvent) JacksonEvent.fromMessage("a".repeat((int) (thresholdConfig.getMaxRequestSizeBytes()/24)));
+            JacksonEvent mockJacksonEvent =
+                    (JacksonEvent) JacksonEvent.fromMessage(RandomStringUtils.insecure().nextAlphabetic(messageSize));
             returnCollection.add(new Record<>(mockJacksonEvent));
         }
 
@@ -105,8 +107,10 @@ class CloudWatchLogsServiceTest {
 
     Collection<Record<Event>> getSampleRecordsOfLimitSize() {
         final ArrayList<Record<Event>> returnCollection = new ArrayList<>();
+        int messageSize = (int) thresholdConfig.getMaxEventSizeBytes();
         for (int i = 0; i < thresholdConfig.getBatchSize(); i++) {
-            JacksonEvent mockJacksonEvent = (JacksonEvent) JacksonEvent.fromMessage("testMessage".repeat((int) thresholdConfig.getMaxEventSizeBytes()));
+            JacksonEvent mockJacksonEvent =
+                    (JacksonEvent) JacksonEvent.fromMessage(RandomStringUtils.insecure().nextAlphabetic(messageSize));
             returnCollection.add(new Record<>(mockJacksonEvent));
         }
 
@@ -248,8 +252,8 @@ class CloudWatchLogsServiceTest {
     }
 
      private Record<Event> getLargeRecord(long size) {
-        final Event event = JacksonLog.builder().withData(Map.of("key", RandomStringUtils.randomAlphabetic((int)size))).withEventHandle(eventHandle).build();
+        final Event event = JacksonLog.builder().withData(Map.of("key", RandomStringUtils.insecure().nextAlphabetic((int)size))).withEventHandle(eventHandle).build();
 
         return new Record<>(event);
-    }   
+    }
 }

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -108,12 +108,18 @@ public class DateProcessorConfig {
         }
 
         public static boolean isValidPattern(final String pattern) {
+            // Check for valid epoch patterns first
             if (pattern.equals("epoch_second") ||
                 pattern.equals("epoch_milli") ||
                 pattern.equals("epoch_micro") ||
                 pattern.equals("epoch_nano")) {
                     return true;
             }
+            // Reject any other pattern starting with "epoch_" as invalid
+            if (pattern.startsWith("epoch_")) {
+                return false;
+            }
+            // Validate as DateTimeFormatter pattern
             try {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
                 return true;

--- a/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
+++ b/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
@@ -69,23 +69,28 @@ class DateProcessorConfigTest {
             assertThat(dateProcessorConfig.isValidMatchAndFromTimestampReceived(), equalTo(false));
         }
 
-        @Test
-        void testValidAndInvalidOutputFormats() throws NoSuchFieldException, IllegalAccessException {
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", random);
-            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(false));
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "epoch_second",
+            "epoch_milli",
+            "epoch_nano",
+            "epoch_micro",
+            "yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX"
+        })
+        void testValidOutputFormats(String outputFormat) throws NoSuchFieldException, IllegalAccessException {
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", outputFormat);
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
+        }
 
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_second");
-            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_milli");
-            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_nano");
-            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_micro");
-            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_xyz");
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "invalid[pattern]format",
+            "epoch_xyz",
+            "epoch_invalid"
+        })
+        void testInvalidOutputFormats(String outputFormat) throws NoSuchFieldException, IllegalAccessException {
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", outputFormat);
             assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(false));
-            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX");
-            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
         }
 
         @Test

--- a/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts'
     implementation 'javax.inject:javax.inject:1'
     testImplementation 'com.amazonaws:DynamoDBLocal:2.2.1'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 configurations {

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceConfigHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceConfigHelperTest.java
@@ -118,7 +118,7 @@ public class ConfluenceConfigHelperTest {
 
     @Test
     void testValidateConfigBasic() {
-        when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://test.com");
+        when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://somedomain.atlassian.net");
         when(confluenceSourceConfig.getAuthType()).thenReturn(BASIC);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getBasicConfig()).thenReturn(basicConfig);
@@ -137,7 +137,7 @@ public class ConfluenceConfigHelperTest {
 
     @Test
     void testValidateConfigOauth2() {
-        when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://test.com");
+        when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://somedomain.atlassian.net");
         when(confluenceSourceConfig.getAuthType()).thenReturn(OAUTH2);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getOauth2Config()).thenReturn(oauth2Config);

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraConfigHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraConfigHelperTest.java
@@ -126,7 +126,7 @@ public class JiraConfigHelperTest {
     void testValidateConfig() {
         assertThrows(RuntimeException.class, () -> JiraConfigHelper.validateConfig(jiraSourceConfig));
 
-        when(jiraSourceConfig.getAccountUrl()).thenReturn("https://test.com");
+        when(jiraSourceConfig.getAccountUrl()).thenReturn("https://somedomain.atlassian.net");
         assertThrows(RuntimeException.class, () -> JiraConfigHelper.validateConfig(jiraSourceConfig));
 
         when(jiraSourceConfig.getAuthType()).thenReturn("fakeType");
@@ -135,7 +135,7 @@ public class JiraConfigHelperTest {
 
     @Test
     void testValidateConfigBasic() {
-        when(jiraSourceConfig.getAccountUrl()).thenReturn("https://test.com");
+        when(jiraSourceConfig.getAccountUrl()).thenReturn("https://somedomain.atlassian.net");
         when(jiraSourceConfig.getAuthType()).thenReturn(BASIC);
         when(jiraSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getBasicConfig()).thenReturn(basicConfig);
@@ -154,7 +154,7 @@ public class JiraConfigHelperTest {
 
     @Test
     void testValidateConfigOauth2() {
-        when(jiraSourceConfig.getAccountUrl()).thenReturn("https://test.com");
+        when(jiraSourceConfig.getAccountUrl()).thenReturn("https://somedomain.atlassian.net");
         when(jiraSourceConfig.getAuthType()).thenReturn(OAUTH2);
         when(jiraSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getOauth2Config()).thenReturn(oauth2Config);

--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/test/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClientTest.java
@@ -10,7 +10,6 @@
 package org.opensearch.dataprepper.plugins.source.microsoft_office365;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,9 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -53,7 +49,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.microsoft_office365.utils.Constants.CONTENT_TYPES;

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/MetricsHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/MetricsHelperTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.source_crawler.utils;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.lenient;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MetricsHelperTest {
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Counter mockCounter;
+
+    @Mock
+    private DistributionSummary mockDistributionSummary;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(pluginMetrics.counter(anyString())).thenReturn(mockCounter);
+        lenient().when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+    }
+
+    @Test
+    void testGetErrorTypeMetricCounterMap() {
+        Map<String, Counter> result = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+
+        assertNotNull(result);
+        assertEquals(4, result.size());
+
+        // Verify expected HTTP status mappings
+        assertTrue(result.containsKey(HttpStatus.FORBIDDEN.getReasonPhrase()));
+        assertTrue(result.containsKey(HttpStatus.UNAUTHORIZED.getReasonPhrase()));
+        assertTrue(result.containsKey(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase()));
+        assertTrue(result.containsKey(HttpStatus.NOT_FOUND.getReasonPhrase()));
+
+        result.values().forEach(counter -> assertEquals(mockCounter, counter));
+
+        // requestAccessDenied is called twice for FORBIDDEN and UNAUTHORIZED
+        verify(pluginMetrics, times(2)).counter("requestAccessDenied");
+        verify(pluginMetrics).counter("requestThrottled");
+        verify(pluginMetrics).counter("resourceNotFound");
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithHttpClientErrorException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.FORBIDDEN);
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        verify(mockCounter).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithHttpServerErrorException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        HttpServerErrorException exception = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        // Should not increment because INTERNAL_SERVER_ERROR is not in the supported error map
+        verify(mockCounter, never()).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithSecurityException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        SecurityException exception = new SecurityException("Access denied");
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        verify(mockCounter).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithUnauthorizedException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        verify(mockCounter).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithTooManyRequestsException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS);
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        verify(mockCounter).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithNotFoundException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.NOT_FOUND);
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        verify(mockCounter).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithUnsupportedException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        RuntimeException exception = new RuntimeException("Unsupported exception");
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        // Should not increment because RuntimeException is not handled
+        verify(mockCounter, never()).increment();
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithNullMap() {
+        HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.FORBIDDEN);
+
+        // Should not throw exception when map is null
+        assertDoesNotThrow(() ->
+                MetricsHelper.publishErrorTypeMetricCounter(exception, null)
+        );
+    }
+
+    @Test
+    void testPublishErrorTypeMetricCounterWithBadRequestException() {
+        Map<String, Counter> errorTypeMetricCounterMap = MetricsHelper.getErrorTypeMetricCounterMap(pluginMetrics);
+        HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.BAD_REQUEST);
+
+        MetricsHelper.publishErrorTypeMetricCounter(exception, errorTypeMetricCounterMap);
+
+        // Should not increment because BAD_REQUEST is not in the supported error map
+        verify(mockCounter, never()).increment();
+    }
+
+    // Data providers for parameterized tests
+    static Stream<Arguments> responseEntityTestCases() {
+        return Stream.of(
+                Arguments.of("ValidResponse", 1024L, "test body", 1024L),
+                Arguments.of("NullResponse", null, null, -1L),
+                Arguments.of("NullBody", 1024L, null, -1L),
+                Arguments.of("ZeroContentLength", 0L, "", 0L),
+                Arguments.of("NoContentLength", -1L, "test body", -1L),
+                Arguments.of("LargeContentLength", 10_485_760L, "large body", 10_485_760L)
+        );
+    }
+
+    static Stream<Arguments> stringTestCases() {
+        return Stream.of(
+                Arguments.of("ValidString", "test response content"),
+                Arguments.of("NullString", null),
+                Arguments.of("EmptyString", ""),
+                Arguments.of("Utf8String", "test with unicode: 测试 and émojis 🎉")
+        );
+    }
+
+    static Stream<Arguments> metricMethods() {
+        return Stream.of(
+                Arguments.of("search", "searchResponseSizeBytes",
+                        (BiConsumer<PluginMetrics, ResponseEntity<?>>) MetricsHelper::publishSearchResponseSizeMetricInBytes,
+                        (BiConsumer<PluginMetrics, String>) MetricsHelper::publishSearchResponseSizeMetricInBytes),
+                Arguments.of("get", "getResponseSizeBytes",
+                        (BiConsumer<PluginMetrics, ResponseEntity<?>>) MetricsHelper::publishGetResponseSizeMetricInBytes,
+                        (BiConsumer<PluginMetrics, String>) MetricsHelper::publishGetResponseSizeMetricInBytes)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} ResponseEntity test: {1}")
+    @MethodSource("responseEntityTestCases")
+    void testResponseSizeMetricWithResponseEntity(String testName, Long contentLength, String body, long expectedRecord) {
+        metricMethods().forEach(args -> {
+            String methodType = (String) args.get()[0];
+            String metricName = (String) args.get()[1];
+            BiConsumer<PluginMetrics, ResponseEntity<?>> method =
+                    (BiConsumer<PluginMetrics, ResponseEntity<?>>) args.get()[2];
+
+            reset(pluginMetrics, mockDistributionSummary);
+            when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+            ResponseEntity<String> response = null;
+            if (contentLength != null) {
+                HttpHeaders headers = new HttpHeaders();
+                if (contentLength >= 0) {
+                    headers.setContentLength(contentLength);
+                }
+                response = new ResponseEntity<>(body, headers, HttpStatus.OK);
+            }
+
+            method.accept(pluginMetrics, response);
+
+            verify(pluginMetrics).summary(metricName);
+            verify(mockDistributionSummary).record(expectedRecord);
+        });
+    }
+
+    @ParameterizedTest(name = "{0} String test: {1}")
+    @MethodSource("stringTestCases")
+    void testResponseSizeMetricWithString(String testName, String responseBody) {
+        metricMethods().forEach(args -> {
+            String methodType = (String) args.get()[0];
+            String metricName = (String) args.get()[1];
+            BiConsumer<PluginMetrics, String> method =
+                    (BiConsumer<PluginMetrics, String>) args.get()[3];
+
+            reset(pluginMetrics, mockDistributionSummary);
+            when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+            method.accept(pluginMetrics, responseBody);
+
+            long expectedSize = responseBody != null ?
+                    responseBody.getBytes(java.nio.charset.StandardCharsets.UTF_8).length : -1L;
+
+            verify(pluginMetrics).summary(metricName);
+            verify(mockDistributionSummary).record(expectedSize);
+        });
+    }
+
+
+    @ParameterizedTest(name = "Success metric for {0} requests")
+    @MethodSource({"org.opensearch.dataprepper.plugins.source.source_crawler.utils.MetricsHelperTest#successMetricMethods"})
+    void testSuccessMetrics(String methodType, String expectedMetricName) {
+        if ("search".equals(methodType)) {
+            MetricsHelper.publishSearchRequestsSuccessMetric(pluginMetrics);
+        } else {
+            MetricsHelper.publishGetRequestsSuccessMetric(pluginMetrics);
+        }
+
+        verify(pluginMetrics).counter(expectedMetricName);
+        verify(mockCounter).increment();
+    }
+
+    static Stream<Arguments> successMetricMethods() {
+        return Stream.of(
+                Arguments.of("search", "searchRequestsSuccess"),
+                Arguments.of("get", "getRequestsSuccess")
+        );
+    }
+
+    @ParameterizedTest(name = "Failure counter provider for {0} requests")
+    @MethodSource({"org.opensearch.dataprepper.plugins.source.source_crawler.utils.MetricsHelperTest#failureCounterMethods"})
+    void testFailureCounterProviders(String methodType, String expectedMetricName) {
+        Counter result;
+        if ("search".equals(methodType)) {
+            result = MetricsHelper.provideSearchRequestFailureCounter(pluginMetrics);
+        } else {
+            result = MetricsHelper.provideGetRequestsFailureCounter(pluginMetrics);
+        }
+
+        verify(pluginMetrics).counter(expectedMetricName);
+        verify(mockCounter, never()).increment(); // Should NOT increment - RetryHandler's responsibility
+        assertEquals(mockCounter, result);
+    }
+
+    static Stream<Arguments> failureCounterMethods() {
+        return Stream.of(
+                Arguments.of("search", "searchRequestsFailed"),
+                Arguments.of("get", "getRequestsFailed")
+        );
+    }
+
+    @Test
+    void testResponseEntityCompatibilityWithVariousResponseTypes() {
+        // Test that ResponseEntity<?> methods work with different ResponseEntity types
+
+        reset(pluginMetrics, mockDistributionSummary);
+        when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+        String testContent = "test content for ResponseEntity compatibility";
+
+        // Test search methods with ResponseEntity<String>
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentLength(1000L);
+        ResponseEntity<String> responseEntity = new ResponseEntity<>(testContent, headers, HttpStatus.OK);
+        MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, responseEntity);
+
+        // Test get methods with ResponseEntity<String>
+        headers.setContentLength(2000L);
+        ResponseEntity<String> getResponseEntity = new ResponseEntity<>(testContent, headers, HttpStatus.OK);
+        MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, getResponseEntity);
+
+        // Verify both method types use their respective metric names
+        verify(pluginMetrics).summary("searchResponseSizeBytes");
+        verify(pluginMetrics).summary("getResponseSizeBytes");
+
+        // Test with different ResponseEntity generic types
+        HttpHeaders genericHeaders = new HttpHeaders();
+        genericHeaders.setContentLength(500L);
+        ResponseEntity<String> stringEntityResponse = new ResponseEntity<>("test string", genericHeaders, HttpStatus.OK);
+
+        assertDoesNotThrow(() -> {
+            MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, stringEntityResponse);
+            MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, stringEntityResponse);
+        });
+    }
+
+    @Test
+    void testSearchResponseSizeMetricWithGenericResponseEntity() {
+        // Test the new ResponseEntity<?> overload that handles ResponseEntity<List<Map<String, Object>>>
+
+        reset(pluginMetrics, mockDistributionSummary);
+        when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+        // Test with ResponseEntity<List<Map<String, Object>>> like used in OktaSSORestClient
+        java.util.List<java.util.Map<String, Object>> eventsList = java.util.Arrays.asList(
+                java.util.Map.of("id", "123", "message", "test event"),
+                java.util.Map.of("id", "456", "message", "another event")
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentLength(3000L);
+        ResponseEntity<java.util.List<java.util.Map<String, Object>>> genericResponse =
+                new ResponseEntity<>(eventsList, headers, HttpStatus.OK);
+
+        // This should work with the new ResponseEntity<?> overload
+        MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, genericResponse);
+
+        verify(pluginMetrics).summary("searchResponseSizeBytes");
+        verify(mockDistributionSummary).record(3000L);
+    }
+
+    @Test
+    void testGetResponseSizeMetricWithGenericResponseEntity() {
+        // Test the new ResponseEntity<?> overload for GET requests
+
+        reset(pluginMetrics, mockDistributionSummary);
+        when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+        // Test with ResponseEntity<List<Map<String, Object>>> like used in OktaSSORestClient
+        java.util.List<java.util.Map<String, Object>> eventsList = java.util.Arrays.asList(
+                java.util.Map.of("id", "789", "content", "single event detail")
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentLength(1500L);
+        ResponseEntity<java.util.List<java.util.Map<String, Object>>> genericResponse =
+                new ResponseEntity<>(eventsList, headers, HttpStatus.OK);
+
+        // This should work with the new ResponseEntity<?> overload
+        MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, genericResponse);
+
+        verify(pluginMetrics).summary("getResponseSizeBytes");
+        verify(mockDistributionSummary).record(1500L);
+    }
+
+    @Test
+    void testGenericResponseEntityOverloadsWithNullValues() {
+        // Test the new generic ResponseEntity<?> overloads with null scenarios
+
+        reset(pluginMetrics, mockDistributionSummary);
+        when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+        // Test null response
+        MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, (ResponseEntity<?>) null);
+        verify(pluginMetrics).summary("searchResponseSizeBytes");
+        verify(mockDistributionSummary).record(-1L);
+
+        reset(mockDistributionSummary);
+
+        // Test null body
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentLength(2000L);
+        ResponseEntity<java.util.List<java.util.Map<String, Object>>> responseWithNullBody =
+                new ResponseEntity<>(null, headers, HttpStatus.OK);
+
+        MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, responseWithNullBody);
+        verify(mockDistributionSummary).record(-1L);
+
+        reset(mockDistributionSummary);
+
+        // Test GET request with null
+        MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, (ResponseEntity<?>) null);
+        verify(pluginMetrics).summary("getResponseSizeBytes");
+        verify(mockDistributionSummary).record(-1L);
+    }
+
+    @Test
+    void testGenericResponseEntityCompatibilityWithVariousTypes() {
+        // Test that the generic ResponseEntity<?> works with various response types
+
+        reset(pluginMetrics, mockDistributionSummary);
+        when(pluginMetrics.summary(anyString())).thenReturn(mockDistributionSummary);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentLength(4000L);
+
+        // Test with different generic types to ensure wildcard compatibility
+        ResponseEntity<String> stringResponse = new ResponseEntity<>("test", headers, HttpStatus.OK);
+        ResponseEntity<Integer> integerResponse = new ResponseEntity<>(42, headers, HttpStatus.OK);
+        ResponseEntity<java.util.Map<String, String>> mapResponse =
+                new ResponseEntity<>(java.util.Map.of("key", "value"), headers, HttpStatus.OK);
+
+        // All should work with the generic ResponseEntity<?> overloads
+        assertDoesNotThrow(() -> {
+            MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, stringResponse);
+            MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, integerResponse);
+            MetricsHelper.publishSearchResponseSizeMetricInBytes(pluginMetrics, mapResponse);
+
+            MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, stringResponse);
+            MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, integerResponse);
+            MetricsHelper.publishGetResponseSizeMetricInBytes(pluginMetrics, mapResponse);
+        });
+
+        // Verify all calls recorded the same Content-Length header value
+        verify(mockDistributionSummary, times(6)).record(4000L);
+    }
+}


### PR DESCRIPTION
### Description

Backports #6348 to `2.13`.

Making the tests less flaky. More reliable. Avoiding possible Out of memory issue with large pay load generation.

(cherry picked from commit 442cd7058c5546ea6337f48c55d180fa3ac8c590)

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
