### PR TITLE
Refactors how expression functions handle arguments

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
@@ -8,6 +12,7 @@ package org.opensearch.dataprepper.expression;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
 
 import javax.inject.Named;
 import java.util.List;
@@ -17,7 +22,6 @@ import java.util.stream.Collectors;
 
 @Named
 public class CidrExpressionFunction implements ExpressionFunction {
-
     private static final String FUNCTION_NAME = "cidrContains";
     @Override
     public String getFunctionName() {
@@ -30,19 +34,22 @@ public class CidrExpressionFunction implements ExpressionFunction {
             throw new IllegalArgumentException(FUNCTION_NAME + "() takes at least two arguments");
         }
 
-        final List<String> argStrings;
-        try {
-            argStrings = args.stream()
-                    .map(arg -> ((String)arg).trim())
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Arguments in " + FUNCTION_NAME + "() function should be of Json Pointer type or String type");
+        final String ipAddressInEvent;
+        final Object firstArg = args.get(0);
+        if (firstArg instanceof EventKey) {
+            ipAddressInEvent = event.get((EventKey) firstArg, String.class);
+        } else {
+            throw new RuntimeException("Unexpected argument type for first argument: " + firstArg.getClass());
         }
 
-        final String ipAddressInEvent = event.get(argStrings.get(0), String.class);
-        final List<String> cidrBlockStrs = argStrings.subList(1, argStrings.size()).stream()
-                .map(str -> str.substring(1, str.length() - 1))
+        final List<String> cidrBlockStrs = args.subList(1, args.size()).stream()
+                .map(arg -> {
+                    if (arg instanceof String) {
+                        return (String) arg;
+                    } else {
+                        throw new RuntimeException("Unexpected argument type: " + arg.getClass());
+                    }
+                })
                 .collect(Collectors.toList());
 
         return isIpInCidr(ipAddressInEvent, cidrBlockStrs);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ContainsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ContainsExpressionFunction.java
@@ -1,13 +1,19 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
-import java.util.List;
+import org.opensearch.dataprepper.model.event.EventKey;
+
 import javax.inject.Named;
+import java.util.List;
 import java.util.function.Function;
 
 @Named
@@ -25,28 +31,22 @@ public class ContainsExpressionFunction implements ExpressionFunction {
         String[] strArgs = new String[NUMBER_OF_ARGS];
         for (int i = 0; i < NUMBER_OF_ARGS; i++) {
             Object arg = args.get(i);
-            if (!(arg instanceof String)) {
-                throw new RuntimeException(String.format("containsSubstring() takes only string type arguments. \"%s\" is not of type string", arg));
-            }
-            String str = (String) arg;
-            if (str.charAt(0) == '"') {
-                strArgs[i] = str.substring(1, str.length()-1);
-            } else if (str.charAt(0) == '/') {
-                Object obj = event.get(str, Object.class);
+            if (arg instanceof EventKey) {
+                EventKey eventKey = (EventKey) arg;
+                Object obj = event.get(eventKey, Object.class);
                 if (obj == null) {
                     return false;
                 }
                 if (!(obj instanceof String)) {
                     throw new RuntimeException(String.format("containsSubstring() takes only string type arguments. \"%s\" is not of type string", obj));
                 }
-                strArgs[i] = (String)obj;
+                strArgs[i] = (String) obj;
+            } else if (arg instanceof String) {
+                strArgs[i] = (String) arg;
             } else {
-                throw new RuntimeException(String.format("Arguments to contains() must be a literal string or a Json Pointer. \"%s\" is not string literal or json pointer", str));
+                throw new RuntimeException("Unexpected argument type: " + arg.getClass());
             }
         }
         return strArgs[0].contains(strArgs[1]);
     }
 }
-
-
-

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/FormatDateTimeExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/FormatDateTimeExpressionFunction.java
@@ -5,21 +5,20 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
  */
 
 package org.opensearch.dataprepper.expression;
 
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+
+import javax.inject.Named;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import javax.inject.Named;
-
-import org.opensearch.dataprepper.model.event.Event;
 
 @Named
 public class FormatDateTimeExpressionFunction implements ExpressionFunction {
@@ -37,24 +36,21 @@ public class FormatDateTimeExpressionFunction implements ExpressionFunction {
         if (args.size() > 4) {
             throw new IllegalArgumentException(getFunctionName() + "() takes at most 4 arguments");
         }
-        List<String> argStrings;
-        try {
-            argStrings = args.stream()
-                    .map(String.class::cast)
-                    .map(String::trim)
-                    .collect(Collectors.toUnmodifiableList());
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Arguments in " + getFunctionName() + "() function should be of Json Pointer type or String type");
+
+        final Object firstArg = args.get(0);
+        final EventKey eventKey;
+        if (firstArg instanceof EventKey) {
+            eventKey = (EventKey) firstArg;
+        } else {
+            throw new RuntimeException("Unexpected argument type for first argument: " + firstArg.getClass() +
+                    ". Expected EventKey.");
         }
 
-        String eventKey = argStrings.get(0);
-        String pattern = argStrings.get(1);
-        pattern = unquote(pattern);
-
+        final String pattern = getStringArg(args.get(1), "pattern");
 
         ZoneId destinationTimeZone = ZoneOffset.UTC;
-        if (argStrings.size() > 2) {
-            String destinationZoneIdArg = unquote(argStrings.get(2));
+        if (args.size() > 2) {
+            String destinationZoneIdArg = getStringArg(args.get(2), "destination timezone");
             try {
                 destinationTimeZone = ZoneId.of(destinationZoneIdArg);
             } catch (Exception e) {
@@ -63,9 +59,8 @@ public class FormatDateTimeExpressionFunction implements ExpressionFunction {
         }
 
         ZoneId sourceTimeZone = ZoneOffset.UTC;
-
-        if (argStrings.size() > 3) {
-            String sourceTimeZoneArg = unquote(argStrings.get(3));
+        if (args.size() > 3) {
+            String sourceTimeZoneArg = getStringArg(args.get(3), "source timezone");
             try {
                 sourceTimeZone = ZoneId.of(sourceTimeZoneArg);
             } catch (Exception e) {
@@ -90,10 +85,11 @@ public class FormatDateTimeExpressionFunction implements ExpressionFunction {
         throw new IllegalArgumentException("Unsupported type passed as function argument: " + target.getClass());
     }
 
-    static String unquote(String input) {
-        if (input.startsWith("\"") && input.endsWith("\"")) {
-            return input.substring(1, input.length() - 1);
+    private String getStringArg(Object arg, String argName) {
+        if (arg instanceof String) {
+            return ((String) arg).trim();
         }
-        return input;
+        throw new RuntimeException("Unexpected argument type for " + argName + ": " + arg.getClass() +
+                ". Expected String.");
     }
 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunction.java
@@ -1,13 +1,18 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
-import java.util.List;
+
 import javax.inject.Named;
+import java.util.List;
 import java.util.function.Function;
 
 @Named
@@ -22,16 +27,9 @@ public class GetMetadataExpressionFunction implements ExpressionFunction {
         }
         Object arg = args.get(0);
         if (!(arg instanceof String)) {
-            throw new RuntimeException("getMetadata() takes only String type arguments");
+            throw new RuntimeException("Unexpected argument type: " + arg.getClass() + ". getMetadata() takes only String type arguments");
         }
         String argStr = ((String)arg).trim();
-        if (argStr.length() == 0) {
-            return null;
-        }
-        if (argStr.charAt(0) != '\"' || argStr.length() < 2) {
-            throw new RuntimeException("Literal string expected as argument to getMetadata()");
-        } 
-        argStr = argStr.substring(1, argStr.length()-1).trim();
         if (argStr.isEmpty()) {
             return null;
         }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
@@ -1,15 +1,20 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
-import java.util.stream.Collectors;
-import java.util.List;
+
 import javax.inject.Named;
+import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Named
 public class HasTagsExpressionFunction implements ExpressionFunction {
@@ -18,18 +23,18 @@ public class HasTagsExpressionFunction implements ExpressionFunction {
     }
 
     public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
-        if (args.size() == 0) {
+        if (args.isEmpty()) {
             throw new RuntimeException("hasTags() takes at least one argument");
         }
-        if(!args.stream().allMatch(a -> ((a instanceof String) && (((String)a).length() > 0) && (((String)a).charAt(0) == '"')))) {
-            throw new RuntimeException("hasTags() takes only non-empty string literal type arguments");
+        if (!args.stream().allMatch(a -> a instanceof String)) {
+            throw new RuntimeException("Unexpected argument type. hasTags() takes only String type arguments");
         }
         final List<String> tags = args.stream()
-                                    .map(a -> {
-                                        String str = (String) a;
-                                        return str.substring(1, str.length()-1);
-                                     })
+                                    .map(a -> (String) a)
                                     .collect(Collectors.toList());
+        if (tags.stream().anyMatch(String::isEmpty)) {
+            throw new RuntimeException("Unexpected argument value. hasTags() requires non-empty strings.");
+        }
         return event.getMetadata().hasTags(tags);
     }
 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
@@ -1,15 +1,20 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
 
+import javax.inject.Named;
 import java.util.HashMap;
 import java.util.List;
-import javax.inject.Named;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -30,31 +35,40 @@ public class JoinExpressionFunction implements  ExpressionFunction {
             throw new IllegalArgumentException(FUNCTION_NAME + "() takes one or two arguments");
         }
 
-        final List<String> argStrings;
-        try {
-            argStrings = args.stream()
-                    .map(arg -> ((String)arg).trim())
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Arguments in " + FUNCTION_NAME + "() function should be of Json Pointer type or String type");
-        }
-
         final String delimiter;
-        final String sourceKey;
-        if (argStrings.size() == 2) {
-            final String trimmedDelimiter = argStrings.get(0).substring(1, argStrings.get(0).length() - 1);
+        final EventKey sourceKey;
 
-            // remove slashes used to escape comma
-            delimiter = trimmedDelimiter.replace("\\\\,", ",");
-            sourceKey = argStrings.get(1);
+        if (args.size() == 2) {
+            final Object delimiterArg = args.get(0);
+            final Object sourceKeyArg = args.get(1);
+
+            if (delimiterArg instanceof String) {
+                // remove slashes used to escape comma
+                delimiter = ((String) delimiterArg).replace("\\\\,", ",");
+            } else {
+                throw new RuntimeException("Unexpected argument type for delimiter: " + delimiterArg.getClass() +
+                        ". Expected String.");
+            }
+
+            if (sourceKeyArg instanceof EventKey) {
+                sourceKey = (EventKey) sourceKeyArg;
+            } else {
+                throw new RuntimeException("Unexpected argument type for source key: " + sourceKeyArg.getClass() +
+                        ". Expected EventKey.");
+            }
         } else {
             delimiter = ",";
-            sourceKey = argStrings.get(0);
+            final Object sourceKeyArg = args.get(0);
+            if (sourceKeyArg instanceof EventKey) {
+                sourceKey = (EventKey) sourceKeyArg;
+            } else {
+                throw new RuntimeException("Unexpected argument type for source key: " + sourceKeyArg.getClass() +
+                        ". Expected EventKey.");
+            }
         }
 
         try {
-            if (event.isValueAList(sourceKey)) {
+            if (event.isValueAList(sourceKey.getKey())) {
                 final List<Object> sourceList = event.get(sourceKey, List.class);
                 return joinList(sourceList, delimiter);
             } else {
@@ -62,7 +76,7 @@ public class JoinExpressionFunction implements  ExpressionFunction {
                 return joinListsInMap(sourceMap, delimiter);
             }
         } catch (Exception ex) {
-            throw new RuntimeException("Unable to perform join function on " + sourceKey, ex);
+            throw new RuntimeException("Unable to perform join function on " + sourceKey.getKey(), ex);
         }
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LengthExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LengthExpressionFunction.java
@@ -1,13 +1,19 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
-import java.util.List;
+import org.opensearch.dataprepper.model.event.EventKey;
+
 import javax.inject.Named;
+import java.util.List;
 import java.util.function.Function;
 
 @Named
@@ -21,26 +27,18 @@ public class LengthExpressionFunction implements ExpressionFunction {
             throw new RuntimeException("length() takes only one argument");
         }
         Object arg = args.get(0);
-        if (!(arg instanceof String)) {
-            throw new RuntimeException("length() takes only String type arguments");
-        }
-        String argStr = ((String)arg).trim();
-        if (argStr.length() == 0) {
-            return 0;
-        }
-        if (argStr.charAt(0) == '\"') {
-            throw new RuntimeException("Literal strings not supported as arguments to length()");
-        } else {
-            // argStr must be JsonPointer
-            final Object value = event.get(argStr, Object.class);
+        if (arg instanceof EventKey) {
+            EventKey eventKey = (EventKey) arg;
+            final Object value = event.get(eventKey, Object.class);
             if (value == null) {
                 return null;
-            } 
-            
-            if (!(value instanceof String)) {
-                throw new RuntimeException(argStr + " is not String type");
             }
-            return Integer.valueOf(((String)value).length());
+            if (!(value instanceof String)) {
+                throw new RuntimeException(eventKey.getKey() + " is not String type");
+            }
+            return Integer.valueOf(((String) value).length());
+        } else {
+            throw new RuntimeException("Unexpected argument type: " + arg.getClass());
         }
     }
 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
@@ -126,13 +130,13 @@ class ParseTreeCoercionService {
                     continue;
                 }
                 if (trimmedArg.charAt(0) == '/') {
-                    argList.add(trimmedArg);
+                    argList.add(eventKeyFactory.createEventKey(trimmedArg));
                 } else if (trimmedArg.charAt(0) == '"') {
                     if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length() - 1) != '"') {
                         throw new ExpressionCoercionException(
                                 INVALID_STRING_ARG);
                     }
-                    argList.add(trimmedArg);
+                    argList.add(trimmedArg.substring(1, trimmedArg.length() - 1));
                 } else {
                     throw new ExpressionCoercionException(UNSUPPORTED_ARG_TYPE);
                 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunction.java
@@ -1,6 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
 
 import javax.inject.Named;
 import java.util.List;
@@ -29,23 +39,20 @@ public class StartsWithExpressionFunction implements ExpressionFunction {
         String[] strArgs = new String[NUMBER_OF_ARGS];
         for (int i = 0; i < NUMBER_OF_ARGS; i++) {
             Object arg = args.get(i);
-            if (!(arg instanceof String)) {
-                throw new RuntimeException(String.format("startsWith() takes only string type arguments. \"%s\" is not of type string", arg));
-            }
-            String stringOrKey = (String) arg;
-            if (stringOrKey.charAt(0) == '"') {
-                strArgs[i] = stringOrKey.substring(1, stringOrKey.length()-1);
-            } else if (stringOrKey.charAt(0) == '/') {
-                Object obj = event.get(stringOrKey, Object.class);
+            if (arg instanceof EventKey) {
+                EventKey eventKey = (EventKey) arg;
+                Object obj = event.get(eventKey, Object.class);
                 if (obj == null) {
                     return false;
                 }
                 if (!(obj instanceof String)) {
-                    throw new RuntimeException(String.format("startsWith() only operates on string types. The value at \"%s\" is \"%s\" which is not a string type.", stringOrKey, obj));
+                    throw new RuntimeException(String.format("startsWith() takes only string type arguments. \"%s\" is not of type string", obj));
                 }
-                strArgs[i] = (String)obj;
+                strArgs[i] = (String) obj;
+            } else if (arg instanceof String) {
+                strArgs[i] = (String) arg;
             } else {
-                throw new RuntimeException(String.format("Arguments to startsWith() must be a literal string or a Json Pointer. \"%s\" is not string literal or json pointer", stringOrKey));
+                throw new RuntimeException("Unexpected argument type: " + arg.getClass());
             }
         }
         return strArgs[0].startsWith(strArgs[1]);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
@@ -13,7 +17,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.List;
@@ -28,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class CidrExpressionFunctionTest {
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
     private CidrExpressionFunction cidrExpressionFunction;
     private Event testEvent;
 
@@ -50,85 +58,88 @@ class CidrExpressionFunctionTest {
     @ParameterizedTest
     @MethodSource("ipv4AddressesInRange")
     void testIpv4MatchWithSingleCidrBlock(String testIp) {
-        String network = "\"192.0.2.0/26\"";
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", testIp));
-        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(true));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of(sourceIpKey, "192.0.2.0/26"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(true));
     }
 
     @ParameterizedTest
     @MethodSource("ipv4AddressesInRange")
     void testIpv4MatchWithMultipleCidrBlocks(String testIp) {
-        String network1 = "\"192.0.2.0/26\"";
-        String network2 = "\"192.168.1.0/24\"";
-        String network3 = "\"10.0.1.0/24\"";
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", testIp));
         Object expressionResult = cidrExpressionFunction.evaluate(
-                List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(true));
+                List.of(sourceIpKey, "192.0.2.0/26", "192.168.1.0/24", "10.0.1.0/24"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(true));
     }
 
     @Test
     void testIpv4NonMatchWithMultipleCidrBlocks() {
-        String network1 = "\"192.0.2.0/24\"";
-        String network2 = "\"192.168.1.0/24\"";
-        String network3 = "\"10.0.1.0/24\"";
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", "192.0.5.3"));
         Object expressionResult = cidrExpressionFunction.evaluate(
-                List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(false));
+                List.of(sourceIpKey, "192.0.2.0/24", "192.168.1.0/24", "10.0.1.0/24"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(false));
     }
 
     @ParameterizedTest
     @MethodSource("ipv6AddressesInRange")
     void testIpv6MatchWithSingleCidrBlock(String testIp) {
-        String network = "\"2001:0db8::/32\"";
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", testIp));
-        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(true));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of(sourceIpKey, "2001:0db8::/32"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(true));
     }
 
     @ParameterizedTest
     @MethodSource("ipv6AddressesInRange")
     void testIpv6MatchWithMultipleCidrBlocks(String testIp) {
-        String network1 = "\"2001:0db8::/32\"";
-        String network2 = "\"2001:aaaa::/32\"";
-        String network3 = "\"2001:bbbb:cccc::/48\"";
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", testIp));
-        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(true));
+        Object expressionResult = cidrExpressionFunction.evaluate(
+                List.of(sourceIpKey, "2001:0db8::/32", "2001:aaaa::/32", "2001:bbbb:cccc::/48"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(true));
     }
 
     @Test
     void testIpv6NonMatchWithMultipleCidrBlocks() {
-        String network1 = "\"2001:0db8::/32\"";
-        String network2 = "\"2001:aaaa::/32\"";
-        String network3 = "\"2001:bbbb:cccc::/48\"";
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", "2001:dddd:aaaa:bbbb::"));
-        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(false));
+        Object expressionResult = cidrExpressionFunction.evaluate(
+                List.of(sourceIpKey, "2001:0db8::/32", "2001:aaaa::/32", "2001:bbbb:cccc::/48"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(false));
     }
 
     @Test
     void testTooFewArgumentsThrowsException() {
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
         testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
         assertThrows(IllegalArgumentException.class,
-                () -> cidrExpressionFunction.evaluate(List.of("/sourceIp"), testEvent, testFunction));
+                () -> cidrExpressionFunction.evaluate(List.of(sourceIpKey), testEvent, testFunction));
     }
 
     @Test
-    void testArgumentTypeNotSupportedThrowsException() {
+    void testUnexpectedFirstArgTypeThrowsException() {
         testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
-        assertThrows(IllegalArgumentException.class,
-                () -> cidrExpressionFunction.evaluate(List.of("/sourceIp", 123), testEvent, testFunction));
+        assertThrows(RuntimeException.class,
+                () -> cidrExpressionFunction.evaluate(List.of("not-an-event-key", "192.0.2.0/24"), testEvent, testFunction));
+    }
+
+    @Test
+    void testUnexpectedCidrArgTypeThrowsException() {
+        EventKey sourceIpKey = eventKeyFactory.createEventKey("/sourceIp");
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        assertThrows(RuntimeException.class,
+                () -> cidrExpressionFunction.evaluate(List.of(sourceIpKey, 123), testEvent, testFunction));
     }
 
     @Test
     void testIpAddressNotExistInEventReturnsFalse() {
-        String network = "\"192.0.2.0/24\"";
+        EventKey destIpKey = eventKeyFactory.createEventKey("/destinationIp");
         testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
-        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/destinationIp", network), testEvent, testFunction);
-        assertThat((boolean)expressionResult, equalTo(false));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of(destIpKey, "192.0.2.0/24"), testEvent, testFunction);
+        assertThat((boolean) expressionResult, equalTo(false));
     }
 
     private static Stream<Arguments> ipv4AddressesInRange() {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ContainsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ContainsExpressionFunctionTest.java
@@ -1,33 +1,40 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.apache.commons.lang3.RandomStringUtils;
-import static org.mockito.Mockito.mock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
 class ContainsExpressionFunctionTest {
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
     private ContainsExpressionFunction containsExpressionFunction;
     private Event testEvent;
     private Function<Object, Object> testFunction;
-    private List<Object> tags;
     private String testKey;
     private String testKey2;
     private String testKey3;
@@ -45,9 +52,8 @@ class ContainsExpressionFunctionTest {
         testKey2 = RandomStringUtils.randomAlphabetic(5);
         testKey3 = RandomStringUtils.randomAlphabetic(5);
         testValue = RandomStringUtils.randomAlphabetic(testValueLength);
-        testValue2 = testValue.substring(2,6);
+        testValue2 = testValue.substring(2, 6);
         testEvent = createTestEvent(Map.of(testKey, testValue, testKey2, testValue2, testKey3, 1234));
-        tags = new ArrayList<>();
         testFunction = mock(Function.class);
     }
 
@@ -56,14 +62,76 @@ class ContainsExpressionFunctionTest {
     }
 
     @Test
-    void testContainsBasic() {containsExpressionFunction = createObjectUnderTest();
-        assertThat(containsExpressionFunction.evaluate(List.of("\"abcde\"", "\"abcd\""), testEvent, testFunction), equalTo(true));
-        assertThat(containsExpressionFunction.evaluate(List.of("/"+testKey, "/"+testKey2), testEvent, testFunction), equalTo(true));
-        assertThat(containsExpressionFunction.evaluate(List.of("\""+testValue+"\"", "/"+testKey2), testEvent, testFunction), equalTo(true));
-        assertThat(containsExpressionFunction.evaluate(List.of("/"+testKey, "\""+testValue2+"\""), testEvent, testFunction), equalTo(true));
-        assertThat(containsExpressionFunction.evaluate(List.of("\"abcde\"", "\"xyz\""), testEvent, testFunction), equalTo(false));
-        assertThat(containsExpressionFunction.evaluate(List.of("/unknown", "xyz"), testEvent, testFunction), equalTo(false));
-        assertThat(containsExpressionFunction.evaluate(List.of("\"abcde\"", "/unknown"), testEvent, testFunction), equalTo(false));
+    void evaluate_with_two_eventKeys_when_first_argument_contains_second() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/" + testKey);
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/" + testKey2);
+        assertThat(containsExpressionFunction.evaluate(List.of(eventKey1, eventKey2), testEvent, testFunction), equalTo(true));
+    }
+
+    @Test
+    void evaluate_with_two_eventKeys_when_first_argument_does_not_contain_second() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/" + testKey);
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/" + testKey2);
+        assertThat(containsExpressionFunction.evaluate(List.of(eventKey2, eventKey1), testEvent, testFunction), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "abcde,abcde",
+            "abcde,abcd",
+            "abcde,a"
+    })
+    void evaluate_with_two_literal_strings_returns_when_first_argument_contains_second(final String arg1, final String arg2) {
+        containsExpressionFunction = createObjectUnderTest();
+        assertThat(containsExpressionFunction.evaluate(List.of(arg1, arg2), testEvent, testFunction), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "abcde,xyz",
+            "abc,abcd"
+    })
+    void evaluate_with_two_literal_strings_returns_when_first_argument_does_not_contain_second() {
+        containsExpressionFunction = createObjectUnderTest();
+        assertThat(containsExpressionFunction.evaluate(List.of("abcde", "xyz"), testEvent, testFunction), equalTo(false));
+    }
+
+    @Test
+    void testContainsEventKeyAndLiteralString() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey);
+        assertThat(containsExpressionFunction.evaluate(List.of(eventKey, testValue2), testEvent, testFunction), equalTo(true));
+    }
+
+    @Test
+    void testContainsLiteralStringAndEventKey() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey2);
+        assertThat(containsExpressionFunction.evaluate(List.of(testValue, eventKey), testEvent, testFunction), equalTo(true));
+    }
+
+    @Test
+    void testContainsReturnsFalseWhenNotContained() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey);
+        assertThat(containsExpressionFunction.evaluate(List.of(eventKey, "xyz"), testEvent, testFunction), equalTo(false));
+    }
+
+    @Test
+    void testContainsReturnsFalseWhenEventKeyResolvesToNull() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/unknownKey");
+        assertThat(containsExpressionFunction.evaluate(List.of(eventKey, "value"), testEvent, testFunction), equalTo(false));
+    }
+
+    @Test
+    void testContainsReturnsFalseWhenSecondEventKeyResolvesToNull() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/" + testKey);
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/unknownKey");
+        assertThat(containsExpressionFunction.evaluate(List.of(eventKey1, eventKey2), testEvent, testFunction), equalTo(false));
     }
 
     @ParameterizedTest
@@ -71,17 +139,25 @@ class ContainsExpressionFunctionTest {
     void testContainsMultipleSubstrings(int endOffset) {
         containsExpressionFunction = createObjectUnderTest();
         String testString = RandomStringUtils.randomAlphabetic(10);
-        assertThat(containsExpressionFunction.evaluate(List.of("\""+testString+"\"", "\""+testString.substring(0, endOffset)+"\""), testEvent, testFunction), equalTo(true));
+        assertThat(containsExpressionFunction.evaluate(List.of(testString, testString.substring(0, endOffset)), testEvent, testFunction), equalTo(true));
     }
 
     @Test
-    void testInvalidContains() {
+    void testThrowsWhenWrongNumberOfArgs() {
         containsExpressionFunction = createObjectUnderTest();
         assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("abcd"), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("\"abcd\"", 1234), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("\"abcd\"", "/"+testKey3), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("abcd", "/"+testKey3), testEvent, testFunction));
     }
 
-}
+    @Test
+    void testThrowsWhenEventKeyResolvesToNonString() {
+        containsExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey3);
+        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of(eventKey, "value"), testEvent, testFunction));
+    }
 
+    @Test
+    void testThrowsWhenUnexpectedArgumentType() {
+        containsExpressionFunction = createObjectUnderTest();
+        assertThrows(RuntimeException.class, () -> containsExpressionFunction.evaluate(List.of("abcd", 1234), testEvent, testFunction));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/FormatDateTimeExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/FormatDateTimeExpressionFunctionTest.java
@@ -5,10 +5,19 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
  */
 
 package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -21,228 +30,126 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-
 import static java.util.function.Function.identity;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class FormatDateTimeExpressionFunctionTest {
+    private static final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
+    private static final EventKey TIME_KEY = eventKeyFactory.createEventKey("/time");
     private final FormatDateTimeExpressionFunction target = new FormatDateTimeExpressionFunction();
 
     @ParameterizedTest
     @MethodSource("functionArgumentsAndExpectedResults")
-    void shouldCorrectlyReturnResult(String formatString, String dstTimeZone, String sourceTimeZone, Event input, String result) {
-        List<Object> args = Stream.of("/time", formatString, dstTimeZone, sourceTimeZone).filter(Objects::nonNull).collect(Collectors.toUnmodifiableList());
+    void shouldCorrectlyReturnResult(String fmt, String dst, String src, Event input, String result) {
+        List<Object> args = Stream.of(TIME_KEY, fmt, dst, src)
+                .filter(Objects::nonNull).collect(Collectors.toUnmodifiableList());
         assertThat(target.evaluate(args, input, identity()), is(result));
     }
 
     private static Event eventWithTime(final Object data) {
-        JacksonEvent result = JacksonEvent.builder().withEventType("event").build();
-        result.put("time", data);
-        return result;
+        JacksonEvent event = JacksonEvent.builder()
+                .withEventType("event").build();
+        event.put("time", data);
+        return event;
     }
 
     private static Stream<Arguments> functionArgumentsAndExpectedResults() {
         return Stream.of(
-                arguments("\"'year='yyyy'/month='MM'/day='dd\"",
-                        null,
-                        null,
+                arguments("'year='yyyy'/month='MM'/day='dd", null, null,
                         eventWithTime(LocalDateTime.of(2025, 4, 1, 23, 59).toInstant(ZoneOffset.UTC).toEpochMilli()),
-                        "year=2025/month=04/day=01"
-                ),
-                arguments("\"'year='yyyy'/month='MM'/day='dd\"",
-                        "\"UTC-8\"",
-                        null,
-                        eventWithTime("2025-04-01T23:59:00"),
-                        "year=2025/month=04/day=01"
-                ),
-                arguments("\"yyyy-MM-dd HH:mm:ss\"",
-                        "\"UTC\"",
-                        "\"UTC\"",
-                        eventWithTime(Instant.parse("2025-06-15T14:30:45Z").toEpochMilli()),
-                        "2025-06-15 14:30:45"
-                ),
-                arguments("\"yyyy-MM-dd HH:mm:ss\"",
-                        "\"America/New_York\"",
-                        "\"UTC\"",
-                        eventWithTime(Instant.parse("2025-06-15T18:30:45Z").toEpochMilli()),
-                        "2025-06-15 14:30:45"
-                ),
-                arguments("\"yyyy-MM-dd HH:mm:ss\"",
-                        "\"America/New_York\"",
-                        "\"UTC+5\"",
-                        eventWithTime("2025-06-15T18:30:45"), //no zone in the string, so source timezone takes place
-                        "2025-06-15 09:30:45"
-                ),
-                arguments("\"dd/MM/yyyy HH:mm\"",
-                        "\"UTC\"",
-                        "\"UTC\"",
+                        "year=2025/month=04/day=01"),
+                arguments("'year='yyyy'/month='MM'/day='dd", "UTC-8", null,
+                        eventWithTime("2025-04-01T23:59:00"), "year=2025/month=04/day=01"),
+                arguments("yyyy-MM-dd HH:mm:ss", "UTC", "UTC",
+                        eventWithTime(Instant.parse("2025-06-15T14:30:45Z").toEpochMilli()), "2025-06-15 14:30:45"),
+                arguments("yyyy-MM-dd HH:mm:ss", "America/New_York", "UTC",
+                        eventWithTime(Instant.parse("2025-06-15T18:30:45Z").toEpochMilli()), "2025-06-15 14:30:45"),
+                arguments("yyyy-MM-dd HH:mm:ss", "America/New_York", "UTC+5",
+                        eventWithTime("2025-06-15T18:30:45"), "2025-06-15 09:30:45"),
+                arguments("dd/MM/yyyy HH:mm", "UTC", "UTC",
                         eventWithTime(LocalDateTime.of(2025, 3, 20, 9, 15).toInstant(ZoneOffset.UTC).toEpochMilli()),
-                        "20/03/2025 09:15"
-                ),
-                arguments("\"dd/MM/yyyy HH:mm\"",
-                        "\"Europe/London\"",
-                        "\"UTC\"",
+                        "20/03/2025 09:15"),
+                arguments("dd/MM/yyyy HH:mm", "Europe/London", "UTC",
                         eventWithTime(LocalDateTime.of(2025, 8, 20, 12, 0).toInstant(ZoneOffset.UTC).toEpochMilli()),
-                        "20/08/2025 13:00"
-                ),
-                arguments("\"yyyy-MM-dd'T'HH:mm:ssXXX\"",
-                        "\"UTC\"",
-                        "\"UTC\"",
+                        "20/08/2025 13:00"),
+                arguments("yyyy-MM-dd'T'HH:mm:ssXXX", "UTC", "UTC",
                         eventWithTime(OffsetDateTime.parse("2025-12-25T10:30:00+02:00").toInstant().toEpochMilli()),
-                        "2025-12-25T08:30:00Z"
-                ),
-                arguments("\"MM/dd/yyyy HH:mm\"",
-                        "\"America/Los_Angeles\"",
-                        "\"UTC\"",
+                        "2025-12-25T08:30:00Z"),
+                arguments("MM/dd/yyyy HH:mm", "America/Los_Angeles", "UTC",
                         eventWithTime(OffsetDateTime.parse("2025-07-04T16:45:30-05:00").toInstant().toEpochMilli()),
-                        "07/04/2025 14:45"
-                ),
-                arguments("\"yyyy-MM-dd HH:mm:ss z\"",
-                        "\"UTC\"",
-                        "\"UTC\"",
+                        "07/04/2025 14:45"),
+                arguments("yyyy-MM-dd HH:mm:ss z", "UTC", "UTC",
                         eventWithTime(ZonedDateTime.parse("2025-09-10T22:15:30+03:00[Europe/Moscow]").toInstant().toEpochMilli()),
-                        "2025-09-10 19:15:30 UTC"
-                ),
-                arguments("\"MMM dd, yyyy h:mm a\"",
-                        "\"Asia/Tokyo\"",
-                        "\"UTC\"",
+                        "2025-09-10 19:15:30 UTC"),
+                arguments("MMM dd, yyyy h:mm a", "Asia/Tokyo", "UTC",
                         eventWithTime(ZonedDateTime.parse("2025-01-01T12:00:00Z[UTC]").toInstant().toEpochMilli()),
-                        "Jan 01, 2025 9:00 PM"
-                ),
-                arguments("\"yyyy-MM-dd HH:mm:ss\"",
-                        "\"Europe/Paris\"",
-                        "\"America/Chicago\"",
+                        "Jan 01, 2025 9:00 PM"),
+                arguments("yyyy-MM-dd HH:mm:ss", "Europe/Paris", "America/Chicago",
                         eventWithTime(LocalDateTime.of(2025, 6, 15, 14, 30).atZone(ZoneId.of("America/Chicago")).toInstant().toEpochMilli()),
-                        "2025-06-15 21:30:00"
-                ),
-                arguments("\"HH:mm:ss\"",
-                        "\"Australia/Sydney\"",
-                        "\"Europe/Berlin\"",
+                        "2025-06-15 21:30:00"),
+                arguments("HH:mm:ss", "Australia/Sydney", "Europe/Berlin",
                         eventWithTime(OffsetDateTime.parse("2025-04-10T08:00:00+02:00").toInstant().toEpochMilli()),
-                        "16:00:00"
-                )
+                        "16:00:00")
         );
     }
 
-    // Negative and edge cases below are to satisfy 100% JaCoCo coverage
-
     @Test
-    void unquoteShouldNotModifyStringsWithoutQuotes() {
-        assertThat(FormatDateTimeExpressionFunction.unquote("noquotes"), is("noquotes"));
+    void shouldThrowWhenTooFewArguments() {
+        Event e = eventWithTime(123456789L);
+        assertThrows(IllegalArgumentException.class, () -> target.evaluate(List.of(TIME_KEY), e, identity()));
     }
 
     @Test
-    void shouldThrowExceptionWhenTooFewArguments() {
-        List<Object> args = List.of("/time");
-        Event event = eventWithTime(123456789L);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage(), is("formatDateTime() takes at least 2 arguments"));
+    void shouldThrowWhenTooManyArguments() {
+        Event e = eventWithTime(123456789L);
+        assertThrows(IllegalArgumentException.class,
+                () -> target.evaluate(List.of(TIME_KEY, "yyyy", "UTC", "UTC", "extra"), e, identity()));
     }
 
     @Test
-    void shouldThrowExceptionWhenTooManyArguments() {
-        List<Object> args = List.of("/time", "\"yyyy-MM-dd\"", "\"UTC\"", "\"UTC\"", "\"extra\"");
-        Event event = eventWithTime(123456789L);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage(), is("formatDateTime() takes at most 4 arguments"));
+    void shouldThrowWhenFirstArgIsNotEventKey() {
+        Event e = eventWithTime(123456789L);
+        assertThrows(RuntimeException.class, () -> target.evaluate(List.of("bad", "yyyy"), e, identity()));
     }
 
     @Test
-    void shouldThrowExceptionWhenArgumentsAreNotStrings() {
-        List<Object> args = List.of("/time", 123);
-        Event event = eventWithTime(123456789L);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage(), is("Arguments in formatDateTime() function should be of Json Pointer type or String type"));
+    void shouldThrowWhenPatternArgIsNotString() {
+        Event e = eventWithTime(123456789L);
+        assertThrows(RuntimeException.class, () -> target.evaluate(List.of(TIME_KEY, 123), e, identity()));
     }
 
     @Test
-    void shouldThrowExceptionWhenInvalidDestinationTimeZone() {
-        List<Object> args = List.of("/time", "\"yyyy-MM-dd\"", "\"Invalid/TimeZone\"");
-        Event event = eventWithTime(123456789L);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage(), is("Destination time zone [Invalid/TimeZone] is invalid"));
+    void shouldThrowWhenInvalidDestinationTimeZone() {
+        Event e = eventWithTime(123456789L);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> target.evaluate(List.of(TIME_KEY, "yyyy-MM-dd", "Invalid/TZ"), e, identity()));
+        assertThat(ex.getMessage(), is("Destination time zone [Invalid/TZ] is invalid"));
     }
 
     @Test
-    void shouldThrowExceptionWhenInvalidSourceTimeZone() {
-        List<Object> args = List.of("/time", "\"yyyy-MM-dd\"", "\"UTC\"", "\"Invalid/TimeZone\"");
-        Event event = eventWithTime(123456789L);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage(), is("Source time zone [Invalid/TimeZone] is invalid"));
+    void shouldThrowWhenInvalidSourceTimeZone() {
+        Event e = eventWithTime(123456789L);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> target.evaluate(List.of(TIME_KEY, "yyyy-MM-dd", "UTC", "Invalid/TZ"), e, identity()));
+        assertThat(ex.getMessage(), is("Source time zone [Invalid/TZ] is invalid"));
     }
 
     @Test
-    void shouldThrowExceptionWhenInvalidDatePattern() {
-        List<Object> args = List.of("/time", "\"[invalid pattern\"");
-        Event event = eventWithTime(123456789L);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage(), is("Date pattern [[invalid pattern] is invalid"));
+    void shouldThrowWhenInvalidDatePattern() {
+        Event e = eventWithTime(123456789L);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> target.evaluate(List.of(TIME_KEY, "[bad"), e, identity()));
+        assertThat(ex.getMessage(), is("Date pattern [[bad] is invalid"));
     }
 
     @Test
-    void shouldThrowExceptionWhenUnsupportedTargetType() {
-        List<Object> args = List.of("/time", "\"yyyy-MM-dd\"");
-        JacksonEvent event = JacksonEvent.builder().withEventType("event").build();
-        event.put("time", new int[5]);
-        
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> target.evaluate(args, event, identity())
-        );
-        assertThat(exception.getMessage().startsWith("Unsupported type passed as function argument:"), is(true));
-    }
-
-    @Test
-    void unquoteShouldRemoveQuotesFromQuotedString() {
-        assertThat(FormatDateTimeExpressionFunction.unquote("\"quoted\""), is("quoted"));
-    }
-
-    @Test
-    void unquoteShouldHandleEmptyString() {
-        assertThat(FormatDateTimeExpressionFunction.unquote(""), is(""));
-    }
-
-    @Test
-    void unquoteShouldHandleStringWithOnlyOneQuote() {
-        assertThat(FormatDateTimeExpressionFunction.unquote("\"onlystart"), is("\"onlystart"));
-        assertThat(FormatDateTimeExpressionFunction.unquote("onlyend\""), is("onlyend\""));
-    }
-
-    @Test
-    void unquoteShouldHandleStringWithJustTwoQuotes() {
-        assertThat(FormatDateTimeExpressionFunction.unquote("\"\""), is(""));
+    void shouldThrowWhenUnsupportedTargetType() {
+        JacksonEvent e = JacksonEvent.builder().withEventType("event").build();
+        e.put("time", new int[5]);
+        assertThrows(IllegalArgumentException.class,
+                () -> target.evaluate(List.of(TIME_KEY, "yyyy-MM-dd"), e, identity()));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GetMetadataExpressionFunctionTest.java
@@ -1,27 +1,31 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.apache.commons.lang3.RandomStringUtils;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GetMetadataExpressionFunctionTest {
     private GetMetadataExpressionFunction getMetadataExpressionFunction;
@@ -53,16 +57,14 @@ class GetMetadataExpressionFunctionTest {
     void testGetMetadataBasic(final String key, final Object value) {
         getMetadataExpressionFunction = createObjectUnderTest();
         when(testFunction.apply(value)).thenReturn(value);
-        assertThat(getMetadataExpressionFunction.evaluate(List.of("\""+key+"\""), testEvent, testFunction), equalTo(value));
-        assertThat(getMetadataExpressionFunction.evaluate(List.of("\""+key+"notPresent\""), testEvent, testFunction), equalTo(null));
+        assertThat(getMetadataExpressionFunction.evaluate(List.of(key), testEvent, testFunction), equalTo(value));
+        assertThat(getMetadataExpressionFunction.evaluate(List.of(key + "notPresent"), testEvent, testFunction), equalTo(null));
     }
 
     @Test
     void testGetMetadataWithMoreArguments() {
         getMetadataExpressionFunction = createObjectUnderTest();
-        String testString = RandomStringUtils.randomAlphabetic(5);
         assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("arg1", "arg2"), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("\"arg1\"", "\"arg2\""), testEvent, testFunction));
         assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("arg1", "arg2", "arg3/arg4"), testEvent, testFunction));
     }
 
@@ -73,25 +75,15 @@ class GetMetadataExpressionFunctionTest {
     }
 
     @Test
-    void testGetMetadataWithNonLiteralStringArguments() {
-        getMetadataExpressionFunction = createObjectUnderTest();
-        String testString = RandomStringUtils.randomAlphabetic(5);
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("testString"), testEvent, testFunction));
-    }
-
-    @Test
     void testGetMetadataWithInvalidArguments() {
         getMetadataExpressionFunction = createObjectUnderTest();
         assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of(), testEvent, testFunction));
-        assertThrows(RuntimeException.class, () -> getMetadataExpressionFunction.evaluate(List.of("\""), testEvent, testFunction));
     }
 
     @Test
     void testGetMetadataWithEmptyStringArgument() {
         getMetadataExpressionFunction = createObjectUnderTest();
         assertThat(getMetadataExpressionFunction.evaluate(List.of("  "), testEvent, testFunction), equalTo(null));
-        assertThat(getMetadataExpressionFunction.evaluate(List.of("\"\""), testEvent, testFunction), equalTo(null));
+        assertThat(getMetadataExpressionFunction.evaluate(List.of(""), testEvent, testFunction), equalTo(null));
     }
-
-
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
@@ -1,26 +1,31 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.jupiter.api.BeforeEach;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.apache.commons.lang3.RandomStringUtils;
 import static org.mockito.Mockito.mock;
-
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.function.Function;
 
 class HasTagsExpressionFunctionTest {
     private HasTagsExpressionFunction hasTagsExpressionFunction;
@@ -45,7 +50,7 @@ class HasTagsExpressionFunctionTest {
         for (int i = 0; i < numTags; i++) {
             String tag = RandomStringUtils.randomAlphabetic(5);
             testEvent.getMetadata().addTags(List.of(tag));
-            tags.add("\""+tag+"\"");
+            tags.add(tag);
         }
     }
 
@@ -69,7 +74,7 @@ class HasTagsExpressionFunctionTest {
         generateTags(testEvent, numTags);
         hasTagsExpressionFunction = createObjectUnderTest();
         for (int i = 0; i < numTags; i++) {
-            String unknownTag = "\""+RandomStringUtils.randomAlphabetic(5)+"\"";
+            String unknownTag = RandomStringUtils.randomAlphabetic(5);
             List<Object> tagsList = tags.subList(0, i);
             tagsList.add((Object)unknownTag);
             assertThat(hasTagsExpressionFunction.evaluate(tagsList, testEvent, testFunction), equalTo(false));
@@ -99,11 +104,4 @@ class HasTagsExpressionFunctionTest {
         hasTagsExpressionFunction = createObjectUnderTest();
         assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(30), testEvent, testFunction));
     }
-
-    @Test
-    void testHasTagsWithStringTagsWithOutQuotes() {
-        hasTagsExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of("tag"), testEvent, testFunction));
-    }
-
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
@@ -11,7 +15,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.List;
@@ -19,13 +26,13 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JoinExpressionFunctionTest {
 
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
     private JoinExpressionFunction joinExpressionFunction;
     private Event testEvent;
 
@@ -39,7 +46,7 @@ class JoinExpressionFunctionTest {
 
     @ParameterizedTest
     @MethodSource("joinSingleList")
-    void testJoinSingleListSuccess(final String sourceKey, final String delimiter, final String inputData, final String expectedOutput) {
+    void testJoinSingleListSuccess(final EventKey sourceKey, final String delimiter, final String inputData, final String expectedOutput) {
         testEvent = createTestEvent(inputData);
         List<Object> args;
         if (delimiter == null) {
@@ -53,7 +60,7 @@ class JoinExpressionFunctionTest {
 
     @ParameterizedTest
     @MethodSource("joinListsInMap")
-    void testJoinListsInMapSuccess(final String sourceKey, final String delimiter, final String inputData, final Map<String, Object> expectedOutput) {
+    void testJoinListsInMapSuccess(final EventKey sourceKey, final String delimiter, final String inputData, final Map<String, Object> expectedOutput) {
         testEvent = createTestEvent(inputData);
         List<Object> args;
         if (delimiter == null) {
@@ -75,49 +82,70 @@ class JoinExpressionFunctionTest {
     @Test
     void testTooManyArgumentsThrowsException() {
         testEvent = createTestEvent(Map.of("key", "value"));
+        EventKey eventKey = eventKeyFactory.createEventKey("/list");
         assertThrows(IllegalArgumentException.class,
-                () -> joinExpressionFunction.evaluate(List.of("/list", " ", false), testEvent, testFunction));
+                () -> joinExpressionFunction.evaluate(List.of(eventKey, " ", false), testEvent, testFunction));
     }
 
     @Test
-    void testArgumentTypeNotSupportedThrowsException() {
+    void testUnexpectedSourceKeyTypeThrowsException() {
         testEvent = createTestEvent(Map.of("key", "value"));
-        Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> joinExpressionFunction.evaluate(List.of("/list", Map.of("key", "value")), testEvent, testFunction));
-        assertThat(exception.getMessage(), containsStringIgnoringCase("should be of Json Pointer type or String type"));
+        assertThrows(RuntimeException.class,
+                () -> joinExpressionFunction.evaluate(List.of("not-an-event-key"), testEvent, testFunction));
+    }
+
+    @Test
+    void testUnexpectedSourceKeyTypeWithDelimiterThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        assertThrows(RuntimeException.class,
+                () -> joinExpressionFunction.evaluate(List.of(",", "not-an-event-key"), testEvent, testFunction));
+    }
+
+    @Test
+    void testUnexpectedDelimiterTypeThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        EventKey eventKey = eventKeyFactory.createEventKey("/list");
+        assertThrows(RuntimeException.class,
+                () -> joinExpressionFunction.evaluate(List.of(1234, eventKey), testEvent, testFunction));
     }
 
     @Test
     void testSourceFieldNotExistsInEventThrowsException() {
         testEvent = createTestEvent(Map.of("key", "value"));
+        EventKey eventKey = eventKeyFactory.createEventKey("/missingKey");
         assertThrows(RuntimeException.class,
-                () -> joinExpressionFunction.evaluate(List.of("/missingKey"), testEvent, testFunction));
+                () -> joinExpressionFunction.evaluate(List.of(eventKey), testEvent, testFunction));
     }
 
     @Test
     void testSourceFieldNotListOrMapThrowsException() {
         testEvent = createTestEvent(Map.of("key", "value"));
+        EventKey eventKey = eventKeyFactory.createEventKey("/key");
         assertThrows(RuntimeException.class,
-                () -> joinExpressionFunction.evaluate(List.of("/key"), testEvent, testFunction));
+                () -> joinExpressionFunction.evaluate(List.of(eventKey), testEvent, testFunction));
     }
 
     private static Stream<Arguments> joinSingleList() {
+        final EventKeyFactory factory = TestEventKeyFactory.getTestEventFactory();
+        final EventKey listKey = factory.createEventKey("/list");
         final String inputData = "{\"list\":[\"string\", 1, true]}";
         return Stream.of(
-                Arguments.of("/list", null, inputData, "string,1,true"),
-                Arguments.of("/list", "\"\\\\, \"", inputData, "string, 1, true"),
-                Arguments.of("/list", "\" \"", inputData, "string 1 true")
+                Arguments.of(listKey, null, inputData, "string,1,true"),
+                Arguments.of(listKey, "\\\\, ", inputData, "string, 1, true"),
+                Arguments.of(listKey, " ", inputData, "string 1 true")
         );
     }
 
     private static Stream<Arguments> joinListsInMap() {
+        final EventKeyFactory factory = TestEventKeyFactory.getTestEventFactory();
+        final EventKey listKey = factory.createEventKey("/list");
         String testData1 = "{\"list\":{\"key\": [\"string\", 1, true]}}";
         String testData2 = "{\"list\":{\"key1\": [\"string\", 1, true], \"key2\": [1,2,3], \"key3\": \"value3\"}}";
         return Stream.of(
-                Arguments.of("/list", null, testData1, Map.of("key", "string,1,true")),
-                Arguments.of("/list", "\"\\\\, \"", testData1, Map.of("key", "string, 1, true")),
-                Arguments.of("/list", "\" \"", testData1, Map.of("key", "string 1 true")),
-                Arguments.of("/list", null, testData2, Map.of("key1", "string,1,true", "key2", "1,2,3", "key3", "value3"))
+                Arguments.of(listKey, null, testData1, Map.of("key", "string,1,true")),
+                Arguments.of(listKey, "\\\\, ", testData1, Map.of("key", "string, 1, true")),
+                Arguments.of(listKey, " ", testData1, Map.of("key", "string 1 true")),
+                Arguments.of(listKey, null, testData2, Map.of("key1", "string,1,true", "key2", "1,2,3", "key3", "value3"))
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LengthExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LengthExpressionFunctionTest.java
@@ -1,26 +1,35 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.apache.commons.lang3.RandomStringUtils;
-import static org.mockito.Mockito.mock;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
 class LengthExpressionFunctionTest {
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
     private LengthExpressionFunction lengthExpressionFunction;
     private Event testEvent;
     private Function<Object, Object> testFunction;
@@ -36,50 +45,49 @@ class LengthExpressionFunctionTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 5, 10, 20, 50})
-    void testWithOneStringArgumentWithOutQuotes(int stringLength) {
+    void testWithEventKeyResolvingToString(int stringLength) {
         lengthExpressionFunction = createObjectUnderTest();
         String testString = RandomStringUtils.randomAlphabetic(stringLength);
         testEvent = createTestEvent(Map.of("key", testString));
-        assertThat(lengthExpressionFunction.evaluate(List.of("/key"), testEvent, testFunction), equalTo(testString.length()));
+        EventKey eventKey = eventKeyFactory.createEventKey("/key");
+        assertThat(lengthExpressionFunction.evaluate(List.of(eventKey), testEvent, testFunction), equalTo(testString.length()));
     }
 
     @Test
-    void testWithOneStringArgumentWithQuotes() {
+    void testWithEventKeyResolvingToNull() {
         lengthExpressionFunction = createObjectUnderTest();
-        String testString = RandomStringUtils.randomAlphabetic(5);
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("\"" + testString + "\""), testEvent, testFunction));
+        testEvent = createTestEvent(Map.of("key", "value"));
+        EventKey eventKey = eventKeyFactory.createEventKey("/unknownKey");
+        assertThat(lengthExpressionFunction.evaluate(List.of(eventKey), testEvent, testFunction), equalTo(null));
+    }
+
+    @Test
+    void testWithEventKeyResolvingToNonString() {
+        lengthExpressionFunction = createObjectUnderTest();
+        testEvent = createTestEvent(Map.of("key", 10));
+        EventKey eventKey = eventKeyFactory.createEventKey("/key");
+        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of(eventKey), testEvent, testFunction));
     }
 
     @Test
     void testWithTwoArgs() {
         lengthExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("arg1", "arg2"), testEvent, testFunction));
-    }
-    
-    @Test
-    void testWithNonStringArgument() {
-        lengthExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of(10), testEvent, testFunction));
-    }
-    
-    @Test
-    void testWithInvalidArgument() {
-        lengthExpressionFunction = createObjectUnderTest();
-        testEvent = createTestEvent(Map.of("key", 10));
-        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("/key"), testEvent, testFunction));
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/key1");
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/key2");
+        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of(eventKey1, eventKey2), testEvent, testFunction));
     }
 
     @Test
