### PR TITLE
Convert Kafka Header values to Strings

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -510,11 +510,16 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             Map<String, Object> headerData = new HashMap<>();
             for (Header header: headers) {
                 byte[] headerValue = header.value();
-                try {
-                    headerData.put(header.key(), ((headerValue != null) ? new String(header.value(), StandardCharsets.UTF_8) : null));
-                } catch (Exception e) {
-                    headerData.put(header.key(), headerValue);
+                if (headerValue == null) {
+                    headerData.put(header.key(), null);
+                    continue;
                 }
+                String strValue = new String(header.value(), StandardCharsets.UTF_8);
+                if (Arrays.equals(headerValue, strValue.getBytes())) {
+                    headerData.put(header.key(), strValue);
+                    continue;
+                }
+                headerData.put(header.key(), headerValue);
             }
             eventMetadata.setAttribute("kafka_headers", headerData);
         }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -505,22 +505,8 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         if (kafkaKeyMode == KafkaKeyMode.INCLUDE_AS_METADATA) {
             eventMetadata.setAttribute("kafka_key", key);
         }
-        Headers headers = consumerRecord.headers();
-        if (headers != null) {
-            Map<String, Object> headerData = new HashMap<>();
-            for (Header header: headers) {
-                byte[] headerValue = header.value();
-                if (headerValue == null) {
-                    headerData.put(header.key(), null);
-                    continue;
-                }
-                String strValue = new String(header.value(), StandardCharsets.UTF_8);
-                if (Arrays.equals(headerValue, strValue.getBytes())) {
-                    headerData.put(header.key(), strValue);
-                    continue;
-                }
-                headerData.put(header.key(), headerValue);
-            }
+        Map<String, Object> headerData = KafkaHeadersExtractor.extractMessageHeaders(consumerRecord.headers());
+        if (headerData != null) {
             eventMetadata.setAttribute("kafka_headers", headerData);
         }
         final long receivedTimeStamp = getRecordTimeStamp(consumerRecord, now.toEpochMilli());

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -51,6 +51,7 @@ import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -506,9 +507,14 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         }
         Headers headers = consumerRecord.headers();
         if (headers != null) {
-            Map<String, byte[]> headerData = new HashMap<>();
+            Map<String, Object> headerData = new HashMap<>();
             for (Header header: headers) {
-                headerData.put(header.key(), header.value());
+                byte[] headerValue = header.value();
+                try {
+                    headerData.put(header.key(), ((headerValue != null) ? new String(header.value(), StandardCharsets.UTF_8) : null));
+                } catch (Exception e) {
+                    headerData.put(header.key(), headerValue);
+                }
             }
             eventMetadata.setAttribute("kafka_headers", headerData);
         }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -27,8 +27,6 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.errors.RecordDeserializationException;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -51,7 +49,6 @@ import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractor.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KafkaHeadersExtractor {
+    public static Map<String, Object> extractMessageHeaders(Headers headers) {
+        if (headers == null) {
+            return null;
+        }
+        Map<String, Object> headerData = new HashMap<>();
+        for (Header header: headers) {
+            byte[] headerValue = header.value();
+            if (headerValue == null) {
+                headerData.put(header.key(), null);
+                continue;
+            }
+            String strValue = new String(header.value(), StandardCharsets.UTF_8);
+            System.out.println("____"+headerValue.length+"...."+strValue.getBytes().length);
+            if (Arrays.equals(headerValue, strValue.getBytes())) {
+                System.out.println("___1___key_"+header.key());
+                headerData.put(header.key(), strValue);
+                continue;
+            }
+            System.out.println("___2___key_"+header.key());
+            headerData.put(header.key(), headerValue);
+        }
+        return headerData;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractor.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractor.java
@@ -18,22 +18,30 @@ public class KafkaHeadersExtractor {
             return null;
         }
         Map<String, Object> headerData = new HashMap<>();
-        for (Header header: headers) {
+        for (Header header : headers) {
             byte[] headerValue = header.value();
             if (headerValue == null) {
                 headerData.put(header.key(), null);
                 continue;
             }
-            String strValue = new String(header.value(), StandardCharsets.UTF_8);
-            System.out.println("____"+headerValue.length+"...."+strValue.getBytes().length);
-            if (Arrays.equals(headerValue, strValue.getBytes())) {
-                System.out.println("___1___key_"+header.key());
+            String strValue = new String(headerValue, StandardCharsets.UTF_8);
+            if (Arrays.equals(headerValue, strValue.getBytes(StandardCharsets.UTF_8))
+                    && isPrintableString(strValue)) {
                 headerData.put(header.key(), strValue);
-                continue;
+            } else {
+                headerData.put(header.key(), headerValue);
             }
-            System.out.println("___2___key_"+header.key());
-            headerData.put(header.key(), headerValue);
         }
         return headerData;
+    }
+
+    private static boolean isPrintableString(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.isISOControl(c) && c != '\t' && c != '\n' && c != '\r') {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractor.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractor.java
@@ -1,7 +1,12 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
+
 package org.opensearch.dataprepper.plugins.kafka.consumer;
 
 import org.apache.kafka.common.header.Header;

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -19,7 +19,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.RecordDeserializationException;
@@ -51,6 +54,8 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConsumerConfi
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaTopicConsumerMetrics;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -59,6 +64,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
@@ -68,6 +74,7 @@ import java.util.stream.Stream;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -146,6 +153,7 @@ public class KafkaCustomConsumerTest {
     private double overflowCount;
     private boolean paused;
     private boolean resumed;
+    private String testStringHeader;
 
     @BeforeEach
     public void setUp() throws JsonProcessingException {
@@ -196,7 +204,7 @@ public class KafkaCustomConsumerTest {
         }).when(overflowCounter).increment();
         doAnswer((i)-> {return posCount;}).when(posCounter).count();
         doAnswer((i)-> {return negCount;}).when(negCounter).count();
-        callbackExecutor = Executors.newScheduledThreadPool(2); 
+        callbackExecutor = Executors.newScheduledThreadPool(2);
         acknowledgementSetManager = new DefaultAcknowledgementSetManager(callbackExecutor, Duration.ofMillis(2000));
 
         sourceConfig = mock(KafkaConsumerConfig.class);
@@ -337,6 +345,54 @@ public class KafkaCustomConsumerTest {
             }
             if (value2 != null) {
                 Assertions.assertEquals(value2, testValue2);
+            }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+        }
+
+        verify(topicMetrics).recordTimeBetweenPolls();
+    }
+
+    @Test
+    public void testPlainTextConsumeRecordsWithHeaders() throws InterruptedException {
+        testStringHeader = UUID.randomUUID().toString();
+        String topic = topicConfig.getName();
+        consumerRecords = createPlainTextRecordsWithHeaders(topic, 0L);
+        when(kafkaConsumer.poll(any(Duration.class))).thenReturn(consumerRecords);
+        consumer = createObjectUnderTest("plaintext", false);
+
+        try {
+            consumer.onPartitionsAssigned(List.of(new TopicPartition(topic, testPartition)));
+            consumer.consumeRecords();
+        } catch (Exception e){}
+        final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
+        ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
+        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
+        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
+            Assertions.assertEquals(topicPartition.partition(), testPartition);
+            Assertions.assertEquals(topicPartition.topic(), topic);
+            Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
+        });
+        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
+
+
+        for (Record<Event> record: bufferedRecords) {
+            Event event = record.getData();
+            String value1 = event.get(testKey1, String.class);
+            String value2 = event.get(testKey2, String.class);
+            Map<String, Object> attributes = event.getMetadata().getAttributes();
+            Map<String, Object> kafkaHeaders = (Map<String, Object>) attributes.get("kafka_headers");
+            assertThat(kafkaHeaders.get("test-string-header"), equalTo(testStringHeader));
+            assertTrue(value1 != null || value2 != null);
+            if (value1 != null) {
+                Assertions.assertEquals(value1, testValue1);
+                assertThat(kafkaHeaders.get("test-int-header"), notNullValue());
+            }
+            if (value2 != null) {
+                Assertions.assertEquals(value2, testValue2);
+                assertThat(kafkaHeaders.get("test-double-header"), notNullValue());
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
@@ -790,6 +846,29 @@ public class KafkaCustomConsumerTest {
         records.put(new TopicPartition(topic, testPartition), Arrays.asList(record1, record2));
         return new ConsumerRecords(records);
     }
+
+    private ConsumerRecords createPlainTextRecordsWithHeaders(String topic, final long startOffset) {
+        Map<TopicPartition, List<ConsumerRecord>> records = new HashMap<>();
+        RecordHeaders headers1 = new RecordHeaders();
+        RecordHeaders headers2 = new RecordHeaders();
+
+        // Adding a String header
+        headers1.add("test-string-header", testStringHeader.getBytes(StandardCharsets.UTF_8));
+        headers2.add("test-string-header", testStringHeader.getBytes(StandardCharsets.UTF_8));
+
+        // Adding an Integer header (stored as 4 bytes)
+        int testIntHeader = 5;
+        byte[] intBytes = ByteBuffer.allocate(4).putInt(testIntHeader).array();
+        headers1.add("test-int-header", intBytes);
+        ConsumerRecord<String, String> record1 = new ConsumerRecord<>(topic, testPartition, startOffset, System.currentTimeMillis(), TimestampType.CREATE_TIME, 0L, 0, 0,testKey1, testValue1, headers1);
+        double testDoubleHeader = 5.125d;
+        byte[] doubleBytes = ByteBuffer.allocate(8).putDouble(testDoubleHeader).array();
+        headers2.add("test-double-header", doubleBytes);
+        ConsumerRecord<String, String> record2 = new ConsumerRecord<>(topic, testPartition, startOffset+1, System.currentTimeMillis(), TimestampType.CREATE_TIME, 0L, 0, 0, testKey2, testValue2, headers2);
+        records.put(new TopicPartition(topic, testPartition), Arrays.asList(record1, record2));
+        return new ConsumerRecords(records);
+    }
+
 
     private ConsumerRecords createJsonRecords(String topic) throws Exception {
         final ObjectMapper mapper = new ObjectMapper();

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -20,13 +20,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.RecordDeserializationException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,6 +76,9 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -285,15 +286,15 @@ public class KafkaCustomConsumerTest {
 
         final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        assertEquals(consumerRecords.count(), bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
+            assertEquals(topicPartition.partition(), testPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(offsetAndMetadata.offset(), 2L);
         });
-        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
+        assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -301,13 +302,13 @@ public class KafkaCustomConsumerTest {
             String value2 = event.get(testKey2, String.class);
             assertTrue(value1 != null || value2 != null);
             if (value1 != null) {
-                Assertions.assertEquals(value1, testValue1);
+                assertEquals(value1, testValue1);
             }
             if (value2 != null) {
-                Assertions.assertEquals(value2, testValue2);
+                assertEquals(value2, testValue2);
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
     }
 
@@ -324,16 +325,15 @@ public class KafkaCustomConsumerTest {
         } catch (Exception e){}
         final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        assertEquals(consumerRecords.count(), bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
+            assertEquals(topicPartition.partition(), testPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(offsetAndMetadata.offset(), 2L);
         });
-        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
-
+        assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -341,13 +341,13 @@ public class KafkaCustomConsumerTest {
             String value2 = event.get(testKey2, String.class);
             assertTrue(value1 != null || value2 != null);
             if (value1 != null) {
-                Assertions.assertEquals(value1, testValue1);
+                assertEquals(value1, testValue1);
             }
             if (value2 != null) {
-                Assertions.assertEquals(value2, testValue2);
+                assertEquals(value2, testValue2);
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
 
         verify(topicMetrics).recordTimeBetweenPolls();
@@ -367,16 +367,15 @@ public class KafkaCustomConsumerTest {
         } catch (Exception e){}
         final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        assertEquals(consumerRecords.count(), bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
+            assertEquals(topicPartition.partition(), testPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(offsetAndMetadata.offset(), 2L);
         });
-        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
-
+        assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -387,15 +386,15 @@ public class KafkaCustomConsumerTest {
             assertThat(kafkaHeaders.get("test-string-header"), equalTo(testStringHeader));
             assertTrue(value1 != null || value2 != null);
             if (value1 != null) {
-                Assertions.assertEquals(value1, testValue1);
+                assertEquals(value1, testValue1);
                 assertThat(kafkaHeaders.get("test-int-header"), notNullValue());
             }
             if (value2 != null) {
-                Assertions.assertEquals(value2, testValue2);
+                assertEquals(value2, testValue2);
                 assertThat(kafkaHeaders.get("test-double-header"), notNullValue());
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
 
         verify(topicMetrics).recordTimeBetweenPolls();
@@ -414,9 +413,9 @@ public class KafkaCustomConsumerTest {
         } catch (Exception e){}
         final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        assertEquals(consumerRecords.count(), bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 0);
+        assertEquals(offsetsToCommit.size(), 0);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -424,13 +423,13 @@ public class KafkaCustomConsumerTest {
             String value2 = event.get(testKey2, String.class);
             assertTrue(value1 != null || value2 != null);
             if (value1 != null) {
-                Assertions.assertEquals(value1, testValue1);
+                assertEquals(value1, testValue1);
             }
             if (value2 != null) {
-                Assertions.assertEquals(value2, testValue2);
+                assertEquals(value2, testValue2);
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -441,14 +440,14 @@ public class KafkaCustomConsumerTest {
 
         consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
+            assertEquals(topicPartition.partition(), testPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(offsetAndMetadata.offset(), 2L);
         });
         // This counter should not be incremented with acknowledgements
-        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 0L);
+        assertEquals(consumer.getNumRecordsCommitted(), 0L);
 
         verify(topicMetrics).recordTimeBetweenPolls();
     }
@@ -466,9 +465,9 @@ public class KafkaCustomConsumerTest {
         } catch (Exception e){}
         final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        assertEquals(consumerRecords.count(), bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 0);
+        assertEquals(offsetsToCommit.size(), 0);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -476,13 +475,13 @@ public class KafkaCustomConsumerTest {
             String value2 = event.get(testKey2, String.class);
             assertTrue(value1 != null || value2 != null);
             if (value1 != null) {
-                Assertions.assertEquals(value1, testValue1);
+                assertEquals(value1, testValue1);
             }
             if (value2 != null) {
-                Assertions.assertEquals(value2, testValue2);
+                assertEquals(value2, testValue2);
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(false);
         }
         // Wait for acknowledgement callback function to run
@@ -493,7 +492,7 @@ public class KafkaCustomConsumerTest {
 
         consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 0);
+        assertEquals(offsetsToCommit.size(), 0);
 
         verify(topicMetrics).recordTimeBetweenPolls();
     }
@@ -511,14 +510,14 @@ public class KafkaCustomConsumerTest {
         consumer.consumeRecords();
         final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(consumerRecords.count(), bufferedRecords.size());
+        assertEquals(consumerRecords.count(), bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testJsonPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(offsetAndMetadata.offset(), 102L);
+            assertEquals(topicPartition.partition(), testJsonPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(offsetAndMetadata.offset(), 102L);
         });
-        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
+        assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -531,8 +530,8 @@ public class KafkaCustomConsumerTest {
             if (kafkaKey.equals(testKey2)) {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
 
         verify(topicMetrics).recordTimeBetweenPolls();
@@ -573,9 +572,9 @@ public class KafkaCustomConsumerTest {
 
         Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(2, bufferedRecords.size());
+        assertEquals(2, bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 0);
+        assertEquals(offsetsToCommit.size(), 0);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -588,8 +587,8 @@ public class KafkaCustomConsumerTest {
             if (kafkaKey.equals(testKey2)) {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -599,11 +598,11 @@ public class KafkaCustomConsumerTest {
 
         consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testJsonPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(103L, offsetAndMetadata.offset());
+            assertEquals(topicPartition.partition(), testJsonPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(103L, offsetAndMetadata.offset());
         });
     }
 
@@ -642,9 +641,9 @@ public class KafkaCustomConsumerTest {
 
         Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
         ArrayList<Record<Event>> bufferedRecords = new ArrayList<>(bufferRecords.getKey());
-        Assertions.assertEquals(2, bufferedRecords.size());
+        assertEquals(2, bufferedRecords.size());
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 0);
+        assertEquals(offsetsToCommit.size(), 0);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -657,8 +656,8 @@ public class KafkaCustomConsumerTest {
             if (kafkaKey.equals(testKey2)) {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
-            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
-            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
+            assertNotNull(event.getMetadata().getExternalOriginationTime());
+            assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -668,11 +667,11 @@ public class KafkaCustomConsumerTest {
 
         consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
-        Assertions.assertEquals(offsetsToCommit.size(), 1);
+        assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {
-            Assertions.assertEquals(topicPartition.partition(), testJsonPartition);
-            Assertions.assertEquals(topicPartition.topic(), topic);
-            Assertions.assertEquals(103L, offsetAndMetadata.offset());
+            assertEquals(topicPartition.partition(), testJsonPartition);
+            assertEquals(topicPartition.topic(), topic);
+            assertEquals(103L, offsetAndMetadata.offset());
         });
     }
 
@@ -697,8 +696,8 @@ public class KafkaCustomConsumerTest {
         consumer.consumeRecords();
 
         Map<TopicPartition, OffsetAndMetadata> offsetsBeforeCommit = new HashMap<>(consumer.getOffsetsToCommit());
-        Assertions.assertFalse(offsetsBeforeCommit.isEmpty(), "Offsets should be populated after consuming records");
-        Assertions.assertEquals(102L, offsetsBeforeCommit.get(topicPartition).offset());
+        assertFalse(offsetsBeforeCommit.isEmpty(), "Offsets should be populated after consuming records");
+        assertEquals(102L, offsetsBeforeCommit.get(topicPartition).offset());
 
         Thread testThread = new Thread(() -> {
             try {
@@ -713,9 +712,9 @@ public class KafkaCustomConsumerTest {
         testThread.join(5000);
 
         Map<TopicPartition, OffsetAndMetadata> offsetsAfterFailedCommit = consumer.getOffsetsToCommit();
-        Assertions.assertFalse(offsetsAfterFailedCommit.isEmpty(),
+        assertFalse(offsetsAfterFailedCommit.isEmpty(),
             "Offsets should NOT be cleared after RebalanceInProgressException");
-        Assertions.assertEquals(offsetsBeforeCommit.get(topicPartition).offset(),
+        assertEquals(offsetsBeforeCommit.get(topicPartition).offset(),
             offsetsAfterFailedCommit.get(topicPartition).offset(),
             "Offset value should remain unchanged for retry after rebalance completes");
     }
@@ -739,7 +738,7 @@ public class KafkaCustomConsumerTest {
 
         consumer.consumeRecords();
 
-        Assertions.assertFalse(consumer.getOffsetsToCommit().isEmpty(),
+        assertFalse(consumer.getOffsetsToCommit().isEmpty(),
             "Offsets should be populated after consuming records");
 
         Thread testThread = new Thread(() -> {
@@ -754,7 +753,7 @@ public class KafkaCustomConsumerTest {
         testThread.join(5000);
 
         Map<TopicPartition, OffsetAndMetadata> offsetsAfterFailedCommit = consumer.getOffsetsToCommit();
-        Assertions.assertTrue(offsetsAfterFailedCommit.isEmpty(),
+        assertTrue(offsetsAfterFailedCommit.isEmpty(),
             "Offsets should be cleared after non-rebalance exception");
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -335,20 +335,17 @@ public class KafkaCustomConsumerTest {
         });
         assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
-        for (Record<Event> record: bufferedRecords) {
-            Event event = record.getData();
-            String value1 = event.get(testKey1, String.class);
-            String value2 = event.get(testKey2, String.class);
-            assertTrue(value1 != null || value2 != null);
-            if (value1 != null) {
-                assertEquals(value1, testValue1);
-            }
-            if (value2 != null) {
-                assertEquals(value2, testValue2);
-            }
-            assertNotNull(event.getMetadata().getExternalOriginationTime());
-            assertNotNull(event.getEventHandle().getExternalOriginationTime());
-        }
+        Event event = bufferedRecords.get(0).getData();
+        String value1 = event.get(testKey1, String.class);
+        assertEquals(value1, testValue1);
+        assertNotNull(event.getMetadata().getExternalOriginationTime());
+        assertNotNull(event.getEventHandle().getExternalOriginationTime());
+
+        event = bufferedRecords.get(1).getData();
+        String value2 = event.get(testKey2, String.class);
+        assertEquals(value2, testValue2);
+        assertNotNull(event.getMetadata().getExternalOriginationTime());
+        assertNotNull(event.getEventHandle().getExternalOriginationTime());
 
         verify(topicMetrics).recordTimeBetweenPolls();
     }
@@ -377,25 +374,25 @@ public class KafkaCustomConsumerTest {
         });
         assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
-        for (Record<Event> record: bufferedRecords) {
-            Event event = record.getData();
-            String value1 = event.get(testKey1, String.class);
-            String value2 = event.get(testKey2, String.class);
-            Map<String, Object> attributes = event.getMetadata().getAttributes();
-            Map<String, Object> kafkaHeaders = (Map<String, Object>) attributes.get("kafka_headers");
-            assertThat(kafkaHeaders.get("test-string-header"), equalTo(testStringHeader));
-            assertTrue(value1 != null || value2 != null);
-            if (value1 != null) {
-                assertEquals(value1, testValue1);
-                assertThat(kafkaHeaders.get("test-int-header"), notNullValue());
-            }
-            if (value2 != null) {
-                assertEquals(value2, testValue2);
-                assertThat(kafkaHeaders.get("test-double-header"), notNullValue());
-            }
-            assertNotNull(event.getMetadata().getExternalOriginationTime());
-            assertNotNull(event.getEventHandle().getExternalOriginationTime());
-        }
+        Event event = bufferedRecords.get(0).getData();
+        String value1 = event.get(testKey1, String.class);
+        assertEquals(value1, testValue1);
+        assertNotNull(event.getMetadata().getExternalOriginationTime());
+        assertNotNull(event.getEventHandle().getExternalOriginationTime());
+        Map<String, Object> attributes = event.getMetadata().getAttributes();
+        Map<String, Object> kafkaHeaders = (Map<String, Object>) attributes.get("kafka_headers");
+        assertThat(kafkaHeaders.get("test-string-header"), equalTo(testStringHeader));
+        assertThat(kafkaHeaders.get("test-int-header"), notNullValue());
+
+        event = bufferedRecords.get(1).getData();
+        String value2 = event.get(testKey2, String.class);
+        assertEquals(value2, testValue2);
+        assertNotNull(event.getMetadata().getExternalOriginationTime());
+        assertNotNull(event.getEventHandle().getExternalOriginationTime());
+        attributes = event.getMetadata().getAttributes();
+        kafkaHeaders = (Map<String, Object>) attributes.get("kafka_headers");
+        assertThat(kafkaHeaders.get("test-string-header"), equalTo(testStringHeader));
+        assertThat(kafkaHeaders.get("test-double-header"), notNullValue());
 
         verify(topicMetrics).recordTimeBetweenPolls();
     }
@@ -795,7 +792,7 @@ public class KafkaCustomConsumerTest {
         consumer.consumeRecords();
         consumer.consumeRecords();
 
-        Assertions.assertFalse(shutdownInProgress.get(),
+        assertFalse(shutdownInProgress.get(),
                 "Consumer should not shut down on auth failures");
         ArgumentCaptor<Long> sleepCaptor = ArgumentCaptor.forClass(Long.class);
         verify(consumer, times(3)).sleepMillis(sleepCaptor.capture());

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractorTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+public class KafkaHeadersExtractorTest {
+    private static String TEST_STRING_HEADER_KEY = "string-header-key";
+    private static String TEST_INT_HEADER_KEY = "int-header-key";
+    private static String TEST_DOUBLE_HEADER_KEY = "double-header-key";
+
+    private String testStringHeader;
+    private Random random;
+
+    @BeforeEach
+    public void setUp() {
+        random = new Random();
+    }
+
+    @Test
+    public void testExtractMessageHeadersWithValidStrings() {
+        testStringHeader = UUID.randomUUID().toString();
+        RecordHeaders headers = new RecordHeaders();
+
+        int testIntValue = random.nextInt(500);
+        //int testIntValue = 50;
+        byte[] intBytes = ByteBuffer.allocate(4).putInt(testIntValue).array();
+
+        //double testDoubleValue = random.nextDouble();
+        double testDoubleValue = 4.0d;
+        byte[] doubleBytes = ByteBuffer.allocate(8).putDouble(testDoubleValue).array();
+        headers.add(TEST_STRING_HEADER_KEY, testStringHeader.getBytes(StandardCharsets.UTF_8));
+        headers.add(TEST_INT_HEADER_KEY, intBytes);
+        headers.add(TEST_DOUBLE_HEADER_KEY, doubleBytes);
+
+        Map<String, Object> headerData = KafkaHeadersExtractor.extractMessageHeaders(headers);
+        final String stringHeader = (String)headerData.get(TEST_STRING_HEADER_KEY);
+        assertThat(stringHeader, equalTo(testStringHeader));
+        final byte[] intValue = (byte[])headerData.get(TEST_INT_HEADER_KEY);
+        assertThat(ByteBuffer.wrap(intValue).getInt(), equalTo(testIntValue));
+        final byte[] doubleValue = (byte[])headerData.get(TEST_DOUBLE_HEADER_KEY);
+        assertThat(ByteBuffer.wrap(doubleValue).getDouble(), equalTo(testDoubleValue));
+
+    }
+}
+

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractorTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractorTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.kafka.consumer;

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractorTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaHeadersExtractorTest.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.plugins.kafka.consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
@@ -38,11 +37,9 @@ public class KafkaHeadersExtractorTest {
         RecordHeaders headers = new RecordHeaders();
 
         int testIntValue = random.nextInt(500);
-        //int testIntValue = 50;
         byte[] intBytes = ByteBuffer.allocate(4).putInt(testIntValue).array();
 
-        //double testDoubleValue = random.nextDouble();
-        double testDoubleValue = 4.0d;
+        double testDoubleValue = random.nextDouble();
         byte[] doubleBytes = ByteBuffer.allocate(8).putDouble(testDoubleValue).array();
         headers.add(TEST_STRING_HEADER_KEY, testStringHeader.getBytes(StandardCharsets.UTF_8));
         headers.add(TEST_INT_HEADER_KEY, intBytes);


### PR DESCRIPTION
### Description
See the discussion - https://github.com/opensearch-project/data-prepper/discussions/4917
The issue is that kafka source keeps all headers to bytes because kafka header values are byte arrays. But if the input data has headers as strings they are converted to byte arrays by Kafka on the producer side. The consumer side (ie Data Prepper kafka source) keeps them byte arrays. This can cause problem if the original header value is a string. 

So, it makes sense to convert the header values that can be converted to Strings to Strings. Those values that cannot be converted to Strings are left as bytes. Customer could potentially use type conversion processor to convert them to desired type.


 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
