### PR TITLE
Fix for commenting using the GitHub Action for license header checks

### DIFF
--- a/.github/scripts/check-license-headers.py
+++ b/.github/scripts/check-license-headers.py
@@ -126,11 +126,9 @@ def main():
         
         violation_text = '\n'.join(violations)
         
-        # Set output for GitHub Actions
-        github_output = os.environ.get('GITHUB_OUTPUT')
-        if github_output:
-            with open(github_output, 'a') as f:
-                f.write(f"violations<<EOF\n{violation_text}\nEOF\n")
+        # Write violations file for the comment workflow artifact
+        with open('violations.txt', 'w') as f:
+            f.write(violation_text + '\n')
         
         print("\nViolations:")
         for violation in violations:
@@ -139,11 +137,6 @@ def main():
         sys.exit(1)
     else:
         print("\n✅ All files have proper license headers!")
-        # Set empty output for GitHub Actions
-        github_output = os.environ.get('GITHUB_OUTPUT')
-        if github_output:
-            with open(github_output, 'a') as f:
-                f.write("violations=\n")
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -8,7 +8,7 @@
 #
 
 # Performs a license header check on new files.
-# It will comment on PRs if it finds violations.
+# Results are uploaded as an artifact for the comment workflow.
 
 name: License Header Check
 
@@ -16,106 +16,36 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   license-header-check:
     runs-on: ubuntu-latest
     name: Check License Headers on New Files
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
-          
+
       - name: Run License Header Check
         id: license-check
         run: |
           python .github/scripts/get-new-files.py | python .github/scripts/check-license-headers.py
-          
-      - name: Comment on PR
-        if: failure() && steps.license-check.outputs.violations != ''
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const violations = process.env.VIOLATIONS;
-            
-            const body = [
-              '## ⚠️ License Header Violations Found',
-              '',
-              'The following newly added files are missing required license headers:',
-              '',
-              violations,
-              '',
-              'Please add the appropriate license header to each file and push your changes.',
-              '',
-              '**See the license header requirements:** https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md#license-headers'
-            ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('License Header Violations Found')
-            );
-            
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
-        env:
-          VIOLATIONS: ${{ steps.license-check.outputs.violations }}
-          
-      - name: Update PR comment (all violations resolved)
-        if: success()
-        uses: actions/github-script@v8
+      - name: Save PR number
+        if: always()
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && 
-              (comment.body.includes('License Header Violations Found') || comment.body.includes('License Header Check Passed'))
-            );
-            
-            if (botComment) {
-              const successBody = [
-                '## ✅ License Header Check Passed',
-                '',
-                'All newly added files have proper license headers. Great work! 🎉'
-              ].join('\n');
-              
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: successBody
-              });
-            }
+          name: license-check-results
+          path: |
+            pr_number.txt
+            violations.txt

--- a/.github/workflows/license-header-comment.yml
+++ b/.github/workflows/license-header-comment.yml
@@ -1,0 +1,99 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+# Comments on PRs with license header check results.
+# Triggered by the License Header Check workflow.
+
+name: License Header Comment
+
+on:
+  workflow_run:
+    workflows: ['License Header Check']
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          name: license-check-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+            const failed = '${{ github.event.workflow_run.conclusion }}' === 'failure';
+            const hasViolations = fs.existsSync('violations.txt');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              (comment.body.includes('License Header Violations Found') || comment.body.includes('License Header Check Passed'))
+            );
+
+            let body;
+            if (failed && hasViolations) {
+              const violations = fs.readFileSync('violations.txt', 'utf8').trim();
+              body = [
+                '## ⚠️ License Header Violations Found',
+                '',
+                'The following newly added files are missing required license headers:',
+                '',
+                violations,
+                '',
+                'Please add the appropriate license header to each file and push your changes.',
+                '',
+                '**See the license header requirements:** https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md#license-headers'
+              ].join('\n');
+            } else if (!failed && botComment) {
+              body = [
+                '## ✅ License Header Check Passed',
+                '',
+                'All newly added files have proper license headers. Great work! 🎉'
+              ].join('\n');
+            } else {
+              return;
+            }
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }


### PR DESCRIPTION
### Description

The license header check currently fails and reports files. But it isn't commenting on issues as desired. This is because the permissions for commenting are not available in the `pull_request` workflows.

Split the GitHub Action for license header checks into two workflows. One for checking the PR and the other for posting PR comments.

The current approach is resulting in permissions failures when trying to post comments. This approach should give the necessary permissions. It also does it securely following the recommendation from the GitHub security lab.

 
https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

Here is a PR from my fork showing it in action: https://github.com/dlvenable/data-prepper/pull/400. The old approach worked in my fork as well, so I suppose I can't be completely certain this will fix it, but it does follow the prescribed pattern.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
