### PR TITLE
Kafka buffer metrics for write timeout counts and time elapsed

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -120,7 +120,7 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
     }
 
     @Override
-    public void writeBytes(final byte[] bytes, final String key, int timeoutInMillis) throws Exception {
+    public void doWriteBytes(final byte[] bytes, final String key, int timeoutInMillis) throws Exception {
         try {
             setMdc();
             producer.produceRawData(bytes, key);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -385,8 +385,8 @@ class KafkaBufferTest {
         }
 
         @Test
-        void writeBytes_sets_and_clears_MDC() throws Exception {
-            createObjectUnderTest().writeBytes(new byte[] {}, UUID.randomUUID().toString(), 100);
+        void doWriteBytes_sets_and_clears_MDC() throws Exception {
+            createObjectUnderTest().doWriteBytes(new byte[] {}, UUID.randomUUID().toString(), 100);
 
             mdcMockedStatic.verify(() -> MDC.put(KafkaMdc.MDC_KAFKA_PLUGIN_KEY, "buffer"));
             mdcMockedStatic.verify(() -> MDC.remove(KafkaMdc.MDC_KAFKA_PLUGIN_KEY));


### PR DESCRIPTION
### Description

Corrects Kafka buffer metrics related to write timeouts and write time elapsed. This is solved by implementing `writeBytes` in `AbstractBuffer` and adding a `doWriteBytes` method that throws by default. This keeps the default behavior of throwing, but with correct metric reporting.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
