### PR TITLE
Reduces Dockerfile image size by 46%

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 
 ARG TARGETARCH
 
-RUN dnf -y install tar gzip
+RUN dnf -y install tar gzip && dnf clean all
 
 # Copy all archives and extract only the correct one
 COPY *.tar.gz /tmp/
@@ -19,27 +19,29 @@ ENV DATA_PREPPER_PATH=/usr/share/data-prepper
 ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
 ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 
-# Update all packages
-RUN dnf -y update
-RUN dnf -y install bash bc shadow-utils
-RUN dnf -y upgrade
-
 # Create a dedicated user and group with specific UID/GID
-RUN useradd -u 1000 -M -U -d / -s /sbin/nologin -c "Data Prepper" data_prepper
+RUN dnf -y install shadow-utils && \
+    useradd -u 1000 -M -U -d / -s /sbin/nologin -c "Data Prepper" data_prepper && \
+    dnf -y remove shadow-utils && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Setup the Adoptium package repo and install Temurin Java
 ADD adoptium.repo /etc/yum.repos.d/adoptium.repo
-RUN dnf -y install temurin-17-jdk
+RUN dnf -y upgrade && \
+    dnf -y install temurin-17-jdk bc && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
-RUN mkdir -p /var/log/data-prepper
+RUN mkdir -p /var/log/data-prepper && \
+    chown 1000:1000 /var/log/data-prepper
 
 # Copy extracted data-prepper from builder stage
-COPY --from=builder /tmp/data-prepper /usr/share/data-prepper
+COPY --from=builder --chown=1000:1000 /tmp/data-prepper /usr/share/data-prepper
 
-COPY default-data-prepper-config.yaml $ENV_CONFIG_FILEPATH
-COPY default-keystore.p12 /usr/share/data-prepper/keystore.p12
+COPY --chown=1000:1000 default-data-prepper-config.yaml $ENV_CONFIG_FILEPATH
+COPY --chown=1000:1000 default-keystore.p12 /usr/share/data-prepper/keystore.p12
 
-RUN chown -R 1000:1000 $DATA_PREPPER_PATH /var/log/data-prepper
 USER data_prepper
 
 WORKDIR $DATA_PREPPER_PATH


### PR DESCRIPTION
### Description

Reduces the Docker image size by 46%. This also removes seven layers. This has the following optimizations:

* Run `chown` on `COPY`. The previous approach resulted in duplicate data from copies.
* Consolidated layers that could be combined. This probably doesn't reduce the overall size, but helps with pull time through reduced layers.
* Install, use, and remove `shadow-utils` in a single layer to keep the project out of the image.
* Remove dnf caches by running `dnf clean` and `rm -rf /var/cache/dnf`

#### Comparisons

**Data Prepper 2.13.0 layers** - The latest release

```
docker history opensearchproject/data-prepper:2.13.0 --human
```
```
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
7fa42f9657cc   2 months ago   CMD ["bin/data-prepper"]                        0B        buildkit.dockerfile.v0
<missing>      2 months ago   WORKDIR /usr/share/data-prepper                 0B        buildkit.dockerfile.v0
<missing>      2 months ago   USER data_prepper                               0B        buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   334MB     buildkit.dockerfile.v0
<missing>      2 months ago   COPY default-keystore.p12 /usr/share/data-pr…   2.47kB    buildkit.dockerfile.v0
<missing>      2 months ago   COPY default-data-prepper-config.yaml /usr/s…   245B      buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   334MB     buildkit.dockerfile.v0
<missing>      2 months ago   ADD opensearch-data-prepper-2.13.0-linux-x64…   334MB     buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   0B        buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   357MB     buildkit.dockerfile.v0
<missing>      2 months ago   ADD adoptium.repo /etc/yum.repos.d/adoptium.…   192B      buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   2.86kB    buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   195kB     buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   7.94MB    buildkit.dockerfile.v0
<missing>      2 months ago   RUN |4 PIPELINE_FILEPATH=/usr/share/data-pre…   114MB     buildkit.dockerfile.v0
<missing>      2 months ago   ENV ENV_PIPELINE_FILEPATH=/usr/share/data-pr…   0B        buildkit.dockerfile.v0
<missing>      2 months ago   ENV ENV_CONFIG_FILEPATH=/usr/share/data-prep…   0B        buildkit.dockerfile.v0
<missing>      2 months ago   ENV DATA_PREPPER_PATH=/usr/share/data-prepper   0B        buildkit.dockerfile.v0
<missing>      2 months ago   ARG ARCHIVE_FILE_UNPACKED=opensearch-data-pr…   0B        buildkit.dockerfile.v0
<missing>      2 months ago   ARG ARCHIVE_FILE=opensearch-data-prepper-2.1…   0B        buildkit.dockerfile.v0
<missing>      2 months ago   ARG CONFIG_FILEPATH=/usr/share/data-prepper/…   0B        buildkit.dockerfile.v0
<missing>      2 months ago   ARG PIPELINE_FILEPATH=/usr/share/data-preppe…   0B        buildkit.dockerfile.v0
<missing>      3 months ago   CMD ["/bin/bash"]                               0B        buildkit.dockerfile.v0
<missing>      3 months ago   ADD al2023-container-raw-2023.9.20251117.1-a…   148MB     buildkit.dockerfile.v0
``` 