-    void testWithUnknownKeyArgument() {
+    void testWithUnexpectedArgumentType() {
         lengthExpressionFunction = createObjectUnderTest();
         testEvent = createTestEvent(Map.of("key", "value"));
-        assertThat(lengthExpressionFunction.evaluate(List.of("/unknownKey"), testEvent, testFunction), equalTo(null));
+        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of(10), testEvent, testFunction));
     }
 
     @Test
-    void testWithZeroLengthString() {
+    void testWithStringArgumentThrowsRuntimeException() {
         lengthExpressionFunction = createObjectUnderTest();
-        testEvent = createTestEvent(Map.of("key", 10));
-        assertThat(lengthExpressionFunction.evaluate(List.of(""), testEvent, testFunction), equalTo(0));
+        testEvent = createTestEvent(Map.of("key", "value"));
+        assertThrows(RuntimeException.class, () -> lengthExpressionFunction.evaluate(List.of("someString"), testEvent, testFunction));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceParameterizedTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
@@ -133,7 +137,7 @@ class ParseTreeCoercionServiceParameterizedTest {
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn("test(\"\")");
         final Event testEvent = mock(Event.class);
-        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("\"\"")), eq(testEvent), any()))
+        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("")), eq(testEvent), any()))
                 .thenReturn("result");
         
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
@@ -147,7 +151,8 @@ class ParseTreeCoercionServiceParameterizedTest {
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn("test(/key, , \"value\")");
         final Event testEvent = mock(Event.class);
-        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("/key", "\"value\"")), eq(testEvent), any()))
+        final EventKey expectedKey = eventKeyFactory.createEventKey("/key");
+        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of(expectedKey, "value")), eq(testEvent), any()))
                 .thenReturn("result");
         
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
@@ -161,7 +166,8 @@ class ParseTreeCoercionServiceParameterizedTest {
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn("test(/key, \"value\")");
         final Event testEvent = mock(Event.class);
-        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of("/key", "\"value\"")), eq(testEvent), any()))
+        final EventKey expectedKey = eventKeyFactory.createEventKey("/key");
+        when(expressionFunctionProvider.provideFunction(eq("test"), eq(java.util.List.<Object>of(expectedKey, "value")), eq(testEvent), any()))
                 .thenReturn("result");
         
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.expression;
@@ -16,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.event.TestEventKeyFactory;
@@ -68,7 +73,7 @@ class ParseTreeCoercionServiceTest {
         final CountDownLatch completionLatch = new CountDownLatch(numThreads);
         final Event testEvent = createTestEvent(Collections.singletonMap("test", "value"));
         final String functionString = "length(/test)";
-        
+
         when(terminalNode.getSymbol()).thenReturn(token);
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         when(terminalNode.getText()).thenReturn(functionString);
@@ -94,11 +99,12 @@ class ParseTreeCoercionServiceTest {
         completionLatch.await(5, TimeUnit.SECONDS);
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.SECONDS);
-        
+
         // Verify one last time that the function still works correctly
         Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
         assertThat(result, equalTo(5));
     }
