### PR TITLE
test(otel_logs_source): invert default httpPath in test config fixtur…

### DIFF
--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceGrpcTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceGrpcTest.java
@@ -341,6 +341,17 @@ class OTelLogsSourceGrpcTest {
     }
 
     @Test
+    void start_withoutHttpPath_doesNotThrowNPE() {
+        final OTelLogsSourceConfig config = createDefaultConfigBuilder()
+                .path("/test-pipeline/v1/logs")
+                .build();
+        final OTelLogsSource source = new OTelLogsSource(config, pluginMetrics, pluginFactory,
+                certificateProviderFactory, pipelineDescription);
+        source.start(buffer);
+        source.stop();
+    }
+
+    @Test
     void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(createDefaultConfig(), pluginMetrics, pluginFactory, pipelineDescription);

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createConfigBuilderWithBasicAuth;
-import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createDefaultConfig;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createDefaultConfigBuilder;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createJsonHttpPayload;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createBuilderForConfigWithSsl;
@@ -175,7 +174,7 @@ class OTelLogsSourceHttpTest {
     }
 
     private void configureSource() {
-        configureSource(createDefaultConfig());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).build());
     }
 
     private void configureSource(OTelLogsSourceConfig config) {
@@ -213,7 +212,7 @@ class OTelLogsSourceHttpTest {
 
     @Test
     void httpsRequest_requestIsProcessed_writesToBufferAndReturnsSuccessfulResponse() throws Exception {
-        configureSource(createBuilderForConfigWithSsl().build());
+        configureSource(createBuilderForConfigWithSsl().httpPath(CONFIG_HTTP_PATH).build());
         SOURCE.start(buffer);
         ExportLogsServiceRequest request = createExportLogsRequest();
 
@@ -256,7 +255,7 @@ class OTelLogsSourceHttpTest {
 
     @Test
     void httpRequest_payloadIsCompressed_returns200() throws IOException {
-        configureSource( createDefaultConfigBuilder().compression(CompressionOption.GZIP).build());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).compression(CompressionOption.GZIP).build());
         SOURCE.start(buffer);
 
         WebClient.of().execute(getDefaultRequestHeadersBuilder()
@@ -272,9 +271,8 @@ class OTelLogsSourceHttpTest {
     @MethodSource("getBasicAuthTestData")
     void httpRequest_withBasicAuth_returnsAppropriateResponse(String givenUsername, String givenPassword, HttpStatus expectedStatus, VerificationMode expectedBufferWrites) throws Exception {
         final HttpBasicAuthenticationConfig basicAuthConfig = new HttpBasicAuthenticationConfig(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
-        final HttpBasicArmeriaHttpAuthenticationProvider authProvider = new HttpBasicArmeriaHttpAuthenticationProvider(basicAuthConfig);
-        when(pluginFactory.loadPlugin(eq(ArmeriaHttpAuthenticationProvider.class), any(PluginSetting.class))).thenReturn(authProvider);
-        configureSource(createConfigBuilderWithBasicAuth().build());
+        when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class))).thenReturn(new GrpcBasicAuthenticationProvider(basicAuthConfig));
+        configureSource(createConfigBuilderWithBasicAuth().httpPath(CONFIG_HTTP_PATH).build());
         SOURCE.start(buffer);
 
         final String encodedCredentials = Base64.getEncoder().encodeToString(String.format("%s:%s", givenUsername, givenPassword).getBytes(StandardCharsets.UTF_8));
@@ -299,7 +297,7 @@ class OTelLogsSourceHttpTest {
     @ParameterizedTest
     @MethodSource("getHealthCheckParams")
     void healthCheckRequest_requestIsProcesses_returnsStatusCodeAccordingToConfig(boolean givenHealthCheckConfig, HttpStatus expectedStatus) throws IOException {
-        configureSource(createDefaultConfigBuilder().healthCheck(givenHealthCheckConfig).build());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).healthCheck(givenHealthCheckConfig).build());
         SOURCE.start(buffer);
 
         WebClient.of().execute(getDefaultRequestHeadersBuilder()
@@ -347,7 +345,7 @@ class OTelLogsSourceHttpTest {
 
     @Test
     void httpRequest_requestBodyIsTooLarge_returns413() throws InvalidProtocolBufferException {
-        configureSource(createDefaultConfigBuilder().maxRequestLength(ByteCount.ofBytes(4)).build());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).maxRequestLength(ByteCount.ofBytes(4)).build());
         SOURCE.start(buffer);
 
         WebClient.of()

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OtelLogsSourceConfigFixture.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OtelLogsSourceConfigFixture.java
@@ -14,7 +14,6 @@ import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceC
 import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.BASIC_AUTH_PASSWORD;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.BASIC_AUTH_USERNAME;
-import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.CONFIG_HTTP_PATH;
 
 import java.util.Map;
 
@@ -42,7 +41,6 @@ public class OtelLogsSourceConfigFixture {
     public static OTelLogsSourceConfig.OTelLogsSourceConfigBuilder createDefaultConfigBuilder() {
         return OTelLogsSourceConfig.builder()
                 .healthCheck(true)
-                .httpPath(CONFIG_HTTP_PATH)
                 .port(DEFAULT_PORT)
                 .enableUnframedRequests(false)
                 .ssl(false)


### PR DESCRIPTION
…e (#6575)

(cherry picked from commit 06603180ee4637e276a8430324f301ec32e8d793)

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