**Data Prepper 2.14.0-SNAPSHOT layers** - The local changes

```
docker history opensearch-data-prepper:2.14.0-SNAPSHOT --human
```
```
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
25d9b6aeef14   19 minutes ago   CMD ["bin/data-prepper"]                        0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   WORKDIR /usr/share/data-prepper                 0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   USER data_prepper                               0B        buildkit.dockerfile.v0
<missing>      19 minutes ago   COPY --chown=1000:1000 default-keystore.p12 …   2.47kB    buildkit.dockerfile.v0
<missing>      19 minutes ago   COPY --chown=1000:1000 default-data-prepper-…   245B      buildkit.dockerfile.v0
<missing>      19 minutes ago   COPY --chown=1000:1000 /tmp/data-prepper /us…   335MB     buildkit.dockerfile.v0
<missing>      19 minutes ago   RUN |2 PIPELINE_FILEPATH=/usr/share/data-pre…   0B        buildkit.dockerfile.v0
<missing>      47 minutes ago   RUN |2 PIPELINE_FILEPATH=/usr/share/data-pre…   368MB     buildkit.dockerfile.v0
<missing>      48 minutes ago   ADD adoptium.repo /etc/yum.repos.d/adoptium.…   192B      buildkit.dockerfile.v0
<missing>      48 minutes ago   RUN |2 PIPELINE_FILEPATH=/usr/share/data-pre…   3.54MB    buildkit.dockerfile.v0
<missing>      48 minutes ago   ENV ENV_PIPELINE_FILEPATH=/usr/share/data-pr…   0B        buildkit.dockerfile.v0
<missing>      48 minutes ago   ENV ENV_CONFIG_FILEPATH=/usr/share/data-prep…   0B        buildkit.dockerfile.v0
<missing>      48 minutes ago   ENV DATA_PREPPER_PATH=/usr/share/data-prepper   0B        buildkit.dockerfile.v0
<missing>      48 minutes ago   ARG CONFIG_FILEPATH=/usr/share/data-prepper/…   0B        buildkit.dockerfile.v0
<missing>      48 minutes ago   ARG PIPELINE_FILEPATH=/usr/share/data-preppe…   0B        buildkit.dockerfile.v0
<missing>      13 days ago      CMD ["/bin/bash"]                               0B        buildkit.dockerfile.v0
<missing>      13 days ago      ADD al2023-container-raw-2023.10.20260202.2-…   182MB     buildkit.dockerfile.v0
```

**Final image sizes**

```
docker image ls | grep data-prepper
```
```
opensearch-data-prepper                  2.14.0-SNAPSHOT   25d9b6aeef14   20 minutes ago   888MB
opensearchproject/data-prepper           2.13.0            7fa42f9657cc   2 months ago     1.63GB
```

### Issues Resolved

Resolves #3356
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
