### PR TITLE
Fix flaky PipelinesWithAcksIT by awaiting async ack callback

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -30,9 +30,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @FixMethodOrder()
 class PipelinesWithAcksIT {
@@ -81,7 +79,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
 
     }
 
@@ -97,7 +98,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -112,7 +116,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -127,7 +134,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -139,11 +149,10 @@ class PipelinesWithAcksIT {
         await().atMost(40000, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
                     assertNotNull(inMemorySourceAccessor);
-                    assertNotNull(inMemorySourceAccessor.getAckReceived());
+                    assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
         });
         List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
         assertThat(outputRecords.size(), equalTo(0));
-        assertTrue(inMemorySourceAccessor.getAckReceived());
     }
 
     @Test
@@ -158,7 +167,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), lessThanOrEqualTo(numRecords));
         });
-        assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -174,7 +186,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(2*numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -189,7 +204,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(2*numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -204,7 +222,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(3*numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -219,7 +240,10 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(3*numRecords));
         });
-        assertTrue(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(true));
+        });
     }
 
     @Test
@@ -250,6 +274,9 @@ class PipelinesWithAcksIT {
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), equalTo(3*numRecords));
         });
-        assertFalse(inMemorySourceAccessor.getAckReceived());
+        await().atMost(40000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySourceAccessor.getAckReceived(), equalTo(false));
+        });
     }
 }


### PR DESCRIPTION
### Description
Fix flaky `PipelinesWithAcksIT` tests that intermittently fail with `NullPointerException`.

The acknowledgement callback (`setAckReceived`) is invoked asynchronously after sink processing completes. The existing tests assert the ack result immediately after confirming sink output arrival, without waiting for the async callback. Under CI load, this race condition causes `getAckReceived()` to return `null`, which triggers a `NullPointerException` when unboxed by `assertTrue(Boolean)`.

This change wraps all ack assertions in `await().untilAsserted()` to poll until the acknowledgement callback has been invoked, consistent with the existing pattern already used in `three_pipelines_with_all_unrouted_records()`.

### CI impact
This fix targets the `Gradle Build / build` workflow (`gradle.yml`), which runs `./gradlew build` including `:data-prepper-core:integrationTest`. The following test methods in `PipelinesWithAcksIT` have been observed to fail intermittently across Java 11, 17, and 21 matrix jobs.

Local verification (10 consecutive runs each):
* Before: 8/10 passed (2 failures)
* After: 10/10 passed (0 failures)

### Issues Resolved
Related #3481

### Check List
- [] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO