### PR TITLE
fix: add BackoffCredentialsProvider to mitigate STS throttling across all plugins

### DIFF
--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/BackoffCredentialsProvider.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/BackoffCredentialsProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkException;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * A credentials provider wrapper that applies exponential backoff when the
+ * delegate provider fails to resolve credentials. During the backoff window,
+ * this provider throws the cached exception without calling the delegate,
+ * preventing excessive STS AssumeRole calls when a role is deleted or
+ * misconfigured.
+ *
+ * <p>On successful credential resolution, the backoff state is reset.</p>
+ */
+class BackoffCredentialsProvider implements AwsCredentialsProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(BackoffCredentialsProvider.class);
+
+    static final Duration INITIAL_BACKOFF = Duration.ofSeconds(10);
+    static final Duration MAX_BACKOFF = Duration.ofMinutes(10);
+    static final int BACKOFF_MULTIPLIER = 2;
+
+    private final AwsCredentialsProvider delegate;
+    private final Clock clock;
+
+    private volatile SdkException lastException;
+    private volatile Instant backoffUntil;
+    private volatile int failureCount;
+
+    BackoffCredentialsProvider(final AwsCredentialsProvider delegate) {
+        this(delegate, Clock.systemUTC());
+    }
+
+    BackoffCredentialsProvider(final AwsCredentialsProvider delegate, final Clock clock) {
+        this.delegate = delegate;
+        this.clock = clock;
+        this.backoffUntil = Instant.MIN;
+        this.failureCount = 0;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        final Instant now = clock.instant();
+
+        final SdkException cachedException = lastException;
+        if (cachedException != null && now.isBefore(backoffUntil)) {
+            LOG.debug("Credentials resolution in backoff period until {}. Throwing cached exception.", backoffUntil);
+            throw cachedException;
+        }
+
+        try {
+            final AwsCredentials credentials = delegate.resolveCredentials();
+            resetBackoff();
+            return credentials;
+        } catch (final SdkException e) {
+            applyBackoff(e);
+            throw e;
+        }
+    }
+
+    private synchronized void resetBackoff() {
+        if (failureCount > 0) {
+            LOG.info("Credentials resolution succeeded after {} failures. Resetting backoff.", failureCount);
+        }
+        failureCount = 0;
+        lastException = null;
+        backoffUntil = Instant.MIN;
+    }
+
+    private synchronized void applyBackoff(final SdkException exception) {
+        failureCount++;
+        lastException = exception;
+
+        long backoffMillis = INITIAL_BACKOFF.toMillis() * (long) Math.pow(BACKOFF_MULTIPLIER, failureCount - 1);
+        backoffMillis = Math.min(backoffMillis, MAX_BACKOFF.toMillis());
+
+        backoffUntil = clock.instant().plus(Duration.ofMillis(backoffMillis));
+        LOG.warn("Credentials resolution failed (attempt {}). Backing off for {}ms until {}.",
+                failureCount, backoffMillis, backoffUntil, exception);
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -109,10 +109,10 @@ class CredentialsProviderFactory {
                     .overrideConfiguration(configuration -> awsStsHeaderOverrides.forEach(configuration::putHeader));
         }
 
-        return StsAssumeRoleCredentialsProvider.builder()
+        return new BackoffCredentialsProvider(StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
                 .refreshRequest(assumeRoleRequestBuilder.build())
-                .build();
+                .build());
     }
 
     private void validateStsRoleArn(final String stsRoleArn) {

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
@@ -22,7 +22,6 @@ import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -81,7 +80,7 @@ public class AwsPluginIT {
 
         final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
 
-        assertThat(awsCredentialsProvider1, instanceOf(StsAssumeRoleCredentialsProvider.class));
+        assertThat(awsCredentialsProvider1, instanceOf(BackoffCredentialsProvider.class));
 
         final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
                 .withStsRoleArn(stsRole)
@@ -150,7 +149,7 @@ public class AwsPluginIT {
 
         final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
 
-        assertThat(awsCredentialsProvider1, instanceOf(StsAssumeRoleCredentialsProvider.class));
+        assertThat(awsCredentialsProvider1, instanceOf(BackoffCredentialsProvider.class));
 
         final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
                 .withRegion(Region.US_EAST_1)

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/BackoffCredentialsProviderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/BackoffCredentialsProviderTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BackoffCredentialsProviderTest {
+
+    private static final Instant BASE_TIME = Instant.parse("2025-01-01T00:00:00Z");
+
+    @Mock
+    private AwsCredentialsProvider delegate;
+
+    @Mock
+    private AwsCredentials credentials;
+
+    @Mock
+    private Clock clock;
+
+    private BackoffCredentialsProvider createObjectUnderTest() {
+        return new BackoffCredentialsProvider(delegate, clock);
+    }
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(BASE_TIME);
+    }
+
+    @Test
+    void constructor_with_delegate_only_creates_provider() {
+        final BackoffCredentialsProvider provider = new BackoffCredentialsProvider(delegate);
+        when(delegate.resolveCredentials()).thenReturn(credentials);
+
+        final AwsCredentials result = provider.resolveCredentials();
+
+        assertThat(result, sameInstance(credentials));
+    }
+
+    @Test
+    void resolveCredentials_delegates_on_success() {
+        when(delegate.resolveCredentials()).thenReturn(credentials);
+
+        final AwsCredentials result = createObjectUnderTest().resolveCredentials();
+
+        assertThat(result, sameInstance(credentials));
+        verify(delegate).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_on_failure_throws_and_applies_backoff() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials()).thenThrow(exception);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        final SdkException thrown = assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        assertThat(thrown, sameInstance(exception));
+    }
+
+    @Test
+    void resolveCredentials_during_backoff_throws_cached_exception_without_calling_delegate() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials()).thenThrow(exception);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+        when(clock.instant()).thenReturn(BASE_TIME.plusSeconds(5));
+
+        final SdkException thrown = assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        assertThat(thrown, sameInstance(exception));
+        verify(delegate, times(1)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_after_backoff_expires_calls_delegate_again() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials()).thenThrow(exception).thenReturn(credentials);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+        when(clock.instant()).thenReturn(BASE_TIME.plusSeconds(11));
+
+        final AwsCredentials result = objectUnderTest.resolveCredentials();
+        assertThat(result, sameInstance(credentials));
+        verify(delegate, times(2)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_success_after_failure_resets_backoff() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials())
+                .thenThrow(exception)
+                .thenReturn(credentials)
+                .thenThrow(exception);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+        when(clock.instant()).thenReturn(BASE_TIME.plusSeconds(11));
+        objectUnderTest.resolveCredentials();
+
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+        when(clock.instant()).thenReturn(BASE_TIME.plusSeconds(16));
+
+        final SdkException thrown = assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        assertThat(thrown, sameInstance(exception));
+        verify(delegate, times(3)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_exponential_backoff_progression() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials()).thenThrow(exception);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+        when(clock.instant()).thenReturn(BASE_TIME.plusSeconds(9));
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        verify(delegate, times(1)).resolveCredentials();
+
+        when(clock.instant()).thenReturn(BASE_TIME.plus(BackoffCredentialsProvider.INITIAL_BACKOFF).plusMillis(1));
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        verify(delegate, times(2)).resolveCredentials();
+
+        when(clock.instant()).thenReturn(BASE_TIME.plus(BackoffCredentialsProvider.INITIAL_BACKOFF).plusSeconds(21));
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        verify(delegate, times(3)).resolveCredentials();
+
+        when(clock.instant()).thenReturn(BASE_TIME.plus(BackoffCredentialsProvider.INITIAL_BACKOFF).plusSeconds(61));
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+        verify(delegate, times(4)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_backoff_caps_at_max() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials()).thenThrow(exception);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        Instant currentTime = BASE_TIME;
+        for (int i = 0; i < 10; i++) {
+            long expectedBackoffMs = BackoffCredentialsProvider.INITIAL_BACKOFF.toMillis()
+                    * (long) Math.pow(BackoffCredentialsProvider.BACKOFF_MULTIPLIER, i);
+            expectedBackoffMs = Math.min(expectedBackoffMs, BackoffCredentialsProvider.MAX_BACKOFF.toMillis());
+
+            when(clock.instant()).thenReturn(currentTime);
+            assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+            currentTime = currentTime.plus(Duration.ofMillis(expectedBackoffMs)).plusMillis(1);
+        }
+
+        verify(delegate, times(10)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_when_now_equals_backoffUntil_calls_delegate() {
+        final SdkException exception = SdkClientException.create("access denied");
+        when(delegate.resolveCredentials()).thenThrow(exception).thenReturn(credentials);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SdkException.class, objectUnderTest::resolveCredentials);
+
+        when(clock.instant()).thenReturn(BASE_TIME.plus(BackoffCredentialsProvider.INITIAL_BACKOFF));
+
+        final AwsCredentials result = objectUnderTest.resolveCredentials();
+        assertThat(result, sameInstance(credentials));
+        verify(delegate, times(2)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_first_success_does_not_affect_state() {
+        when(delegate.resolveCredentials()).thenReturn(credentials);
+
+        final BackoffCredentialsProvider objectUnderTest = createObjectUnderTest();
+        objectUnderTest.resolveCredentials();
+        objectUnderTest.resolveCredentials();
+
+        verify(delegate, times(2)).resolveCredentials();
+    }
+
+    @Test
+    void resolveCredentials_constants_have_expected_values() {
+        assertThat(BackoffCredentialsProvider.INITIAL_BACKOFF, equalTo(Duration.ofSeconds(10)));
+        assertThat(BackoffCredentialsProvider.MAX_BACKOFF, equalTo(Duration.ofMinutes(10)));
+        assertThat(BackoffCredentialsProvider.BACKOFF_MULTIPLIER, equalTo(2));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -113,7 +113,7 @@ class CredentialsProviderFactoryTest {
         when(awsCredentialsOptions.getRegion())
                 .thenReturn(Region.US_EAST_1);
         final AwsCredentialsProvider awsCredentialsProvider = createObjectUnderTest().providerFromOptions(awsCredentialsOptions);
-        assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+        assertThat(awsCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
     }
 
     @ParameterizedTest
@@ -185,8 +185,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
-            assertThat(actualCredentialsProvider, equalTo(stsCredentialsProvider));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             verify(stsClientBuilder).region(region);
             verify(stsClientBuilder).overrideConfiguration(any(ClientOverrideConfiguration.class));
@@ -227,8 +226,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
-            assertThat(actualCredentialsProvider, equalTo(stsCredentialsProvider));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             verify(stsClientBuilder).region(region);
             verify(stsClientBuilder).overrideConfiguration(any(ClientOverrideConfiguration.class));
@@ -261,7 +259,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             verify(stsClientBuilder, never()).region(any(Region.class));
         }
@@ -291,7 +289,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -335,7 +333,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -371,7 +369,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -413,7 +411,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -444,7 +442,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -474,7 +472,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -508,8 +506,7 @@ class CredentialsProviderFactoryTest {
                 actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
             }
 
-            assertThat(actualCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
-            assertThat(actualCredentialsProvider, equalTo(stsCredentialsProvider));
+            assertThat(actualCredentialsProvider, instanceOf(BackoffCredentialsProvider.class));
 
             final ArgumentCaptor<ClientOverrideConfiguration> clientOverrideConfigurationArgumentCaptor =
                     ArgumentCaptor.forClass(ClientOverrideConfiguration.class);


### PR DESCRIPTION
### Description

Wrap StsAssumeRoleCredentialsProvider with BackoffCredentialsProvider in CredentialsProviderFactory. When credential resolution fails (e.g. role deleted or trust policy misconfigured), the wrapper caches the failure and applies exponential backoff (10s to 10min) before retrying STS, preventing excessive AssumeRole calls that cause STS throttling.

This protects all plugins that use CredentialsProviderFactory including S3, OpenSearch, Lambda, SQS, and most AWS-integrated sources and sinks.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
