### PR TITLE
Fix unecessary logging for query manager with 0 terms

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -452,6 +452,7 @@ public final class BulkRetryStrategy {
 
     private boolean shouldSendAllForQuerying(final Exception exception) {
         if (exception != null && existingDocumentQueryManager != null) {
+            LOG.warn("Received exception that may result in querying for duplicate documents", exception);
             if (SOCKET_TIMEOUT_EXCEPTIONS.contains(exception.getClass())) {
                 return true;
             }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManager.java
@@ -125,7 +125,7 @@ public class ExistingDocumentQueryManager implements Runnable {
 
     @VisibleForTesting
     void runQueryLoop() {
-        if (!bulkOperationsWaitingForQuery.isEmpty()) {
+        if (!bulkOperationsWaitingForQuery.isEmpty() && documentsCurrentlyBeingQueriedGauge.get() > 0) {
 
             // Query for existing documents
             final MsearchRequest msearchRequest = buildMultiSearchRequest();
@@ -197,7 +197,7 @@ public class ExistingDocumentQueryManager implements Runnable {
                     m.searches(s -> s
                             .header(h -> h.index(index))
                             .body(b -> b
-                                    .size(chunk.size())
+                                    .size(chunk.size() * 2)
                                     .source(source -> source.filter(f -> f.includes(queryTerm)))
                                     .query(Query.of(q -> q
                                             .terms(TermsQuery.of(t -> t

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManagerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ExistingDocumentQueryManagerTest.java
@@ -128,6 +128,7 @@ public class ExistingDocumentQueryManagerTest {
         final ExistingDocumentQueryManager objectUnderTest = createObjectUnderTest();
 
         objectUnderTest.addBulkOperation(bulkOperationWrapper);
+        when(documentsCurrentlyQueried.get()).thenReturn(1);
 
         objectUnderTest.runQueryLoop();
 
@@ -180,6 +181,8 @@ public class ExistingDocumentQueryManagerTest {
         ReflectivelySetField.setField(ExistingDocumentQueryManager.class, objectUnderTest, "lastQueryTime", Instant.now().plusMillis(100));
 
         objectUnderTest.addBulkOperation(bulkOperationWrapper);
+
+        when(documentsCurrentlyQueried.get()).thenReturn(1);
 
         Thread.sleep(20);
 
@@ -287,6 +290,7 @@ public class ExistingDocumentQueryManagerTest {
         final ExistingDocumentQueryManager objectUnderTest = createObjectUnderTest();
 
         objectUnderTest.addBulkOperation(bulkOperationWrapper);
+        when(documentsCurrentlyQueried.get()).thenReturn(1);
 
         objectUnderTest.runQueryLoop();
 


### PR DESCRIPTION
### Description
This change adds a couple of metrics for visibility into request latency with KafkaBuffer and OtelLogsSource. Enables the following kafka producer side metrics

```
"request-latency-avg", "requestLatencyAvg",
            "request-latency-max", "requestLatencyMax",
            "produce-throttle-time-avg", "produceThrottleTimeAvg",
            "produce-throttle-time-max", "produceThrottleTimeMax"
```

Also adds one metric to the otel logs source time to parse the ExportLogsServiceRequest (`requestParsingDuration`)

One more metric is added `produceDataPreparationTime` for Kafka producers which tracks time taken to prepare the data to send to Kafka (currently just the compression piece).
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
