### PR TITLE
Fix duplicate _seconds suffix in APM latency metric name

### DIFF
--- a/data-prepper-plugins/otel-apm-service-map-processor/README.md
+++ b/data-prepper-plugins/otel-apm-service-map-processor/README.md
@@ -205,7 +205,7 @@ The processor generates time-series metrics as JacksonMetric events:
 | `request` | Sum (monotonic) | `1` | Number of requests |
 | `error` | Sum (monotonic) | `1` | Number of error requests (HTTP 4xx) |
 | `fault` | Sum (monotonic) | `1` | Number of fault requests (HTTP 5xx or ERROR status) |
-| `latency_seconds` | Histogram | `s` | Request latency distribution |
+| `latency` | Histogram | `s` | Request latency distribution |
 
 **Histogram Bucket Boundaries:**
 `[0.0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]`

--- a/data-prepper-plugins/otel-apm-service-map-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/utils/ApmServiceMapMetricsUtil.java
+++ b/data-prepper-plugins/otel-apm-service-map-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/utils/ApmServiceMapMetricsUtil.java
@@ -196,7 +196,7 @@ public final class ApmServiceMapMetricsUtil {
             // Create latency_seconds histogram (only if there are duration samples)
             if (!state.getLatencyDurations().isEmpty()) {
                 metrics.add(createJacksonStandardHistogram(
-                        "latency_seconds",
+                        "latency",
                         "Request latency in seconds",
                         state.getLatencyDurations(),
                         metricKey.getLabels(),

--- a/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessorTest.java
+++ b/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessorTest.java
@@ -1182,7 +1182,7 @@ class OTelApmServiceMapProcessorTest extends BaseDataPrepperPluginStandardTestSu
         event = resultList.get(2).getData();
         assertThat(event.get("name", String.class), equalTo("fault"));
         event = resultList.get(3).getData();
-        assertThat(event.get("name", String.class), equalTo("latency_seconds"));
+        assertThat(event.get("name", String.class), equalTo("latency"));
         event = resultList.get(4).getData();
         String sourceNodeName4 = event.get("sourceNode/keyAttributes/name", String.class);
         event = resultList.get(5).getData();

--- a/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/utils/ApmServiceMapMetricsUtilTest.java
+++ b/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/utils/ApmServiceMapMetricsUtilTest.java
@@ -298,7 +298,7 @@ class ApmServiceMapMetricsUtilTest {
         List<JacksonMetric> metrics = ApmServiceMapMetricsUtil.createMetricsFromAggregatedState(metricsStateByKey);
 
         // Then
-        assertEquals(3, metrics.size()); // Only request, error, fault (no latency_seconds)
+        assertEquals(3, metrics.size()); // Only request, error, fault (no latency)
     }
 
     @Test
@@ -521,7 +521,7 @@ class ApmServiceMapMetricsUtilTest {
         List<JacksonMetric> metrics = ApmServiceMapMetricsUtil.createMetricsFromAggregatedState(metricsStateByKey);
 
         // Then
-        assertEquals(4, metrics.size()); // request, error, fault, latency_seconds
+        assertEquals(4, metrics.size()); // request, error, fault, latency
 
         // Verify metric names
         List<String> metricNames = metrics.stream()
@@ -530,7 +530,7 @@ class ApmServiceMapMetricsUtilTest {
         assertTrue(metricNames.contains("request"));
         assertTrue(metricNames.contains("error"));
         assertTrue(metricNames.contains("fault"));
-        assertTrue(metricNames.contains("latency_seconds"));
+        assertTrue(metricNames.contains("latency"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The Prometheus sink automatically appends unit suffixes to metric names (e.g., unit `"s"` → `_seconds`)
- The APM service map processor was naming the histogram metric `latency_seconds` with unit `"s"`, resulting in `latency_seconds_seconds` when exported to Prometheus
- Renamed the metric to `latency` so the final Prometheus metric name is correctly `latency_seconds`

## Test plan
- [x] Unit tests updated and passing for `ApmServiceMapMetricsUtilTest` and `OTelApmServiceMapProcessorTest`