### PR TITLE
Remove the release step for updating DataPrepperVersion

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,16 +63,6 @@ If you have just created a release branch, you should also create a PR on the `m
 
 For example, if you have started the `2.7` branch, you will need to update the `main` branch from `2.6.0-SNAPSHOT` to `2.7.0-SNAPSHOT`.
 
-#### Update the version of DataPrepperVersion
-
-If you have just created a release branch, you should also create a PR on the `main` branch to bump the version in `DataPrepperVersion`.
-
-Steps:
-1. Modify the `DataPrepperVersion` class to update `CURRENT_VERSION` to the next version.
-2. Create a PR targeting `main`
-
-Note: This step can be automated through [#4877](https://github.com/opensearch-project/data-prepper/issues/4877).
-
 ### Update the THIRD-PARTY file
 
 We should update the `THIRD-PARTY` file for every release.


### PR DESCRIPTION
### Description

With the completion of PR #6182 (issue #4877), the `DataPrepperVersion`'s version is generated as part of the build and used dynamically.

We no longer need this step, so this current PR removes the step from the `RELEASING.md` file.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
