### PR TITLE
Distribute ARM archives

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -101,6 +101,8 @@ pipeline {
                             dir('archive') {
                                 sh "curl -sSL ${archivePath}/opensearch-data-prepper-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-${VERSION}-linux-x64.tar.gz"
                                 sh "curl -sSL ${archivePath}/opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz"
+                                sh "curl -sSL ${archivePath}/opensearch-data-prepper-${VERSION}-linux-arm64.tar.gz -o opensearch-data-prepper-${VERSION}-linux-arm64.tar.gz"
+                                sh "curl -sSL ${archivePath}/opensearch-data-prepper-jdk-${VERSION}-linux-arm64.tar.gz -o opensearch-data-prepper-jdk-${VERSION}-linux-arm64.tar.gz"
                             }
                         }
                     }


### PR DESCRIPTION
### Description

This change to the Jenkins job copies the ARM archives during the promote archives step.
 
### Issues Resolved

Contributes toward #640.

Resolves https://github.com/opensearch-project/opensearch-build/issues/5977

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
