### PR TITLE
Updates to the CDK stack to support the S3 sink integration tests.

### DIFF
--- a/testing/aws-testing-cdk/lib/common/GitHubAccessStack.ts
+++ b/testing/aws-testing-cdk/lib/common/GitHubAccessStack.ts
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 import {Stack, StackProps} from 'aws-cdk-lib';
@@ -10,6 +14,7 @@ import {
   CompositePrincipal,
   OpenIdConnectPrincipal,
   OpenIdConnectProvider,
+  PolicyStatement,
   Role
 } from 'aws-cdk-lib/aws-iam'
 
@@ -57,5 +62,10 @@ export class GitHubAccessStack extends Stack {
         currentAccountPrincipal
       )
     });
+
+    this.gitHubActionsTestingRole.addToPolicy(new PolicyStatement({
+      actions: ['cloudformation:DescribeStacks'],
+      resources: [`arn:aws:cloudformation:*:${this.account}:stack/*`],
+    }));
   }
 }

--- a/testing/aws-testing-cdk/lib/common/KmsStack.ts
+++ b/testing/aws-testing-cdk/lib/common/KmsStack.ts
@@ -1,9 +1,13 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
-import {Stack, StackProps} from 'aws-cdk-lib';
+import {CfnOutput, Stack, StackProps} from 'aws-cdk-lib';
 import {Construct} from 'constructs';
 import {Role} from 'aws-cdk-lib/aws-iam';
 import {Key} from 'aws-cdk-lib/aws-kms';
@@ -27,6 +31,11 @@ export class KmsStack extends Stack {
     });
 
     this.kmsKey.grantEncryptDecrypt(props.testingRole)
+
+    new CfnOutput(this, 'KmsKeyId', {
+      value: this.kmsKey.keyArn,
+      exportName: 'DataPrepperAwsTesting-KmsKeyId',
+    });
   }
 }
 

--- a/testing/aws-testing-cdk/lib/s3/S3SinkStack.ts
+++ b/testing/aws-testing-cdk/lib/s3/S3SinkStack.ts
@@ -1,9 +1,13 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
-import {Duration, RemovalPolicy, Stack, StackProps} from 'aws-cdk-lib';
+import {CfnOutput, Duration, RemovalPolicy, Stack, StackProps} from 'aws-cdk-lib';
 import {Construct} from 'constructs';
 import {Role} from 'aws-cdk-lib/aws-iam';
 import {Bucket} from 'aws-cdk-lib/aws-s3';
@@ -13,7 +17,7 @@ export interface S3SinkStackProps extends StackProps {
 }
 
 /**
- * CDK stack that creates a common KMS key.
+ * CDK stack for resources needed by the S3 sink integration tests.
  */
 export class S3SinkStack extends Stack {
   readonly bucket: Bucket;
@@ -30,7 +34,12 @@ export class S3SinkStack extends Stack {
       ]
     });
 
-    this.bucket.grantWrite(props.testingRole)
+    this.bucket.grantReadWrite(props.testingRole)
+
+    new CfnOutput(this, 'BucketName', {
+      value: this.bucket.bucketName,
+      exportName: 'DataPrepperAwsTesting-S3SinkBucketName',
+    });
   }
 }
 


### PR DESCRIPTION
### Description

This makes changes to the CDK project to support an integration test for the `s3` sink. Another PR will add the integration test GitHub Action, but the CDK needs to deploy first.

Exports the resources and grants permissions so that the integration tests on GitHub can pull in the exports. Also grants read permissions to the S3 bucket since the tests need to read to verify the results.

See #6663 (currently a draft PR) for the GitHub Action that this will support.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
