### PR TITLE
Netty 4.1.131

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,11 +237,11 @@ subprojects {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty') {
                 if (details.requested.name == 'netty') {
-                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.124.Final'
-                    details.because 'Fixes CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.131.Final'
+                    details.because 'Fixes CVE-2025-67735, CVE-2025-59419, CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.125.Final'
-                    details.because 'Fixes CVE-2025-58057, CVE-2025-58056, CVE-2025-55163, CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                    details.useVersion '4.1.131.Final'
+                    details.because 'Fixes CVE-2025-67735, CVE-2025-59419, CVE-2025-58057, CVE-2025-58056, CVE-2025-55163, CVE-2025-24970, CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
                 details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'


### PR DESCRIPTION
### Description

Updates Netty to the latest 4.1.x version: 4.1.131.
 
### Issues Resolved

N/A

Resolves CVE-2025-67735, CVE-2025-59419.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
