### PR TITLE
Adding support for pipeline DLQ to SQS sink

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFailureMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFailureMetadata.java
@@ -11,5 +11,15 @@ package org.opensearch.dataprepper.model.event;
 
 public interface EventFailureMetadata {
     EventFailureMetadata with(String key, Object value);
+
+    EventFailureMetadata withPluginId(String value);
+
+    EventFailureMetadata withPluginName(String value);
+
+    EventFailureMetadata withPipelineName(String value);
+
+    EventFailureMetadata withErrorMessage(Object value);
+
+
 }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -64,10 +64,31 @@ import static org.opensearch.dataprepper.model.event.JacksonEventKey.trimTrailin
 public class JacksonEvent implements Event {
     class DefaultEventFailureMetadata implements EventFailureMetadata {
         static final String FAILURE_METADATA = "_failure_metadata";
+        static final String PLUGIN_ID = "pluginId";
+        static final String PLUGIN_NAME = "pluginName";
+        static final String PIPELINE_NAME = "pipelineName";
+        static final String ERROR_MESSAGE = "errorMessage";
+
 
         public DefaultEventFailureMetadata with(String key, Object value) {
             put(FAILURE_METADATA+"/"+key, value);
             return this;
+        }
+
+        public DefaultEventFailureMetadata withPluginId(String value) {
+            return with(PLUGIN_ID, value);
+        }
+
+        public DefaultEventFailureMetadata withPluginName(String value) {
+            return with(PLUGIN_NAME, value);
+        }
+
+        public DefaultEventFailureMetadata withPipelineName(String value) {
+            return with(PIPELINE_NAME, value);
+        }
+
+        public DefaultEventFailureMetadata withErrorMessage(Object value) {
+            return with(ERROR_MESSAGE, value);
         }
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -202,15 +202,28 @@ public class JacksonEventTest {
     @Test
     public void testDefaultEventFailureMetadata() {
         String eventType = UUID.randomUUID().toString();
-
+        String pluginId = UUID.randomUUID().toString();
+        String pluginName = UUID.randomUUID().toString();
+        String pipelineName = UUID.randomUUID().toString();
+        String errorMessage = UUID.randomUUID().toString();
         Event event = JacksonEvent.builder()
                 .withEventType(eventType)
                 .build();
 
         EventFailureMetadata eventFailureMetadata = event.updateFailureMetadata();
         eventFailureMetadata.with("key1", "value1").with("key2", 2);
-        assertThat(event.get(JacksonEvent.DefaultEventFailureMetadata.FAILURE_METADATA+"/key1", String.class), equalTo("value1"));
-        assertThat(event.get(JacksonEvent.DefaultEventFailureMetadata.FAILURE_METADATA+"/key2", Integer.class), equalTo(2));
+        eventFailureMetadata.withPluginId(pluginId);
+        eventFailureMetadata.withPluginName(pluginName);
+        eventFailureMetadata.withPipelineName(pipelineName);
+        eventFailureMetadata.withErrorMessage(errorMessage);
+        String base = JacksonEvent.DefaultEventFailureMetadata.FAILURE_METADATA + "/";
+        assertThat(event.get(base + "key1", String.class), equalTo("value1"));
+        assertThat(event.get(base + "key2", Integer.class), equalTo(2));
+        assertThat(event.get(base + JacksonEvent.DefaultEventFailureMetadata.PLUGIN_ID, String.class), equalTo(pluginId));
+        assertThat(event.get(base + JacksonEvent.DefaultEventFailureMetadata.PLUGIN_NAME, String.class), equalTo(pluginName));
+        assertThat(event.get(base + JacksonEvent.DefaultEventFailureMetadata.PIPELINE_NAME, String.class), equalTo(pipelineName));
+        assertThat(event.get(base + JacksonEvent.DefaultEventFailureMetadata.ERROR_MESSAGE, String.class), equalTo(errorMessage));
+
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -641,10 +641,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
         if (event != null) {
             event.updateFailureMetadata()
-                .with("pluginId", dlqObject.getPluginId())
-                .with("pluginName", dlqObject.getPluginName())
-                .with("pipelineName", dlqObject.getPipelineName())
-                .with("message",  ((FailedDlqData) dlqObject.getFailedData()).getMessage())
+                .withPluginId(dlqObject.getPluginId())
+                .withPluginName(dlqObject.getPluginName())
+                .withPipelineName(dlqObject.getPipelineName())
+                .withErrorMessage(((FailedDlqData) dlqObject.getFailedData()).getMessage())
                 .with("status", ((FailedDlqData) dlqObject.getFailedData()).getStatus())
                 .with("index", ((FailedDlqData) dlqObject.getFailedData()).getIndex())
                 .with("indexId", ((FailedDlqData) dlqObject.getFailedData()).getIndexId());

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
@@ -93,11 +93,11 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
             }
             event.updateFailureMetadata()
                 .with("statusCode", statusCode)
-                .with("pluginName", PLUGIN_NAME)
-                .with("pipelineName", pipelineDescription.getPipelineName());
+                .withPluginName(PLUGIN_NAME)
+                .withPipelineName(pipelineDescription.getPipelineName());
             if (ex != null) {
                 event.updateFailureMetadata()
-                    .with("message",  ex.getMessage());
+                    .withErrorMessage(ex.getMessage());
             }
             dlqRecords.add(new Record<>(event));
         }

--- a/data-prepper-plugins/sqs-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkIT.java
+++ b/data-prepper-plugins/sqs-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.sqs;
 
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
@@ -116,6 +117,9 @@ public class SqsSinkIT {
 
     @Mock
     private PluginModel codec;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
 
     @Mock
     private Counter eventsSuccessCounter;
@@ -256,7 +260,7 @@ public class SqsSinkIT {
         when(sqsSinkConfig.getCodec()).thenReturn(codec);
         when(sqsSinkConfig.getAwsConfig()).thenReturn(awsConfig);
         when(sqsSinkConfig.getDlq()).thenReturn(null);
-
+        when(pipelineDescription.getPipelineName()).thenReturn("test-pipeline");
         thresholdConfig = mock(SqsThresholdConfig.class);
         lenient().when(sqsSinkConfig.getMaxRetries()).thenReturn(3);
         when(thresholdConfig.getMaxEventsPerMessage()).thenReturn(1);
@@ -323,7 +327,7 @@ public class SqsSinkIT {
     }
 
     private SqsSink createObjectUnderTest() {
-        return new SqsSink(pluginSetting, pluginMetrics, pluginFactory, sqsSinkConfig, sinkContext, expressionEvaluator, awsCredentialsSupplier);
+        return new SqsSink(pluginSetting, pluginMetrics, pluginFactory, sqsSinkConfig, sinkContext, expressionEvaluator, awsCredentialsSupplier, pipelineDescription);
     }
 
     private List<Message> getMessages(final String queueUrl) {

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSink.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSink.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.sqs;
 
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -54,7 +55,8 @@ public class SqsSink extends AbstractSink<Record<Event>> {
                    final SqsSinkConfig sqsSinkConfig,
                    final SinkContext sinkContext,
                    final ExpressionEvaluator expressionEvaluator,
-                   final AwsCredentialsSupplier awsCredentialsSupplier) {
+                   final AwsCredentialsSupplier awsCredentialsSupplier,
+                   final PipelineDescription pipelineDescription) {
         super(pluginSetting);
         this.sqsSinkConfig = sqsSinkConfig;
         sinkInitialized = false;
@@ -86,7 +88,7 @@ public class SqsSink extends AbstractSink<Record<Event>> {
             dlqPushHandler = new DlqPushHandler(pluginFactory, pluginSetting, pluginMetrics, sqsSinkConfig.getDlq(), region.toString(), role, "sqsSink");
         }
         final OutputCodec outputCodec = pluginFactory.loadPlugin(OutputCodec.class, codecPluginSettings);
-        sqsSinkService = new SqsSinkService(sqsSinkConfig, sqsClient, expressionEvaluator, outputCodec, sinkContext, dlqPushHandler, pluginMetrics);
+        sqsSinkService = new SqsSinkService(sqsSinkConfig, sqsClient, expressionEvaluator, outputCodec, sinkContext, dlqPushHandler, pluginMetrics, pluginSetting, pipelineDescription);
     }
 
     private static AwsCredentialsOptions convertToCredentialOptions(final AwsConfig awsConfig) {
@@ -106,6 +108,7 @@ public class SqsSink extends AbstractSink<Record<Event>> {
     @Override
     public void doInitialize() {
         sinkInitialized = true;
+        sqsSinkService.setDlqPipeline(getFailurePipeline());
     }
 
     /**

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntry.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntry.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 public class SqsSinkBatchEntry {
     private final List<EventHandle> eventHandles;
+    private final List<Event> events;
     private final String groupId;
     private final String deDupId;
     private final Buffer buffer;
@@ -29,6 +30,7 @@ public class SqsSinkBatchEntry {
 
     public SqsSinkBatchEntry(final Buffer buffer, final String groupId, final String deDupId, final OutputCodec codec, final OutputCodecContext codecContext) {
         this.eventHandles = new ArrayList<>();
+        this.events = new ArrayList<>();
         this.buffer = buffer;
         completed = false;
         this.groupId = groupId;
@@ -58,6 +60,7 @@ public class SqsSinkBatchEntry {
             writer = codec.createWriter(buffer.getOutputStream(), null, codecContext);
         }
         writer.writeEvent(event);
+        events.add(event);
         eventHandles.add(event.getEventHandle());
         eventCount++;
     }
@@ -89,6 +92,10 @@ public class SqsSinkBatchEntry {
 
     public int getEventCount() {
         return eventCount;
+    }
+
+    public List<Event> getEvents() {
+        return events;
     }
 
 }

--- a/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkService.java
+++ b/data-prepper-plugins/sqs-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkService.java
@@ -12,6 +12,9 @@ package org.opensearch.dataprepper.plugins.sink.sqs;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.plugins.accumulator.BufferFactory;
 import org.opensearch.dataprepper.plugins.accumulator.InMemoryBufferFactory;
@@ -62,6 +65,10 @@ public class SqsSinkService extends SqsSinkExecutor {
     private final SqsSinkMetrics sinkMetrics;
     private final DlqPushHandler dlqPushHandler;
     private final List<DlqObject> dlqObjects;
+    private HeadlessPipeline dlqPipeline;
+    private final List<Record<Event>> dlqPipelineRecords;
+    private final PluginSetting pluginSetting;
+    private final PipelineDescription pipelineDescription;
 
     public SqsSinkService(final SqsSinkConfig sqsSinkConfig,
                           final SqsClient sqsClient,
@@ -69,9 +76,13 @@ public class SqsSinkService extends SqsSinkExecutor {
                           final OutputCodec codec,
                           final SinkContext sinkContext,
                           final DlqPushHandler dlqPushHandler,
-                          final PluginMetrics pluginMetrics) {
+                          final PluginMetrics pluginMetrics,
+                          final PluginSetting pluginSetting,
+                          final PipelineDescription pipelineDescription
+                          ) {
         batchUrlMap = new HashMap<>();
         dlqObjects = new ArrayList<>();
+        dlqPipelineRecords = new ArrayList<>();
         inMemoryBufferFactory =new InMemoryBufferFactory();
         this.sqsClient = sqsClient;
         this.dlqPushHandler = dlqPushHandler;
@@ -82,7 +93,8 @@ public class SqsSinkService extends SqsSinkExecutor {
         this.sqsSinkConfig = sqsSinkConfig;
         reentrantLock = new ReentrantLock();
         this.sinkMetrics = new SqsSinkMetrics(pluginMetrics);
-
+        this.pluginSetting = pluginSetting;
+        this.pipelineDescription = pipelineDescription;
         queueUrl = sqsSinkConfig.getQueueUrl();
         isDynamicQueueUrl = queueUrl.contains("${");
         if (isDynamicQueueUrl) {
@@ -109,6 +121,10 @@ public class SqsSinkService extends SqsSinkExecutor {
 
     }
 
+    public void setDlqPipeline(HeadlessPipeline pipeline) {
+        this.dlqPipeline = pipeline;
+    }
+
     @Override
     public boolean exceedsMaxEventSizeThreshold(final long estimatedSize) {
         return estimatedSize > MAX_EVENT_SIZE;
@@ -116,6 +132,12 @@ public class SqsSinkService extends SqsSinkExecutor {
 
     @Override
     public void pushDLQList() {
+        if (dlqPipeline != null && !dlqPipelineRecords.isEmpty()) {
+            dlqPipeline.sendEvents(dlqPipelineRecords);
+            dlqPipelineRecords.clear();
+            return;
+        }
+
         // If DLQ push handler is null, dlqObjects list
         // would be empty
         if (dlqObjects.size() == 0) {
@@ -286,10 +308,24 @@ public class SqsSinkService extends SqsSinkExecutor {
     }
 
     private void addBatchEntryToDLQ(final SqsSinkBatchEntry batchEntry, final String errorMessage) {
-        addMessageToDLQ(batchEntry.getBody(), batchEntry.getEventHandles(), errorMessage);
+        addMessageToDLQ(batchEntry.getBody(), batchEntry.getEventHandles(), batchEntry.getEvents(), errorMessage);
     }
 
-    private void addMessageToDLQ(final String message, final List<EventHandle> eventHandles, final String errorMessage) {
+    private void addMessageToDLQ(final String message, final List<EventHandle> eventHandles, List<Event> events, final String errorMessage) {
+        if (dlqPipeline != null) {
+            for (Event event: events) {
+                if (event != null) {
+                   event.updateFailureMetadata()
+                       .withPluginId(pluginSetting.getName())
+                       .withPluginName(pluginSetting.getName())
+                       .withPipelineName(pipelineDescription.getPipelineName())
+                       .withErrorMessage(errorMessage)
+                       .with("sqsSinkQueueUrl", queueUrl);
+                    dlqPipelineRecords.add(new Record<>(event));
+                }
+            }
+            return;
+        }
         if (dlqPushHandler != null) {
             SqsSinkDlqData sqsSinkDlqData = SqsSinkDlqData.createDlqData(message, errorMessage);
             DlqObject dlqObject = DlqObject.createDlqObject(dlqPushHandler.getPluginSetting(), eventHandles, sqsSinkDlqData);
@@ -309,8 +345,9 @@ public class SqsSinkService extends SqsSinkExecutor {
     @Override
     public void addEventToDLQList(final Event event, Throwable ex) {
         List<EventHandle> eventHandles = new ArrayList<>();
+        List<Event> events = List.of(event);
         eventHandles.add(event.getEventHandle());
-        addMessageToDLQ(event.toJsonString(), eventHandles, ex.getMessage());
+        addMessageToDLQ(event.toJsonString(), eventHandles, events, ex.getMessage());
     }
 
     @Override

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntryTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkBatchEntryTest.java
@@ -67,6 +67,7 @@ public class SqsSinkBatchEntryTest {
         assertThat(sqsSinkBatchEntry.getGroupId(), equalTo(groupId));
         assertThat(sqsSinkBatchEntry.getDedupId(), equalTo(deDupId));
         assertTrue(sqsSinkBatchEntry.getEventHandles().isEmpty());
+        assertTrue(sqsSinkBatchEntry.getEvents().isEmpty());
     }
      
     @Test
@@ -83,6 +84,7 @@ public class SqsSinkBatchEntryTest {
         assertThat(sqsSinkBatchEntry.getGroupId(), equalTo(groupId));
         assertThat(sqsSinkBatchEntry.getDedupId(), equalTo(deDupId));
         assertThat(sqsSinkBatchEntry.getEventHandles().size(), equalTo(1));
+        assertThat(sqsSinkBatchEntry.getEvents().size(), equalTo(1));
     }
     
 
@@ -123,6 +125,7 @@ public class SqsSinkBatchEntryTest {
         assertThat(sqsSinkBatchEntry.getDedupId(), equalTo(deDupId));
         assertThat(sqsSinkBatchEntry.getSize(), equalTo(expectedSize));
         assertThat(sqsSinkBatchEntry.getEventHandles().size(), equalTo(numRecords));
+        assertThat(sqsSinkBatchEntry.getEvents().size(), equalTo(numRecords));
     }
 
     @Test

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkServiceTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkServiceTest.java
@@ -13,6 +13,8 @@ import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -28,7 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -37,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -92,6 +97,12 @@ class SqsSinkServiceTest {
     @Mock(strictness = Mock.Strictness.LENIENT)
     private SinkContext sinkContext;
 
+    private HeadlessPipeline dlqPipeline;
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    private PipelineDescription pipelineDescription;
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    private PluginSetting pluginSetting;
+
     @Mock
     private Counter eventsSuccessCounter;
     @Mock
@@ -117,8 +128,12 @@ class SqsSinkServiceTest {
     private OutputCodecContext outputCodecContext;
     private String queueUrl;
 
+    private String pluginName;
+    private String pipelineName;
+
     private SqsSinkService createObjectUnderTest() {
-        return new SqsSinkService(sqsSinkConfig, sqsClient, expressionEvaluator, outputCodec, sinkContext, dlqPushHandler, pluginMetrics);
+        return new SqsSinkService(sqsSinkConfig, sqsClient, expressionEvaluator, outputCodec, sinkContext, dlqPushHandler,
+                pluginMetrics, pluginSetting, pipelineDescription);
     }
 
     @BeforeEach
@@ -139,14 +154,16 @@ class SqsSinkServiceTest {
         when (thresholdConfig.getMaxMessageSizeBytes()).thenReturn(256*1024L);
         when (thresholdConfig.getMaxEventsPerMessage()).thenReturn(1);
         when (sqsSinkConfig.getThresholdConfig()).thenReturn(thresholdConfig);
+        pipelineName = UUID.randomUUID().toString();
+        when (pipelineDescription.getPipelineName()).thenReturn(pipelineName);
         lenient().when (sqsSinkConfig.getMaxRetries()).thenReturn(3);
         lenient().when(flushResponse.hasFailed()).thenReturn(false);
         when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(flushResponse);
         when(expressionEvaluator.isValidFormatExpression(anyString())).thenReturn(true);
         when(dlqPushHandler.perform(any(List.class))).thenReturn(true);
-        PluginSetting pluginSetting = mock(PluginSetting.class);
-        lenient().when(pluginSetting.getName()).thenReturn("name");
-        lenient().when(pluginSetting.getPipelineName()).thenReturn("pipeline");
+        pluginName = UUID.randomUUID().toString();
+        lenient().when(pluginSetting.getName()).thenReturn(pluginName);
+        lenient().when(pluginSetting.getPipelineName()).thenReturn(pipelineName);
         when(dlqPushHandler.getPluginSetting()).thenReturn(pluginSetting);
         lenient().doNothing().when(summary).record(any(Double.class));
         lenient().doNothing().when(timer).record(any(Long.class), any(TimeUnit.class));
@@ -518,6 +535,82 @@ class SqsSinkServiceTest {
         assertThat(eventsSuccessCount.get(), equalTo(numRecords));
         assertThat(requestsSuccessCount.get(), equalTo(numRecords/10));
         verify(eventHandle, times(numRecords)).release(true);
+    }
+
+    @Test
+    void TestLargeRecordToPipelineDLQ() {
+        dlqPipeline = mock(HeadlessPipeline.class);
+        List<Record<Event>> capturedRecords = new ArrayList<>();
+        doAnswer(invocation -> {
+            List<Record<Event>> arg = invocation.getArgument(0);
+            capturedRecords.addAll(arg);
+            return null;
+        }).when(dlqPipeline).sendEvents(any());
+        SqsSinkService sqsSinkService = createObjectUnderTest();
+        sqsSinkService.setDlqPipeline(dlqPipeline);
+        Record<Event> record = getLargeRecord(300 * 1024);
+        sqsSinkService.execute(List.of(record));
+
+        verify(dlqPipeline, times(1)).sendEvents(any());
+        assertThat(capturedRecords.size(), equalTo(1));
+
+        Event event = capturedRecords.get(0).getData();
+        assertThat(event.get("_failure_metadata/pluginId", String.class), equalTo(pluginName));
+        assertThat(event.get("_failure_metadata/pluginName", String.class), equalTo(pluginName));
+        assertThat(event.get("_failure_metadata/pipelineName", String.class), equalTo(pipelineName));
+        assertThat(event.get("_failure_metadata/sqsSinkQueueUrl", String.class), equalTo(queueUrl));
+        verify(eventHandle, never()).release(anyBoolean());
+    }
+
+    @Test
+    void TestSendingToPipelineDLQAfterMultipleRetries() {
+        dlqPipeline = mock(HeadlessPipeline.class);
+        List<Record<Event>> capturedRecords = new ArrayList<>();
+        doAnswer(invocation -> {
+            List<Record<Event>> arg = invocation.getArgument(0);
+            capturedRecords.addAll(arg);
+            return null;
+        }).when(dlqPipeline).sendEvents(any());
+
+        final int numRecords = 10;
+        RequestThrottledException requestThrottledException = mock(RequestThrottledException.class);
+        when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenThrow(requestThrottledException);
+
+        SqsSinkService sqsSinkService = createObjectUnderTest();
+        sqsSinkService.setDlqPipeline(dlqPipeline);
+        List<Record<Event>> records = getRecordList(numRecords);
+        sqsSinkService.execute(records);
+
+        assertThat(capturedRecords.size(), equalTo(numRecords));
+        assertThat(sqsSinkService.getBatchUrlMap().size(), equalTo(0));
+        assertThat(eventsSuccessCount.get(), equalTo(0));
+        assertThat(requestsSuccessCount.get(), equalTo(0));
+        verify(eventHandle, never()).release(anyBoolean());
+    }
+
+    @Test
+    void TestSendingToPipelineDLQAfterNonRetryableException() {
+        dlqPipeline = mock(HeadlessPipeline.class);
+        List<Record<Event>> capturedRecords = new ArrayList<>();
+        doAnswer(invocation -> {
+            List<Record<Event>> arg = invocation.getArgument(0);
+            capturedRecords.addAll(arg);
+            return null;
+        }).when(dlqPipeline).sendEvents(any());
+
+        final int numRecords = 10;
+        UnsupportedOperationException unsupportedOperationException = mock(UnsupportedOperationException.class);
+        when(unsupportedOperationException.getMessage()).thenReturn("Unsupported operation");
+        when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenThrow(unsupportedOperationException);
+
+        SqsSinkService sqsSinkService = createObjectUnderTest();
+        sqsSinkService.setDlqPipeline(dlqPipeline);
+
+        List<Record<Event>> records = getRecordList(numRecords);
+        sqsSinkService.execute(records);
+
+        assertThat(capturedRecords.size(), equalTo(numRecords));
+        verify(eventHandle, never()).release(anyBoolean());
     }
 
     private List<Record<Event>> getLargeRecordList(int numberOfRecords) {

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.sqs;
 
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
@@ -24,8 +25,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -78,6 +77,8 @@ public class SqsSinkTest {
     private AwsCredentialsProvider awsCredentialsProvider;
     @Mock
     private AwsConfig awsConfig;
+    @Mock
+    private PipelineDescription pipelineDescription;
 
     private SqsClient sqsClient;
     private PluginModel codecConfig;
@@ -112,10 +113,11 @@ public class SqsSinkTest {
         when(sqsSinkConfig.getAwsConfig()).thenReturn(awsConfig);
         when(pluginSetting.getName()).thenReturn(TEST_PLUGIN_NAME);
         when(pluginSetting.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
+        pipelineDescription = mock(PipelineDescription.class);
 
     }
     SqsSink createObjectUnderTest() {
-        return new SqsSink(pluginSetting, pluginMetrics, pluginFactory, sqsSinkConfig, sinkContext, expressionEvaluator, awsCredentialsSupplier);
+        return new SqsSink(pluginSetting, pluginMetrics, pluginFactory, sqsSinkConfig, sinkContext, expressionEvaluator, awsCredentialsSupplier, pipelineDescription);
     }
 
     @Test


### PR DESCRIPTION
### Description
Add support for pipeline DLQ to SQS sink. When "dlq_pipeline" is present in the configuration, SQS sink uses that for DLQ and ignores the sink level dlq config, if present.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
