### PR TITLE
Run older OpenSearch 2.x integration tests against Ubuntu 22 to fix failures

### DIFF
--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -42,9 +42,16 @@ jobs:
           - 2.19.5
           - 3.0.0
           - 3.5.0
+        include:
+          - opensearch: 2.0.1
+            runner: ubuntu-22.04
+          - opensearch: 2.1.0
+            runner: ubuntu-22.04
+          - opensearch: 2.3.0
+            runner: ubuntu-22.04
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
 
     steps:
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
### Description

Our `opensearch` sink tests are failing consistently for some earlier 2.x OpenSearch versions.

I noticed that `logstash-output-plugin` also has similarly failing tests:

https://github.com/opensearch-project/logstash-output-opensearch/actions/runs/22923600745/job/66528189340

OpenSearch is failing to start with this error.

```
java.lang.ExceptionInInitializerError
integration-1  | 	at org.opensearch.bootstrap.Bootstrap.initializeProbes(Bootstrap.java:177)
integration-1  | 	at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:199)
integration-1  | 	at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:404)
integration-1  | 	at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:180)
integration-1  | 	at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171)
integration-1  | 	at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
integration-1  | 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
integration-1  | 	at org.opensearch.cli.Command.main(Command.java:101)
integration-1  | 	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137)
integration-1  | 	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103)
integration-1  | Caused by: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
integration-1  | 	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:80)
integration-1  | 	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:114)
integration-1  | 	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:177)
integration-1  | 	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
integration-1  | 	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
integration-1  | 	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
integration-1  | 	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
integration-1  | 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
integration-1  | 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
integration-1  | 	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
integration-1  | 	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:687)
integration-1  | 	at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(ManagementFactory.java:389)
integration-1  | 	at org.opensearch.monitor.process.ProcessProbe.<clinit>(ProcessProbe.java:51)
integration-1  | 	... 10 more

```
 
The fix is to run these tests against Ubuntu 22 instead of the latest (24). This older version doesn't have the same cgroup issues.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
