### PR TITLE
Data Prepper 2.13.1 release notes and change log

### DIFF
--- a/release/release-notes/data-prepper.change-log-2.13.1.md
+++ b/release/release-notes/data-prepper.change-log-2.13.1.md
@@ -1,0 +1,127 @@
+
+* __Prepare release 2.13.1 (#6523)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Mon, 16 Feb 2026 12:06:23 -0800
+    
+    EAD -&gt; refs/heads/2.13, tag: refs/tags/2.13.1, refs/remotes/upstream/2.13
+    Signed-off-by: github-actions[bot]
+    &lt;41898282+github-actions[bot]@users.noreply.github.com&gt; Co-authored-by:
+    dlvenable &lt;293424+dlvenable@users.noreply.github.com&gt;
+
+* __Updates Rhino to 1.7.15.1. Fixes CVE-2025-66453. (#6519) (#6522)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Mon, 16 Feb 2026 10:47:47 -0800
+    
+    
+    (cherry picked from commit 77449a93c58fa6ae31dc7aa50659b99e2077cdc1)
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt; Co-authored-by: David Venable
+    &lt;dlv@amazon.com&gt;
+
+* __Update Netty to 4.1.131. Resolves CVE-2025-67735, CVE-2025-59419. (#6518) (#6521)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Mon, 16 Feb 2026 10:47:25 -0800
+    
+    
+    (cherry picked from commit 5ebad970eaf6113423317a83f79ecae33925af73)
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt; Co-authored-by: David Venable
+    &lt;dlv@amazon.com&gt;
+
+* __Bump org.apache.logging.log4j:log4j-bom in /data-prepper-expression (#6379) (#6517)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Mon, 16 Feb 2026 07:52:31 -0800
+    
+    
+    Bumps
+    [org.apache.logging.log4j:log4j-bom](https://github.com/apache/logging-log4j2)
+    from 2.25.1 to 2.25.3.
+    - [Release notes](https://github.com/apache/logging-log4j2/releases)
+    -
+    [Changelog](https://github.com/apache/logging-log4j2/blob/2.x/RELEASE-NOTES.adoc)
+    -
+    [Commits](https://github.com/apache/logging-log4j2/compare/rel/2.25.1...rel/2.25.3)
+    
+    --- updated-dependencies:
+    - dependency-name: org.apache.logging.log4j:log4j-bom
+     dependency-version: 2.25.3
+     dependency-type: direct:production
+     update-type: version-update:semver-patch
+    ...
+    
+    
+    
+    (cherry picked from commit f71b5b74c76533da0b7495e40178fc51656e6c1a)
+    
+    Signed-off-by: dependabot[bot] &lt;support@github.com&gt; Co-authored-by:
+    dependabot[bot] &lt;49699333+dependabot[bot]@users.noreply.github.com&gt;
+
+* __Bump org.apache.logging.log4j:log4j-bom in /data-prepper-core (#6376) (#6516)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Mon, 16 Feb 2026 07:52:06 -0800
+    
+    
+    Bumps
+    [org.apache.logging.log4j:log4j-bom](https://github.com/apache/logging-log4j2)
+    from 2.25.1 to 2.25.3.
+    - [Release notes](https://github.com/apache/logging-log4j2/releases)
+    -
+    [Changelog](https://github.com/apache/logging-log4j2/blob/2.x/RELEASE-NOTES.adoc)
+    -
+    [Commits](https://github.com/apache/logging-log4j2/compare/rel/2.25.1...rel/2.25.3)
+    
+    --- updated-dependencies:
+    - dependency-name: org.apache.logging.log4j:log4j-bom
+     dependency-version: 2.25.3
+     dependency-type: direct:production
+     update-type: version-update:semver-patch
+    ...
+    
+    
+    
+    (cherry picked from commit 1ed9cfb1e9ef969dc193e731badf797d8dcad41a)
+    
+    Signed-off-by: dependabot[bot] &lt;support@github.com&gt; Co-authored-by:
+    dependabot[bot] &lt;49699333+dependabot[bot]@users.noreply.github.com&gt;
+
+* __Testing stability changes. This is a partial commit from #6348. (#6493)__
+
+    [David Venable](mailto:dlv@amazon.com) - Mon, 9 Feb 2026 06:50:24 -0800
+    
+    
+    Taken from 442cd7058c5546ea6337f48c55d180fa3ac8c590
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt; Co-authored-by: Santhosh Gandhe
+    &lt;1909520+san81@users.noreply.github.com&gt;
+
+* __remove json creator annotation from no-arg constructor in SinkForwardConfig (#6419) (#6474)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Fri, 6 Feb 2026 07:18:54 -0800
+    
+    
+    (cherry picked from commit 48e7d5d5ddb94861715753f8cc546bac8e53eaef)
+    
+    Signed-off-by: Kennedy Onyia &lt;kennedy.onyia@gmail.com&gt; Co-authored-by: Kennedy
+    Onyia &lt;145404406+kennedy-onyia@users.noreply.github.com&gt;
+
+* __GitHub Action to prepare a branch for the next release. (#6487) (#6490)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Thu, 5 Feb 2026 10:36:57 -0800
+    
+    
+    (cherry picked from commit fbdc8a002683ddb6c722697a720df624192f1c0d)
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt; Co-authored-by: David Venable
+    &lt;dlv@amazon.com&gt;
+
+* __Various improvements to the 2.13 release notes. (#6289) (#6290)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Wed, 7 Jan 2026 14:51:19 -0800
+    
+    efs/remotes/origin/backport/backport-6348-to-2.13
+    (cherry picked from commit 19d8abb599bf86363b77bd3a14b6f03523068e68)
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt; Co-authored-by: David Venable
+    &lt;dlv@amazon.com&gt;
+
+

--- a/release/release-notes/data-prepper.release-notes-2.13.1.md
+++ b/release/release-notes/data-prepper.release-notes-2.13.1.md
@@ -1,0 +1,15 @@
+## 2026-02-16 Version 2.13.1
+
+---
+
+
+### Bug Fixes
+
+* Remove json creator annotation from no-arg constructor in SinkForward ([#6474](https://github.com/opensearch-project/data-prepper/pull/6474))
+
+
+### Security
+
+* Rhino 1.7.15.1 ([#6522](https://github.com/opensearch-project/data-prepper/pull/6522))
+* Netty 4.1.131 ([#6521](https://github.com/opensearch-project/data-prepper/pull/6521))
+* Log4j 2.25.3 ([#6517](https://github.com/opensearch-project/data-prepper/pull/6517))


### PR DESCRIPTION
### Description

Adds the release notes and changelog for Data Prepper 2.13.1

Changelog:

```
git-release-notes 2.13.0..2.13.1 markdown > release/release-notes/data-prepper.change-log-2.13.1.md
```

Release notes

```
./generate-initial-release-notes.sh v2.13.1
```

Edited and prepared.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