+
     private static final ObjectMapper mapper = new ObjectMapper();
 
     @Mock
@@ -183,7 +189,7 @@ class ParseTreeCoercionServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings={"integer", "boolean", "long", "string", "double", "map", "array"})
+    @ValueSource(strings = {"integer", "boolean", "long", "string", "double", "map", "array"})
     void testCoerceTerminalNodeDataTypesType(String testString) {
         when(token.getType()).thenReturn(DataPrepperExpressionParser.DataTypes);
         when(terminalNode.getSymbol()).thenReturn(token);
@@ -335,10 +341,15 @@ class ParseTreeCoercionServiceTest {
         final String value = RandomStringUtils.randomAlphabetic(10);
         final Event testEvent = createTestEvent(Map.of(key, value));
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("length(/"+key+")");
-        when(expressionFunctionProvider.provideFunction(eq("length"), any(List.class), any(Event.class), any(Function.class))).thenReturn(value.length());
+        when(terminalNode.getText()).thenReturn("length(/" + key + ")");
+        final ArgumentCaptor<List<Object>> argListCaptor = ArgumentCaptor.forClass(List.class);
+        when(expressionFunctionProvider.provideFunction(eq("length"), argListCaptor.capture(), any(Event.class), any(Function.class))).thenReturn(value.length());
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         assertThat(objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent), equalTo(value.length()));
+        final List<Object> capturedArgs = argListCaptor.getValue();
+        assertThat(capturedArgs.size(), equalTo(1));
+        assertThat(capturedArgs.get(0), instanceOf(EventKey.class));
+        assertThat(((EventKey) capturedArgs.get(0)).getKey(), equalTo("/" + key));
     }
 
     @Test
