### PR TITLE
Add additional metrics for otel logs source and kafka buffer producer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.kafka.source;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -103,6 +104,8 @@ public class KafkaSourceJsonTypeIT {
 
     private Counter counter;
 
+    private Timer timer;
+
     private List<Record> receivedRecords;
 
     private String bootstrapServers;
@@ -138,6 +141,7 @@ public class KafkaSourceJsonTypeIT {
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(pluginMetrics.counter(anyString())).thenReturn(counter);
+        when(pluginMetrics.timer(anyString())).thenReturn(timer);
         when(pipelineDescription.getPipelineName()).thenReturn("testPipeline");
         try {
             doAnswer(args -> {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -43,6 +43,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -118,10 +119,13 @@ public class KafkaCustomProducer<T> {
 
     public void produceRawData(final byte[] bytes, final String key) throws Exception{
         try {
+            long startPreparationTime = System.currentTimeMillis();
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             OutputStream compressedOutputStream = compressionConfig.getCompressionEngine().createOutputStream(byteArrayOutputStream);
             compressedOutputStream.write(bytes);
             compressedOutputStream.close();
+
+            topicMetrics.getProduceDataPreparationTimer().record(System.currentTimeMillis() - startPreparationTime, TimeUnit.MILLISECONDS);
             send(topicName, key, byteArrayOutputStream.toByteArray()).get();
 
             topicMetrics.update(producer);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaProducerMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaProducerMetrics.java
@@ -21,7 +21,11 @@ public final class KafkaProducerMetrics {
             "record-queue-time-avg", "recordQueueTimeAvg",
             "record-queue-time-max", "recordQueueTimeMax",
             "buffer-exhausted-rate", "bufferExhaustedRate",
-            "buffer-available-bytes", "bufferAvailableBytes"
+            "buffer-available-bytes", "bufferAvailableBytes",
+            "request-latency-avg", "requestLatencyAvg",
+            "request-latency-max", "requestLatencyMax",
+            "produce-throttle-time-avg", "produceThrottleTimeAvg",
+            "produce-throttle-time-max", "produceThrottleTimeMax"
     );
 
     private KafkaProducerMetrics() { }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicProducerMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicProducerMetrics.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.kafka.util;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -31,6 +32,7 @@ public class KafkaTopicProducerMetrics {
     static final String NUMBER_OF_RAW_DATA_SEND_ERRORS = "numberOfRawDataSendErrors";
     static final String NUMBER_OF_RECORD_SEND_ERRORS = "numberOfRecordSendErrors";
     static final String NUMBER_OF_RECORD_PROCESSING_ERRORS = "numberOfRecordProcessingErrors";
+    static final String PRODUCE_DATA_PREPARATION_TIME = "produceDataPreparationTime";
     private final String topicName;
     private Map<String, String> metricsNameMap;
     private Map<KafkaProducer, Map<String, Double>> metricValues;
@@ -40,6 +42,7 @@ public class KafkaTopicProducerMetrics {
     private final Counter numberOfRawDataSendErrors;
     private final Counter numberOfRecordSendErrors;
     private final Counter numberOfRecordProcessingErrors;
+    private final Timer produceDataPreparationTimer;
 
     public KafkaTopicProducerMetrics(final String topicName, final PluginMetrics pluginMetrics,
                                      final boolean topicNameInMetrics) {
@@ -52,6 +55,7 @@ public class KafkaTopicProducerMetrics {
         this.numberOfRawDataSendErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RAW_DATA_SEND_ERRORS, topicNameInMetrics));
         this.numberOfRecordSendErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORD_SEND_ERRORS, topicNameInMetrics));
         this.numberOfRecordProcessingErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORD_PROCESSING_ERRORS, topicNameInMetrics));
+        this.produceDataPreparationTimer = pluginMetrics.timer(getTopicMetricName(PRODUCE_DATA_PREPARATION_TIME, topicNameInMetrics));
     }
 
     private void initializeMetricNamesMap(final boolean topicNameInMetrics) {
@@ -103,6 +107,10 @@ public class KafkaTopicProducerMetrics {
 
     public Counter getNumberOfRecordProcessingErrors() {
         return numberOfRecordProcessingErrors;
+    }
+
+    public Timer getProduceDataPreparationTimer() {
+        return produceDataPreparationTimer;
     }
 
     private String getTopicMetricName(final String metricName, final boolean topicNameInMetrics) {

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
@@ -36,6 +37,7 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
     public static final String SUCCESS_REQUESTS = "successRequests";
     public static final String PAYLOAD_SIZE = "payloadSize";
     public static final String REQUEST_PROCESS_DURATION = "requestProcessDuration";
+    public static final String REQUEST_PARSING_DURATION = "requestParsingDuration";
 
     private final int bufferWriteTimeoutInMillis;
 
@@ -48,6 +50,7 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
     private final Counter successRequestsCounter;
     private final DistributionSummary payloadSizeSummary;
     private final Timer requestProcessDuration;
+    private final Timer requestParsingDuration;
 
     public OTelLogsGrpcService(int bufferWriteTimeoutInMillis,
                                final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
@@ -62,11 +65,14 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
             successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS, metricsPrefix);
             payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE, metricsPrefix);
             requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION, metricsPrefix);
+            requestParsingDuration = pluginMetrics.timer(REQUEST_PARSING_DURATION, metricsPrefix);
+
         } else {
             requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
             successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
             payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
             requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
+            requestParsingDuration = pluginMetrics.timer(REQUEST_PARSING_DURATION);
         }
 
         this.oTelProtoDecoder = oTelProtoDecoder;
@@ -92,17 +98,19 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
         final List<OpenTelemetryLog> logs;
 
         try {
+            final long startParsingTime = System.currentTimeMillis();
             logs = oTelProtoDecoder.parseExportLogsServiceRequest(request, Instant.now());
+            requestParsingDuration.record(System.currentTimeMillis() - startParsingTime, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             LOG.error("Failed to parse the request {} due to:", request, e);
             throw new BadRequestException(e.getMessage(), e);
         }
 
-        final List<Record<Object>> records = logs.stream().map(log -> new Record<Object>(log)).collect(Collectors.toList());
         try {
             if (buffer.isByteBuffer()) {
                 buffer.writeBytes(request.toByteArray(), null, bufferWriteTimeoutInMillis);
             } else {
+                final List<Record<Object>> records = logs.stream().map(log -> new Record<Object>(log)).collect(Collectors.toList());
                 buffer.writeAll(records, bufferWriteTimeoutInMillis);
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Description
This change adds a couple of metrics for visibility into request latency with KafkaBuffer and OtelLogsSource. Enables the following kafka producer side metrics

```
"request-latency-avg", "requestLatencyAvg",
            "request-latency-max", "requestLatencyMax",
            "produce-throttle-time-avg", "produceThrottleTimeAvg",
            "produce-throttle-time-max", "produceThrottleTimeMax"
```

Also adds one metric to the otel logs source time to parse the ExportLogsServiceRequest (`requestParsingDuration`)

One more metric is added `produceDataPreparationTime` for Kafka producers which tracks time taken to prepare the data to send to Kafka (currently just the compression piece).
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
