### PR TITLE
Add support for resolving dynamic variable-values inside pipeline

### DIFF
--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DataPrepperExtensionPoints.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/DataPrepperExtensionPoints.java
@@ -1,27 +1,29 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 
 package org.opensearch.dataprepper.plugin;
 
 import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
 import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.support.GenericApplicationContext;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.Objects;
+import java.util.Set;
 
 @Named
 public class DataPrepperExtensionPoints implements ExtensionPoints {
     private static final ExtensionProvider.Context EMPTY_CONTEXT = new EmptyContext();
     private final GenericApplicationContext sharedApplicationContext;
     private final GenericApplicationContext coreApplicationContext;
-    private Set<Class> providerClassesSet;
+    private Set<String> registeredBeanNames;
 
     @Inject
     public DataPrepperExtensionPoints(
@@ -31,23 +33,26 @@ public class DataPrepperExtensionPoints implements ExtensionPoints {
         Objects.requireNonNull(pluginBeanFactoryProvider.getSharedPluginApplicationContext());
         this.sharedApplicationContext = pluginBeanFactoryProvider.getSharedPluginApplicationContext();
         this.coreApplicationContext = pluginBeanFactoryProvider.getCoreApplicationContext();
-        this.providerClassesSet = new HashSet<>();
+        this.registeredBeanNames = new HashSet<>();
     }
 
     @Override
     public void addExtensionProvider(final ExtensionProvider extensionProvider) {
-        if (providerClassesSet.contains(extensionProvider.supportedClass())) {
+        final String beanName = resolveBeanName(extensionProvider);
+        if (registeredBeanNames.contains(beanName)) {
             return;
         }
         coreApplicationContext.registerBean(
+                beanName,
                 extensionProvider.supportedClass(),
                 () -> extensionProvider.provideInstance(EMPTY_CONTEXT).orElse(null),
                 b -> b.setScope(BeanDefinition.SCOPE_PROTOTYPE));
         sharedApplicationContext.registerBean(
+                beanName,
                 extensionProvider.supportedClass(),
                 () -> extensionProvider.provideInstance(EMPTY_CONTEXT),
                 b -> b.setScope(BeanDefinition.SCOPE_PROTOTYPE));
-        providerClassesSet.add(extensionProvider.supportedClass());
+        registeredBeanNames.add(beanName);
     }
 
     @Override
@@ -56,7 +61,16 @@ public class DataPrepperExtensionPoints implements ExtensionPoints {
         return sharedApplicationContext.getBean(type);
     }
 
-    private static class EmptyContext implements ExtensionProvider.Context {
+    private String resolveBeanName(final ExtensionProvider extensionProvider) {
+        if (PluginConfigValueTranslator.class.isAssignableFrom(extensionProvider.supportedClass())) {
+            return PluginConfigValueTranslator.class.getName() + "_" + extensionProvider.provideInstance(EMPTY_CONTEXT)
+                    .filter(instance -> instance instanceof PluginConfigValueTranslator)
+                    .map(instance -> ((PluginConfigValueTranslator) instance).getPrefix())
+                    .orElse(extensionProvider.supportedClass().getName());
+        }
+        return extensionProvider.supportedClass().getName();
+    }
 
+    private static class EmptyContext implements ExtensionProvider.Context {
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DataPrepperExtensionPointsTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DataPrepperExtensionPointsTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 
 package org.opensearch.dataprepper.plugin;
@@ -12,6 +13,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.test.TestExtension;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionCustomizer;
@@ -25,12 +28,13 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +61,6 @@ class DataPrepperExtensionPointsTest {
                 .thenReturn(sharedApplicationContext);
 
         extensionClass = TestExtension.TestModel.class;
-
         when(extensionProvider.supportedClass()).thenReturn(extensionClass);
     }
 
@@ -68,7 +71,6 @@ class DataPrepperExtensionPointsTest {
     @Test
     void constructor_throws_if_provider_is_null() {
         pluginBeanFactoryProvider = null;
-
         assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
@@ -77,7 +79,6 @@ class DataPrepperExtensionPointsTest {
         reset(pluginBeanFactoryProvider);
         when(pluginBeanFactoryProvider.getCoreApplicationContext())
                 .thenReturn(coreApplicationContext);
-
         assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
@@ -86,7 +87,6 @@ class DataPrepperExtensionPointsTest {
         reset(pluginBeanFactoryProvider);
         when(pluginBeanFactoryProvider.getSharedPluginApplicationContext())
                 .thenReturn(sharedApplicationContext);
-
         assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
@@ -94,21 +94,78 @@ class DataPrepperExtensionPointsTest {
     void addExtensionProvider_should_registerBean() {
         createObjectUnderTest().addExtensionProvider(extensionProvider);
 
-        verify(sharedApplicationContext).registerBean(eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
-        verify(coreApplicationContext).registerBean(eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(sharedApplicationContext).registerBean(anyString(), eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(coreApplicationContext).registerBean(anyString(), eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
     }
 
     @Test
-    void addExtensionProvider_should_not_registerBean_for_the_sameClass() {
-        DataPrepperExtensionPoints dataPrepperExtensionPoints = createObjectUnderTest();
-        dataPrepperExtensionPoints.addExtensionProvider(extensionProvider);
+    void addExtensionProvider_should_not_registerBean_for_same_provider_twice() {
+        final DataPrepperExtensionPoints objectUnderTest = createObjectUnderTest();
+        objectUnderTest.addExtensionProvider(extensionProvider);
+        objectUnderTest.addExtensionProvider(extensionProvider);
 
-        verify(sharedApplicationContext, times(1)).registerBean(eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
-        verify(coreApplicationContext, times(1)).registerBean(eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(sharedApplicationContext, times(1)).registerBean(anyString(), eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(coreApplicationContext, times(1)).registerBean(anyString(), eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+    }
 
-        dataPrepperExtensionPoints.addExtensionProvider(extensionProvider);
-        verify(sharedApplicationContext, times(1)).registerBean(eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
-        verify(coreApplicationContext, times(1)).registerBean(eq(extensionClass), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+    @Test
+    void addExtensionProvider_should_registerBean_as_prototype() {
+        createObjectUnderTest().addExtensionProvider(extensionProvider);
+
+        verifyRegisteredAsPrototype(sharedApplicationContext);
+        verifyRegisteredAsPrototype(coreApplicationContext);
+    }
+
+    @Test
+    void addExtensionProvider_two_PluginConfigValueTranslators_with_different_prefixes_both_registered() {
+        final ExtensionProvider<PluginConfigValueTranslator> firstProvider = translatorProvider("env");
+        final ExtensionProvider<PluginConfigValueTranslator> secondProvider = translatorProvider("file");
+
+        final DataPrepperExtensionPoints objectUnderTest = createObjectUnderTest();
+        objectUnderTest.addExtensionProvider(firstProvider);
+        objectUnderTest.addExtensionProvider(secondProvider);
+
+        verify(sharedApplicationContext, times(2)).registerBean(anyString(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(coreApplicationContext, times(2)).registerBean(anyString(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+    }
+
+    @Test
+    void addExtensionProvider_two_PluginConfigValueTranslators_same_prefix_only_first_registered() {
+        final ExtensionProvider<PluginConfigValueTranslator> firstProvider = translatorProvider("env");
+        final ExtensionProvider<PluginConfigValueTranslator> duplicateProvider = translatorProvider("env");
+
+        final DataPrepperExtensionPoints objectUnderTest = createObjectUnderTest();
+        objectUnderTest.addExtensionProvider(firstProvider);
+        objectUnderTest.addExtensionProvider(duplicateProvider);
+
+        verify(sharedApplicationContext, times(1)).registerBean(anyString(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(coreApplicationContext, times(1)).registerBean(anyString(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+    }
+
+    @Test
+    void addExtensionProvider_three_PluginConfigValueTranslators_all_different_prefixes_all_registered() {
+        final ExtensionProvider<PluginConfigValueTranslator> envProvider = translatorProvider("env");
+        final ExtensionProvider<PluginConfigValueTranslator> fileProvider = translatorProvider("file");
+        final ExtensionProvider<PluginConfigValueTranslator> awsProvider = translatorProvider("aws_secrets");
+
+        final DataPrepperExtensionPoints objectUnderTest = createObjectUnderTest();
+        objectUnderTest.addExtensionProvider(envProvider);
+        objectUnderTest.addExtensionProvider(fileProvider);
+        objectUnderTest.addExtensionProvider(awsProvider);
+
+        verify(sharedApplicationContext, times(3)).registerBean(anyString(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        verify(coreApplicationContext, times(3)).registerBean(anyString(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+    }
+
+    @Test
+    void addExtensionProvider_bean_name_for_translator_contains_prefix() {
+        final ArgumentCaptor<String> beanNameCaptor = ArgumentCaptor.forClass(String.class);
+        final ExtensionProvider<PluginConfigValueTranslator> provider = translatorProvider("env");
+
+        createObjectUnderTest().addExtensionProvider(provider);
+
+        verify(sharedApplicationContext).registerBean(beanNameCaptor.capture(), eq(PluginConfigValueTranslator.class), any(Supplier.class), any(BeanDefinitionCustomizer.class));
+        assertThat(beanNameCaptor.getValue().contains("env"), equalTo(true));
     }
 
     @Test
@@ -120,79 +177,81 @@ class DataPrepperExtensionPointsTest {
     }
 
     @Test
-    void addExtensionProvider_should_registerBean_as_prototype() {
-        createObjectUnderTest().addExtensionProvider(extensionProvider);
-
-        verifyRegisterBeanAsPrototype(sharedApplicationContext);
-        verifyRegisterBeanAsPrototype(coreApplicationContext);
-    }
-
-    @Test
     void getExtensionProvider_refreshes_shared_context_and_returns_correct_bean() {
         final Class<DefaultPluginFactory> defaultPluginFactoryClass = DefaultPluginFactory.class;
         final DefaultPluginFactory defaultPluginFactory = mock(DefaultPluginFactory.class);
-
         when(sharedApplicationContext.getBean(defaultPluginFactoryClass)).thenReturn(defaultPluginFactory);
 
         final DefaultPluginFactory result = createObjectUnderTest().getExtensionProvider(defaultPluginFactoryClass);
 
         assertThat(result, equalTo(defaultPluginFactory));
-
         verify(sharedApplicationContext).refresh();
+    }
+
+    private ExtensionProvider<PluginConfigValueTranslator> translatorProvider(final String prefix) {
+        final PluginConfigValueTranslator translator = new PluginConfigValueTranslator() {
+            @Override
+            public Object translate(final String value) {
+                return value;
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefix;
+            }
+
+            @Override
+            public PluginConfigVariable translateToPluginConfigVariable(final String value) {
+                return null;
+            }
+        };
+
+        @SuppressWarnings("unchecked")
+        final ExtensionProvider<PluginConfigValueTranslator> provider = mock(ExtensionProvider.class);
+        when(provider.supportedClass()).thenReturn(PluginConfigValueTranslator.class);
+        when(provider.provideInstance(any())).thenReturn(Optional.of(translator));
+        return provider;
     }
 
     private void verifyRegisterBeanWithProvideInstance(final GenericApplicationContext applicationContext) {
         reset(extensionProvider);
-        final ArgumentCaptor<Supplier<Object>> supplierArgumentCaptor =
-                ArgumentCaptor.forClass(Supplier.class);
+        final ArgumentCaptor<Supplier<Object>> supplierCaptor = ArgumentCaptor.forClass(Supplier.class);
 
-        verify(applicationContext).registerBean(eq(extensionClass), supplierArgumentCaptor.capture(), any(BeanDefinitionCustomizer.class));
-
-        final Supplier<Object> extensionProviderSupplier = supplierArgumentCaptor.getValue();
+        verify(applicationContext).registerBean(anyString(), eq(extensionClass), supplierCaptor.capture(), any(BeanDefinitionCustomizer.class));
 
         verify(extensionProvider, never()).provideInstance(any());
 
-        Object providedInstance = mock(Object.class);
+        final Object providedInstance = mock(Object.class);
         when(extensionProvider.provideInstance(any())).thenReturn(Optional.of(providedInstance));
-        final Object actualValueFromSupplier = extensionProviderSupplier.get();
+        final Object actual = supplierCaptor.getValue().get();
 
-        assertThat(actualValueFromSupplier, instanceOf(Optional.class));
-        Optional<Object> optionalWrapper = (Optional) actualValueFromSupplier;
-        assertThat(optionalWrapper.isPresent(), equalTo(true));
-        final Object actualInstance = optionalWrapper.get();
-        assertThat(actualInstance, equalTo(providedInstance));
-        verify(extensionProvider).provideInstance(any());
+        assertThat(actual, instanceOf(Optional.class));
+        assertThat(((Optional<Object>) actual).get(), equalTo(providedInstance));
     }
 
     private void verifyRegisterBeanWithProvideInstanceOrElse(final GenericApplicationContext applicationContext) {
         reset(extensionProvider);
-        final ArgumentCaptor<Supplier<Object>> supplierArgumentCaptor =
-                ArgumentCaptor.forClass(Supplier.class);
+        final ArgumentCaptor<Supplier<Object>> supplierCaptor = ArgumentCaptor.forClass(Supplier.class);
 
-        verify(applicationContext).registerBean(eq(extensionClass), supplierArgumentCaptor.capture(), any(BeanDefinitionCustomizer.class));
-
-        final Supplier<Object> extensionProviderSupplier = supplierArgumentCaptor.getValue();
+        verify(applicationContext).registerBean(anyString(), eq(extensionClass), supplierCaptor.capture(), any(BeanDefinitionCustomizer.class));
 
         verify(extensionProvider, never()).provideInstance(any());
 
-        Object providedInstance = mock(Object.class);
+        final Object providedInstance = mock(Object.class);
         when(extensionProvider.provideInstance(any())).thenReturn(Optional.of(providedInstance));
-        final Object actualValueFromSupplier = extensionProviderSupplier.get();
+        final Object actual = supplierCaptor.getValue().get();
 
-        assertThat(actualValueFromSupplier, equalTo(providedInstance));
-        verify(extensionProvider).provideInstance(any());
+        assertThat(actual, equalTo(providedInstance));
     }
 
-    private void verifyRegisterBeanAsPrototype(final GenericApplicationContext applicationContext) {
-        final ArgumentCaptor<BeanDefinitionCustomizer> beanDefinitionCustomizerArgumentCaptor =
+    private void verifyRegisteredAsPrototype(final GenericApplicationContext applicationContext) {
+        final ArgumentCaptor<BeanDefinitionCustomizer> customizerCaptor =
                 ArgumentCaptor.forClass(BeanDefinitionCustomizer.class);
 
-        verify(applicationContext).registerBean(eq(extensionClass), any(Supplier.class), beanDefinitionCustomizerArgumentCaptor.capture());
-
-        final BeanDefinitionCustomizer beanDefinitionCustomizer = beanDefinitionCustomizerArgumentCaptor.getValue();
+        verify(applicationContext).registerBean(anyString(), eq(extensionClass), any(Supplier.class), customizerCaptor.capture());
 
         final BeanDefinition beanDefinition = mock(BeanDefinition.class);
-        beanDefinitionCustomizer.customize(beanDefinition);
+        customizerCaptor.getValue().customize(beanDefinition);
 
         verify(beanDefinition).setScope(BeanDefinition.SCOPE_PROTOTYPE);
     }

--- a/data-prepper-plugins/variable-template-plugin/README.md
+++ b/data-prepper-plugins/variable-template-plugin/README.md
@@ -1,0 +1,80 @@
+# variable-template-plugin
+
+Resolves dynamic value expressions in Data Prepper pipeline configurations at startup. Has to be enabled via config otherwhise it gets interpreted as a string. File and store allows all standard formats like .env, .txt, etc.
+
+## Configuration
+
+```yaml
+extensions:
+  variable_sources:
+    resolvers:
+      env: true
+      file: true
+      store:
+        enabled: true
+        sources:
+          - /path/to/.env
+          - /path/to/another.env
+```
+
+## Resolvers
+
+### env
+
+Reads a value from the process environment.
+
+```yaml
+password: ${{env:OPENSEARCH_PASSWORD}}
+```
+
+The environment variable must be set when Data Prepper starts. If it is not set, startup fails with a descriptive error.
+
+### file
+
+Reads the contents of a file from disk. Leading and trailing whitespace (including newlines) is stripped, so files written with a trailing newline behave as expected. Both absolute and relative paths are supported.
+
+```yaml
+password: ${{file:/var/secrets/opensearch/password}}
+```
+
+### store
+
+Reads key/value pairs from one or more `.env`-style files and resolves them by key.
+
+```yaml
+image: ${{store:LOCAL_IMAGE_NAME_DOCKERHUB}}
+```
+
+`.env, .txt or other` file format:
+```
+# comments are ignored
+KEY=value
+QUOTED="also works"
+SPECIAL=p@$$w0rd!
+URL=https://host.docker.internal:9200
+```
+
+Rules:
+- Lines starting with `#` are comments and are ignored
+- Empty lines are ignored
+- Format is `KEY=VALUE`
+- Values may be quoted with `"` or `'` — quotes are stripped
+- Inline comments (`KEY=value # comment`) are stripped
+- If multiple store files define the same key, the last file wins
+- Missing `=`, empty key, or missing source file causes startup to fail with a descriptive error
+
+## Behaviour
+
+All values are resolved once at pipeline startup and are static for the lifetime of the process. Changes to environment variables or file contents require a restart to take effect.
+
+## Coexistence with other plugins
+
+This plugin uses the Data Prepper extension framework's `PluginConfigValueTranslator` interface. It coexists with the `aws-plugin` (`${{aws_secrets:...}}`) and any other translator plugins without conflict, provided the framework patch in `DataPrepperExtensionPoints` is applied
+
+## Known Limitations
+
+Because of how the variables get templated it wont work if you use the variables in the aws section.
+And you can only set variables as standalone. So you cant define them inside a string. 
+This will be supported in upcomming feature.
+
+${{env:OPENSEARCH_HOST}}:9200

--- a/data-prepper-plugins/variable-template-plugin/README.md
+++ b/data-prepper-plugins/variable-template-plugin/README.md
@@ -132,8 +132,6 @@ simple-sample-pipeline:
             value: ${{store:STORE_FIRST_ENTRY}}
           - key: "store_second_variable"
             value: ${{store:STORE_SECOND_ENTRY}}
-          - key: "store_second_variable"
-            value: ${{store:STORE_THIRD_ENTRY}}
           - key: "aws_secret_variable"
             value: "${{aws_secrets:aws_example_secret}}"
   sink:
@@ -154,13 +152,13 @@ simple-sample-pipeline:
 ```
 
 ```json
-# opensearch sink
+# document in opensearch
 {
   "_index" : "index-name-from-store",
   "_id" : "C-V-7JwB-wKI_oflC0Kg",
   "_score" : 1.0,
   "_source" : {
-    "message" : "43a60d0b-026a-4bf5-9d19-6b55f689fd91",
+    "message" : "058b3a98-fc63-428c-b43b-e9c85ce469c7",
     "env-variable" : "VALUE_FROM_ENVIRONMENT",
     "file-variable" : "value-from-secret-file",
     "store_first_variable" : "FIRST_STORE_VALUE",

--- a/data-prepper-plugins/variable-template-plugin/README.md
+++ b/data-prepper-plugins/variable-template-plugin/README.md
@@ -42,7 +42,7 @@ password: ${{file:/var/secrets/opensearch/password}}
 Reads key/value pairs from one or more `.env`-style files and resolves them by key.
 
 ```yaml
-image: ${{store:LOCAL_IMAGE_NAME_DOCKERHUB}}
+image: ${{store:OPENSEARCH_URL}}
 ```
 
 `.env, .txt or other` file format:
@@ -51,7 +51,7 @@ image: ${{store:LOCAL_IMAGE_NAME_DOCKERHUB}}
 KEY=value
 QUOTED="also works"
 SPECIAL=p@$$w0rd!
-URL=https://host.docker.internal:9200
+OPENSEARCH_URL=https://host.docker.internal:9200
 ```
 
 Rules:
@@ -73,8 +73,18 @@ This plugin uses the Data Prepper extension framework's `PluginConfigValueTransl
 
 ## Known Limitations
 
-Because of how the variables get templated it wont work if you use the variables in the aws section.
-And you can only set variables as standalone. So you cant define them inside a string. 
+Because of how the variables get templated it wont work if you use the variables in the aws-extension config.
+And you can only set variables as standalone. So you cant define them inside a string. This applies also to expression.
 This will be supported in upcomming feature.
 
-${{env:OPENSEARCH_HOST}}:9200
+- Wont work:
+URL: ${{env:OPENSEARCH_HOST}}:9200
+---
+processor:
+    - add_entries:
+        entries:
+          - key: "Resolve worked?"
+            value: "yes"
+            add_when: "/event_key == ${{store:TEST_KEY}}"
+
+

--- a/data-prepper-plugins/variable-template-plugin/README.md
+++ b/data-prepper-plugins/variable-template-plugin/README.md
@@ -77,14 +77,94 @@ Because of how the variables get templated it wont work if you use the variables
 And you can only set variables as standalone. So you cant define them inside a string. This applies also to expression.
 This will be supported in upcomming feature.
 
-- Wont work:
+## Wont work:
+```yaml
 URL: ${{env:OPENSEARCH_HOST}}:9200
----
+```
+
+```yaml
 processor:
     - add_entries:
         entries:
           - key: "Resolve worked?"
             value: "yes"
             add_when: "/event_key == ${{store:TEST_KEY}}"
+```
 
+## Full Setup:
+```yaml
+# data-prepper-config.yaml
+ssl: false
+extensions:
+  variable_sources:
+    resolvers:
+      env: true
+      file: true
+      store:
+        enabled: true
+        sources:
+          - /var/secrets/.env
+          - /var/secrets/store.txt
+  aws:
+    secrets:
+      aws_example_secret:
+        secret_id: dataprepper_local
+        region: us-east-1
+  geoip_service:
+    maxmind:
+```
 
+```yaml
+# pipelines.yaml
+simple-sample-pipeline:
+  workers: 2
+  delay: "5000"
+  source:
+    random:
+  processor:
+    - add_entries:
+        entries:
+          - key: "env-variable"
+            value: "${{env:DEMO_ENVIRONMENT_KEY}}"
+          - key: "file-variable"
+            value: ${{file:/var/secrets/secret-file.txt}}
+          - key: "store_first_variable"
+            value: ${{store:STORE_FIRST_ENTRY}}
+          - key: "store_second_variable"
+            value: ${{store:STORE_SECOND_ENTRY}}
+          - key: "store_second_variable"
+            value: ${{store:STORE_THIRD_ENTRY}}
+          - key: "aws_secret_variable"
+            value: "${{aws_secrets:aws_example_secret}}"
+  sink:
+    - stdout:
+    - file:
+        path: ${{store:OUTPUT_FILE}}
+    - opensearch:
+        hosts: ["${{store:OPENSEARCH_HOST}}"]
+        index: ${{store:INDEX_NAME}}
+        username: "admin"
+        password: "${{env:OPENSEARCH_PASSWORD}}"
+        insecure: true
+```
+
+```json
+# stdout sink
+{"message":"058b3a98-fc63-428c-b43b-e9c85ce469c7","env-variable":"VALUE_FROM_ENVIRONMENT","file-variable":"value-from-secret-file","store_first_variable":"FIRST_STORE_VALUE","store_second_variable":"SECOND_STORE_VALUE","aws_secret_variable":"{\"aws_demo_key\":\"secret_from_aws\"}"}
+```
+
+```json
+# opensearch sink
+{
+  "_index" : "index-name-from-store",
+  "_id" : "C-V-7JwB-wKI_oflC0Kg",
+  "_score" : 1.0,
+  "_source" : {
+    "message" : "43a60d0b-026a-4bf5-9d19-6b55f689fd91",
+    "env-variable" : "VALUE_FROM_ENVIRONMENT",
+    "file-variable" : "value-from-secret-file",
+    "store_first_variable" : "FIRST_STORE_VALUE",
+    "store_second_variable" : "SECOND_STORE_VALUE",
+    "aws_secret_variable" : "{\"aws_demo_key\":\"secret_from_aws\"}"
+}
+```

--- a/data-prepper-plugins/variable-template-plugin/build.gradle
+++ b/data-prepper-plugins/variable-template-plugin/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+dependencies {
+    implementation project(':data-prepper-api')
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    testImplementation project(':data-prepper-test:test-common')
+}
+
+test {
+    useJUnitPlatform()
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 1.0
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/EnvVariableTranslator.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/EnvVariableTranslator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+public class EnvVariableTranslator implements PluginConfigValueTranslator {
+
+    static final String PREFIX = "env";
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public Object translate(final String name) {
+        final String value = getenv(name);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    String.format("Environment variable '%s' is not set.", name));
+        }
+        return value;
+    }
+
+    @Override
+    public PluginConfigVariable translateToPluginConfigVariable(final String name) {
+        return new ImmutablePluginConfigVariable(translate(name));
+    }
+
+    String getenv(final String name) {
+        return System.getenv(name);
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/FileVariableTranslator.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/FileVariableTranslator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+public class FileVariableTranslator implements PluginConfigValueTranslator {
+
+    static final String PREFIX = "file";
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public Object translate(final String path) {
+        try {
+            return Files.readString(Path.of(path)).strip();
+        } catch (final NoSuchFileException e) {
+            throw new IllegalArgumentException(
+                    String.format("Secret file not found: '%s'.", path), e);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException(
+                    String.format("Failed to read secret file '%s': %s", path, e.getMessage()), e);
+        }
+    }
+
+    @Override
+    public PluginConfigVariable translateToPluginConfigVariable(final String path) {
+        return new ImmutablePluginConfigVariable(translate(path));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/ImmutablePluginConfigVariable.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/ImmutablePluginConfigVariable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.opensearch.dataprepper.model.plugin.FailedToUpdatePluginConfigValueException;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+public class ImmutablePluginConfigVariable implements PluginConfigVariable {
+
+    private final Object value;
+
+    public ImmutablePluginConfigVariable(final Object value) {
+        this.value = value;
+    }
+
+    @Override
+    public Object getValue() {
+        return value;
+    }
+
+    @Override
+    public void setValue(final Object newValue) {
+        throw new FailedToUpdatePluginConfigValueException("This variable is immutable and cannot be updated.");
+    }
+
+    @Override
+    public void refresh() {
+    }
+
+    @Override
+    public boolean isUpdatable() {
+        return false;
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/StoreVariableTranslator.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/StoreVariableTranslator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class StoreVariableTranslator implements PluginConfigValueTranslator {
+
+    static final String PREFIX = "store";
+
+    private final Map<String, String> store;
+
+    public StoreVariableTranslator(final List<String> sources) {
+        this.store = loadSources(sources);
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public Object translate(final String key) {
+        final String value = store.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    String.format("Key '%s' not found in variable store.", key));
+        }
+        return value;
+    }
+
+    @Override
+    public PluginConfigVariable translateToPluginConfigVariable(final String key) {
+        return new ImmutablePluginConfigVariable(translate(key));
+    }
+
+    private Map<String, String> loadSources(final List<String> sources) {
+        final Map<String, String> result = new HashMap<>();
+        for (final String source : sources) {
+            result.putAll(parseEnvFile(source));
+        }
+        return result;
+    }
+
+    private Map<String, String> parseEnvFile(final String path) {
+        final List<String> lines;
+        try {
+            lines = Files.readAllLines(Path.of(path));
+        } catch (final NoSuchFileException e) {
+            throw new IllegalArgumentException(
+                    String.format("Store source file not found: '%s'.", path), e);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException(
+                    String.format("Failed to read store source file '%s': %s", path, e.getMessage()), e);
+        }
+
+        final Map<String, String> entries = new HashMap<>();
+        int lineNumber = 0;
+        for (final String rawLine : lines) {
+            lineNumber++;
+            final String line = rawLine.strip();
+
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue;
+            }
+
+            final int separatorIndex = line.indexOf('=');
+            if (separatorIndex < 1) {
+                throw new IllegalArgumentException(
+                        String.format(
+                        "Invalid entry in store file '%s' at line %d: '%s'. Expected KEY=VALUE.", path, lineNumber, rawLine));
+            }
+
+            final String key = line.substring(0, separatorIndex).strip();
+            final String rawValue = line.substring(separatorIndex + 1);
+            entries.put(key, unquote(rawValue.strip()));
+        }
+        return entries;
+    }
+
+    private String unquote(final String value) {
+        if (value.length() >= 2) {
+            if ((value.startsWith("\"") && value.endsWith("\""))
+                    || (value.startsWith("'") && value.endsWith("'"))) {
+                return value.substring(1, value.length() - 1);
+            }
+        }
+        final int commentIndex = findInlineComment(value);
+        if (commentIndex >= 0) {
+            return value.substring(0, commentIndex).stripTrailing();
+        }
+        return value;
+    }
+
+    private int findInlineComment(final String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == '#' && (i == 0 || value.charAt(i - 1) == ' ')) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplateExtensionProvider.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplateExtensionProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+
+import java.util.Optional;
+
+public class VariableTemplateExtensionProvider implements ExtensionProvider<PluginConfigValueTranslator> {
+
+    private final PluginConfigValueTranslator translator;
+
+    public VariableTemplateExtensionProvider(final PluginConfigValueTranslator translator) {
+        this.translator = translator;
+    }
+
+    @Override
+    public Optional<PluginConfigValueTranslator> provideInstance(final Context context) {
+        return Optional.of(translator);
+    }
+
+    @Override
+    public Class<PluginConfigValueTranslator> supportedClass() {
+        return PluginConfigValueTranslator.class;
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePlugin.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePlugin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperExtensionPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.plugin.ExtensionPlugin;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@DataPrepperExtensionPlugin(
+        modelType = VariableTemplatePluginConfig.class,
+        rootKeyJsonPath = "/variable_sources",
+        allowInPipelineConfigurations = false)
+public class VariableTemplatePlugin implements ExtensionPlugin {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VariableTemplatePlugin.class);
+
+    private final VariableTemplatePluginConfig config;
+
+    @DataPrepperPluginConstructor
+    public VariableTemplatePlugin(final VariableTemplatePluginConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void apply(final ExtensionPoints extensionPoints) {
+        if (config == null) {
+            return;
+        }
+
+        final VariableTemplatePluginConfig.Resolvers resolvers = config.getResolvers();
+
+        if (resolvers.isEnvEnabled()) {
+            LOG.info("VariableTemplatePlugin: registering env resolver.");
+            extensionPoints.addExtensionProvider(
+                    new VariableTemplateExtensionProvider(new EnvVariableTranslator()));
+        }
+
+        if (resolvers.isFileEnabled()) {
+            LOG.info("VariableTemplatePlugin: registering file resolver.");
+            extensionPoints.addExtensionProvider(
+                    new VariableTemplateExtensionProvider(new FileVariableTranslator()));
+        }
+
+        final VariableTemplatePluginConfig.StoreResolverConfig storeConfig = resolvers.getStore();
+        if (storeConfig != null && storeConfig.isEnabled()) {
+            LOG.info("VariableTemplatePlugin: registering store resolver with {} source(s).", storeConfig.getSources().size());
+            extensionPoints.addExtensionProvider(
+                    new VariableTemplateExtensionProvider(new StoreVariableTranslator(storeConfig.getSources())));
+        }
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginConfig.java
+++ b/data-prepper-plugins/variable-template-plugin/src/main/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class VariableTemplatePluginConfig {
+
+    @JsonProperty("resolvers")
+    private Resolvers resolvers = new Resolvers();
+
+    public Resolvers getResolvers() {
+        return resolvers;
+    }
+
+    public static class Resolvers {
+
+        @JsonProperty("env")
+        private boolean envEnabled = false;
+
+        @JsonProperty("file")
+        private boolean fileEnabled = false;
+
+        @JsonProperty("store")
+        private StoreResolverConfig store = null;
+
+        public boolean isEnvEnabled() {
+            return envEnabled;
+        }
+
+        public boolean isFileEnabled() {
+            return fileEnabled;
+        }
+
+        public StoreResolverConfig getStore() {
+            return store;
+        }
+    }
+
+    public static class StoreResolverConfig {
+
+        @JsonProperty("enabled")
+        private boolean enabled = false;
+
+        @JsonProperty("sources")
+        private java.util.List<String> sources = java.util.Collections.emptyList();
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public java.util.List<String> getSources() {
+            return sources;
+        }
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/EnvVariableTranslatorTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/EnvVariableTranslatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.opensearch.dataprepper.plugins.variabletemplate.EnvVariableTranslator.PREFIX;
+
+@ExtendWith(MockitoExtension.class)
+class EnvVariableTranslatorTest {
+
+    @Spy
+    private EnvVariableTranslator objectUnderTest;
+
+    @Test
+    void testGetPrefix_returnsEnv() {
+        assertThat(objectUnderTest.getPrefix(), equalTo(PREFIX));
+    }
+
+    @Test
+    void testTranslate_returnsEnvValue() {
+        doReturn("test-value").when(objectUnderTest).getenv("MY_VAR");
+        assertThat(objectUnderTest.translate("MY_VAR"), equalTo("test-value"));
+    }
+
+    @Test
+    void testTranslate_realEnvVar_returnsValue() {
+        assertThat(objectUnderTest.translate("PATH"), equalTo(System.getenv("PATH")));
+    }
+
+    @Test
+    void testTranslate_unsetVariable_throwsIllegalArgumentException() {
+        final String varName = "__UNSET_" + UUID.randomUUID().toString().replace("-", "") + "__";
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> objectUnderTest.translate(varName));
+        assertThat(ex.getMessage().contains(varName), equalTo(true));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_returnsImmutableVariable() {
+        doReturn("test-value").when(objectUnderTest).getenv("MY_VAR");
+        final PluginConfigVariable variable = objectUnderTest.translateToPluginConfigVariable("MY_VAR");
+        assertThat(variable, instanceOf(ImmutablePluginConfigVariable.class));
+        assertThat(variable.getValue(), equalTo("test-value"));
+        assertThat(variable.isUpdatable(), equalTo(false));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_setValue_throwsException() {
+        doReturn("test-value").when(objectUnderTest).getenv("MY_VAR");
+        final PluginConfigVariable variable = objectUnderTest.translateToPluginConfigVariable("MY_VAR");
+        assertThrows(Exception.class, () -> variable.setValue("new"));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_refresh_isNoOp() {
+        doReturn("test-value").when(objectUnderTest).getenv("MY_VAR");
+        final PluginConfigVariable variable = objectUnderTest.translateToPluginConfigVariable("MY_VAR");
+        variable.refresh();
+        assertThat(variable.getValue(), equalTo("test-value"));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/FileVariableTranslatorTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/FileVariableTranslatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.plugins.variabletemplate.FileVariableTranslator.PREFIX;
+
+@ExtendWith(MockitoExtension.class)
+class FileVariableTranslatorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private FileVariableTranslator objectUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        objectUnderTest = new FileVariableTranslator();
+    }
+
+    @Test
+    void testGetPrefix_returnsFile() {
+        assertThat(objectUnderTest.getPrefix(), equalTo(PREFIX));
+    }
+
+    @Test
+    void testTranslate_stripsTrailingNewline() throws IOException {
+        final Path file = tempDir.resolve("secret.txt");
+        Files.writeString(file, "s3cr3t\n");
+        assertThat(objectUnderTest.translate(file.toString()), equalTo("s3cr3t"));
+    }
+
+    @Test
+    void testTranslate_stripsLeadingAndTrailingWhitespace() throws IOException {
+        final Path file = tempDir.resolve("padded.txt");
+        Files.writeString(file, "  value  ");
+        assertThat(objectUnderTest.translate(file.toString()), equalTo("value"));
+    }
+
+    @Test
+    void testTranslate_specialCharacters_returnedVerbatim() throws IOException {
+        final Path file = tempDir.resolve("special.txt");
+        final String value = "p@$$w0rd!#%^&*()-+=[]{}|;:,.<>?";
+        Files.writeString(file, value);
+        assertThat(objectUnderTest.translate(file.toString()), equalTo(value));
+    }
+
+    @Test
+    void testTranslate_integerValue_returnedAsString() throws IOException {
+        final Path file = tempDir.resolve("port.txt");
+        Files.writeString(file, "9200");
+        assertThat(objectUnderTest.translate(file.toString()), equalTo("9200"));
+    }
+
+    @Test
+    void testTranslate_missingFile_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> objectUnderTest.translate(tempDir.resolve("ghost.txt").toString()));
+    }
+
+    @Test
+    void testTranslate_unreadableFile_throwsIllegalArgumentException() throws IOException {
+        final Path file = tempDir.resolve("locked.txt");
+        Files.writeString(file, "value");
+        assertThat(file.toFile().setReadable(false), is(true));
+        assertThrows(IllegalArgumentException.class,
+                () -> objectUnderTest.translate(file.toString()));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_returnsImmutableVariable() throws IOException {
+        final Path file = tempDir.resolve("token.txt");
+        Files.writeString(file, "my-token");
+        final PluginConfigVariable variable = objectUnderTest.translateToPluginConfigVariable(file.toString());
+        assertThat(variable, instanceOf(ImmutablePluginConfigVariable.class));
+        assertThat(variable.getValue(), equalTo("my-token"));
+        assertThat(variable.isUpdatable(), equalTo(false));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_setValue_throwsException() throws IOException {
+        final Path file = tempDir.resolve("token2.txt");
+        Files.writeString(file, "my-token");
+        final PluginConfigVariable variable = objectUnderTest.translateToPluginConfigVariable(file.toString());
+        assertThrows(Exception.class, () -> variable.setValue("new"));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_refresh_isNoOp() throws IOException {
+        final Path file = tempDir.resolve("token3.txt");
+        Files.writeString(file, "my-token");
+        final PluginConfigVariable variable = objectUnderTest.translateToPluginConfigVariable(file.toString());
+        variable.refresh();
+        assertThat(variable.getValue(), equalTo("my-token"));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/ImmutablePluginConfigVariableTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/ImmutablePluginConfigVariableTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ImmutablePluginConfigVariableTest {
+
+    @Test
+    void testGetValue_returnsConstructedValue() {
+        assertThat(new ImmutablePluginConfigVariable("my-value").getValue(), equalTo("my-value"));
+    }
+
+    @Test
+    void testIsUpdatable_returnsFalse() {
+        assertThat(new ImmutablePluginConfigVariable("v").isUpdatable(), equalTo(false));
+    }
+
+    @Test
+    void testSetValue_throwsException() {
+        assertThrows(Exception.class, () -> new ImmutablePluginConfigVariable("v").setValue("new"));
+    }
+
+    @Test
+    void testRefresh_isNoOp() {
+        final ImmutablePluginConfigVariable variable = new ImmutablePluginConfigVariable("v");
+        variable.refresh();
+        assertThat(variable.getValue(), equalTo("v"));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/StoreVariableTranslatorTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/StoreVariableTranslatorTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.plugins.variabletemplate.StoreVariableTranslator.PREFIX;
+
+@ExtendWith(MockitoExtension.class)
+class StoreVariableTranslatorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private StoreVariableTranslator buildTranslator(final String content) throws IOException {
+        final Path file = tempDir.resolve("store.env");
+        Files.writeString(file, content);
+        return new StoreVariableTranslator(List.of(file.toString()));
+    }
+
+    @Test
+    void testGetPrefix_returnsStore() {
+        final StoreVariableTranslator translator = new StoreVariableTranslator(Collections.emptyList());
+        assertThat(translator.getPrefix(), equalTo(PREFIX));
+    }
+
+    @Test
+    void testTranslate_simpleKeyValue() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("MY_KEY=my-value\n");
+        assertThat(translator.translate("MY_KEY"), equalTo("my-value"));
+    }
+
+    @Test
+    void testTranslate_integerValue() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("PORT=9200\n");
+        assertThat(translator.translate("PORT"), equalTo("9200"));
+    }
+
+    @Test
+    void testTranslate_specialCharactersInValue() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("SECRET=p@$$w0rd!%^&*()\n");
+        assertThat(translator.translate("SECRET"), equalTo("p@$$w0rd!%^&*()"));
+    }
+
+    @Test
+    void testTranslate_doubleQuotedValue() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=\"quoted value\"\n");
+        assertThat(translator.translate("KEY"), equalTo("quoted value"));
+    }
+
+    @Test
+    void testTranslate_singleQuotedValue() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY='single quoted'\n");
+        assertThat(translator.translate("KEY"), equalTo("single quoted"));
+    }
+
+    @Test
+    void testTranslate_valueWithEqualsSign() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("JDBC_URL=jdbc:postgresql://host:5432/db?ssl=true\n");
+        assertThat(translator.translate("JDBC_URL"), equalTo("jdbc:postgresql://host:5432/db?ssl=true"));
+    }
+
+    @Test
+    void testTranslate_emptyValue() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("EMPTY=\n");
+        assertThat(translator.translate("EMPTY"), equalTo(""));
+    }
+
+    @Test
+    void testTranslate_commentsIgnored() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("# this is a comment\nKEY=value\n");
+        assertThat(translator.translate("KEY"), equalTo("value"));
+    }
+
+    @Test
+    void testTranslate_emptyLinesIgnored() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("\n\nKEY=value\n\n");
+        assertThat(translator.translate("KEY"), equalTo("value"));
+    }
+
+    @Test
+    void testTranslate_inlineComment_stripped() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=value # inline comment\n");
+        assertThat(translator.translate("KEY"), equalTo("value"));
+    }
+
+    @Test
+    void testTranslate_missingKey_throwsIllegalArgumentException() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=value\n");
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> translator.translate("MISSING"));
+        assertThat(ex.getMessage().contains("MISSING"), equalTo(true));
+    }
+
+    @Test
+    void testTranslate_multipleFiles_laterOverridesEarlier() throws IOException {
+        final Path file1 = tempDir.resolve("base.env");
+        final Path file2 = tempDir.resolve("override.env");
+        Files.writeString(file1, "KEY=base-value\n");
+        Files.writeString(file2, "KEY=override-value\n");
+        final StoreVariableTranslator translator = new StoreVariableTranslator(
+                List.of(file1.toString(), file2.toString()));
+        assertThat(translator.translate("KEY"), equalTo("override-value"));
+    }
+
+    @Test
+    void testTranslate_multipleFiles_uniqueKeysFromBoth() throws IOException {
+        final Path file1 = tempDir.resolve("a.env");
+        final Path file2 = tempDir.resolve("b.env");
+        Files.writeString(file1, "KEY_A=value-a\n");
+        Files.writeString(file2, "KEY_B=value-b\n");
+        final StoreVariableTranslator translator = new StoreVariableTranslator(
+                List.of(file1.toString(), file2.toString()));
+        assertThat(translator.translate("KEY_A"), equalTo("value-a"));
+        assertThat(translator.translate("KEY_B"), equalTo("value-b"));
+    }
+
+    @Test
+    void testConstructor_missingSourceFile_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new StoreVariableTranslator(List.of("/nonexistent/path/.env")));
+    }
+
+    @Test
+    void testConstructor_missingEqualsSign_throwsIllegalArgumentException() throws IOException {
+        assertThrows(IllegalArgumentException.class,
+                () -> buildTranslator("INVALID_LINE_NO_EQUALS\n"));
+    }
+
+    @Test
+    void testTranslate_inlineComment_atStartOfValue_stripped() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=#startcomment\n");
+        assertThat(translator.translate("KEY"), equalTo(""));
+    }
+
+    @Test
+    void testConstructor_unreadableFile_throwsIllegalArgumentException() throws IOException {
+        final Path file = tempDir.resolve("locked.env");
+        Files.writeString(file, "KEY=value\n");
+        assertThat(file.toFile().setReadable(false), is(true));
+        assertThrows(IllegalArgumentException.class,
+                () -> new StoreVariableTranslator(List.of(file.toString())));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_returnsImmutableVariable() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=val\n");
+        final PluginConfigVariable variable = translator.translateToPluginConfigVariable("KEY");
+        assertThat(variable, instanceOf(ImmutablePluginConfigVariable.class));
+        assertThat(variable.getValue(), equalTo("val"));
+        assertThat(variable.isUpdatable(), equalTo(false));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_setValue_throwsException() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=val\n");
+        final PluginConfigVariable variable = translator.translateToPluginConfigVariable("KEY");
+        assertThrows(Exception.class, () -> variable.setValue("new"));
+    }
+
+    @Test
+    void testTranslateToPluginConfigVariable_refresh_isNoOp() throws IOException {
+        final StoreVariableTranslator translator = buildTranslator("KEY=val\n");
+        final PluginConfigVariable variable = translator.translateToPluginConfigVariable("KEY");
+        variable.refresh();
+        assertThat(variable.getValue(), equalTo("val"));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplateExtensionProviderTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplateExtensionProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class VariableTemplateExtensionProviderTest {
+
+    @Mock
+    private ExtensionProvider.Context context;
+
+    @Test
+    void testProvideInstance_returnsTranslator() {
+        final PluginConfigValueTranslator translator = new EnvVariableTranslator();
+        final VariableTemplateExtensionProvider provider = new VariableTemplateExtensionProvider(translator);
+
+        final Optional<PluginConfigValueTranslator> result = provider.provideInstance(context);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get(), equalTo(translator));
+    }
+
+    @Test
+    void testSupportedClass_returnsInterface() {
+        final VariableTemplateExtensionProvider provider =
+                new VariableTemplateExtensionProvider(new EnvVariableTranslator());
+        assertThat(provider.supportedClass(), equalTo(PluginConfigValueTranslator.class));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginConfigTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginConfigTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class VariableTemplatePluginConfigTest {
+
+    @Test
+    void testDefaults_envAndFileDisabled() {
+        final VariableTemplatePluginConfig config = new VariableTemplatePluginConfig();
+        assertThat(config.getResolvers(), notNullValue());
+        assertThat(config.getResolvers().isEnvEnabled(), is(false));
+        assertThat(config.getResolvers().isFileEnabled(), is(false));
+        assertThat(config.getResolvers().getStore(), equalTo(null));
+    }
+
+    @Test
+    void testStoreResolverConfig_defaults() {
+        final VariableTemplatePluginConfig.StoreResolverConfig storeConfig =
+                new VariableTemplatePluginConfig.StoreResolverConfig();
+        assertThat(storeConfig.isEnabled(), is(false));
+        assertThat(storeConfig.getSources(), equalTo(List.of()));
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginIT.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class VariableTemplatePluginIT {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private ExtensionPoints extensionPoints;
+
+    @Mock
+    private ExtensionProvider.Context context;
+
+    @Captor
+    private ArgumentCaptor<ExtensionProvider<?>> providerCaptor;
+
+    @Test
+    void testAllThreeResolvers_allRegisterAndResolveCorrectly() throws IOException {
+        final Path storeFile = tempDir.resolve("store.env");
+        Files.writeString(storeFile, "STORE_KEY=store-value\n");
+
+        final Path secretFile = tempDir.resolve("secret.txt");
+        Files.writeString(secretFile, "file-secret\n");
+
+        final VariableTemplatePluginConfig config = buildConfig(true, true, true,
+                List.of(storeFile.toString()));
+        new VariableTemplatePlugin(config).apply(extensionPoints);
+
+        verify(extensionPoints, times(3)).addExtensionProvider(providerCaptor.capture());
+        final List<ExtensionProvider<?>> providers = providerCaptor.getAllValues();
+
+        final PluginConfigValueTranslator envTranslator = translatorFrom(providers.get(0));
+        final PluginConfigValueTranslator fileTranslator = translatorFrom(providers.get(1));
+        final PluginConfigValueTranslator storeTranslator = translatorFrom(providers.get(2));
+
+        assertThat(envTranslator.getPrefix(), equalTo("env"));
+        assertThat(fileTranslator.getPrefix(), equalTo("file"));
+        assertThat(storeTranslator.getPrefix(), equalTo("store"));
+
+        assertThat(envTranslator.translate("PATH"), equalTo(System.getenv("PATH")));
+        assertThat(fileTranslator.translate(secretFile.toString()), equalTo("file-secret"));
+        assertThat(storeTranslator.translate("STORE_KEY"), equalTo("store-value"));
+    }
+
+    @Test
+    void testAllThreeResolvers_haveDistinctPrefixes() throws IOException {
+        final Path storeFile = tempDir.resolve("store.env");
+        Files.writeString(storeFile, "K=v\n");
+
+        new VariableTemplatePlugin(buildConfig(true, true, true, List.of(storeFile.toString())))
+                .apply(extensionPoints);
+
+        verify(extensionPoints, times(3)).addExtensionProvider(providerCaptor.capture());
+        final List<ExtensionProvider<?>> providers = providerCaptor.getAllValues();
+
+        final String p1 = translatorFrom(providers.get(0)).getPrefix();
+        final String p2 = translatorFrom(providers.get(1)).getPrefix();
+        final String p3 = translatorFrom(providers.get(2)).getPrefix();
+
+        assertThat(p1.equals(p2), is(false));
+        assertThat(p1.equals(p3), is(false));
+        assertThat(p2.equals(p3), is(false));
+    }
+
+    @Test
+    void testEnvTranslator_missingVar_throwsIllegalArgumentException() throws IOException {
+        new VariableTemplatePlugin(buildConfig(true, false, false, Collections.emptyList()))
+                .apply(extensionPoints);
+        verify(extensionPoints, times(1)).addExtensionProvider(providerCaptor.capture());
+        assertThrows(IllegalArgumentException.class,
+                () -> translatorFrom(providerCaptor.getValue()).translate("__UNSET_VAR_XYZ__"));
+    }
+
+    @Test
+    void testFileTranslator_missingFile_throwsIllegalArgumentException() {
+        new VariableTemplatePlugin(buildConfig(false, true, false, Collections.emptyList()))
+                .apply(extensionPoints);
+        verify(extensionPoints, times(1)).addExtensionProvider(providerCaptor.capture());
+        assertThrows(IllegalArgumentException.class,
+                () -> translatorFrom(providerCaptor.getValue()).translate(
+                        tempDir.resolve("ghost.txt").toString()));
+    }
+
+    @Test
+    void testStoreTranslator_missingKey_throwsIllegalArgumentException() throws IOException {
+        final Path storeFile = tempDir.resolve("store.env");
+        Files.writeString(storeFile, "KEY=value\n");
+
+        new VariableTemplatePlugin(buildConfig(false, false, true, List.of(storeFile.toString())))
+                .apply(extensionPoints);
+        verify(extensionPoints, times(1)).addExtensionProvider(providerCaptor.capture());
+        assertThrows(IllegalArgumentException.class,
+                () -> translatorFrom(providerCaptor.getValue()).translate("MISSING"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private PluginConfigValueTranslator translatorFrom(final ExtensionProvider<?> provider) {
+        return ((ExtensionProvider<PluginConfigValueTranslator>) provider)
+                .provideInstance(context).orElseThrow();
+    }
+
+    private VariableTemplatePluginConfig buildConfig(
+            final boolean envEnabled, final boolean fileEnabled,
+            final boolean storeEnabled, final List<String> storeSources) {
+        return new VariableTemplatePluginConfig() {
+            @Override
+            public Resolvers getResolvers() {
+                return new Resolvers() {
+                    @Override public boolean isEnvEnabled() { return envEnabled; }
+                    @Override public boolean isFileEnabled() { return fileEnabled; }
+                    @Override public StoreResolverConfig getStore() {
+                        if (!storeEnabled) return null;
+                        return new StoreResolverConfig() {
+                            @Override public boolean isEnabled() { return true; }
+                            @Override public List<String> getSources() { return storeSources; }
+                        };
+                    }
+                };
+            }
+        };
+    }
+}

--- a/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginTest.java
+++ b/data-prepper-plugins/variable-template-plugin/src/test/java/org/opensearch/dataprepper/plugins/variabletemplate/VariableTemplatePluginTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.variabletemplate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class VariableTemplatePluginTest {
+
+    @Mock
+    private ExtensionPoints extensionPoints;
+
+    @Captor
+    private ArgumentCaptor<ExtensionProvider<?>> providerCaptor;
+
+    private VariableTemplatePluginConfig configWith(
+            final boolean envEnabled, final boolean fileEnabled, final boolean storeEnabled,
+            final List<String> storeSources) {
+        final VariableTemplatePluginConfig config = new VariableTemplatePluginConfig();
+        final VariableTemplatePluginConfig.Resolvers resolvers = new VariableTemplatePluginConfig.Resolvers() {
+            @Override public boolean isEnvEnabled() { return envEnabled; }
+            @Override public boolean isFileEnabled() { return fileEnabled; }
+            @Override public VariableTemplatePluginConfig.StoreResolverConfig getStore() {
+                if (!storeEnabled) return null;
+                return new VariableTemplatePluginConfig.StoreResolverConfig() {
+                    @Override public boolean isEnabled() { return true; }
+                    @Override public List<String> getSources() { return storeSources; }
+                };
+            }
+        };
+        return new VariableTemplatePluginConfig() {
+            @Override public Resolvers getResolvers() { return resolvers; }
+        };
+    }
+
+    @Test
+    void testApply_nullConfig_noProviders() {
+        new VariableTemplatePlugin(null).apply(extensionPoints);
+        verifyNoInteractions(extensionPoints);
+    }
+
+    @Test
+    void testApply_allDisabled_noProviders() {
+        new VariableTemplatePlugin(new VariableTemplatePluginConfig()).apply(extensionPoints);
+        verifyNoInteractions(extensionPoints);
+    }
+
+    @Test
+    void testApply_envOnly_registersEnvProvider() {
+        new VariableTemplatePlugin(configWith(true, false, false, null)).apply(extensionPoints);
+        verify(extensionPoints, times(1)).addExtensionProvider(providerCaptor.capture());
+        assertThat(providerCaptor.getValue().provideInstance(null).orElseThrow(),
+                instanceOf(EnvVariableTranslator.class));
+    }
+
+    @Test
+    void testApply_fileOnly_registersFileProvider() {
+        new VariableTemplatePlugin(configWith(false, true, false, null)).apply(extensionPoints);
+        verify(extensionPoints, times(1)).addExtensionProvider(providerCaptor.capture());
+        assertThat(providerCaptor.getValue().provideInstance(null).orElseThrow(),
+                instanceOf(FileVariableTranslator.class));
+    }
+
+    @Test
+    void testApply_allEnabled_registersThreeProviders() {
+        new VariableTemplatePlugin(configWith(true, true, true, Collections.emptyList())).apply(extensionPoints);
+        verify(extensionPoints, times(3)).addExtensionProvider(providerCaptor.capture());
+        final List<ExtensionProvider<?>> providers = providerCaptor.getAllValues();
+        assertThat(providers.get(0).provideInstance(null).orElseThrow(), instanceOf(EnvVariableTranslator.class));
+        assertThat(providers.get(1).provideInstance(null).orElseThrow(), instanceOf(FileVariableTranslator.class));
+        assertThat(providers.get(2).provideInstance(null).orElseThrow(), instanceOf(StoreVariableTranslator.class));
+    }
+
+    @Test
+    void testApply_storeConfigPresent_butDisabled_noStoreProvider() {
+        new VariableTemplatePlugin(configWith(false, false, false, null)).apply(extensionPoints);
+        verifyNoInteractions(extensionPoints);
+    }
+
+        @Test
+    void testShutdown_doesNotThrow() {
+        new VariableTemplatePlugin(new VariableTemplatePluginConfig()).shutdown();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -212,6 +212,7 @@ include 'data-prepper-plugins:saas-source-plugins:crowdstrike-source'
 include 'data-prepper-plugins:saas-source-plugins:microsoft-office365-source'
 include 'data-prepper-plugins:otlp-sink'
 include 'data-prepper-plugins:otel-apm-service-map-processor'
+include 'data-prepper-plugins:variable-template-plugin'
 
 
 include 'e2e-test:kafka-buffer-backward-compatibility'


### PR DESCRIPTION
### Description
## Summary

This PR adds support for resolving dynamic values in Data Prepper pipeline configurations from multiple local sources such as environment variables, files on disk, and `.env`-style key/value store files to give the users maximum flexibility. Its based on the framework-plugin and draws on the aws-extension implementation, as well as @dlvenable suggestions in/and several issue proposals and use cases.
It also fixes a framework limitation that prevented multiple `PluginConfigValueTranslator` implementations from coexisting.

## Changes for the foundation

### 1. Framework fix — `data-prepper-plugin-framework`

**File:** `DataPrepperExtensionPoints.java`

**Problem:** `addExtensionProvider()` used a `Set<Class>` keyed by `supportedClass()` to prevent duplicate registrations. For `PluginConfigValueTranslator`, all implementations share the same `supportedClass()` return value (`PluginConfigValueTranslator.class`), so only the first registered translator was kept. This made it structurally impossible for `store`, `env`, `file`, and `aws_secrets` to coexist.

**Fix:** The guard set is changed from `Set<Class>` to `Set<String>`, keyed by a resolved bean name. For `PluginConfigValueTranslator` implementations, the bean name includes the translator's prefix (e.g. `PluginConfigValueTranslator_env`, `PluginConfigValueTranslator_file`, `PluginConfigValueTranslator_aws_secrets`).

**Impact:**
- Existing behaviour for all non-translator extension types is unchanged
- `aws-plugin` continues to work without modification
- Multiple `PluginConfigValueTranslator` implementations from different plugins now coexist correctly
- Future translator plugins (e.g. HashiCorp Vault) will work without further framework changes

### 2. New plugin — `data-prepper-plugins/variable-template-plugin`

Adds three resolvers, each independently opt-in:

| Resolver | Syntax | Source |
|---|---|---|
| `env` | `${{env:VAR_NAME}}` | Process environment |
| `file` | `${{file:/path/to/file}}` | File contents (whitespace stripped) |
| `store` | `${{store:KEY}}` | `.env`-style key/value file(s) |

Configuration:
```yaml
extensions:
  variable_sources:
    resolvers:
      env: true
      file: true
      store:
        enabled: true
        sources:
          - /path/to/.env
```

The `store` resolver supports standard `.env`-like file syntax with key=value: comments (`#`), empty lines, quoted values (`"` and `'`), inline comments, and multiple source files with last-write-wins merge semantics.

All values are resolved once at startup and are static for the lifetime of the process 
-> An example of the config and usage are attached in the plugin readme, also current limitations

## Future improvements
If this pr is acceptable, I would also like to create a following issue to resolve limitations and make new integrations simpler (based on current knowledge, open for discussions / suggestions :) )
- Fix the string-interpolation in variable expander framework to support resolving vars before, inside, or after strings and inside of expressions
- Move the aws scoped refresh logic to the framework so every plugin which uses the framework can use it with same logic and without dupe code
 
### Issues Resolved
Resolves #3335, #3684, #947, #949
 
### Check List
- [ x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
