### PR TITLE
Fixes a bug with expressions when functions are combined with and/or operations

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListener.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListener.java
@@ -140,10 +140,11 @@ class ParseTreeEvaluatorListener extends DataPrepperExpressionBaseListener {
         }
 
         if (isInsideFunction()) {
-            // Inside a function context, LPAREN/RPAREN/COMMA are structural - skip them
-            if (nodeType == DataPrepperExpressionParser.LPAREN ||
-                nodeType == DataPrepperExpressionParser.RPAREN ||
-                nodeType == DataPrepperExpressionParser.COMMA) {
+            // Inside a function context, COMMA is structural - skip it.
+            // LPAREN/RPAREN are NOT skipped so they act as a barrier on the
+            // operator stack, preventing outer operators from being evaluated
+            // inside function argument sub-expressions.
+            if (nodeType == DataPrepperExpressionParser.COMMA) {
                 return;
             }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -255,7 +255,8 @@ class GenericExpressionEvaluator_ConditionalIT extends BaseExpressionEvaluatorIT
                 arguments("substringAfter(/path, \"/\") == \"app/src/main.py\"", event("{\"path\": \"/app/src/main.py\"}"), true),
                 arguments("substringBefore(\"key=a=b\", \"=\") == \"key\"", event("{}"), true),
                 arguments("substringAfterLast(\"/app/src/main.py\", \"/\") == \"main.py\"", event("{}"), true),
-                arguments("substringBeforeLast(\"app.src.main\", \".\") == \"app.src\"", event("{}"), true)
+                arguments("substringBeforeLast(\"app.src.main\", \".\") == \"app.src\"", event("{}"), true),
+                arguments("/value == \"value-a\" and contains(/string, \"x/y/\")", event("{\"value\": \"value-a\", \"string\": \"prefix/x/y/postfix\"}"), true)
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -529,4 +529,57 @@ class ParseTreeEvaluatorListenerTest {
         final String statement = "length(/field) + 3";
         assertThat(evaluateStatementOnEvent(statement, testEvent), equalTo(8));
     }
+
+    @Test
+    void testFunctionWithMultipleArgsAsRightOperandOfAnd() {
+        final Event testEvent = createTestEvent(Map.of("value", "value-a", "message", "hello world"));
+        when(expressionFunctionProvider.provideFunction(eq("contains"), argThat(args ->
+                args.size() == 2 && args.get(0) instanceof EventKey && args.get(1) instanceof String
+        ), any(Event.class), any(Function.class))).thenReturn(true);
+        final String statement = "/value == \"value-a\" and contains(/message, \"hello\")";
+        assertThat(evaluateStatementOnEvent(statement, testEvent), is(true));
+    }
+
+    @Test
+    void testFunctionWithMultipleArgsAsRightOperandOfOr() {
+        final Event testEvent = createTestEvent(Map.of("value", "value-b", "message", "hello world"));
+        when(expressionFunctionProvider.provideFunction(eq("contains"), argThat(args ->
+                args.size() == 2 && args.get(0) instanceof EventKey && args.get(1) instanceof String
+        ), any(Event.class), any(Function.class))).thenReturn(true);
+        final String statement = "/value == \"value-a\" or contains(/message, \"hello\")";
+        assertThat(evaluateStatementOnEvent(statement, testEvent), is(true));
+    }
+
+    @Test
+    void testFunctionWithMultipleArgsAsLeftOperandOfAnd() {
+        final Event testEvent = createTestEvent(Map.of("value", "value-a", "message", "hello world"));
+        when(expressionFunctionProvider.provideFunction(eq("contains"), argThat(args ->
+                args.size() == 2 && args.get(0) instanceof EventKey && args.get(1) instanceof String
+        ), any(Event.class), any(Function.class))).thenReturn(true);
+        final String statement = "contains(/message, \"hello\") and /value == \"value-a\"";
+        assertThat(evaluateStatementOnEvent(statement, testEvent), is(true));
+    }
+
+    @Test
+    void testFunctionWithMultipleArgsAndStringContainingSlashes() {
+        final Event testEvent = createTestEvent(Map.of("value", "value-a", "path", "prefix/x/y/postfix"));
+        when(expressionFunctionProvider.provideFunction(eq("contains"), argThat(args ->
+                args.size() == 2 && args.get(0) instanceof EventKey && "x/y/".equals(args.get(1))
+        ), any(Event.class), any(Function.class))).thenReturn(true);
+        final String statement = "/value == \"value-a\" and contains(/path, \"x/y/\")";
+        assertThat(evaluateStatementOnEvent(statement, testEvent), is(true));
+    }
+
+    @Test
+    void testFunctionOnBothSidesOfAnd() {
+        final Event testEvent = createTestEvent(Map.of("msg", "hello", "path", "/a/b"));
+        when(expressionFunctionProvider.provideFunction(eq("contains"), argThat(args ->
+                args.size() == 2 && args.get(0) instanceof EventKey && "hello".equals(args.get(1))
+        ), any(Event.class), any(Function.class))).thenReturn(true);
+        when(expressionFunctionProvider.provideFunction(eq("startsWith"), argThat(args ->
+                args.size() == 2 && args.get(0) instanceof EventKey && "/a".equals(args.get(1))
+        ), any(Event.class), any(Function.class))).thenReturn(true);
+        final String statement = "contains(/msg, \"hello\") and startsWith(/path, \"/a\")";
+        assertThat(evaluateStatementOnEvent(statement, testEvent), is(true));
+    }
 }


### PR DESCRIPTION
### Description

The function composition change (#6628) converted function from a lexer rule to a parser rule, which meant function arguments became full parser sub-expressions (including `conditionalExpression`). The `ParseTreeEvaluatorListener` uses `LPAREN`/`RPAREN` tokens on the `operatorSymbolStack` as barriers to prevent operators from being evaluated inside nested scopes - this is how `parenthesesExpression` works correctly. However, the function composition code explicitly skipped `LPAREN`/`RPAREN` tokens inside functions, removing this barrier. When a multi-argument function appeared as the right operand of `and`/`or`, the `AND` operator sitting on the stack would fire prematurely when the walker exited the inner `conditionalExpression` of a function argument, consuming the function's arguments as boolean operands, silently pushing false, and leaving the function with only one argument instead of two.

The fix simply stops skipping `LPAREN`/`RPAREN` inside functions, letting them flow through to the normal handling where they act as operator stack barriers.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
