### PR TITLE
GitHub Action to verify the Gradle buildSrc.

### DIFF
--- a/.github/workflows/gradle-build-src.yml
+++ b/.github/workflows/gradle-build-src.yml
@@ -1,0 +1,66 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+name: Gradle - Check buildSrc
+
+on:
+  push:
+    paths:
+      - 'buildSrc/**'
+      - '*gradle*'
+  pull_request:
+    paths:
+      - 'buildSrc/**'
+      - '*gradle*'
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [11, 17, 21]
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: temurin
+
+    - name: Checkout Data Prepper
+      uses: actions/checkout@v6
+    - name: Check Gradle buildSrc
+      run: ./gradlew -p buildSrc check
+    - name: Upload Unit Test Results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: data-prepper-test-results-java-${{ matrix.java }}
+        path: '**/test-results/**/*.xml'
+
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: test-results
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "test-results/**/*.xml"


### PR DESCRIPTION
### Description

It appears that Gradle does not run tests for `buildSrc` on normal builds. 

> Tests for buildSrc are no longer automatically run
> When Gradle builds the output of buildSrc it only runs the tasks that produce that output. It no longer runs the build task. In particular, this means that the tests of buildSrc and its subprojects are not built and executed when they are not needed.

https://docs.gradle.org/8.0/release-notes.html

Since this is a special build and doesn't change often, I think having a single GitHub Action that only runs for this directory will be sufficient to verify that it doesn't break.

I tested this on my fork: https://github.com/dlvenable/data-prepper/actions/workflows/gradle-build-src.yml

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
