### PR TITLE
Support validating library compatibility on data-prepper-api.

### DIFF
--- a/.github/workflows/compatibility-data-prepper-api.yml
+++ b/.github/workflows/compatibility-data-prepper-api.yml
@@ -1,0 +1,50 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+name: Verify data-prepper-api compatibility
+
+on:
+  push:
+    paths:
+      - 'data-prepper-api/**'
+      - '*gradle*'
+  pull_request:
+    paths:
+      - 'data-prepper-api/**'
+      - '*gradle*'
+
+  workflow_dispatch:
+
+jobs:
+  verify-api-compatibility:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+
+    - name: Checkout Data Prepper
+      uses: actions/checkout@v6
+
+    - name: Validate API compatibility
+      run: ./gradlew -p data-prepper-api validateCompatibility
+
+    - name: Output compatibility report
+      if: failure()
+      run: cat data-prepper-api/build/reports/library-compatibility/report.txt
+
+    - name: Upload Compatibility Report
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: library-compatibility-report
+        path: ${{ github.workspace }}/data-prepper-api/build/reports/library-compatibility/report.html

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,8 +19,10 @@ repositories {
 
 dependencies {
     implementation('me.champeau.jmh:me.champeau.jmh.gradle.plugin:0.7.2')
+    implementation('me.champeau.gradle:japicmp-gradle-plugin:0.4.2')
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
     testImplementation('org.hamcrest:hamcrest:2.2')
+    testImplementation('org.mockito:mockito-core:5.12.0')
 }
 
 test {

--- a/buildSrc/src/main/groovy/data-prepper.library-compatibility.gradle
+++ b/buildSrc/src/main/groovy/data-prepper.library-compatibility.gradle
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import me.champeau.gradle.japicmp.JapicmpTask
+import org.opensearch.dataprepper.gradle.compatibility.LastReleasedVersionProvider
+
+def lastVersion = LastReleasedVersionProvider.getLastReleasedMajorVersion(project)
+
+if (lastVersion == null) {
+    logger.info('No previous release found, skipping compatibility validation')
+    tasks.register('validateCompatibility') {
+        doLast {
+            logger.info('No previous release to compare against')
+        }
+    }
+} else {
+    def groupPath = project.group.toString().replace('.', '/')
+    def artifactId = project.name
+    
+    tasks.register('downloadLastRelease') {
+        def targetDir = layout.buildDirectory.dir('japicmp-target')
+        def targetJar = layout.buildDirectory.file("japicmp-target/${artifactId}-${lastVersion}.jar")
+        
+        outputs.file(targetJar)
+        doLast {
+            targetDir.get().asFile.mkdirs()
+            new URL("https://repo1.maven.org/maven2/${groupPath}/${artifactId}/${lastVersion}/${artifactId}-${lastVersion}.jar")
+                .withInputStream { input ->
+                    targetJar.get().asFile.withOutputStream { output -> output << input }
+                }
+        }
+    }
+    
+    tasks.register('validateCompatibility', JapicmpTask) {
+        logger.info("Comparing API from ${project.version} to ${lastVersion}")
+        compatibilityChangeExcludes = ['METHOD_ABSTRACT_NOW_DEFAULT', 'METHOD_ADDED_TO_INTERFACE']
+        oldClasspath.from(layout.buildDirectory.file("japicmp-target/${artifactId}-${lastVersion}.jar"))
+        newClasspath.from(tasks.named('jar'))
+        onlyModified = true
+        failOnModification = true
+        ignoreMissingClasses = true
+        failOnSourceIncompatibility = true
+        txtOutputFile = layout.buildDirectory.file('reports/library-compatibility/report.txt')
+        htmlOutputFile = layout.buildDirectory.file('reports/library-compatibility/report.html')
+        dependsOn downloadLastRelease
+    }
+}

--- a/buildSrc/src/main/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProvider.java
+++ b/buildSrc/src/main/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.gradle.compatibility;
+
+import org.gradle.api.Project;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class LastReleasedVersionProvider {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
+
+    public static String getLastReleasedMajorVersion(final Project project) {
+        final String group = project.getGroup().toString();
+        final String artifactId = project.getName();
+        final String currentVersion = project.getVersion().toString();
+        final String groupPath = group.replace('.', '/');
+        final String metadataUrl = String.format("https://repo1.maven.org/maven2/%s/%s/maven-metadata.xml", groupPath, artifactId);
+        
+        try {
+            return getLastReleasedMajorVersion(new URL(metadataUrl).openStream(), currentVersion);
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    static String getLastReleasedMajorVersion(final InputStream metadataStream, final String currentVersion) throws Exception {
+        final String majorVersion = currentVersion.split("\\.")[0];
+        final Document doc = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(metadataStream);
+        
+        final NodeList versions = doc.getElementsByTagName("version");
+        final List<int[]> matchingVersions = new ArrayList<>();
+        
+        for (int i = 0; i < versions.getLength(); i++) {
+            final String version = versions.item(i).getTextContent();
+            if (VERSION_PATTERN.matcher(version).matches() && version.startsWith(majorVersion + ".")) {
+                final String[] parts = version.split("\\.");
+                matchingVersions.add(new int[]{
+                    Integer.parseInt(parts[0]),
+                    Integer.parseInt(parts[1]),
+                    Integer.parseInt(parts[2])
+                });
+            }
+        }
+        
+        if (matchingVersions.isEmpty()) {
+            return null;
+        }
+        
+        final int[] max = Collections.max(matchingVersions,
+                Comparator.comparingInt((int[] a) -> a[0])
+                        .thenComparingInt(a -> a[1])
+                        .thenComparingInt(a -> a[2]));
+        
+        return max[0] + "." + max[1] + "." + max[2];
+    }
+}

--- a/buildSrc/src/test/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProviderTest.java
+++ b/buildSrc/src/test/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProviderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.gradle.compatibility;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+class LastReleasedVersionProviderTest {
+    
+    @ParameterizedTest
+    @CsvSource({
+            "2.15.0, 2.14.0",
+            "3.1.0, 3.0.0"
+    })
+    void testGetLastReleasedMajorVersion_findsLatestInMajor(final String currentVersion, final String expectedVersion) throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<metadata>" +
+            "<versioning>" +
+            "<versions>" +
+            "<version>2.9.0</version>" +
+            "<version>2.10.0</version>" +
+            "<version>2.14.0</version>" +
+            "<version>3.0.0</version>" +
+            "</versions>" +
+            "</versioning>" +
+            "</metadata>";
+        
+        InputStream stream = new ByteArrayInputStream(xml.getBytes());
+        String result = LastReleasedVersionProvider.getLastReleasedMajorVersion(stream, currentVersion);
+        
+        assertThat(result, equalTo(expectedVersion));
+    }
+
+    @Test
+    void testGetLastReleasedMajorVersion_findsLatestInMajor_singleDigits() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<metadata>" +
+            "<versioning>" +
+            "<versions>" +
+            "<version>2.7.0</version>" +
+            "<version>2.8.0</version>" +
+            "<version>3.0.0</version>" +
+            "</versions>" +
+            "</versioning>" +
+            "</metadata>";
+
+        InputStream stream = new ByteArrayInputStream(xml.getBytes());
+        String result = LastReleasedVersionProvider.getLastReleasedMajorVersion(stream, "2.15.0");
+
+        assertThat(result, equalTo("2.8.0"));
+    }
+
+    @Test
+    void testGetLastReleasedMajorVersion_noMatchingVersions() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<metadata>" +
+            "<versioning>" +
+            "<versions>" +
+            "<version>1.0.0</version>" +
+            "<version>3.0.0</version>" +
+            "</versions>" +
+            "</versioning>" +
+            "</metadata>";
+        
+        InputStream stream = new ByteArrayInputStream(xml.getBytes());
+        String result = LastReleasedVersionProvider.getLastReleasedMajorVersion(stream, "2.0.0");
+        
+        assertThat(result, nullValue());
+    }
+    
+    @Test
+    void testGetLastReleasedMajorVersion_ignoresNonReleaseVersions() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<metadata>" +
+            "<versioning>" +
+            "<versions>" +
+            "<version>2.9.0</version>" +
+            "<version>2.15.0-SNAPSHOT</version>" +
+            "<version>2.14.0</version>" +
+            "</versions>" +
+            "</versioning>" +
+            "</metadata>";
+        
+        InputStream stream = new ByteArrayInputStream(xml.getBytes());
+        String result = LastReleasedVersionProvider.getLastReleasedMajorVersion(stream, "2.16.0-SNAPSHOT");
+        
+        assertThat(result, equalTo("2.14.0"));
+    }
+}

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -9,6 +9,7 @@
 
 plugins {
     id 'data-prepper.publish'
+    id 'data-prepper.library-compatibility'
 }
 
 dependencies {
@@ -25,6 +26,7 @@ dependencies {
     testImplementation libs.commons.io
     testImplementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 }
+
 
 jacocoTestCoverageVerification {
     dependsOn(jacocoTestReport)


### PR DESCRIPTION
### Description

Support validating library compatibility on `data-prepper-api`.

This PR adds new Gradle command:

```
./gradlew -p data-prepper-api validateCompatibility
```
 
It also runs this as a new GitHub Action validation step when changes are made to `data-prepper-api`.

Here is a sample PR with a breaking change: #6606. And here is the output from the run: https://github.com/opensearch-project/data-prepper/actions/runs/22681527054/job/65753053707?pr=6606

### Issues Resolved

Resolves #6605.

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
