### PR TITLE
Add configurable path_prefix parameter

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -115,6 +115,7 @@ public class ConnectionConfiguration {
   private final String awsStsExternalId;
   private final Map<String, String> awsStsHeaderOverrides;
   private final Optional<String> proxy;
+  private final String pathPrefix;
   private final boolean serverless;
   private final String serverlessNetworkPolicyName;
   private final String serverlessCollectionName;
@@ -158,6 +159,10 @@ public class ConnectionConfiguration {
 
   Optional<String> getProxy() {
     return proxy;
+  }
+
+  String getPathPrefix() {
+    return pathPrefix;
   }
 
   Integer getSocketTimeout() {
@@ -219,6 +224,7 @@ public class ConnectionConfiguration {
     this.awsStsExternalId = builder.awsStsExternalId;
     this.awsStsHeaderOverrides = builder.awsStsHeaderOverrides;
     this.proxy = builder.proxy;
+    this.pathPrefix = builder.pathPrefix;
     this.serverless = builder.serverless;
     this.serverlessNetworkPolicyName = builder.serverlessNetworkPolicyName;
     this.serverlessCollectionName = builder.serverlessCollectionName;
@@ -312,6 +318,11 @@ public class ConnectionConfiguration {
       builder = builder.withProxy(proxy);
     }
 
+    final String pathPrefix = openSearchSinkConfig.getPathPrefix();
+    if (pathPrefix != null) {
+      builder = builder.withPathPrefix(pathPrefix);
+    }
+
     final boolean requestCompressionEnabled = openSearchSinkConfig.getEnableRequestCompression();
     builder = builder.withRequestCompressionEnabled(requestCompressionEnabled);
 
@@ -327,6 +338,9 @@ public class ConnectionConfiguration {
       i++;
     }
     final RestClientBuilder restClientBuilder = RestClient.builder(httpHosts);
+    if (pathPrefix != null) {
+      restClientBuilder.setPathPrefix(pathPrefix);
+    }
     /*
      * Given that this is a patch release, we will support only the IAM based access policy AES domains.
      * We will not support FGAC and Custom endpoint domains. This will be followed in the next version.
@@ -654,6 +668,7 @@ public class ConnectionConfiguration {
     private String awsStsExternalId;
     private Map<String, String> awsStsHeaderOverrides;
     private Optional<String> proxy = Optional.empty();
+    private String pathPrefix;
     private String pipelineName;
     private boolean serverless;
     private String serverlessNetworkPolicyName;
@@ -788,6 +803,11 @@ public class ConnectionConfiguration {
 
     public Builder withProxy(final String proxy) {
       this.proxy = Optional.ofNullable(proxy);
+      return this;
+    }
+
+    public Builder withPathPrefix(final String pathPrefix) {
+      this.pathPrefix = pathPrefix;
       return this;
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -77,6 +77,10 @@ public class OpenSearchSinkConfig {
     private String proxy = null;
 
     @Getter
+    @JsonProperty("path_prefix")
+    private String pathPrefix = null;
+
+    @Getter
     @JsonProperty("distribution_version")
     private String distributionVersion = DistributionVersion.DEFAULT.getVersion();
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
@@ -93,6 +93,7 @@ class ConnectionConfigurationTests {
         assertNull(connectionConfiguration.getCertPath());
         assertNull(connectionConfiguration.getConnectTimeout());
         assertNull(connectionConfiguration.getSocketTimeout());
+        assertNull(connectionConfiguration.getPathPrefix());
         assertTrue(connectionConfiguration.isRequestCompressionEnabled());
     }
 
@@ -126,6 +127,17 @@ class ConnectionConfigurationTests {
         final RestHighLevelClient client = connectionConfiguration.createClient(awsCredentialsSupplier);
         assertNotNull(client);
         client.close();
+    }
+
+    @Test
+    void testReadConnectionConfigurationWithPathPrefix() throws JsonProcessingException {
+        final Map<String, Object> configMetadata = generateConfigurationMetadata(
+                TEST_HOSTS, null, null, null, null, false, null, null, null, false);
+        configMetadata.put("path_prefix", "/os");
+        final OpenSearchSinkConfig openSearchSinkConfig = getOpenSearchSinkConfigByConfigMetadata(configMetadata);
+        final ConnectionConfiguration connectionConfiguration =
+                ConnectionConfiguration.readConnectionConfiguration(openSearchSinkConfig);
+        assertEquals("/os", connectionConfiguration.getPathPrefix());
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -31,6 +31,7 @@ public class OpenSearchSinkConfigurationTests {
     private static final String INVALID_ACTIONS_WITH_EXPRESSION_CONFIG = "invalid-actions-with-expression";
     private static final String CREATE_ACTION_CONFIG = "create-action";
     private static final String CREATE_ACTIONS_WITH_EXPRESSION_CONFIG = "create-actions-with-expression";
+    private static final String VALID_SINK_WITH_PATH_PREFIX_CONFIG = "valid-sink-with-path-prefix";
     private ExpressionEvaluator expressionEvaluator;
 
     ObjectMapper objectMapper;
@@ -92,6 +93,13 @@ public class OpenSearchSinkConfigurationTests {
         assertNotNull(openSearchSinkConfiguration.getConnectionConfiguration());
         assertNotNull(openSearchSinkConfiguration.getIndexConfiguration());
         assertNotNull(openSearchSinkConfiguration.getRetryConfiguration());
+    }
+
+    @Test
+    public void testReadOSConfigWithPathPrefix() throws IOException {
+        final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfig(VALID_SINK_WITH_PATH_PREFIX_CONFIG);
+
+        assertEquals("/os", openSearchSinkConfig.getPathPrefix());
     }
 
 

--- a/data-prepper-plugins/opensearch/src/test/resources/open-search-sink-configurations.yaml
+++ b/data-prepper-plugins/opensearch/src/test/resources/open-search-sink-configurations.yaml
@@ -8,6 +8,12 @@ valid-sink:
         sts_role_arn: "arn:aws:iam::123456789012:role/test-role"
         region: "us-east-2"
         serverless: true
+valid-sink-with-path-prefix:
+  sink:
+    opensearch:
+      hosts: [ "http://localhost:9200" ]
+      index: "no-more-plugin-setting"
+      path_prefix: "/os"
 invalid-action:
   sink:
     opensearch:


### PR DESCRIPTION
### Description
Introduce an optional `path_prefix` sink parameter to support OpenSearch instances served behind a reverse proxy under a custom subdirectory.
 
### Issues Resolved
Resolves #6654
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
