### PR TITLE
Current release as a GitHub label on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img src="https://raw.githubusercontent.com/opensearch-project/data-prepper/main/docs/images/DataPrepper_auto.svg" height="64px" alt="OpenSearch Data Prepper">
 
+[![GitHub release](https://img.shields.io/github/v/release/opensearch-project/data-prepper?sort=semver)](https://github.com/opensearch-project/data-prepper/releases)
 [![codecov](https://codecov.io/gh/opensearch-project/data-prepper/branch/main/graph/badge.svg?token=IS7GOIY622)](https://codecov.io/gh/opensearch-project/data-prepper)
 # OpenSearch Data Prepper
 


### PR DESCRIPTION
### Description

Adds the current release as a GitHub label on the README. It links to the releases tab in GitHub.

I'm adding this to follow how other projects work and keep the version information prominent since it is a key value for the community.

You can see it here: https://github.com/dlvenable/data-prepper/tree/readme-tag-release
 
### Issues Resolved

None
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
