### PR TITLE
Fix flaky Router_ThreeRoutesDefaultIT by polling all assertions

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_ThreeRoutesDefaultIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_ThreeRoutesDefaultIT.java
@@ -130,42 +130,34 @@ class Router_ThreeRoutesDefaultIT {
 
         inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
 
-        await().atMost(2, TimeUnit.SECONDS)
+        await().atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
-                    assertThat(inMemorySinkAccessor.get(ALPHA_SOURCE_KEY), not(empty()));
-                    assertThat(inMemorySinkAccessor.get(BETA_SOURCE_KEY), not(empty()));
+                    final List<Record<Event>> actualAlphaRecords = inMemorySinkAccessor.get(ALPHA_SOURCE_KEY);
+                    assertThat(actualAlphaRecords.size(), equalTo(alphaEvents.size()));
+                    assertThat(actualAlphaRecords, containsInAnyOrder(allEvents.stream()
+                            .filter(alphaEvents::contains).toArray()));
+
+                    final List<Record<Event>> actualBetaRecords = inMemorySinkAccessor.get(BETA_SOURCE_KEY);
+                    assertThat(actualBetaRecords.size(), equalTo(betaEvents.size()));
+                    assertThat(actualBetaRecords, containsInAnyOrder(allEvents.stream()
+                            .filter(betaEvents::contains).toArray()));
+
+                    final List<Record<Event>> actualDefaultRecords = inMemorySinkAccessor.get(DEFAULT_SOURCE_KEY);
+                    assertThat(actualDefaultRecords.size(), equalTo(defaultEvents.size()));
+                    assertThat(actualDefaultRecords, containsInAnyOrder(allEvents.stream()
+                            .filter(defaultEvents::contains).toArray()));
+
                     assertThat(inMemorySinkAccessor.get(ALL_SOURCE_KEY), not(empty()));
                     assertThat(inMemorySinkAccessor.get(ALPHA_DEFAULT_SOURCE_KEY), not(empty()));
                     assertThat(inMemorySinkAccessor.get(ALPHA_BETA_GAMMA_SOURCE_KEY), not(empty()));
-                    assertThat(inMemorySinkAccessor.get(DEFAULT_SOURCE_KEY), not(empty()));
+
+                    final List<Record<Event>> actualAlphaDefaultRecords = new ArrayList<>();
+                    actualAlphaDefaultRecords.addAll(actualAlphaRecords);
+                    actualAlphaDefaultRecords.addAll(actualDefaultRecords);
+                    assertThat(actualAlphaDefaultRecords.size(), equalTo(defaultEvents.size() + alphaEvents.size()));
+                    assertThat(actualAlphaDefaultRecords, containsInAnyOrder(allEvents.stream()
+                            .filter(event -> defaultEvents.contains(event) || alphaEvents.contains(event)).toArray()));
                 });
-
-        final List<Record<Event>> actualAlphaRecords = inMemorySinkAccessor.get(ALPHA_SOURCE_KEY);
-
-        assertThat(actualAlphaRecords.size(), equalTo(alphaEvents.size()));
-
-        assertThat(actualAlphaRecords, containsInAnyOrder(allEvents.stream()
-                .filter(alphaEvents::contains).toArray()));
-
-        final List<Record<Event>> actualBetaRecords = inMemorySinkAccessor.get(BETA_SOURCE_KEY);
-
-        assertThat(actualBetaRecords.size(), equalTo(betaEvents.size()));
-
-        assertThat(actualBetaRecords, containsInAnyOrder(allEvents.stream()
-                .filter(betaEvents::contains).toArray()));
-
-        final List<Record<Event>> actualDefaultRecords = inMemorySinkAccessor.get(DEFAULT_SOURCE_KEY);
-
-        assertThat(actualDefaultRecords.size(), equalTo(defaultEvents.size()));
-        assertThat(actualDefaultRecords, containsInAnyOrder(allEvents.stream()
-                .filter(defaultEvents::contains).toArray()));
-
-        final List<Record<Event>> actualAlphaDefaultRecords = new ArrayList<>();
-        actualAlphaDefaultRecords.addAll(actualAlphaRecords);
-        actualAlphaDefaultRecords.addAll(actualDefaultRecords);
-        assertThat(actualAlphaDefaultRecords.size(), equalTo(defaultEvents.size()+alphaEvents.size()));
-        assertThat(actualAlphaDefaultRecords, containsInAnyOrder(allEvents.stream()
-                .filter(event -> defaultEvents.contains(event) || alphaEvents.contains(event)).toArray()));
 
     }
 


### PR DESCRIPTION
### Description
Move all assertions inside the await() block so they are polled until they pass, rather than checking sinks are non-empty and then immediately asserting exact counts outside the polling loop. Also increase the timeout from 2s to 10s to accommodate slow CI runners.

 
### Issues Resolved
Resolves flakiness of IT

### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
