### PR TITLE
fix: Dedup failure metrics

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/microsoft-office365-source/src/main/java/org/opensearch/dataprepper/plugins/source/microsoft_office365/Office365RestClient.java
@@ -269,7 +269,6 @@ public class Office365RestClient {
                 );
             } catch (Exception e) {
                 metricsRecorder.recordError(e);
-                metricsRecorder.recordSearchFailure();
                 log.error(NOISY, "Error while fetching audit logs for content type {} from URL: {}",
                         contentType, url, e);
                 throw new SaaSCrawlerException("Failed to fetch audit logs", e, true);
@@ -314,7 +313,6 @@ public class Office365RestClient {
                 return response;
             } catch (Exception e) {
                 metricsRecorder.recordError(e);
-                metricsRecorder.recordGetFailure();
                 log.error(NOISY, "Error while fetching audit log content from URI: {}", contentUri, e);
                 throw new SaaSCrawlerException("Failed to fetch audit log", e, true);
             }


### PR DESCRIPTION
### Description
* Dedup Get and Search failure metrics. These metrics are already emitted by the retry handler, so emitting them again when catching exceptions in the rest client creates duplicate failure metrics. See: https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/retry/RetryHandler.java#L99
* This duplication was introduced during the RetryHandler and metric migration.
* Added unit test coverage to prevent this issue in the future.
### Testing Results
* Unit tests ran successfully. 