### PR TITLE
[Backport 2.14] Remove httpPath from default test config fixture in otel_logs_source

### DIFF
--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceGrpcTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceGrpcTest.java
@@ -344,7 +344,6 @@ class OTelLogsSourceGrpcTest {
     @Test
     void start_withoutHttpPath_doesNotThrowNPE() {
         final OTelLogsSourceConfig config = createDefaultConfigBuilder()
-                .httpPath(null)
                 .path("/test-pipeline/v1/logs")
                 .build();
         final OTelLogsSource source = new OTelLogsSource(config, pluginMetrics, pluginFactory,

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createConfigBuilderWithBasicAuth;
-import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createDefaultConfig;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createDefaultConfigBuilder;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createJsonHttpPayload;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigFixture.createBuilderForConfigWithSsl;
@@ -173,7 +172,7 @@ class OTelLogsSourceHttpTest {
     }
 
     private void configureSource() {
-        configureSource(createDefaultConfig());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).build());
     }
 
     private void configureSource(OTelLogsSourceConfig config) {
@@ -211,7 +210,7 @@ class OTelLogsSourceHttpTest {
 
     @Test
     void httpsRequest_requestIsProcessed_writesToBufferAndReturnsSuccessfulResponse() throws Exception {
-        configureSource(createBuilderForConfigWithSsl().build());
+        configureSource(createBuilderForConfigWithSsl().httpPath(CONFIG_HTTP_PATH).build());
         SOURCE.start(buffer);
         ExportLogsServiceRequest request = createExportLogsRequest();
 
@@ -254,7 +253,7 @@ class OTelLogsSourceHttpTest {
 
     @Test
     void httpRequest_payloadIsCompressed_returns200() throws IOException {
-        configureSource( createDefaultConfigBuilder().compression(CompressionOption.GZIP).build());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).compression(CompressionOption.GZIP).build());
         SOURCE.start(buffer);
 
         WebClient.of().execute(getDefaultRequestHeadersBuilder()
@@ -271,7 +270,7 @@ class OTelLogsSourceHttpTest {
     void httpRequest_withBasicAuth_returnsAppropriateResponse(String givenUsername, String givenPassword, HttpStatus expectedStatus, VerificationMode expectedBufferWrites) throws Exception {
         final HttpBasicAuthenticationConfig basicAuthConfig = new HttpBasicAuthenticationConfig(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class))).thenReturn(new GrpcBasicAuthenticationProvider(basicAuthConfig));
-        configureSource(createConfigBuilderWithBasicAuth().build());
+        configureSource(createConfigBuilderWithBasicAuth().httpPath(CONFIG_HTTP_PATH).build());
         SOURCE.start(buffer);
 
         final String encodedCredentials = Base64.getEncoder().encodeToString(String.format("%s:%s", givenUsername, givenPassword).getBytes(StandardCharsets.UTF_8));
@@ -296,7 +295,7 @@ class OTelLogsSourceHttpTest {
     @ParameterizedTest
     @MethodSource("getHealthCheckParams")
     void healthCheckRequest_requestIsProcesses_returnsStatusCodeAccordingToConfig(boolean givenHealthCheckConfig, HttpStatus expectedStatus) throws IOException {
-        configureSource(createDefaultConfigBuilder().healthCheck(givenHealthCheckConfig).build());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).healthCheck(givenHealthCheckConfig).build());
         SOURCE.start(buffer);
 
         WebClient.of().execute(getDefaultRequestHeadersBuilder()
@@ -344,7 +343,7 @@ class OTelLogsSourceHttpTest {
 
     @Test
     void httpRequest_requestBodyIsTooLarge_returns413() throws InvalidProtocolBufferException {
-        configureSource(createDefaultConfigBuilder().maxRequestLength(ByteCount.ofBytes(4)).build());
+        configureSource(createDefaultConfigBuilder().httpPath(CONFIG_HTTP_PATH).maxRequestLength(ByteCount.ofBytes(4)).build());
         SOURCE.start(buffer);
 
         WebClient.of()

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OtelLogsSourceConfigFixture.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OtelLogsSourceConfigFixture.java
@@ -14,7 +14,6 @@ import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceC
 import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.BASIC_AUTH_PASSWORD;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.BASIC_AUTH_USERNAME;
-import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceConfigTestData.CONFIG_HTTP_PATH;
 
 import java.util.Map;
 
@@ -42,7 +41,6 @@ public class OtelLogsSourceConfigFixture {
     public static OTelLogsSourceConfig.OTelLogsSourceConfigBuilder createDefaultConfigBuilder() {
         return OTelLogsSourceConfig.builder()
                 .healthCheck(true)
-                .httpPath(CONFIG_HTTP_PATH)
                 .port(DEFAULT_PORT)
                 .enableUnframedRequests(false)
                 .ssl(false)


### PR DESCRIPTION
Backport commit 06603180ee4637e276a8430324f301ec32e8d793 from #6575

### Description
Manual backport
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
