### PR TITLE
Fixes the cache for the KMS encryption plugin.

### DIFF
--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionEngineFactory.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionEngineFactory.java
@@ -1,22 +1,29 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
 
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.encryption.EncryptionEngine;
 import org.opensearch.dataprepper.model.encryption.KeyProvider;
 
 class EncryptionEngineFactory {
     private final KeyProviderFactory keyProviderFactory;
+    private final PluginMetrics pluginMetrics;
 
-    public static EncryptionEngineFactory create(final KeyProviderFactory keyProviderFactory) {
-        return new EncryptionEngineFactory(keyProviderFactory);
+    public static EncryptionEngineFactory create(final KeyProviderFactory keyProviderFactory, final PluginMetrics pluginMetrics) {
+        return new EncryptionEngineFactory(keyProviderFactory, pluginMetrics);
     }
 
-    private EncryptionEngineFactory(final KeyProviderFactory keyProviderFactory) {
+    private EncryptionEngineFactory(final KeyProviderFactory keyProviderFactory, final PluginMetrics pluginMetrics) {
         this.keyProviderFactory = keyProviderFactory;
+        this.pluginMetrics = pluginMetrics;
     }
 
     public EncryptionEngine createEncryptionEngine(final EncryptionEngineConfiguration encryptionEngineConfiguration,
@@ -24,7 +31,7 @@ class EncryptionEngineFactory {
         if (encryptionEngineConfiguration instanceof KmsEncryptionEngineConfiguration) {
             final KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration =
                     (KmsEncryptionEngineConfiguration) encryptionEngineConfiguration;
-            final KeyProvider keyProvider = keyProviderFactory.createKmsKeyProvider(kmsEncryptionEngineConfiguration);
+            final KeyProvider keyProvider = keyProviderFactory.createKmsKeyProvider(kmsEncryptionEngineConfiguration, pluginMetrics);
             final EncryptionContext encryptionContext = new EncryptionContext();
             return new DefaultEncryptionEngine(keyProvider, encryptionContext, encryptedDataKeySupplier);
         } else {

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionPlugin.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionPlugin.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
@@ -35,13 +39,13 @@ public class EncryptionPlugin implements ExtensionPlugin {
     @DataPrepperPluginConstructor
     public EncryptionPlugin(final EncryptionPluginConfig encryptionPluginConfig) {
         final KeyProviderFactory keyProviderFactory = KeyProviderFactory.create();
-        final EncryptionEngineFactory encryptionEngineFactory = EncryptionEngineFactory.create(keyProviderFactory);
+        pluginMetrics = PluginMetrics.fromPrefix("encryption");
+        final EncryptionEngineFactory encryptionEngineFactory = EncryptionEngineFactory.create(keyProviderFactory, pluginMetrics);
         final EncryptedDataKeySupplierFactory encryptedDataKeySupplierFactory =
                 EncryptedDataKeySupplierFactory.create();
         if (encryptionPluginConfig != null) {
             encryptionSupplier = new DefaultEncryptionSupplier(
                     encryptionPluginConfig, encryptionEngineFactory, encryptedDataKeySupplierFactory);
-            pluginMetrics = PluginMetrics.fromPrefix("encryption");
             final EncryptedDataKeyWriterFactory encryptedDataKeyWriterFactory = new EncryptedDataKeyWriterFactory();
             final EncryptionRotationHandlerFactory encryptionRotationHandlerFactory =
                     EncryptionRotationHandlerFactory.create(pluginMetrics, encryptedDataKeyWriterFactory);

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/KeyProviderFactory.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/KeyProviderFactory.java
@@ -1,9 +1,15 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
+
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 
 class KeyProviderFactory {
 
@@ -14,7 +20,8 @@ class KeyProviderFactory {
     private KeyProviderFactory() {}
 
     public KmsKeyProvider createKmsKeyProvider(
-            final KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration) {
-        return new KmsKeyProvider(kmsEncryptionEngineConfiguration);
+            final KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration,
+            final PluginMetrics pluginMetrics) {
+        return new KmsKeyProvider(kmsEncryptionEngineConfiguration, pluginMetrics);
     }
 }

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/KmsKeyProvider.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/KmsKeyProvider.java
@@ -1,43 +1,70 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.encryption.KeyProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
 
 class KmsKeyProvider implements KeyProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(KmsKeyProvider.class);
+    private static final String REQUESTS_SUCCEEDED_METRIC_NAME = "kmsRequestsSucceeded";
+    private static final String REQUESTS_FAILED_METRIC_NAME = "kmsRequestsFailed";
+
     static final Integer MAXIMUM_CACHED_KEYS = 5;
 
     private final KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration;
     private final KmsClient kmsClient;
-    private final Cache<byte[], byte[]> decryptedKeyCache =
+    private final Cache<SdkBytes, byte[]> decryptedKeyCache =
             Caffeine.newBuilder()
                     .maximumSize(MAXIMUM_CACHED_KEYS)
                     .build();
+    private final Counter requestsSucceeded;
+    private final Counter requestsFailed;
 
-    public KmsKeyProvider(final KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration) {
+    public KmsKeyProvider(final KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration,
+                          final PluginMetrics pluginMetrics) {
         kmsClient = kmsEncryptionEngineConfiguration.createKmsClient();
         this.kmsEncryptionEngineConfiguration = kmsEncryptionEngineConfiguration;
+        pluginMetrics.gauge("kmsDecryptedKeys", decryptedKeyCache, Cache::estimatedSize);
+        requestsSucceeded = pluginMetrics.counter(REQUESTS_SUCCEEDED_METRIC_NAME);
+        requestsFailed = pluginMetrics.counter(REQUESTS_FAILED_METRIC_NAME);
     }
 
     @Override
     public byte[] decryptKey(final byte[] encryptionKey) {
-        return decryptedKeyCache.asMap().computeIfAbsent(encryptionKey, key -> {
+        final SdkBytes encryptionKeyCacheable = SdkBytes.fromByteArray(encryptionKey);
+        return decryptedKeyCache.asMap().computeIfAbsent(encryptionKeyCacheable, key -> {
             final String kmsKeyId = kmsEncryptionEngineConfiguration.getKeyId();
             final DecryptRequest decryptRequest = DecryptRequest.builder()
                     .keyId(kmsKeyId)
-                    .ciphertextBlob(SdkBytes.fromByteArray(key))
+                    .ciphertextBlob(key)
                     .encryptionContext(kmsEncryptionEngineConfiguration.getEncryptionContext())
                     .build();
-            final DecryptResponse decryptResponse = kmsClient.decrypt(decryptRequest);
+            LOG.debug("Calling KMS decrypt for keyId={}", kmsKeyId);
+            final DecryptResponse decryptResponse;
+            try {
+                decryptResponse = kmsClient.decrypt(decryptRequest);
+            } catch (final Exception ex) {
+                requestsFailed.increment();
+                throw ex;
+            }
+            requestsSucceeded.increment();
 
             return decryptResponse.plaintext().asByteArray();
         });

--- a/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/EncryptionEngineFactoryTest.java
+++ b/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/EncryptionEngineFactoryTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,18 +29,20 @@ class EncryptionEngineFactoryTest {
     @Mock
     private KeyProviderFactory keyProviderFactory;
     @Mock
+    private PluginMetrics pluginMetrics;
+    @Mock
     private EncryptedDataKeySupplier encryptedDataKeySupplier;
 
     private EncryptionEngineFactory objectUnderTest;
 
     @BeforeEach
     void setUp() {
-        objectUnderTest = EncryptionEngineFactory.create(keyProviderFactory);
+        objectUnderTest = EncryptionEngineFactory.create(keyProviderFactory, pluginMetrics);
     }
 
     @Test
     void testCreateDefaultEncryptionEngine_with_KmsEncryptionEngineConfiguration() {
-        when(keyProviderFactory.createKmsKeyProvider(kmsEncryptionEngineConfiguration)).thenReturn(kmsKeyProvider);
+        when(keyProviderFactory.createKmsKeyProvider(kmsEncryptionEngineConfiguration, pluginMetrics)).thenReturn(kmsKeyProvider);
         assertThat(objectUnderTest.createEncryptionEngine(kmsEncryptionEngineConfiguration, encryptedDataKeySupplier),
                 instanceOf(DefaultEncryptionEngine.class));
     }

--- a/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/EncryptionPluginTest.java
+++ b/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/EncryptionPluginTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
@@ -23,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -63,8 +66,6 @@ class EncryptionPluginTest {
     private EncryptionRotationHandler encryptionRotationHandler;
     @Mock
     private DefaultEncryptionHttpHandler defaultEncryptionHttpHandler;
-    @Mock
-    private ScheduledExecutorService scheduledExecutorService;
 
     private EncryptionPlugin objectUnderTest;
 
@@ -92,7 +93,7 @@ class EncryptionPluginTest {
         ) {
             encryptedDataKeySupplierFactoryMockedStatic.when(EncryptedDataKeySupplierFactory::create)
                     .thenReturn(encryptedDataKeySupplierFactory);
-            encryptionEngineFactoryMockedStatic.when(() -> EncryptionEngineFactory.create(any(KeyProviderFactory.class)))
+            encryptionEngineFactoryMockedStatic.when(() -> EncryptionEngineFactory.create(any(KeyProviderFactory.class), any(PluginMetrics.class)))
                     .thenReturn(encryptionEngineFactory);
             encryptionRotationHandlerFactoryMockedStatic.when(() -> EncryptionRotationHandlerFactory.create(
                     any(PluginMetrics.class), any(EncryptedDataKeyWriterFactory.class)))
@@ -149,7 +150,7 @@ class EncryptionPluginTest {
         ) {
             encryptedDataKeySupplierFactoryMockedStatic.when(EncryptedDataKeySupplierFactory::create)
                     .thenReturn(encryptedDataKeySupplierFactory);
-            encryptionEngineFactoryMockedStatic.when(() -> EncryptionEngineFactory.create(any(KeyProviderFactory.class)))
+            encryptionEngineFactoryMockedStatic.when(() -> EncryptionEngineFactory.create(any(KeyProviderFactory.class), any(PluginMetrics.class)))
                     .thenReturn(encryptionEngineFactory);
             encryptionRotationHandlerFactoryMockedStatic.when(() -> EncryptionRotationHandlerFactory.create(
                             any(PluginMetrics.class), any(EncryptedDataKeyWriterFactory.class)))

--- a/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/KeyProviderFactoryTest.java
+++ b/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/KeyProviderFactoryTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import software.amazon.awssdk.services.kms.KmsClient;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -20,6 +25,9 @@ import static org.mockito.Mockito.when;
 class KeyProviderFactoryTest {
     @Mock
     private KmsEncryptionEngineConfiguration kmsEncryptionEngineConfiguration;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
 
     @Mock
     private KmsClient kmsClient;
@@ -34,7 +42,7 @@ class KeyProviderFactoryTest {
     @Test
     void testCreateKmsKeyProvider() {
         when(kmsEncryptionEngineConfiguration.createKmsClient()).thenReturn(kmsClient);
-        assertThat(keyProviderFactory.createKmsKeyProvider(kmsEncryptionEngineConfiguration),
+        assertThat(keyProviderFactory.createKmsKeyProvider(kmsEncryptionEngineConfiguration, pluginMetrics),
                 instanceOf(KmsKeyProvider.class));
     }
 }

--- a/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/KmsKeyProviderTest.java
+++ b/data-prepper-plugins/encryption-plugin/src/test/java/org/opensearch/dataprepper/plugins/encryption/KmsKeyProviderTest.java
@@ -1,21 +1,32 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.encryption;
 
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.KmsException;
+import software.amazon.awssdk.services.sts.model.StsException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -24,8 +35,10 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -37,33 +50,50 @@ class KmsKeyProviderTest {
     private KmsClient kmsClient;
     @Mock
     private DecryptResponse decryptResponse;
+    @Mock
+    private PluginMetrics pluginMetrics;
+    @Mock
+    private Counter succeededCounter;
+    @Mock
+    private Counter failedCounter;
     @Captor
     private ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor;
+    private String testDecryptedDataKey;
+    private String testKeyId;
+    private String testContextKey;
+    private String testContextValue;
+    private String testEncryptionKey;
 
     private KmsKeyProvider createObjectUnderTest() {
-        return new KmsKeyProvider(kmsEncryptionEngineConfiguration);
+        return new KmsKeyProvider(kmsEncryptionEngineConfiguration, pluginMetrics);
     }
 
     @BeforeEach
     void setUp() {
+        when(pluginMetrics.counter("kmsRequestsSucceeded")).thenReturn(succeededCounter);
+        when(pluginMetrics.counter("kmsRequestsFailed")).thenReturn(failedCounter);
         when(kmsEncryptionEngineConfiguration.createKmsClient()).thenReturn(kmsClient);
+
+        testDecryptedDataKey = UUID.randomUUID().toString();
+        testKeyId = UUID.randomUUID().toString();
+        testContextKey = UUID.randomUUID().toString();
+        testContextValue = UUID.randomUUID().toString();
+
+        testEncryptionKey = UUID.randomUUID().toString();
+
+        when(kmsEncryptionEngineConfiguration.getKeyId()).thenReturn(testKeyId);
     }
 
     @Test
     void decryptKey_returns_plaintext_from_decrypt_request() {
-        final String testDecryptedDataKey = "test_decrypted_data_key";
-        final String testKeyId = UUID.randomUUID().toString();
-        final String testContextKey = UUID.randomUUID().toString();
-        final String testContextValue = UUID.randomUUID().toString();
         final Map<String, String> testEncryptionContext = Map.of(
                 testContextKey, testContextValue);
-        when(kmsEncryptionEngineConfiguration.getKeyId()).thenReturn(testKeyId);
         when(kmsEncryptionEngineConfiguration.getEncryptionContext()).thenReturn(testEncryptionContext);
         when(kmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
         when(decryptResponse.plaintext()).thenReturn(
                 SdkBytes.fromString(testDecryptedDataKey, StandardCharsets.UTF_8));
-        final String testEncryptionKey = "test_encryption_key";
-        KmsKeyProvider objectUnderTest = createObjectUnderTest();
+
+        final KmsKeyProvider objectUnderTest = createObjectUnderTest();
         final byte[] actualBytes = objectUnderTest.decryptKey(testEncryptionKey.getBytes(StandardCharsets.UTF_8));
 
         assertThat(actualBytes, equalTo(testDecryptedDataKey.getBytes(StandardCharsets.UTF_8)));
@@ -77,16 +107,12 @@ class KmsKeyProviderTest {
 
     @Test
     void decryptKey_calls_decrypt_with_correct_values_when_encryption_context_is_null() {
-        final String testDecryptedDataKey = "test_decrypted_data_key";
-        final String testKeyId = UUID.randomUUID().toString();
-
-        when(kmsEncryptionEngineConfiguration.getKeyId()).thenReturn(testKeyId);
         when(kmsEncryptionEngineConfiguration.getEncryptionContext()).thenReturn(null);
         when(kmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
         when(decryptResponse.plaintext()).thenReturn(
                 SdkBytes.fromString(testDecryptedDataKey, StandardCharsets.UTF_8));
-        final String testEncryptionKey = "test_encryption_key";
-        KmsKeyProvider objectUnderTest = createObjectUnderTest();
+
+        final KmsKeyProvider objectUnderTest = createObjectUnderTest();
         final byte[] actualBytes = objectUnderTest.decryptKey(testEncryptionKey.getBytes(StandardCharsets.UTF_8));
 
         assertThat(actualBytes, equalTo(testDecryptedDataKey.getBytes(StandardCharsets.UTF_8)));
@@ -100,32 +126,55 @@ class KmsKeyProviderTest {
 
     @Test
     void decryptKey_on_the_same_encryption_key_returns_result_from_cache() {
-        final String testDecryptedDataKey = "test_decrypted_data_key";
-        final String testKeyId = UUID.randomUUID().toString();
-        final String testContextKey = UUID.randomUUID().toString();
-        final String testContextValue = UUID.randomUUID().toString();
         final Map<String, String> testEncryptionContext = Map.of(
                 testContextKey, testContextValue);
-        when(kmsEncryptionEngineConfiguration.getKeyId()).thenReturn(testKeyId);
         when(kmsEncryptionEngineConfiguration.getEncryptionContext()).thenReturn(testEncryptionContext);
         when(kmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
         when(decryptResponse.plaintext()).thenReturn(
                 SdkBytes.fromString(testDecryptedDataKey, StandardCharsets.UTF_8));
-        final String testEncryptionKey = "test_encryption_key";
-        KmsKeyProvider objectUnderTest = createObjectUnderTest();
+        final byte[] testEncryptionKeyBytes = testEncryptionKey.getBytes(StandardCharsets.UTF_8);
+
+        final KmsKeyProvider objectUnderTest = createObjectUnderTest();
         final byte[] retrievedBytesFirstCall = objectUnderTest.decryptKey(
-                testEncryptionKey.getBytes(StandardCharsets.UTF_8));
+                testEncryptionKeyBytes);
         assertThat(retrievedBytesFirstCall, equalTo(testDecryptedDataKey.getBytes(StandardCharsets.UTF_8)));
-        verify(kmsClient).decrypt(decryptRequestArgumentCaptor.capture());
-        final DecryptRequest decryptRequest = decryptRequestArgumentCaptor.getValue();
-        assertThat(decryptRequest.keyId(), equalTo(testKeyId));
-        assertThat(decryptRequest.ciphertextBlob(),
-                equalTo(SdkBytes.fromByteArray(testEncryptionKey.getBytes(StandardCharsets.UTF_8))));
-        assertThat(decryptRequest.encryptionContext(), equalTo(testEncryptionContext));
 
         final byte[] retrievedBytesSecondCall = objectUnderTest.decryptKey(
                 testEncryptionKey.getBytes(StandardCharsets.UTF_8));
         assertThat(retrievedBytesSecondCall, equalTo(testDecryptedDataKey.getBytes(StandardCharsets.UTF_8)));
+
+        verify(kmsClient).decrypt(decryptRequestArgumentCaptor.capture());
+        final DecryptRequest decryptRequest = decryptRequestArgumentCaptor.getValue();
+        assertThat(decryptRequest.keyId(), equalTo(testKeyId));
+        assertThat(decryptRequest.ciphertextBlob(),
+                equalTo(SdkBytes.fromByteArray(testEncryptionKeyBytes)));
+        assertThat(decryptRequest.encryptionContext(), equalTo(testEncryptionContext));
         verifyNoMoreInteractions(kmsClient);
+    }
+
+    @Test
+    void decryptKey_should_increment_succeeded_counter() {
+        when(kmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
+        when(decryptResponse.plaintext()).thenReturn(
+                SdkBytes.fromString(testDecryptedDataKey, StandardCharsets.UTF_8));
+
+        createObjectUnderTest().decryptKey(testEncryptionKey.getBytes(StandardCharsets.UTF_8));
+
+        verify(succeededCounter).increment();
+        verifyNoInteractions(failedCounter);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {SdkClientException.class, KmsException.class, StsException.class, RuntimeException.class})
+    void decryptKey_should_throw_exception_and_increment_counter_on_failure(final Class<Throwable> exception) {
+        when(kmsClient.decrypt(any(DecryptRequest.class))).thenThrow(exception);
+
+        final KmsKeyProvider objectUnderTest = createObjectUnderTest();
+
+        final byte[] testEncryptionKeyBytes = testEncryptionKey.getBytes(StandardCharsets.UTF_8);
+        assertThrows(exception, () -> objectUnderTest.decryptKey(testEncryptionKeyBytes));
+
+        verify(failedCounter).increment();
+        verifyNoInteractions(succeededCounter);
     }
 }


### PR DESCRIPTION
### Description

The cache was using `byte[]` as the key. As an array it doesn't have `equals`/`hashCode` so the keys would never be found. To cache it correctly I use `SdkBytes` which implements both.

Additionally the tests appeared to be passing. But there is a subtle issue with them. The `verify` call happened before the second call. The `verifyNoMoreInteractions` appears to not verify based on counts. Just by moving the `verify` call below the second call I was able to get the tests to fail before fixing the code.

I also added three metrics for the KMS plugin: 
1. A gauge on decrypted keys in the cache
2. KMS requests succeeded
3. KMS requests failed

You can see the issue using the metrics:


<img width="1606" height="906" alt="KmsCache-PreFix" src="https://github.com/user-attachments/assets/71939ca9-bce4-4194-a90a-2d7dc7a706e3" />

Here it is with the fix:

<img width="1588" height="853" alt="KmsCache-Fixed" src="https://github.com/user-attachments/assets/3888cd91-a954-4e5e-a80c-26533e981526" />

Note, that I renamed the new metric after taking the screenshots to remove the redundant "count."
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
