### PR TITLE
Use a Timer for the sinkRequestLatency to report it with time units

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkMetrics.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkMetrics.java
@@ -1,13 +1,20 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.common.sink;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import java.util.concurrent.TimeUnit;
 
 public class DefaultSinkMetrics implements SinkMetrics {
     static final String DEFAULT_EVENT_NAME = "Event";
@@ -22,7 +29,7 @@ public class DefaultSinkMetrics implements SinkMetrics {
     private final Counter sinkEventsFailed;
     private final Counter sinkEventsDropped;
     private final Counter sinkRetries;
-    private final DistributionSummary sinkRequestLatency;
+    private final Timer sinkRequestLatency;
     private final DistributionSummary sinkRequestSize;
     private final DistributionSummary sinkEventSize;
 
@@ -33,7 +40,7 @@ public class DefaultSinkMetrics implements SinkMetrics {
         this.sinkEventsFailed = pluginMetrics.counter("sink"+eventName+"sFailed");
         this.sinkEventsDropped = pluginMetrics.counter("sink"+eventName+"sDropped");
         this.sinkRetries = pluginMetrics.counter(SINK_RETRIES);
-        this.sinkRequestLatency = pluginMetrics.summary(SINK_REQUEST_LATENCY);
+        this.sinkRequestLatency = pluginMetrics.timer(SINK_REQUEST_LATENCY);
         this.sinkRequestSize = pluginMetrics.summary(SINK_REQUEST_SIZE);
         this.sinkEventSize = pluginMetrics.summary("sink"+eventName+"Size");
     }
@@ -66,8 +73,13 @@ public class DefaultSinkMetrics implements SinkMetrics {
         sinkRetries.increment(value);
     }
 
+    @Override
+    public void recordRequestLatency(final long amount, final TimeUnit unit) {
+        sinkRequestLatency.record(amount, unit);
+    }
+
     public void recordRequestLatency(double value) {
-        sinkRequestLatency.record(value);
+        recordRequestLatency((long)value, TimeUnit.NANOSECONDS);
     }
 
     public void recordRequestSize(double value){

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategy.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategy.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.common.sink;
@@ -14,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public abstract class DefaultSinkOutputStrategy implements SinkBufferEntryProvider, SinkDlqHandler {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultSinkOutputStrategy.class);
@@ -40,7 +45,7 @@ public abstract class DefaultSinkOutputStrategy implements SinkBufferEntryProvid
         try {      
             SinkFlushResult flushResult = flushableBuffer.flush();
             if (flushResult == null) { // success
-                sinkMetrics.recordRequestLatency((double)(System.nanoTime() - startTime));
+                sinkMetrics.recordRequestLatency(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
                 for (final Event event: events) {
                     event.getEventHandle().release(true);
                 }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/SinkMetrics.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/sink/SinkMetrics.java
@@ -1,17 +1,36 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.common.sink;
 
+import java.util.concurrent.TimeUnit;
+
 public interface SinkMetrics {
-    public void incrementEventsSuccessCounter(int value);
-    public void incrementRequestsSuccessCounter(int value);
-    public void incrementEventsFailedCounter(int value);
-    public void incrementRequestsFailedCounter(int value);
-    public void incrementEventsDroppedCounter(int value);
-    public void incrementRetries(int value);
-    public void recordRequestLatency(double value);
-    public void recordRequestSize(double value);
+    void incrementEventsSuccessCounter(int value);
+    void incrementRequestsSuccessCounter(int value);
+    void incrementEventsFailedCounter(int value);
+    void incrementRequestsFailedCounter(int value);
+    void incrementEventsDroppedCounter(int value);
+    void incrementRetries(int value);
+
+    /**
+     * Records request latency
+     * @param amount Amount of time
+     * @param unit Units for amount
+     */
+    void recordRequestLatency(long amount, TimeUnit unit);
+    /**
+     * Records request latency as nanos
+     * @deprecated Use @{link recordRequestLatency(long, TimeUnit)} instead
+     * @param value nanoseconds
+     */
+    @Deprecated
+    void recordRequestLatency(double value);
+    void recordRequestSize(double value);
 }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/sink/DefaultSinkMetricsTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/sink/DefaultSinkMetricsTest.java
@@ -1,13 +1,20 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.common.sink;
 
+import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.RandomStringUtils;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +25,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import org.mockito.Mock;
+
+import java.util.concurrent.TimeUnit;
 
 public class DefaultSinkMetricsTest {
     @Mock
@@ -36,17 +45,16 @@ public class DefaultSinkMetricsTest {
     @Mock
     private Counter sinkRetriesCounter;
     @Mock
-    private DistributionSummary requestLatency;
+    private Timer requestLatency;
     @Mock
     private DistributionSummary requestSize;
     @Mock
     private DistributionSummary eventSize;
 
-    private DefaultSinkMetrics defaultSinkMetrics;
     private String eventName;
 
     @BeforeEach
-    private void setUp() {
+    void setUp() {
         pluginMetrics = mock(PluginMetrics.class);
         eventName = RandomStringUtils.randomNumeric(5);
         requestsSucceededCounter = mock(Counter.class);
@@ -55,13 +63,13 @@ public class DefaultSinkMetricsTest {
         eventsFailedCounter = mock(Counter.class);
         eventsDroppedCounter = mock(Counter.class);
         sinkRetriesCounter = mock(Counter.class);
-        requestLatency = mock(DistributionSummary.class);
+        requestLatency = mock(Timer.class);
         requestSize = mock(DistributionSummary.class);
         eventSize = mock(DistributionSummary.class);
         when(pluginMetrics.counter(eq(DefaultSinkMetrics.SINK_REQUESTS_SUCCEEDED))).thenReturn(requestsSucceededCounter);
         when(pluginMetrics.counter(eq(DefaultSinkMetrics.SINK_REQUESTS_FAILED))).thenReturn(requestsFailedCounter);
         when(pluginMetrics.counter(eq(DefaultSinkMetrics.SINK_RETRIES))).thenReturn(sinkRetriesCounter);
-        when(pluginMetrics.summary(eq(DefaultSinkMetrics.SINK_REQUEST_LATENCY))).thenReturn(requestLatency);
+        when(pluginMetrics.timer(eq(DefaultSinkMetrics.SINK_REQUEST_LATENCY))).thenReturn(requestLatency);
         when(pluginMetrics.summary(eq("sink"+eventName+"Size"))).thenReturn(eventSize);
         when(pluginMetrics.summary(eq(DefaultSinkMetrics.SINK_REQUEST_SIZE))).thenReturn(requestSize);
         when(pluginMetrics.counter(eq("sink"+eventName+"sSucceeded"))).thenReturn(eventsSucceededCounter);
@@ -74,8 +82,8 @@ public class DefaultSinkMetricsTest {
     }
 
     @Test
-    public void test_sink_metrics() {
-        defaultSinkMetrics = createObjectUnderTest();
+    void test_sink_metrics() {
+        DefaultSinkMetrics defaultSinkMetrics = createObjectUnderTest();
         defaultSinkMetrics.incrementRequestsSuccessCounter(1);
         verify(requestsSucceededCounter).increment(1);
         defaultSinkMetrics.incrementRequestsFailedCounter(1);
@@ -88,11 +96,22 @@ public class DefaultSinkMetricsTest {
         verify(eventsDroppedCounter).increment(1);
         defaultSinkMetrics.incrementRetries(1);
         verify(sinkRetriesCounter).increment(1);
-        defaultSinkMetrics.recordRequestLatency(1.0);
-        verify(requestLatency).record(1.0);
         defaultSinkMetrics.recordRequestSize(1.0);
         verify(requestSize).record(1.0);
         defaultSinkMetrics.recordEventSize(1.0);
         verify(eventSize).record(1.0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TimeUnit.class, names = {"SECONDS", "MILLISECONDS", "MICROSECONDS", "NANOSECONDS"})
+    void recordRequestLatency_with_TimeUnit_calls(final TimeUnit timeUnit) {
+        createObjectUnderTest().recordRequestLatency(314, timeUnit);
+        verify(requestLatency).record(314, timeUnit);
+    }
+
+    @Test
+    void recordRequestLatency_with_double_calls_using_NANOSECONDS() {
+        createObjectUnderTest().recordRequestLatency(102.0);
+        verify(requestLatency).record(102, TimeUnit.NANOSECONDS);
     }
 }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategyTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/sink/DefaultSinkOutputStrategyTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.common.sink;
@@ -10,6 +14,8 @@ import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 
 import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -25,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultSinkOutputStrategyTest {
     @Mock
@@ -47,7 +54,7 @@ public class DefaultSinkOutputStrategyTest {
 
 
     @BeforeEach
-    private void setUp() throws Exception {
+    void setUp() throws Exception {
         flushed = false;
         eventsInBuffer = new ArrayList<>();
         lockStrategy = mock(LockStrategy.class);
@@ -101,7 +108,7 @@ public class DefaultSinkOutputStrategyTest {
         sinkOutputStrategy.execute(Collections.emptyList());
 
         verify(sinkBuffer).getFlushableBuffer(any());
-        verify(sinkMetrics).recordRequestLatency(anyDouble());
+        verify(sinkMetrics).recordRequestLatency(anyLong(), eq(TimeUnit.NANOSECONDS));
         verify(eventHandle1).release(true);
         verify(eventHandle2).release(true);
     }
@@ -129,7 +136,7 @@ public class DefaultSinkOutputStrategyTest {
         sinkOutputStrategy.execute(Collections.emptyList());
 
         verify(sinkBuffer, times(2)).getFlushableBuffer(any());
-        verify(sinkMetrics, times(2)).recordRequestLatency(anyDouble());
+        verify(sinkMetrics, times(2)).recordRequestLatency(anyLong(), eq(TimeUnit.NANOSECONDS));
         verify(eventHandle1).release(true);
         verify(eventHandle2).release(true);
     }
@@ -157,7 +164,7 @@ public class DefaultSinkOutputStrategyTest {
         when(sinkBuffer.exceedsFlushTimeInterval()).thenReturn(true);
 
         verify(sinkBuffer, times(2)).getFlushableBuffer(any());
-        verify(sinkMetrics, times(2)).recordRequestLatency(anyDouble());
+        verify(sinkMetrics, times(2)).recordRequestLatency(anyLong(), eq(TimeUnit.NANOSECONDS));
         verify(eventHandle1).release(true);
         verify(eventHandle2).release(true);
     }
@@ -182,7 +189,7 @@ public class DefaultSinkOutputStrategyTest {
         sinkOutputStrategy.execute(Collections.emptyList());
 
         verify(sinkBuffer).getFlushableBuffer(any());
-        verify(sinkMetrics).recordRequestLatency(anyDouble());
+        verify(sinkMetrics).recordRequestLatency(anyLong(), eq(TimeUnit.NANOSECONDS));
         verify(eventHandle1).release(true);
         verify(eventHandle2).release(false);
     }
@@ -207,7 +214,7 @@ public class DefaultSinkOutputStrategyTest {
         sinkOutputStrategy.execute(Collections.emptyList());
 
         verify(sinkBuffer).getFlushableBuffer(any());
-        verify(sinkMetrics).recordRequestLatency(anyDouble());
+        verify(sinkMetrics).recordRequestLatency(anyLong(), eq(TimeUnit.NANOSECONDS));
         verify(eventHandle1).release(true);
         verify(eventHandle2).release(false);
     }


### PR DESCRIPTION
### Description

The `sinkRequestLatency` metric is using `DistributionSummary`. This means that Micrometer will not report units. This PR changes this to a `Timer` so that it includes time units.

Adds a new method to record with time units. Retains the existing method for double. Update usage of this as well.

Per [Micrometer documentation](https://docs.micrometer.io/micrometer/reference/1.15-SNAPSHOT/concepts/timers.html):

> A Timer is really a specialized distribution summary that is aware of how to scale durations to the base unit of time of each monitoring system and has an automatically determined base unit. In every case where you want to measure time, you should use a Timer rather than a DistributionSummary. 

This is an alternative solution to the problem identified in #6508.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