@@ -348,7 +359,7 @@ class ParseTreeCoercionServiceTest {
         final Event testEvent = createTestEvent(Map.of(key, value));
         final String testString = RandomStringUtils.randomAlphabetic(10);
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("length(\""+testString+")");
+        when(terminalNode.getText()).thenReturn("length(\"" + testString + ")");
         when(expressionFunctionProvider.provideFunction(eq("length"), any(List.class), any(Event.class), any(Function.class))).thenReturn(value.length());
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         assertThrows(RuntimeException.class, () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent));
@@ -373,7 +384,7 @@ class ParseTreeCoercionServiceTest {
         final String key2 = RandomStringUtils.randomAlphabetic(5);
         final Event testEvent = createTestEvent(Map.of(key, value));
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("length(/"+key2+")");
+        when(terminalNode.getText()).thenReturn("length(/" + key2 + ")");
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         assertThat(objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent), equalTo(null));
     }
@@ -392,7 +403,7 @@ class ParseTreeCoercionServiceTest {
         final String value = RandomStringUtils.randomAlphabetic(10);
         final Event testEvent = createTestEvent(Map.of(key, value));
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("join(\",\" /" +key+")");
+        when(terminalNode.getText()).thenReturn("join(\",\" /" + key + ")");
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         Throwable exception = assertThrows(RuntimeException.class, () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent));
         assertThat(exception.getMessage(), containsStringIgnoringCase("check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`"));
