### PR TITLE
Fix requestsTooLarge metric reporting when decompression buffer overflows on armeria in otel logs source

### DIFF
--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceHttpTest.java
@@ -46,7 +46,6 @@ import static org.opensearch.dataprepper.plugins.source.otellogs.OtelLogsSourceC
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -390,7 +389,7 @@ class OTelLogsSourceHttpTest {
     private void assertSecureResponseWithStatusCode(final AggregatedHttpResponse response,
                                                     final HttpStatus expectedStatus,
                                                     final Throwable throwable) {
-         assertThat("Http Status", response.status(), equalTo(expectedStatus));
+        assertThat("Http Status", response.status(), equalTo(expectedStatus));
         assertThat("Http Response Throwable", throwable, is(nullValue()));
 
         final List<String> headerKeys = response.headers()


### PR DESCRIPTION


### Description
This change handles an edge case where the otel logs source does not report the "requestsTooLarge" metric despite throwing a 413 exception. 

The edge case happens when the source is receiving compressed requests. If the decompressed request exceeds the max_request_length, the decompression buffer in armeria throws a 413 error, but it does not increment the metric "requestsTooLarge" because the exception handler does not run in this scenario.
 
### Issues Resolved
Related to #5594 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
