### PR TITLE
Release ARM artifacts and run smoke tests for them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,12 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
 name: Release Artifacts
 
 on:
@@ -9,7 +18,8 @@ on:
         type: boolean
       release-latest-tag:
         description: >
-          Whether to create latest tag of docker image or not. This will update the latest tag to point to this version. You should set this when releasing the latest version, but not patches to old versions.
+          Whether to create latest tag of docker image or not. This will update the latest tag to point to this version. 
+          You should set this when releasing the latest version, but not patches to old versions.
         required: true
         type: boolean
 
@@ -25,11 +35,12 @@ jobs:
 
     steps:
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
+        distribution: temurin
     - name: Checkout Data Prepper
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
     - name: Get Version
       run:  grep '^version=' gradle.properties >> $GITHUB_ENV
     - name: Build Jar Files
@@ -61,16 +72,20 @@ jobs:
       env:
         AWS_REGION: us-east-1
     - name: Build and Push Multi-Architecture Docker Image to Staging ECR
-      run: ./gradlew :release:docker:dockerMultiArchitecture -PdockerRepository=${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
+      run: ./gradlew :release:docker:dockerMultiArchitecturePush -PdockerRepository=${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
 
   validate-docker:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [x64, arm64]
+      fail-fast: false
+    runs-on: ${{ matrix.architecture == 'x64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     needs: build
     timeout-minutes: 30
 
     steps:
       - name: Checkout Data Prepper
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Get Version
         run:  grep '^version=' gradle.properties >> $GITHUB_ENV
 
@@ -82,26 +97,36 @@ jobs:
   validate-archive:
     strategy:
       matrix:
-        include:
-          - image : "eclipse-temurin:11"
+        config:
+          - image: "eclipse-temurin:11"
             archive: opensearch-data-prepper
-          - image : "eclipse-temurin:17"
+          - image: "eclipse-temurin:17"
             archive: opensearch-data-prepper
-          - image : "ubuntu:latest"
+          - image: "eclipse-temurin:21"
+            archive: opensearch-data-prepper
+          - image: "ubuntu:latest"
             archive: opensearch-data-prepper-jdk
+        architecture: [x64, arm64]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'x64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     needs: build
     timeout-minutes: 30
 
     steps:
       - name: Checkout Data Prepper
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Get Version
         run:  grep '^version=' gradle.properties >> $GITHUB_ENV
 
       - name: Smoke Test Tarball Files
-        run: ./release/smoke-tests/run-tarball-files-smoke-tests.sh -v ${{ env.version }} -u ${{ secrets.ARCHIVES_PUBLIC_URL }} -n ${{ github.run_number }} -i ${{ matrix.image }} -t ${{ matrix.archive }}
+        run: >-
+          ./release/smoke-tests/run-tarball-files-smoke-tests.sh
+          -u ${{ secrets.ARCHIVES_PUBLIC_URL }}
+          -v ${{ env.version }}
+          -n ${{ github.run_number }}
+          -i ${{ matrix.config.image }}
+          -t ${{ matrix.config.archive }}
+          -a ${{ matrix.architecture }}
 
   promote:
     runs-on: ubuntu-latest
@@ -112,7 +137,7 @@ jobs:
 
     steps:
       - name: Checkout Data Prepper
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Get Version
         run: grep '^version=' gradle.properties >> $GITHUB_ENV
 


### PR DESCRIPTION
### Description

This PR is working on wrapping up the support for ARM artifacts in Data Prepper.

It corrects the job in the release step to `dockerMultiArchitecturePush` which pushes the Docker image to the staging ECR repository.

It also adds smoke tests for ARM artifacts. There is a smoke test for the Docker image and the same four for the archive files that we use for x86. It adds the Java 21 smoke tests for both architectures.

This also updates some of the GitHub Actions plugin versions and make some minor improvements to the release action.

I tested this in my fork. The example run is available: https://github.com/dlvenable/data-prepper/actions/runs/21835866112/job/63011224300
 
### Issues Resolved

Resolves #2294
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
