### PR TITLE
Allow group id for standard queues sqs sink

### DIFF
--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkConfig.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkConfig.java
@@ -46,7 +46,7 @@ public class SqsSinkConfig {
     @JsonProperty("dlq")
     private PluginModel dlq;
 
-    @AssertTrue(message = "FIFO queues wth dynamic group id or dynamic deduplication id and more than one events per message is not valid OR standard queues do not support groupId or deduplication configuration")
+    @AssertTrue(message = "FIFO queues wth dynamic group id or dynamic deduplication id and more than one events per message is not valid OR standard queues do not support deduplication configuration")
     boolean isValidConfig() {
         String deDupId = getDeDuplicationId();
         String groupId = getGroupId();
@@ -64,7 +64,7 @@ public class SqsSinkConfig {
                 return true;
             }
         } else {
-             return (groupId == null && deDupId == null);
+             return (deDupId == null);
         }
     }
 

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkConfigTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkConfigTest.java
@@ -45,7 +45,7 @@ public class SqsSinkConfigTest {
     }
 
     @Test
-    private void TestCustomConfig() throws Exception {
+    void TestCustomConfig() throws Exception {
         AwsConfig awsConfig = mock(AwsConfig.class);
         reflectivelySetField(sqsSinkConfig, "awsConfig", awsConfig);
         assertThat(sqsSinkConfig.getAwsConfig(), equalTo(awsConfig));
@@ -83,7 +83,7 @@ public class SqsSinkConfigTest {
         assertTrue(sqsSinkConfig.isValidConfig());
         String testGroupId = RandomStringUtils.randomAlphabetic(10);
         reflectivelySetField(sqsSinkConfig, "groupId", testGroupId);
-        assertFalse(sqsSinkConfig.isValidConfig());
+        assertTrue(sqsSinkConfig.isValidConfig());
         reflectivelySetField(sqsSinkConfig, "groupId", null);
         String testDeDupId = RandomStringUtils.randomAlphabetic(10);
         reflectivelySetField(sqsSinkConfig, "deDuplicationId", testDeDupId);


### PR DESCRIPTION
### Description
There is a validation in place to not allow standard queues in the sqs sink to configure `group_id`, but this is now supported by SQS (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatchRequestEntry.html#SQS-Type-SendMessageBatchRequestEntry-MessageGroupId)
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
