### PR TITLE
Increasing ack timeout to 4 hours for kds source

### DIFF
--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/processor/KinesisRecordProcessor.java
@@ -55,7 +55,7 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(KinesisRecordProcessor.class);
 
     private static final int DEFAULT_MONITOR_WAIT_TIME_MS = 15_000;
-    private static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(4);
 
     private final StreamIdentifier streamIdentifier;
     private final KinesisStreamConfig kinesisStreamConfig;


### PR DESCRIPTION
### Description
The current acknowledgement timeout is set to 20 seconds which is insufficient. When the acknowledgements timeout, it is leading to checkpoints being skipped indefinitely. This change increases the timeout to 4 hours to prevent false negative acknowledgements due to timeout. 

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
