### PR TITLE
fix: change eventbridge notification file size from int to long

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3EventBridgeNotification.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3EventBridgeNotification.java
@@ -9,7 +9,7 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 import java.util.List;
 
 /**
- * A helper class that represents a strongly typed notification item sent to EvenBridge
+ * A helper class that represents a strongly typed notification item sent to EventBridge
  */
 public class S3EventBridgeNotification {
     private final String version;
@@ -156,13 +156,13 @@ public class S3EventBridgeNotification {
 
     public static class Object {
         private final String key;
-        private final int size;
+        private final long size;
         private final String etag;
         private final String versionId;
         private final String sequencer;
 
         public Object(@JsonProperty(value = "key") final String key,
-                      @JsonProperty(value = "size") final int size,
+                      @JsonProperty(value = "size") final long size,
                       @JsonProperty(value = "etag") final String etag,
                       @JsonProperty(value = "version-id") final String versionId,
                       @JsonProperty(value = "sequencer") final String sequencer) {
@@ -173,7 +173,7 @@ public class S3EventBridgeNotification {
             this.sequencer = sequencer;
         }
 
-        public int getSize() {
+        public long getSize() {
             return size;
         }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
@@ -32,7 +32,7 @@ class ParsedMessageTest {
         message = mock(Message.class);
         testBucketName = UUID.randomUUID().toString();
         testDecodedObjectKey = UUID.randomUUID().toString();
-        testSize = RANDOM.nextInt(1_000_000_000) + 1;
+        testSize = Math.abs(RANDOM.nextLong() % 1_000_000_000_000L) + 1;
     }
 
     @Test
@@ -168,7 +168,7 @@ class ParsedMessageTest {
 
             when(bucket.getName()).thenReturn(testBucketName);
             when(object.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
-            when(object.getSize()).thenReturn((int) testSize);
+            when(object.getSize()).thenReturn(testSize);
             when(s3EventBridgeNotification.getDetailType()).thenReturn(testDetailType);
             when(s3EventBridgeNotification.getTime()).thenReturn(testEventTime);
         }


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Change S3EventBridgeNotification.Detail.Object.size data type from int to long to allow files larger than 2GB (int max).
 
### Issues Resolved
Resolves #5276
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
