### PR TITLE
Fix breaking changes in otel_logs_source

### DIFF
--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.otellogs;
 
-import static org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider.UNAUTHENTICATED_PLUGIN_NAME;
-
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.server.Server;
@@ -18,7 +16,6 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.throttling.ThrottlingService;
 
 import org.opensearch.dataprepper.GrpcRequestExceptionHandler;
-import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.http.LogThrottlingRejectHandler;
 import org.opensearch.dataprepper.http.LogThrottlingStrategy;
@@ -56,8 +53,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -135,7 +130,7 @@ public class OTelLogsSource implements Source<Record<Object>> {
 
     private Server createServer(ServerBuilder serverBuilder, Buffer<Record<Object>> buffer) {
         serverBuilder.disableServerHeader();
-        if (oTelLogsSourceConfig.isSsl()) {
+        if (oTelLogsSourceConfig.isSsl() || oTelLogsSourceConfig.useAcmCertForSSL()) {
             LOG.info("Creating http source with SSL/TLS enabled.");
             final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
             final Certificate certificate = certificateProvider.getCertificate();
@@ -149,11 +144,8 @@ public class OTelLogsSource implements Source<Record<Object>> {
             serverBuilder.http(oTelLogsSourceConfig.getPort());
         }
 
-        if (oTelLogsSourceConfig.getAuthentication() != null) {
-            createHttpAuthentication()
-                    .flatMap(ArmeriaHttpAuthenticationProvider::getAuthenticationDecorator)
-                    .ifPresent(serverBuilder::decorator);
-        }
+        final GrpcAuthenticationProvider authProvider = createGrpcAuthenticationProvider(pluginFactory);
+        authProvider.getHttpAuthenticationService().ifPresent(serverBuilder::decorator);
 
         serverBuilder.maxNumConnections(oTelLogsSourceConfig.getMaxConnectionCount());
         serverBuilder.requestTimeout(Duration.ofMillis(oTelLogsSourceConfig.getRequestTimeoutInMillis()));
@@ -165,13 +157,16 @@ public class OTelLogsSource implements Source<Record<Object>> {
         ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(threadCount);
         serverBuilder.blockingTaskExecutor(executor, true);
 
-        if (oTelLogsSourceConfig.hasHealthCheck()) {
+        if ((oTelLogsSourceConfig.enableUnframedRequests() || oTelLogsSourceConfig.getHttpPath() != null)
+                && oTelLogsSourceConfig.hasHealthCheck()) {
             LOG.info("HTTP source health check is enabled");
             serverBuilder.service(HEALTH_CHECK_PATH, HealthCheckService.builder().longPolling(0).build());
         }
 
-        configureGrpcService(serverBuilder, buffer);
-        configureHttpService(serverBuilder, buffer, executor.getQueue());
+        configureGrpcService(serverBuilder, buffer, authProvider);
+        if (oTelLogsSourceConfig.getHttpPath() != null) {
+            configureHttpService(serverBuilder, buffer, executor.getQueue());
+        }
 
         return serverBuilder.build();
     }
@@ -200,7 +195,8 @@ public class OTelLogsSource implements Source<Record<Object>> {
         }
     }
 
-    private void configureGrpcService(ServerBuilder serverBuilder, Buffer<Record<Object>> buffer) {
+    private void configureGrpcService(ServerBuilder serverBuilder, Buffer<Record<Object>> buffer,
+            GrpcAuthenticationProvider authProvider) {
         LOG.info("Configuring gRPC service");
 
         final GrpcServiceBuilder grpcServiceBuilder = GrpcService
@@ -215,7 +211,6 @@ public class OTelLogsSource implements Source<Record<Object>> {
                 pluginMetrics,
                 null
         );
-        GrpcAuthenticationProvider authProvider = createGrpcAuthenticationProvider(pluginFactory);
 
         final List<ServerInterceptor> interceptors = new ArrayList<>();
         if (authProvider.getAuthenticationInterceptor() != null) {
@@ -294,21 +289,6 @@ public class OTelLogsSource implements Source<Record<Object>> {
         }
         authenticationPluginSetting.setPipelineName(pipelineName);
         return pluginFactory.loadPlugin(GrpcAuthenticationProvider.class, authenticationPluginSetting);
-    }
-
-    private Optional<ArmeriaHttpAuthenticationProvider> createHttpAuthentication() {
-        if (oTelLogsSourceConfig.getAuthentication() == null || oTelLogsSourceConfig.getAuthentication().getPluginName().equals(UNAUTHENTICATED_PLUGIN_NAME)) {
-            LOG.warn("Creating otel_trace_source http service without authentication. This is not secure.");
-            LOG.warn("In order to set up Http Basic authentication for the otel-trace-source, go here: https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/otel-trace-source#authentication-configurations");
-            return Optional.empty();
-        } else {
-            return Optional.of(createGrpcAuthenticationProvider(oTelLogsSourceConfig.getAuthentication()));
-        }
-    }
-
-    private ArmeriaHttpAuthenticationProvider createGrpcAuthenticationProvider(final PluginModel authenticationConfiguration) {
-        Map<String, Object> pluginSettings = authenticationConfiguration.getPluginSettings();
-        return pluginFactory.loadPlugin(ArmeriaHttpAuthenticationProvider.class, new PluginSetting(authenticationConfiguration.getPluginName(), pluginSettings));
     }
 
     private GrpcExceptionHandlerFunction createGrpExceptionHandler(OTelLogsSourceConfig config) {

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceGrpcTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceGrpcTest.java
@@ -113,6 +113,7 @@ import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceC
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createBuilderForConfigWithAcmeSsl;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createConfigBuilderWithBasicAuth;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createDefaultConfig;
+import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createDefaultConfigBuilder;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createBuilderForConfigWithSsl;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.BASIC_AUTH_PASSWORD;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.BASIC_AUTH_USERNAME;
@@ -338,6 +339,18 @@ class OTelLogsSourceGrpcTest {
     void testStartWithEmptyBuffer() {
         final OTelLogsSource source = new OTelLogsSource(createDefaultConfig(), pluginMetrics, pluginFactory, pipelineDescription);
         assertThrows(IllegalStateException.class, () -> source.start(null));
+    }
+
+    @Test
+    void start_withoutHttpPath_doesNotThrowNPE() {
+        final OTelLogsSourceConfig config = createDefaultConfigBuilder()
+                .httpPath(null)
+                .path("/test-pipeline/v1/logs")
+                .build();
+        final OTelLogsSource source = new OTelLogsSource(config, pluginMetrics, pluginFactory,
+                certificateProviderFactory, pipelineDescription);
+        source.start(buffer);
+        source.stop();
     }
 
     @Test

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
@@ -69,7 +69,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.verification.VerificationMode;
-import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
@@ -81,7 +80,6 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.GrpcBasicAuthenticationProvider;
-import org.opensearch.dataprepper.plugins.HttpBasicArmeriaHttpAuthenticationProvider;
 import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelLogsDecoder;
@@ -272,8 +270,7 @@ class OTelLogsSourceHttpTest {
     @MethodSource("getBasicAuthTestData")
     void httpRequest_withBasicAuth_returnsAppropriateResponse(String givenUsername, String givenPassword, HttpStatus expectedStatus, VerificationMode expectedBufferWrites) throws Exception {
         final HttpBasicAuthenticationConfig basicAuthConfig = new HttpBasicAuthenticationConfig(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
-        final HttpBasicArmeriaHttpAuthenticationProvider authProvider = new HttpBasicArmeriaHttpAuthenticationProvider(basicAuthConfig);
-        when(pluginFactory.loadPlugin(eq(ArmeriaHttpAuthenticationProvider.class), any(PluginSetting.class))).thenReturn(authProvider);
+        when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class))).thenReturn(new GrpcBasicAuthenticationProvider(basicAuthConfig));
         configureSource(createConfigBuilderWithBasicAuth().build());
         SOURCE.start(buffer);
 

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OtelLogsSource_RetryInfoTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OtelLogsSource_RetryInfoTest.java
@@ -21,6 +21,7 @@ import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceC
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.CONFIG_HTTP_PATH;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,7 +80,7 @@ class OtelLogsSource_RetryInfoTest {
 
     @BeforeEach
     void beforeEach() throws Exception {
-        lenient().when(authenticationProvider.getHttpAuthenticationService()).thenCallRealMethod();
+        lenient().when(authenticationProvider.getHttpAuthenticationService()).thenReturn(Optional.empty());
         Mockito.lenient().doThrow(SizeOverflowException.class).when(buffer).writeAll(any(), anyInt());
 
         when(oTelLogsSourceConfig.getPort()).thenReturn(DEFAULT_PORT);


### PR DESCRIPTION
### Description
Commit 8d85609 (#6250) added HTTP service support to otel_logs_source but introduced regressions that break existing users:

  1. NPE on startup — configureHttpService() was called unconditionally, causing String.replace() to throw on a null http_path for any user who only configured a gRPC path.
  2. ACM certificate TLS silently broken — The SSL setup branch dropped the useAcmCertForSSL() check, so users relying on ACM-issued certificates would start without TLS.
  3. HTTP health check registered unconditionally — The old behavior gated the HTTP /health endpoint on enableUnframedRequests() being true; the new code registered it for all configs regardless.
  4. Auth provider split — The server-level HTTP decorator was loaded as an ArmeriaHttpAuthenticationProvider while the gRPC interceptor used a separate GrpcAuthenticationProvider, potentially
  resolving to different plugin implementations. The original code used a single GrpcAuthenticationProvider for both.
 
All changes are confined to OTelLogsSource.java:

  - Gate configureHttpService() on http_path being non-null — making HTTP service opt-in, consistent with how gRPC path works
  - Restore || useAcmCertForSSL() in the SSL condition
  - Restore the HTTP health check gate: registered only when enableUnframedRequests() or http_path is set (the latter ensures the new HTTP service also gets a health endpoint)
  - Hoist GrpcAuthenticationProvider creation into createServer, apply its getHttpAuthenticationService() as the server-level decorator, and pass the same instance into configureGrpcService —
  removing the split-provider pattern and the now-dead createHttpAuthentication() helper

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
