### PR TITLE
feat: add support for now() function evaluation and comparison

### DIFF
--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -98,6 +98,7 @@ setOperatorExpression
     : setOperatorExpression setOperator setInitializer
     | unaryOperatorExpression
     | arithmeticUnaryExpression
+    | arithmeticExpression
     ;
 
 setOperator

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NowExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NowExpressionFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+
+import javax.inject.Named;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Function;
+
+@Named
+public class NowExpressionFunction implements ExpressionFunction {
+
+    static final String NOW_FUNCTION_NAME = "now";
+
+    @Override
+    public String getFunctionName() {
+        return NOW_FUNCTION_NAME;
+    }
+
+    @Override
+    public Object evaluate(final List<Object> args, final Event event, final Function<Object, Object> convertLiteralType) {
+        if (!args.isEmpty()) {
+            throw new RuntimeException("now() does not take any arguments");
+        }
+        return Instant.now().toEpochMilli();
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NowExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NowExpressionFunctionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.opensearch.dataprepper.expression.NowExpressionFunction.NOW_FUNCTION_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.Mockito.mock;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class NowExpressionFunctionTest {
+
+    private Event testEvent;
+
+    private Event createTestEvent(final Object data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+
+    private ExpressionFunction createObjectUnderTest() {
+        return new NowExpressionFunction();
+    }
+
+    @Test
+    void now_returns_current_time_in_millis_when_evaluated() {
+        testEvent = createTestEvent(Map.of());
+
+        final ExpressionFunction objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.getFunctionName(), equalTo(NOW_FUNCTION_NAME));
+
+        final Object result = objectUnderTest.evaluate(List.of(), testEvent, mock(Function.class));
+
+        assertThat(result, instanceOf(Long.class));
+        long nowInMillis = (Long) result;
+        long currentTimeInMillis = Instant.now().toEpochMilli();
+        assertThat(Math.abs(currentTimeInMillis - nowInMillis), lessThan(5000L));
+    }
+
+    @Test
+    void now_with_arguments_throws_exception() {
+        testEvent = createTestEvent(Map.of());
+
+        final ExpressionFunction objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.getFunctionName(), equalTo(NOW_FUNCTION_NAME));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () ->
+                objectUnderTest.evaluate(List.of("unexpected_argument"), testEvent, mock(Function.class))
+        );
+
+        assertThat(exception.getMessage(), equalTo("now() does not take any arguments"));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +31,10 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -119,6 +124,10 @@ class ParseTreeEvaluatorListenerTest {
         final Event testEvent = createTestEvent(data);
         final String testSingleJsonPointerStatement = String.format("/%s", testKey);
         final String testSingleEscapeJsonPointerStatement = String.format("\"/%s\"", testKey);
+        final String testNowFunction = "now()";
+        when(expressionFunctionProvider.provideFunction(eq("now"), any(List.class), any(Event.class), any(Function.class))).thenReturn(
+                Instant.now().toEpochMilli()
+        );
 
         assertThat(evaluateStatementOnEvent(testSingleStringStatement, testEvent), equalTo(testStringValue));
         assertThat(evaluateStatementOnEvent(testSingleIntegerStatement, testEvent), equalTo(testInteger));
@@ -127,6 +136,9 @@ class ParseTreeEvaluatorListenerTest {
         assertThat(evaluateStatementOnEvent(testSingleNullStatement, testEvent), equalTo(null));
         assertThat(evaluateStatementOnEvent(testSingleJsonPointerStatement, testEvent), equalTo(testValue));
         assertThat(evaluateStatementOnEvent(testSingleEscapeJsonPointerStatement, testEvent), equalTo(testValue));
+        assertThat(evaluateStatementOnEvent(testNowFunction, testEvent), is(instanceOf(Long.class)));
+        assertThat((Long)(evaluateStatementOnEvent(testNowFunction, testEvent)), lessThan(Instant.now().toEpochMilli() + 5000L));
+        assertThat((Long)(evaluateStatementOnEvent(testNowFunction, testEvent)), greaterThanOrEqualTo(Instant.now().toEpochMilli() - 5000L));
     }
 
     @Test
@@ -370,6 +382,29 @@ class ParseTreeEvaluatorListenerTest {
         final String addStatement = String.format("/%s + /%s", stringKey1, stringKey2);
         final Event testEvent = createTestEvent(data);
         assertThat(evaluateStatementOnEvent(addStatement, testEvent), equalTo("ab"));
+    }
+
+    @Test
+    void testSimpleAddRelationalEqualityOperatorsExpressionWithFunction() {
+        final String nowFunction = "now()";
+        final String arithmeticDurationExpression = "3 * 24 * 3600 * 1000";
+        when(expressionFunctionProvider.provideFunction(eq("now"), any(List.class), any(Event.class), any(Function.class))).thenReturn(
+                Instant.now().toEpochMilli()
+        );
+        final String addStatement = String.format("%s + %s", nowFunction, arithmeticDurationExpression);
+        Event testEvent = createTestEvent(new HashMap<>());
+        final long expected = Instant.now().toEpochMilli() + 3 * 24 * 3600 * 1000;
+        assertThat((long)(evaluateStatementOnEvent(addStatement, testEvent)), greaterThanOrEqualTo(expected - 5000L));
+        assertThat((long)(evaluateStatementOnEvent(addStatement, testEvent)), lessThanOrEqualTo(expected + 5000L));
+        final String timestampKey = "my_timestamp";
+        final Map<String, Long> data = Map.of(timestampKey, Instant.now().toEpochMilli() - 4 * 24 * 3600 * 1000);
+        testEvent = createTestEvent(data);
+        final String relationalStatement = String.format("/%s < %s - %s", timestampKey, nowFunction, arithmeticDurationExpression);
+        assertThat(evaluateStatementOnEvent(relationalStatement, testEvent), is(true));
+        final String relationalStatement2 = String.format("/%s < %s + %s", timestampKey, nowFunction, arithmeticDurationExpression);
+        assertThat(evaluateStatementOnEvent(relationalStatement2, testEvent), is(true));
+        final String equalityStatement = String.format("/%s == %s - %s", timestampKey, nowFunction, arithmeticDurationExpression);
+        assertThat(evaluateStatementOnEvent(equalityStatement, testEvent), is(false));
     }
 
     @Test


### PR DESCRIPTION
### Description
Add support for `now()` function which returns current time in epoch millis. It can also be used in a relational expression like `/my_timestamp < now() - 3 * 24 * 60 * 60 * 1000`

I don't quite see support for `3d` duration expressions (is it supported?) and did not add that.

If approved, need to add documentation.
 
### Issues Resolved
Resolves #4667
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
