### PR TITLE
Fix race condition between export partition creation and data file partition completion for ddb source

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
@@ -194,6 +194,12 @@ public class ExportScheduler implements Runnable {
         LOG.info("Total of {} data files generated for export {}", dataFileInfo.size(), exportArn);
         AtomicInteger totalRecords = new AtomicInteger();
         AtomicInteger totalFiles = new AtomicInteger();
+
+        // Currently, we need to maintain a global state to track the overall progress.
+        // So that we can easily tell if all the export files are loaded
+        LoadStatus loadStatus = new LoadStatus(totalFiles.get(), 0, totalRecords.get(), 0);
+        enhancedSourceCoordinator.createPartition(new GlobalState(exportArn, Optional.of(loadStatus.toMap())));
+
         dataFileInfo.forEach((key, size) -> {
             DataFileProgressState progressState = new DataFileProgressState();
             progressState.setTotal(size);
@@ -208,11 +214,6 @@ public class ExportScheduler implements Runnable {
 
         exportS3ObjectsTotalCounter.increment(totalFiles.get());
         exportRecordsTotalCounter.increment(totalRecords.get());
-
-        // Currently, we need to maintain a global state to track the overall progress.
-        // So that we can easily tell if all the export files are loaded
-        LoadStatus loadStatus = new LoadStatus(totalFiles.get(), 0, totalRecords.get(), 0);
-        enhancedSourceCoordinator.createPartition(new GlobalState(exportArn, Optional.of(loadStatus.toMap())));
     }
 
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
@@ -15,7 +15,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.DataFilePartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.ExportProgressState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.ExportSummary;
 import org.opensearch.dataprepper.plugins.source.dynamodb.utils.DynamoDBSourceAggregateMetrics;
@@ -30,6 +32,7 @@ import software.amazon.awssdk.services.dynamodb.model.ExportTableToPointInTimeRe
 import software.amazon.awssdk.services.dynamodb.model.InternalServerErrorException;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -171,7 +175,16 @@ class ExportSchedulerTest {
         verify(dynamoDBClient, times(2)).describeExport(any(DescribeExportRequest.class));
 
         // Create 2 data file partitions + 1 global state
-        verify(coordinator, times(3)).createPartition(any(EnhancedSourcePartition.class));
+        final ArgumentCaptor<EnhancedSourcePartition> argumentCaptorPartitionsCreated = ArgumentCaptor.forClass(EnhancedSourcePartition.class);
+
+        verify(coordinator, times(3)).createPartition(argumentCaptorPartitionsCreated.capture());
+
+        final List<EnhancedSourcePartition> createdPartitions = argumentCaptorPartitionsCreated.getAllValues();
+        assertThat(createdPartitions.size(), equalTo(3));
+        assertThat(createdPartitions.get(0), instanceOf(GlobalState.class));
+        assertThat(createdPartitions.get(1), instanceOf(DataFilePartition.class));
+        assertThat(createdPartitions.get(2), instanceOf(DataFilePartition.class));
+
         // Complete the export partition
         verify(coordinator).completePartition(any(EnhancedSourcePartition.class));
         verify(exportJobSuccess).increment();


### PR DESCRIPTION


### Description
There was a potential race condition where the data file partitions could be completed before the export partition is created, and they would not be counted in the total completion of files for the export. 

This is because the data file partitions were being created before the export partition, but the export partition should be created first.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
