### PR TITLE
Verify the correct architecture during smoke tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Smoke Test Docker Image
         run: |
           docker pull ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
-          ./release/smoke-tests/run-smoke-tests.sh -v ${{ env.version }}-${{ github.run_number }} -i ${{ secrets.ECR_REPOSITORY_URL }}
+          ./release/smoke-tests/run-smoke-tests.sh -v ${{ env.version }}-${{ github.run_number }} -i ${{ secrets.ECR_REPOSITORY_URL }} -a ${{ matrix.architecture }}
 
   validate-archive:
     strategy:

--- a/release/smoke-tests/run-tarball-files-smoke-tests.sh
+++ b/release/smoke-tests/run-tarball-files-smoke-tests.sh
@@ -148,7 +148,7 @@ function run_smoke_test() {
     local CURRENT_DIR
     CURRENT_DIR=$(pwd)
 
-    eval "${REPO_DIR}/release/smoke-tests/run-smoke-tests.sh -i ${SMOKE_IMAGE_NAME} -v ${DATA_PREPPER_VERSION}"
+    eval "${REPO_DIR}/release/smoke-tests/run-smoke-tests.sh -i ${SMOKE_IMAGE_NAME} -v ${DATA_PREPPER_VERSION} -a ${ARCHITECTURE}"
 
     echo echo "Completed smoke testing tar ${TAR_FILE}"
 


### PR DESCRIPTION
### Description

When running smoke tests verify the correct architecture. Update GitHub Actions to run for Docker smoke tests.
 
Here is a sample run from my fork:

https://github.com/dlvenable/data-prepper/actions/runs/21910179530

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
