### PR TITLE
Increase the Jenkins job timeout to 2 hours from 1

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -10,7 +10,7 @@ def RELEASE_LATEST_TAG = ''
 
 pipeline {
     options {
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 2, unit: 'HOURS')
     }
     agent none
     triggers {


### PR DESCRIPTION
### Description

The 2.14.1 job is timing out. The current timeout is 1 hour, but this job has grown. The PR doubles the timeout to 2 hours.

https://build.ci.opensearch.org/job/release-data-prepper/

### Issues Resolved

N/A - fill fix 2.14.1 job.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
