### PR TITLE
Additional documentation for browsing Data Prepper snapshots online.

### DIFF
--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -59,6 +59,9 @@ Browse using Maven Central:
 
 Data Prepper Maven artifacts release nightly snapshot builds.
 
+The OpenSearch project has a browsable web interface.
+You can [view Data Prepper snapshots](https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/dataprepper/).
+
 The Maven repository is:
 * `https://central.sonatype.com/repository/maven-snapshots`
 


### PR DESCRIPTION
### Description

The OpenSearch project recently created a snapshot viewing web page.

https://ci.opensearch.org/ci/dbc/snapshots

This PR adds a link to the Data Prepper plugins in this repo to make it easier for plugin developers to find snapshot builds.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
