### PR TITLE
fix: expand necessary OpenSearch permissions for data prepper

### DIFF
--- a/data-prepper-plugins/opensearch/opensearch_security.md
+++ b/data-prepper-plugins/opensearch/opensearch_security.md
@@ -18,6 +18,8 @@ or by using user credential assigned with a role that has the below required per
 - `cluster_all`
 - `indices:admin/template/get`
 - `indices:admin/template/put`
+- `indices:admin/index_template/get`
+- `indices:admin/index_template/put`
 - `indices:data/write/bulk`
 - `indices:data/write/bulks`
 


### PR DESCRIPTION
### Description

PR expands OpenSearch permissions documentation for Data Prepper.

Additional permissions were compiled by trial and error based on logs from Data Prepper and OpenSearch. 

An error occurred in the process of inquiring the composable index templates through **index_template,** adding the corresponding permissions.

```text
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,271 [service-map-pipeline-sink-worker-6-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Initializing OpenSearch sink
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,271 [service-map-pipeline-sink-worker-6-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the username provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,271 [service-map-pipeline-sink-worker-6-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the cert provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,351 [traces-raw-pipeline-sink-worker-8-thread-1] WARN  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Failed to initialize OpenSearch sink, retrying: Forbidden access
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,372 [service-map-pipeline-sink-worker-6-thread-1] WARN  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Failed to initialize OpenSearch sink, retrying: Forbidden access
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,431 [otel-logs-pipeline-sink-worker-10-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Initializing OpenSearch sink
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,431 [otel-logs-pipeline-sink-worker-10-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the username provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,431 [otel-logs-pipeline-sink-worker-10-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the cert provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,511 [otel-logs-pipeline-sink-worker-10-thread-1] WARN  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Failed to initialize OpenSearch sink, retrying: Forbidden access
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,558 [traces-raw-pipeline-sink-worker-8-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Initializing OpenSearch sink
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,558 [traces-raw-pipeline-sink-worker-8-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the username provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,558 [traces-raw-pipeline-sink-worker-8-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the cert provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,603 [service-map-pipeline-sink-worker-6-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Initializing OpenSearch sink
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,603 [service-map-pipeline-sink-worker-6-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the username provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,609 [service-map-pipeline-sink-worker-6-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration - Using the cert provided in the config.
Mar 18 16:07:40 org-dev-gcldep-ctl-1.ad.gabiacloud.internal systemd-gcloud-opensearch-dataprepper[1793440]: 2026-03-18T16:07:40,644 [traces-raw-pipeline-sink-worker-8-thread-1] WARN  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Failed to initialize OpenSearch sink, retrying: Forbidden access
```

```yaml
otel-logs-pipeline:
  source:
    pipeline: { name: "otlp-pipeline" }
  sink:
    - opensearch:
        hosts: [ "$HOST" ]
        username: $USERNAME
        password: $RANDOM_PWD
        # index_type: log-analytics-plain (before: https://github.com/opensearch-project/data-prepper/pull/6647)
        template_type: index-template
        template_file: /usr/share/data-prepper/index-template/logs-otel-v1-index-standard-template.json
        ism_policy_file: /usr/share/data-prepper/index-template/logs-policy-with-ism-template.json
        index_type: custom
        index: logs-otel-v1
```

### Issues Resolved
Resolves #6646
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
