### PR TITLE
Fix flaky DefaultAcknowledgementSetManagerTests

### DIFF
--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetManagerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetManagerTests.java
@@ -110,9 +110,9 @@ class DefaultAcknowledgementSetManagerTests {
     void testExpirations() throws InterruptedException {
         eventHandle2.release(true);
         Thread.sleep(TEST_TIMEOUT.multipliedBy(2).toMillis());
-        assertThat(acknowledgementSetManager.getAcknowledgementSetMonitor().getSize(), equalTo(0));
         await().atMost(TEST_TIMEOUT.multipliedBy(3))
                 .untilAsserted(() -> {
+                    assertThat(acknowledgementSetManager.getAcknowledgementSetMonitor().getSize(), equalTo(0));
                     assertThat(result, equalTo(null));
                 });
     }


### PR DESCRIPTION
### Description
Fix flaky `DefaultAcknowledgementSetManagerTests.testExpirations()` that intermittently fails with `AssertionError: Expected: <0> but: was <1>`.

The test asserts that the acknowledgement set monitor size is 0 immediately after a `Thread.sleep()`, assuming the cleanup thread has already removed the expired set. Under CI load, the cleanup may not have completed in time. The subsequent `await()` block only checks the `result` field, not the monitor size, so the stale size is never retried.

This change moves the `getSize() == 0` assertion into the `await().untilAsserted()` block so both conditions are polled together.

### CI impact
This fix targets `Gradle Build / build` workflow (`gradle.yml`), specifically `DefaultAcknowledgementSetManagerTests.testExpirations()` in `:data-prepper-core:test`.

Local verification (10 consecutive runs each):
The race condition is difficult to reproduce with the default `TEST_TIMEOUT` (400ms) on a local machine. To amplify it, the `Thread.sleep` in `testExpirations` was temporarily hardcoded to 20ms (instead of `TEST_TIMEOUT * 2` = 800ms), reducing the margin for the cleanup thread to near zero.
* Before fix (getSize assertion outside await): 0/10 passed
* After fix (getSize assertion inside await): 10/10 passed

### Issues Resolved
Resolves https://github.com/opensearch-project/data-prepper/issues/6719

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
