### PR TITLE
fix a typo in s3_enrich metrics

### DIFF
--- a/data-prepper-plugins/s3-enrich-processor/src/main/java/org/opensearch/dataprepper/plugins/s3_enrich/processor/S3EnrichProcessor.java
+++ b/data-prepper-plugins/s3-enrich-processor/src/main/java/org/opensearch/dataprepper/plugins/s3_enrich/processor/S3EnrichProcessor.java
@@ -55,7 +55,7 @@ public class S3EnrichProcessor extends AbstractProcessor<Record<Event>, Record<E
     private static final long BYTES_IN_MB = 1024 * 1024;
 
     public static final String NUMBER_OF_RECORDS_ENRICHED_SUCCESS = "numberOfRecordsEnrichedSuccessFromS3";
-    public static final String NUMBER_OF_RECORDS_ENRICHED_FAILED = "numberOfRecordsEnrichedFailerFromS3";
+    public static final String NUMBER_OF_RECORDS_ENRICHED_FAILED = "numberOfRecordsEnrichedFailureFromS3";
 
     private final S3EnrichProcessorConfig s3EnrichProcessorConfig;
     private final ExpressionEvaluator expressionEvaluator;


### PR DESCRIPTION
### Description
Fix the typo in the name of the metrics from "numberOfRecordsEnrichedFailerFromS3" to "numberOfRecordsEnrichedFailureFromS3". 


### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
