### PR TITLE
Use a Timer for the sqsSinkRequestLatency metric to report it with time units

### DIFF
--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkExecutor.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkExecutor.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.sqs;
@@ -14,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 public abstract class SqsSinkExecutor {
     private static final Logger LOG = LoggerFactory.getLogger(SqsSinkExecutor.class);
@@ -82,7 +87,7 @@ public abstract class SqsSinkExecutor {
         if (failedStatus != null) {
             pushFailedObjectsToDlq(failedStatus);
         } else {
-            recordLatency((double)System.nanoTime() - startTime);
+            recordLatency(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
         }
     }
     
@@ -96,7 +101,7 @@ public abstract class SqsSinkExecutor {
     public abstract boolean willExceedMaxBatchSize(final Event event, final long estimatedSize) throws Exception;
     public abstract boolean exceedsMaxEventSizeThreshold(final long estimatedSize);
     public abstract long getEstimatedSize(final Event event) throws Exception;
-    public abstract void recordLatency(double latencyMillis);
+    public abstract void recordLatency(long amount, TimeUnit timeUnit);
 
     public abstract void lock();
     public abstract void unlock();

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkMetrics.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkMetrics.java
@@ -1,13 +1,20 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.sqs;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import java.util.concurrent.TimeUnit;
 
 public class SqsSinkMetrics {
     public static final String SQS_SINK_REQUESTS_SUCCEEDED = "sqsSinkRequestsSucceeded";
@@ -20,7 +27,7 @@ public class SqsSinkMetrics {
     private final Counter sqsSinkEventsSucceeded;
     private final Counter sqsSinkRequestsFailed;
     private final Counter sqsSinkEventsFailed;
-    private final DistributionSummary sqsSinkRequestLatency;
+    private final Timer sqsSinkRequestLatency;
     private final DistributionSummary sqsSinkRequestSize;
 
     public SqsSinkMetrics(final PluginMetrics pluginMetrics) {
@@ -28,7 +35,7 @@ public class SqsSinkMetrics {
         this.sqsSinkEventsSucceeded = pluginMetrics.counter(SQS_SINK_EVENTS_SUCCEEDED);
         this.sqsSinkRequestsFailed = pluginMetrics.counter(SQS_SINK_REQUESTS_FAILED);
         this.sqsSinkEventsFailed = pluginMetrics.counter(SQS_SINK_EVENTS_FAILED);
-        this.sqsSinkRequestLatency = pluginMetrics.summary(SQS_SINK_REQUEST_LATENCY);
+        this.sqsSinkRequestLatency = pluginMetrics.timer(SQS_SINK_REQUEST_LATENCY);
         this.sqsSinkRequestSize = pluginMetrics.summary(SQS_SINK_REQUEST_SIZE);
     }
 
@@ -48,8 +55,8 @@ public class SqsSinkMetrics {
         sqsSinkRequestsFailed.increment(value);
     }
 
-    public void recordRequestLatency(double value) {
-        sqsSinkRequestLatency.record(value);
+    public void recordRequestLatency(final long amount, final TimeUnit timeUnit) {
+        sqsSinkRequestLatency.record(amount, timeUnit);
     }
 
     public void recordRequestSize(double value) {

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkService.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkService.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.sqs;
@@ -30,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
@@ -297,8 +302,8 @@ public class SqsSinkService extends SqsSinkExecutor {
     }
 
     @Override
-    public void recordLatency(double latencyMillis) {
-        sinkMetrics.recordRequestLatency((double)latencyMillis);
+    public void recordLatency(long amount, TimeUnit timeUnit) {
+        sinkMetrics.recordRequestLatency(amount, timeUnit);
     }
 
     @Override


### PR DESCRIPTION
### Description

This uses a Micrometer `Timer` for the `sqsSinkRequestLatency` metrics. This will have it report using time units.

See a similar PR #6510 for more information.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
