### PR TITLE
Add GenAI enrichment documentation to otel_traces processor and output_format to otel_trace_source README

### DIFF
--- a/data-prepper-plugins/otel-trace-raw-processor/README.md
+++ b/data-prepper-plugins/otel-trace-raw-processor/README.md
@@ -17,6 +17,17 @@ processor:
 * `trace_group_cache_ttl`: A `Duration` represents the time-to-live for traces in the trace group cache. Defaults to 15 seconds.
 * `trace_group_cache_max_size`: An `int` representing the total number of traces to keep in the trace group cache.
 
+## GenAI Agent Trace Enrichment
+
+This processor automatically enriches GenAI agent traces. The enrichment is always-on and is a no-op for non-GenAI traces.
+
+**What it does:**
+1. **Vendor attribute normalization** — Maps vendor-specific attributes (OpenInference, OpenLLMetry) to [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Original attributes are preserved. See [`genai-attribute-mappings.yaml`](src/main/resources/genai-attribute-mappings.yaml) for the full mapping table.
+2. **Root span enrichment** — Propagates `gen_ai.system`, `gen_ai.provider.name`, `gen_ai.agent.name`, `gen_ai.request.model`, and `gen_ai.operation.name` from child spans to root (first-child-wins, skip-if-present). Aggregates `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` across children (sum).
+3. **Flattened sub-key stripping** — Removes flattened sub-keys (e.g. `llm.input_messages.0.message.content`) that conflict with parent string values, preventing OpenSearch mapping failures.
+
+**Important:** The enrichment matches attributes by their original OTel key names (e.g. `http.method`). This requires the source to use `output_format: otel` so that attribute keys are not transformed. The default `opensearch` format rewrites keys (e.g. `http.method` → `span.attributes.http@method`), which prevents the enrichment from working. See the [otel-trace-source README](../otel-trace-source/README.md#output-format) for details.
+
 ## Metrics
 In addition to the metrics from [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java):
 

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -38,6 +38,9 @@ For more information on migrating from Data Prepper 1.x to Data Prepper 2.x, see
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`. 
 * authentication(Optional) => An authentication configuration. By default, this runs an unauthenticated server. See below for more information.
 * record_type(Optional) => A string represents the supported record data type that is written into the buffer plugin. Value options are `otlp` or `event`. Default is `otlp`.
+* output_format(Optional) => A string that sets the output format for decoded spans. Default is `opensearch`. Supported values are:
+    * `opensearch`: Attribute keys are prefixed and dots are replaced with `@` (e.g. `http.method` → `span.attributes.http@method`). Use with `index_type: trace-analytics-raw` in the OpenSearch sink.
+    * `otel`: Attribute keys are preserved as-is from the original OTel protobuf (e.g. `http.method`). Use with `index_type: trace-analytics-plain-raw` in the OpenSearch sink. **Required for GenAI agent trace enrichment** in the `otel_traces` processor.
 * compression (Optional) : The compression type applied on the client request payload. Defaults to `none`. Supported values are:
     * `none`: no compression
     * `gzip`: apply GZip de-compression on the incoming request.


### PR DESCRIPTION
### Description

Adds documentation for the GenAI agent trace enrichment feature in the `otel_traces` processor and the previously undocumented `output_format` configuration option in `otel_trace_source`.

**otel-trace-raw-processor/README.md:**
- New "GenAI Agent Trace Enrichment" section covering vendor attribute normalization (OpenInference/OpenLLMetry → OTel GenAI semconv), root span enrichment, and flattened sub-key stripping.
- Notes that `output_format: otel` is required on the source for enrichment to work.

**otel-trace-source/README.md:**
- Documents the `output_format` config option (`opensearch` vs `otel`) which was previously missing from the README.
- Explains the key transformation behavior and the corresponding `index_type` required in the OpenSearch sink.

### Issues Resolved

Resolves opensearch-project/documentation-website#11976

### Check List
- [ ] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR. opensearch-project/documentation-website#11976
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).