### PR TITLE
Fix Sink Metrics Request Latency Metric units

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategy.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategy.java
@@ -40,7 +40,8 @@ public abstract class DefaultSinkOutputStrategy implements SinkBufferEntryProvid
         try {      
             SinkFlushResult flushResult = flushableBuffer.flush();
             if (flushResult == null) { // success
-                sinkMetrics.recordRequestLatency((double)(System.nanoTime() - startTime));
+                double latency = (System.nanoTime() - startTime)/1000_000; // convert to ms
+                sinkMetrics.recordRequestLatency(latency);
                 for (final Event event: events) {
                     event.getEventHandle().release(true);
                 }


### PR DESCRIPTION
### Description
Make Sink Metrics Request Latency Metric units as milliseconds because all other latency metrics in the pipeline are in milliseconds
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
