### PR TITLE
chore: Upgrade Jackson to 2.21.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.17.2')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.21.0')
         implementation platform('org.eclipse.jetty:jetty-bom:9.4.53.v20231009')
         implementation platform('io.micrometer:micrometer-bom:1.10.5')
         implementation libs.guava.core


### PR DESCRIPTION
### Description
Upgrades Jackson BOM from 2.17.2 to 2.21.0 in the root build.gradle. All subprojects inherit this version automatically.
 
### Issues Resolved
N/A (dependency version bump)
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
