### PR TITLE
Fix potential NPE in scroll worker

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -186,10 +186,10 @@ public class ScrollWorker implements SearchWorker {
                     throw e;
                 }
             } while (searchScrollResponse.getDocuments().size() == batchSize);
-        }
 
-        LOG.info("Received {} documents in latest search request, and batch size is {}, exiting pagination",
-                searchScrollResponse.getDocuments().size(), batchSize);
+            LOG.info("Received {} documents in latest search request, and batch size is {}, exiting pagination",
+                        searchScrollResponse.getDocuments().size(), batchSize);
+        }
 
         deleteScroll(createScrollResponse.getScrollId());
 


### PR DESCRIPTION
### Description
Fixes potential NPE in ScrollWorker when the `batch_size` is smaller than the number of documents in an index
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