@@ -405,10 +416,34 @@ class ParseTreeCoercionServiceTest {
         final String output = RandomStringUtils.randomAlphabetic(10);
         final Event testEvent = createTestEvent(Map.of(key, value));
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("join(\"\\\\,\", /"+key+")");
-        when(expressionFunctionProvider.provideFunction(eq("join"), any(List.class), any(Event.class), any(Function.class))).thenReturn(output);
+        when(terminalNode.getText()).thenReturn("join(\"\\\\,\", /" + key + ")");
+        final ArgumentCaptor<List<Object>> argListCaptor = ArgumentCaptor.forClass(List.class);
+        when(expressionFunctionProvider.provideFunction(eq("join"), argListCaptor.capture(), any(Event.class), any(Function.class))).thenReturn(output);
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         assertThat(objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent), equalTo(output));
+        final List<Object> capturedArgs = argListCaptor.getValue();
+        assertThat(capturedArgs.size(), equalTo(2));
+        assertThat(capturedArgs.get(0), instanceOf(String.class));
+        assertThat(capturedArgs.get(0), equalTo("\\\\,"));
+        assertThat(capturedArgs.get(1), instanceOf(EventKey.class));
+        assertThat(((EventKey) capturedArgs.get(1)).getKey(), equalTo("/" + key));
+    }
+
+    @Test
+    void testParseFunctionMetadataProducesEventKeyForJsonPointerAndUnquotedStringForLiteral() {
+        final Event testEvent = createTestEvent(Map.of("field", "value"));
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("contains(/field, \"hello\")");
+        final ArgumentCaptor<List<Object>> argListCaptor = ArgumentCaptor.forClass(List.class);
+        when(expressionFunctionProvider.provideFunction(eq("contains"), argListCaptor.capture(), any(Event.class), any(Function.class))).thenReturn(false);
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        final List<Object> capturedArgs = argListCaptor.getValue();
+        assertThat(capturedArgs.size(), equalTo(2));
+        assertThat(capturedArgs.get(0), instanceOf(EventKey.class));
+        assertThat(((EventKey) capturedArgs.get(0)).getKey(), equalTo("/field"));
+        assertThat(capturedArgs.get(1), instanceOf(String.class));
+        assertThat(capturedArgs.get(1), equalTo("hello"));
     }
 
     private Event createTestEvent(final Object data) {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/StartsWithExpressionFunctionTest.java
@@ -1,111 +1,170 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.dataprepper.expression;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.opensearch.dataprepper.expression.StartsWithExpressionFunction.STARTS_WITH_FUNCTION_NAME;
 
-public class StartsWithExpressionFunctionTest {
-
+class StartsWithExpressionFunctionTest {
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
+    private StartsWithExpressionFunction startsWithExpressionFunction;
     private Event testEvent;
+    private Function<Object, Object> testFunction;
+    private String testKey;
+    private String testKey2;
+    private String testKey3;
+    private String testValue;
+    private String testPrefix;
+    private static final int testValueLength = 10;
 
     private Event createTestEvent(final Object data) {
         return JacksonEvent.builder().withEventType("event").withData(data).build();
     }
 
-    private ExpressionFunction createObjectUnderTest() {
+    @BeforeEach
+    public void setUp() {
+        testKey = RandomStringUtils.randomAlphabetic(5);
+        testKey2 = RandomStringUtils.randomAlphabetic(5);
+        testKey3 = RandomStringUtils.randomAlphabetic(5);
+        testValue = RandomStringUtils.randomAlphabetic(testValueLength);
+        testPrefix = testValue.substring(0, 4);
+        testEvent = createTestEvent(Map.of(testKey, testValue, testKey2, testPrefix, testKey3, 1234));
+        testFunction = mock(Function.class);
+    }
+
+    public StartsWithExpressionFunction createObjectUnderTest() {
         return new StartsWithExpressionFunction();
     }
 
-    @ParameterizedTest
-    @MethodSource("validStartsWithProvider")
-    void startsWith_returns_expected_result_when_evaluated(
-            final String value, final String prefix, final boolean expectedResult) {
-        final String key = "test_key";
-        testEvent = createTestEvent(Map.of(key, value));
-
-        final ExpressionFunction objectUnderTest = createObjectUnderTest();
-        assertThat(objectUnderTest.getFunctionName(), equalTo(STARTS_WITH_FUNCTION_NAME));
-
-        final Object result = objectUnderTest.evaluate(List.of("/" + key, "\"" + prefix + "\""), testEvent, mock(Function.class));
-
-        assertThat(result, equalTo(expectedResult));
+    @Test
+    void testFunctionName() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        assertThat(startsWithExpressionFunction.getFunctionName(), equalTo(STARTS_WITH_FUNCTION_NAME));
     }
 
     @Test
-    void startsWith_with_a_key_as_the_prefix_returns_expected_result() {
-
-        final String prefixKey = "prefix";
-        final String prefixValue = "te";
-
-        final String key = "test_key";
-        final String value = "test";
-        testEvent = createTestEvent(Map.of(key, value, prefixKey, prefixValue));
-
-        final ExpressionFunction objectUnderTest = createObjectUnderTest();
-        assertThat(objectUnderTest.getFunctionName(), equalTo(STARTS_WITH_FUNCTION_NAME));
-
-        final Object result = objectUnderTest.evaluate(List.of("/" + key, "/" + prefixKey), testEvent, mock(Function.class));
-
-        assertThat(result, equalTo(true));
+    void evaluate_with_two_eventKeys_when_first_argument_starts_with_second() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/" + testKey);
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/" + testKey2);
+        assertThat(startsWithExpressionFunction.evaluate(List.of(eventKey1, eventKey2), testEvent, testFunction), equalTo(true));
     }
 
     @Test
-    void startsWith_returns_false_when_key_does_not_exist_in_Event() {
-        final String key = "test_key";
-        testEvent = createTestEvent(Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
-
-        final ExpressionFunction startsWithExpressionFunction = createObjectUnderTest();
-        final Object result = startsWithExpressionFunction.evaluate(List.of("/" + key, "\"abcd\""), testEvent, mock(Function.class));
-
-        assertThat(result, equalTo(false));
-    }
-
-    @Test
-    void startsWith_without_2_arguments_throws_RuntimeException() {
-        final ExpressionFunction startsWithExpressionFunction = createObjectUnderTest();
-        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of("abcd"), testEvent, mock(Function.class)));
+    void evaluate_with_two_eventKeys_when_first_argument_does_not_start_with_second() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/" + testKey);
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/" + testKey2);
+        assertThat(startsWithExpressionFunction.evaluate(List.of(eventKey2, eventKey1), testEvent, testFunction), equalTo(false));
     }
 
     @ParameterizedTest
-    @MethodSource("invalidStartsWithProvider")
-    void invalid_startsWith_arguments_throws_RuntimeException(final String firstArg, final Object secondArg, final Object value) {
-        final ExpressionFunction startsWithExpressionFunction = createObjectUnderTest();
-        final String testKey = "test_key";
-
-        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of(firstArg, secondArg), createTestEvent(Map.of(testKey, value)), mock(Function.class)));
+    @CsvSource({
+            "abcde,abcde",
+            "abcde,abcd",
+            "abcde,a"
+    })
+    void evaluate_with_two_literal_strings_returns_when_first_argument_starts_with_second(final String arg1, final String arg2) {
+        startsWithExpressionFunction = createObjectUnderTest();
+        assertThat(startsWithExpressionFunction.evaluate(List.of(arg1, arg2), testEvent, testFunction), equalTo(true));
     }
 
-    private static Stream<Arguments> validStartsWithProvider() {
-        return Stream.of(
-                Arguments.of("{test", "{te", true),
-                Arguments.of("{test", "{", true),
-                Arguments.of("test", "{", false),
-                Arguments.of("MyPrefix", "My", true),
-                Arguments.of("MyPrefix", "Prefix", false)
-        );
+    @ParameterizedTest
+    @CsvSource({
+            "abcde,xyz",
+            "abc,abcd"
+    })
+    void evaluate_with_two_literal_strings_returns_when_first_argument_does_not_start_with_second() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        assertThat(startsWithExpressionFunction.evaluate(List.of("abcde", "xyz"), testEvent, testFunction), equalTo(false));
     }
 
-    private static Stream<Arguments> invalidStartsWithProvider() {
-        return Stream.of(
-                Arguments.of("\"abc\"", "/test_key", 1234),
-                Arguments.of("abcd", "/test_key", "value"),
-                Arguments.of("\"abcd\"", "/test_key", 1234),
-                Arguments.of("\"/test_key\"", 1234, "value")
-        );
+    @Test
+    void testStartsWithEventKeyAndLiteralString() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey);
+        assertThat(startsWithExpressionFunction.evaluate(List.of(eventKey, testPrefix), testEvent, testFunction), equalTo(true));
+    }
+
+    @Test
+    void testStartsWithLiteralStringAndEventKey() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey2);
+        assertThat(startsWithExpressionFunction.evaluate(List.of(testValue, eventKey), testEvent, testFunction), equalTo(true));
+    }
+
+    @Test
+    void testStartsWithReturnsFalseWhenNotStartingWith() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey);
+        assertThat(startsWithExpressionFunction.evaluate(List.of(eventKey, "xyz"), testEvent, testFunction), equalTo(false));
+    }
+
+    @Test
+    void testStartsWithReturnsFalseWhenEventKeyResolvesToNull() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/unknownKey");
+        assertThat(startsWithExpressionFunction.evaluate(List.of(eventKey, "value"), testEvent, testFunction), equalTo(false));
+    }
+
+    @Test
+    void testStartsWithReturnsFalseWhenSecondEventKeyResolvesToNull() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey1 = eventKeyFactory.createEventKey("/" + testKey);
+        EventKey eventKey2 = eventKeyFactory.createEventKey("/unknownKey");
+        assertThat(startsWithExpressionFunction.evaluate(List.of(eventKey1, eventKey2), testEvent, testFunction), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 3, 4, 5, 6, 7, 8})
+    void testStartsWithMultiplePrefixes(int endOffset) {
+        startsWithExpressionFunction = createObjectUnderTest();
+        String testString = RandomStringUtils.randomAlphabetic(10);
+        assertThat(startsWithExpressionFunction.evaluate(List.of(testString, testString.substring(0, endOffset)), testEvent, testFunction), equalTo(true));
+    }
+
+    @Test
+    void testThrowsWhenWrongNumberOfArgs() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of("abcd"), testEvent, testFunction));
+    }
+
+    @Test
+    void testThrowsWhenEventKeyResolvesToNonString() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        EventKey eventKey = eventKeyFactory.createEventKey("/" + testKey3);
+        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of(eventKey, "value"), testEvent, testFunction));
+    }
+
+    @Test
+    void testThrowsWhenUnexpectedArgumentType() {
+        startsWithExpressionFunction = createObjectUnderTest();
+        assertThrows(RuntimeException.class, () -> startsWithExpressionFunction.evaluate(List.of("abcd", 1234), testEvent, testFunction));
     }
 }


### PR DESCRIPTION
### Description

Refactors how expression functions handle string literals and EventKeys. Now the `ParseTreeCoercionService` will provide either a String without quotes or an `EventKey`. This is important for function composition to work because the result of one function will be a string without the quotes. It also removes a lot of duplicated logic for checking the literal type.

 
### Issues Resolved

None. But, works towards #6322.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
