### PR TITLE
[FEATURE] : Add synchronized buffer plugin

### DIFF
--- a/data-prepper-plugins/synchronized-buffer/build.gradle
+++ b/data-prepper-plugins/synchronized-buffer/build.gradle
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java'
+}
+dependencies {
+    implementation project(':data-prepper-api')
+    implementation 'io.micrometer:micrometer-core'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    testImplementation project(':data-prepper-test:test-common')
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule { //in addition to core projects rule
+            limit {
+                minimum = 0.90
+            }
+        }
+    }
+}

--- a/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/SynchronizedBuffer.java
+++ b/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/SynchronizedBuffer.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.buffer;
+
+import io.micrometer.core.instrument.Counter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.opensearch.dataprepper.metrics.MetricNames;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.buffer.model.ReadBatch;
+import org.opensearch.dataprepper.plugins.buffer.model.SignaledBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A synchronized buffer that provides a blocking write model where the caller
+ * thread waits until its records have been fully processed by worker threads
+ * and acknowledged via checkpointing. This ensures a direct, synchronous flow
+ * of data from source to sink while still leveraging parallel processing
+ * through Data Prepper's process worker threads.
+ */
+@DataPrepperPlugin(name = "synchronized", pluginType = Buffer.class, pluginConfigurationType = SynchronizedBufferConfig.class)
+public class SynchronizedBuffer<T extends Record<?>> implements Buffer<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(SynchronizedBuffer.class);
+    private static final String PLUGIN_COMPONENT_ID = "SynchronizedBuffer";
+
+    private final ConcurrentLinkedQueue<SignaledBatch<T>> queue = new ConcurrentLinkedQueue<>();
+    private final ThreadLocal<List<ReadBatch<T>>> threadLocalReadBatches = new ThreadLocal<>();
+    private final PluginMetrics pluginMetrics;
+    private final Counter writeRecordsCounter;
+    private final Counter readRecordsCounter;
+    private final int batchSize;
+
+    /**
+     * Creates a new SynchronizedBuffer with the specified configuration.
+     *
+     * @param synchronizedBufferConfig The buffer configuration
+     * @param pipelineDescription The pipeline description
+     */
+    @DataPrepperPluginConstructor
+    public SynchronizedBuffer(final SynchronizedBufferConfig synchronizedBufferConfig, final PipelineDescription pipelineDescription) {
+        this.pluginMetrics = PluginMetrics.fromNames(PLUGIN_COMPONENT_ID, pipelineDescription.getPipelineName());
+        this.writeRecordsCounter = pluginMetrics.counter(MetricNames.RECORDS_WRITTEN);
+        this.readRecordsCounter = pluginMetrics.counter(MetricNames.RECORDS_READ);
+        this.batchSize = synchronizedBufferConfig.getBatchSize();
+        LOG.info("Initialized SynchronizedBuffer with batch size: {}", this.batchSize);
+    }
+
+    /**
+     * Writes a single record to the buffer and waits for it to be processed.
+     *
+     * @param record The record to write
+     * @param timeoutInMillis How long to wait before giving up
+     * @throws TimeoutException If the write times out
+     */
+    @Override
+    public void write(T record, int timeoutInMillis) throws TimeoutException {
+        if (record == null) {
+            throw new NullPointerException("The write record cannot be null");
+        }
+
+        SignaledBatch<T> batch = new SignaledBatch<>(List.of(record));
+        queue.offer(batch);
+        writeRecordsCounter.increment();
+
+        try {
+            batch.getSignal().get(timeoutInMillis, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            throw new TimeoutException("Writer timed out waiting for checkpoint");
+        }
+    }
+
+    /**
+     * Writes multiple records to the buffer and waits for them to be processed.
+     *
+     * @param records The records to write
+     * @param timeoutInMillis How long to wait before giving up
+     * @throws Exception If the write fails or times out
+     */
+    @Override
+    public void writeAll(Collection<T> records, int timeoutInMillis) throws Exception {
+        if (records == null) {
+            throw new NullPointerException("The write records cannot be null");
+        }
+
+        if (records.isEmpty()) {
+            LOG.debug("The records are empty");
+            return;
+        }
+
+        SignaledBatch<T> batch = new SignaledBatch<>(new ArrayList<>(records));
+        queue.offer(batch);
+        writeRecordsCounter.increment(records.size());
+
+        try {
+            batch.getSignal().get(timeoutInMillis, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            throw new TimeoutException("Writer timed out waiting for batch checkpoint");
+        }
+    }
+
+    /**
+     * Reads records from the buffer.
+     *
+     * @param timeoutInMillis How long to wait before giving up
+     * @return A collection of records and their checkpoint state
+     */
+    @Override
+    public Map.Entry<Collection<T>, CheckpointState> read(int timeoutInMillis) {
+        final List<T> output = new ArrayList<>();
+        final List<ReadBatch<T>> readBatches = new ArrayList<>();
+
+        while (!queue.isEmpty() && output.size() < batchSize) {
+            SignaledBatch<T> batch = queue.peek();
+            if (batch == null) break;
+
+            int canTake = batchSize - output.size();
+            List<T> slice = batch.readNext(canTake);
+            if (slice.isEmpty()) {
+                queue.poll();
+                continue;
+            }
+
+            output.addAll(slice);
+            readBatches.add(new ReadBatch<>(batch, slice.size()));
+
+            if (batch.getRemaining() == 0) {
+                queue.poll();
+            }
+        }
+
+        if (!output.isEmpty()) {
+            readRecordsCounter.increment(output.size());
+        }
+
+        threadLocalReadBatches.set(readBatches);
+        return Map.entry(output, new CheckpointState(0));
+    }
+
+    /**
+     * Checkpoints the processed records, signaling completion to writers.
+     *
+     * @param checkpointState The checkpoint state
+     */
+    @Override
+    public void checkpoint(final CheckpointState checkpointState) {
+        List<ReadBatch<T>> readBatches = threadLocalReadBatches.get();
+        if (readBatches != null) {
+            for (ReadBatch<T> rb : readBatches) {
+                rb.getBatch().markProcessed(rb.getCount());
+            }
+            threadLocalReadBatches.remove();
+        }
+    }
+
+    /**
+     * Checks if the buffer is empty.
+     *
+     * @return true if the buffer is empty, false otherwise
+     */
+    @Override
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+}

--- a/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/SynchronizedBufferConfig.java
+++ b/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/SynchronizedBufferConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.buffer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration class for SynchronizedBuffer.
+ */
+public class SynchronizedBufferConfig {
+    public static final int DEFAULT_BATCH_SIZE = 2;
+
+    @JsonProperty("batch_size")
+    private int batchSize = DEFAULT_BATCH_SIZE;
+
+    /**
+     * Gets the batch size for reading records from the buffer.
+     *
+     * @return The batch size
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+}

--- a/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/model/ReadBatch.java
+++ b/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/model/ReadBatch.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.buffer.model;
+
+import org.opensearch.dataprepper.model.record.Record;
+
+/**
+ * Tracks a slice of records that a reader has consumed from a {@link SignaledBatch},
+ * along with the count of records in that slice. Used during checkpointing to
+ * mark the correct number of records as processed in the originating batch.
+ */
+public class ReadBatch<T extends Record<?>> {
+    private final SignaledBatch<T> batch;
+    private final int count;
+
+    public ReadBatch(SignaledBatch<T> batch, int count) {
+        this.batch = batch;
+        this.count = count;
+    }
+
+    public SignaledBatch<T> getBatch() {
+        return batch;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/model/SignaledBatch.java
+++ b/data-prepper-plugins/synchronized-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/model/SignaledBatch.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.buffer.model;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.opensearch.dataprepper.model.record.Record;
+
+/**
+ * Represents a batch of records that tracks processing progress and signals
+ * the waiting writer when all records in the batch have been fully processed
+ * and checkpointed. Multiple reader threads can concurrently claim slices of
+ * records from the batch, and each reader marks its slice as processed upon
+ * checkpointing. Once all records are accounted for, the batch notifies the
+ * blocked writer that it is safe to return.
+ */
+public class SignaledBatch<T extends Record<?>> {
+    private final List<T> records;
+    private final AtomicInteger remaining;
+    private final AtomicInteger nextSliceIndex;
+    private final CompletableFuture<Void> signal;
+
+    public SignaledBatch(List<T> records) {
+        this.records = records;
+        this.remaining = new AtomicInteger(records.size());
+        this.nextSliceIndex = new AtomicInteger(0);
+        this.signal = new CompletableFuture<>();
+    }
+
+    public List<T> readNext(int maxSize) {
+        int start = nextSliceIndex.getAndAdd(maxSize);
+        if (start >= records.size()) return List.of();
+        int end = Math.min(start + maxSize, records.size());
+        return records.subList(start, end);
+    }
+
+    public void markProcessed(int count) {
+        if (remaining.addAndGet(-count) <= 0) {
+            signal.complete(null);
+        }
+    }
+
+    public CompletableFuture<Void> getSignal() {
+        return signal;
+    }
+
+    public int getRemaining() {
+        return remaining.get();
+    }
+}

--- a/data-prepper-plugins/synchronized-buffer/src/test/java/org/opensearch/dataprepper/plugins/buffer/SynchronizedBufferTests.java
+++ b/data-prepper-plugins/synchronized-buffer/src/test/java/org/opensearch/dataprepper/plugins/buffer/SynchronizedBufferTests.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.buffer;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+
+@ExtendWith(MockitoExtension.class)
+public class SynchronizedBufferTests {
+    private static final Logger LOG = LoggerFactory.getLogger(SynchronizedBufferTests.class);
+    private static final String MOCK_PIPELINE_NAME = "mock-pipeline";
+    private static final int WRITE_TIMEOUT = 1000;
+    private static final int READ_TIMEOUT = 500;
+    private static final String SINGLE_RECORD_DATA_FORMAT = "{\"message\":\"test\"}";
+    private static final String BATCH_RECORDS_DATA_FORMAT = "{\"message\":\"test-%d\"}";
+    private static final int DEFAULT_BATCH_SIZE = 2;
+    private static final int CUSTOM_BATCH_SIZE = 5;
+
+    @Mock
+    PipelineDescription pipelineDescription;
+
+    @BeforeEach
+    public void setup() {
+        new ArrayList<>(Metrics.globalRegistry.getRegistries())
+                .forEach(Metrics.globalRegistry::remove);
+        new ArrayList<>(Metrics.globalRegistry.getMeters())
+                .forEach(Metrics.globalRegistry::remove);
+        Metrics.addRegistry(new SimpleMeterRegistry());
+    }
+
+    @Nested
+    class WriteTests {
+        @Test
+        public void testSingleWriteAndReadReturnsCorrectRecord() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            // Use helper method for async write
+            CompletableFuture<Void> future = writeRecordAsync(buffer, SINGLE_RECORD_DATA_FORMAT, WRITE_TIMEOUT);
+
+            // Give time for write to be queued
+            Thread.sleep(100);
+
+            Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> readRecords = readResult.getKey();
+            assertEquals(1, readRecords.size());
+            assertEquals(SINGLE_RECORD_DATA_FORMAT, readRecords.iterator().next().getData());
+
+            // Checkpoint to signal completion
+            buffer.checkpoint(readResult.getValue());
+
+            // Verify buffer is now empty
+            assertTrue(buffer.isEmpty());
+
+            // Wait for future to complete
+            future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        public void testMultipleWriteAndReadReturnsCorrectRecords() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            // Write two records using helper methods
+            CompletableFuture<Void> future1 = writeRecordAsync(buffer, SINGLE_RECORD_DATA_FORMAT, WRITE_TIMEOUT);
+            CompletableFuture<Void> future2 = writeRecordAsync(buffer, SINGLE_RECORD_DATA_FORMAT, WRITE_TIMEOUT);
+
+            // Give time for writes to be queued
+            Thread.sleep(100);
+
+            // Read records (should get up to batch size)
+            Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> readRecords = readResult.getKey();
+
+            // Should read up to batch size (DEFAULT_BATCH_SIZE)
+            assertEquals(DEFAULT_BATCH_SIZE, readRecords.size());
+
+            // Checkpoint to signal completion
+            buffer.checkpoint(readResult.getValue());
+
+            // Wait for futures to complete
+            CompletableFuture.allOf(future1, future2).get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        public void testWriteAllAndReadReturnsAllRecords() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            List<String> dataList = IntStream.range(0, 10)
+                    .mapToObj(i -> String.format(BATCH_RECORDS_DATA_FORMAT, i))
+                    .collect(Collectors.toList());
+
+            // Write records using helper method
+            CompletableFuture<Void> future = writeRecordsAsync(buffer, dataList, WRITE_TIMEOUT);
+
+            // Give time for writes to be queued
+            Thread.sleep(100);
+
+            // Read all records (may require multiple reads due to batch size)
+            List<Record<String>> allReadRecords = new ArrayList<>();
+            while (!buffer.isEmpty()) {
+                Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+                Collection<Record<String>> readRecords = readResult.getKey();
+                allReadRecords.addAll(readRecords);
+
+                // Checkpoint to signal completion
+                buffer.checkpoint(readResult.getValue());
+            }
+
+            // Ensure that all write records were read
+            assertEquals(dataList.size(), allReadRecords.size());
+
+            // Wait for future to complete
+            future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        public void testWriteNullRecordThrowsException() {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            Exception writeException = assertThrows(NullPointerException.class, () -> {
+                buffer.write(null, WRITE_TIMEOUT);
+            });
+
+            Exception writeAllException = assertThrows(NullPointerException.class, () -> {
+                buffer.writeAll(null, WRITE_TIMEOUT);
+            });
+
+            assertEquals("The write record cannot be null", writeException.getMessage());
+            assertEquals("The write records cannot be null", writeAllException.getMessage());
+        }
+
+        @Test
+        public void testWriteEmptyRecordDoesNotThrowException() {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+            assertDoesNotThrow(() -> {
+                CompletableFuture<Void> writeFuture = writeRecordAsync(buffer, null, WRITE_TIMEOUT);
+                // Give time for write to be queued
+                Thread.sleep(100);
+                // Read and checkpoint to complete the write
+                Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+                buffer.checkpoint(readResult.getValue());
+
+                writeFuture.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+            });
+
+            assertDoesNotThrow(() -> {
+                CompletableFuture<Void> writeAllFuture = writeRecordsAsync(buffer, null, WRITE_TIMEOUT);
+            });
+        }
+
+        @Test
+        public void testWriteTimeout() {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            // Write a record but don't read/checkpoint it
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<?> future = executor.submit(() -> {
+                try {
+                    buffer.write(generateRecord(SINGLE_RECORD_DATA_FORMAT), 100);
+                    fail("Expected TimeoutException");
+                } catch (TimeoutException e) {
+                    LOG.info("Successfully encountered timeout exception");
+                }
+            });
+
+            // Wait for the future to complete
+            try {
+                future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            } finally {
+                executor.shutdown();
+            }
+        }
+    }
+
+    @Nested
+    class ReadTests {
+        @Test
+        public void testReadFromNonEmptyBufferReturnsCorrectRecords() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            CompletableFuture<Void> future = writeRecordAsync(buffer, SINGLE_RECORD_DATA_FORMAT, WRITE_TIMEOUT);
+
+            // Give time for write to be queued
+            Thread.sleep(100);
+
+            // First read should return the record
+            Map.Entry<Collection<Record<String>>, CheckpointState> initialReadResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> initialReadRecords = initialReadResult.getKey();
+            assertEquals(1, initialReadRecords.size());
+            assertEquals(SINGLE_RECORD_DATA_FORMAT, initialReadRecords.iterator().next().getData());
+
+            // Checkpoint to signal completion
+            buffer.checkpoint(initialReadResult.getValue());
+
+            // Second read should return empty collection
+            Map.Entry<Collection<Record<String>>, CheckpointState> secondReadResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> secondAttemptToReadRecords = secondReadResult.getKey();
+            assertEquals(0, secondAttemptToReadRecords.size());
+
+            // Wait for future to complete
+            future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        public void testReadFromEmptyBufferReturnsNoRecords() {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+            assertTrue(readResult.getKey().isEmpty());
+        }
+
+        @Test
+        public void testReadBatchSizeRespected() throws Exception {
+            // Create buffer with custom batch size
+            SynchronizedBufferConfig config = new SynchronizedBufferConfig();
+            setField(SynchronizedBufferConfig.class, config, "batchSize", CUSTOM_BATCH_SIZE);
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest(config);
+
+            // Write more records than batch size
+            List<String> dataList = IntStream.range(0, CUSTOM_BATCH_SIZE + 3)
+                    .mapToObj(i -> String.format(BATCH_RECORDS_DATA_FORMAT, i))
+                    .collect(Collectors.toList());
+
+            CompletableFuture<Void> future = writeRecordsAsync(buffer, dataList, WRITE_TIMEOUT);
+
+            // Give time for writes to be queued
+            Thread.sleep(100);
+
+            // First read should return exactly batch size records
+            Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> readRecords = readResult.getKey();
+            assertEquals(CUSTOM_BATCH_SIZE, readRecords.size());
+
+            // Checkpoint to signal completion
+            buffer.checkpoint(readResult.getValue());
+
+            // Second read should return remaining records
+            Map.Entry<Collection<Record<String>>, CheckpointState> secondReadResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> secondReadRecords = secondReadResult.getKey();
+            assertEquals(3, secondReadRecords.size());
+
+            // Checkpoint to signal completion
+            buffer.checkpoint(secondReadResult.getValue());
+
+            // Wait for future to complete
+            future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Nested
+    class EmptyBufferTests {
+        @Test
+        public void testIsEmptyReturnsTrueWhenBufferIsEmpty() {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+            assertTrue(buffer.isEmpty());
+        }
+
+        @Test
+        public void testIsEmptyReturnsFalseWhenBufferIsNotEmpty() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            // Write using helper method
+            CompletableFuture<Void> future = writeRecordAsync(buffer, SINGLE_RECORD_DATA_FORMAT, WRITE_TIMEOUT);
+
+            // Give time for write to be queued
+            Thread.sleep(100);
+
+            assertFalse(buffer.isEmpty());
+
+            // Read and checkpoint to complete the write
+            Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+            buffer.checkpoint(readResult.getValue());
+
+            // Wait for future to complete
+            future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Nested
+    class ConcurrencyTests {
+        @Test
+        public void testMultipleWritersAndReaders() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+            int numWriters = 5;
+            int recordsPerWriter = 10;
+            int totalRecords = numWriters * recordsPerWriter;
+
+            // Create multiple writer threads
+            ExecutorService writerExecutor = Executors.newFixedThreadPool(numWriters);
+            List<Future<?>> writerFutures = new ArrayList<>();
+
+            for (int i = 0; i < numWriters; i++) {
+                final int writerIndex = i;
+                writerFutures.add(writerExecutor.submit(() -> {
+                    try {
+                        for (int j = 0; j < recordsPerWriter; j++) {
+                            String data = String.format("{\"writer\":%d,\"record\":%d}", writerIndex, j);
+                            buffer.write(generateRecord(data), WRITE_TIMEOUT);
+                        }
+                    } catch (Exception e) {
+                        fail("Exception in writer thread: " + e.getMessage());
+                    }
+                }));
+            }
+
+            // Create reader thread
+            ExecutorService readerExecutor = Executors.newSingleThreadExecutor();
+            Future<Integer> readerFuture = readerExecutor.submit(() -> {
+                int recordsRead = 0;
+                try {
+                    while (recordsRead < totalRecords) {
+                        Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(READ_TIMEOUT);
+                        Collection<Record<String>> records = readResult.getKey();
+                        if (!records.isEmpty()) {
+                            recordsRead += records.size();
+                            buffer.checkpoint(readResult.getValue());
+                        } else {
+                            Thread.sleep(10); // Small delay if no records
+                        }
+                    }
+                } catch (Exception e) {
+                    fail("Exception in reader thread: " + e.getMessage());
+                }
+                return recordsRead;
+            });
+
+            // Wait for reader to finish
+            int totalReadRecords = readerFuture.get(WRITE_TIMEOUT * 2, TimeUnit.MILLISECONDS);
+            assertEquals(totalRecords, totalReadRecords);
+
+            // Shutdown executors
+            writerExecutor.shutdown();
+            readerExecutor.shutdown();
+            assertTrue(writerExecutor.awaitTermination(WRITE_TIMEOUT, TimeUnit.MILLISECONDS));
+            assertTrue(readerExecutor.awaitTermination(WRITE_TIMEOUT, TimeUnit.MILLISECONDS));
+
+            // Verify all writer futures completed without exceptions
+            for (Future<?> future : writerFutures) {
+                assertDoesNotThrow(() -> future.get(100, TimeUnit.MILLISECONDS));
+            }
+        }
+
+        @Test
+        public void testPartialBatchProcessing() throws Exception {
+            SynchronizedBuffer<Record<String>> buffer = createObjectUnderTest();
+
+            // Write 5 records
+            List<String> dataList = IntStream.range(0, 5)
+                    .mapToObj(i -> String.format(BATCH_RECORDS_DATA_FORMAT, i))
+                    .collect(Collectors.toList());
+
+            // Write records using helper method
+            CompletableFuture<Void> future = writeRecordsAsync(buffer, dataList, WRITE_TIMEOUT);
+
+            // Give time for writes to be queued
+            Thread.sleep(100);
+
+            // Read first batch (should be DEFAULT_BATCH_SIZE)
+            Map.Entry<Collection<Record<String>>, CheckpointState> firstReadResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> firstReadRecords = firstReadResult.getKey();
+            assertEquals(DEFAULT_BATCH_SIZE, firstReadRecords.size());
+
+            // Checkpoint to signal completion of first batch
+            buffer.checkpoint(firstReadResult.getValue());
+
+            // Read second batch (should be remaining records)
+            Map.Entry<Collection<Record<String>>, CheckpointState> secondReadResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> secondReadRecords = secondReadResult.getKey();
+            assertEquals(2, secondReadRecords.size());
+
+            // Checkpoint to signal completion of second batch
+            buffer.checkpoint(secondReadResult.getValue());
+
+            Map.Entry<Collection<Record<String>>, CheckpointState> thirdReadResult = buffer.read(READ_TIMEOUT);
+            Collection<Record<String>> thirdReadRecords = thirdReadResult.getKey();
+            assertEquals(1, thirdReadRecords.size());
+
+            // Checkpoint to signal completion of third batch
+            buffer.checkpoint(thirdReadResult.getValue());
+
+            // Wait for future to complete
+            future.get(WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /*-------------------------Private Helper Methods---------------------------*/
+    private <T> CompletableFuture<Void> writeRecordAsync(SynchronizedBuffer<Record<T>> buffer, T data, int timeout) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                buffer.write(generateRecord(data), timeout);
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    private <T> CompletableFuture<Void> writeRecordsAsync(SynchronizedBuffer<Record<T>> buffer, Collection<T> data, int timeout) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                Collection<Record<T>> records = generateRecords(data);
+                buffer.writeAll(records, timeout);
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    private <T> Record<T> generateRecord(final T data) {
+        return new Record<>(data);
+    }
+
+    private <T> Collection<Record<T>> generateRecords(Collection<T> data) {
+        Collection<Record<T>> records = new ArrayList<>();
+        for (T recordData : data) {
+            Record<T> record = new Record<>(recordData);
+            records.add(record);
+        }
+        return records;
+    }
+
+    private <T> SynchronizedBuffer<Record<T>> createObjectUnderTest() {
+        SynchronizedBufferConfig config = new SynchronizedBufferConfig();
+        return createObjectUnderTest(config);
+    }
+
+    private <T> SynchronizedBuffer<Record<T>> createObjectUnderTest(SynchronizedBufferConfig config) {
+        when(pipelineDescription.getPipelineName()).thenReturn(MOCK_PIPELINE_NAME);
+        return new SynchronizedBuffer<>(config, pipelineDescription);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -212,6 +212,7 @@ include 'data-prepper-plugins:saas-source-plugins:crowdstrike-source'
 include 'data-prepper-plugins:saas-source-plugins:microsoft-office365-source'
 include 'data-prepper-plugins:otlp-sink'
 include 'data-prepper-plugins:otel-apm-service-map-processor'
+include 'data-prepper-plugins:synchronized-buffer'
 
 
 include 'e2e-test:kafka-buffer-backward-compatibility'


### PR DESCRIPTION
Add a synchronized buffer implementation that provides synchronous data flow from source to sink while leveraging parallel processing via Data Prepper's process worker threads. Writers block until their records are fully processed and checkpointed by worker threads.

### Description
In the existing zero buffer, the caller thread handles everything — writing, processing, and publishing to sink — which means process worker threads are unused. The synchronized buffer addresses this by allowing the caller thread to write a batch of records into a shared, thread-safe queue and then block until all records in that batch have been fully processed and checkpointed by the worker threads. This enables use cases like the OpenSearch API source where the HTTP response must only be returned after the data has been delivered to the sink.

Key design:
- The caller wraps records in a `SignaledBatch` and enqueues it, then blocks waiting for completion
- Multiple process worker threads read slices from the batch concurrently, respecting a configurable batch_size
- On checkpoint, each worker marks its slice as processed; once all records in the batch are accounted for, the blocked caller is unblocked
- Metrics are emitted for records written and records read
 
### Issues Resolved
Resolves https://github.com/opensearch-project/data-prepper/issues/5712 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
- [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).