### PR TITLE
Add support for zero dates in mysql mapping

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/TemporalTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/TemporalTypeHandler.java
@@ -88,7 +88,7 @@ public class TemporalTypeHandler implements MySQLDataTypeHandler {
     private Long handleDate(final String dateStr) {
         try {
             // Handle MySQL zero date special case
-            if ("0000-00-00".equals(dateStr)) {
+            if (dateStr.matches("^0000-.*|.*-00-.*|.*-00$")) {
                 return null;
             }
 
@@ -107,6 +107,9 @@ public class TemporalTypeHandler implements MySQLDataTypeHandler {
 
     private Long handleDateTime(final String dateTimeStr) {
         try {
+            if (dateTimeStr.startsWith("0000-00-00")) {
+                return null;
+            }
             final Long dateTimeEpoch = parseDateTimeStrAsEpochMillis(dateTimeStr);
             if (dateTimeEpoch != null) return dateTimeEpoch;
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/TemporalTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/TemporalTypeHandlerTest.java
@@ -60,7 +60,10 @@ class TemporalTypeHandlerTest {
                 Arguments.of("1970-01-01", getEpochMillisFromDate(1970, 1, 1)),
                 Arguments.of("2024-02-29", getEpochMillisFromDate(2024, 2, 29)), // Leap year
                 Arguments.of("0000-00-00", null),
-                Arguments.of("1684108800000", getEpochMillisFromDate(2023, 5, 15))
+                Arguments.of("1684108800000", getEpochMillisFromDate(2023, 5, 15),
+                Arguments.of("1997-00-01", null),
+                Arguments.of("0000-01-12", null),
+                Arguments.of("1997-01-00", null))
         );
     }
 
@@ -94,7 +97,7 @@ class TemporalTypeHandlerTest {
 
     @ParameterizedTest
     @MethodSource("provideDateTimeTestCases")
-    void handle_withDateTimeType_returnsCorrectEpochMillis(String input, long expected) {
+    void handle_withDateTimeType_returnsCorrectEpochMillis(String input, Long expected) {
         Long result = temporalTypeHandler.handle(MySQLDataType.DATETIME, "datetime_column", input, null);
         assertEquals(expected, result);
     }
@@ -104,7 +107,8 @@ class TemporalTypeHandlerTest {
             Arguments.of("2023-12-25 14:30:00.123456", getEpochMillis(2023, 12, 25, 14, 30, 0, 123456000)),
             Arguments.of("1970-01-01 00:00:00", getEpochMillis(1970, 1, 1, 0, 0, 0, 0)),
             Arguments.of("1703509900000", 1703509900000L),
-            Arguments.of("1784161123456789", 1784161123456L)
+            Arguments.of("1784161123456789", 1784161123456L),
+            Arguments.of("0000-00-00 14:30:00.123456", null)
         );
     }
 


### PR DESCRIPTION
### Description
Add support for MySQL zero-in-date values in `TemporalTypeHandler`.

MySQL allows dates with zero components (e.g., 1999-00-20, 2024-05-00, 0000-01-12) when `NO_ZERO_IN_DATE` SQL mode is not enabled. Currently, TemporalTypeHandler only handles the full zero date `0000-00-00` and throws IllegalArgumentException for partial zero dates, causing the entire Parquet file to fail during RDS S3 export ingestion.

This change:

Extends handleDate() to return null for any date with a zero year (0000), zero month (-00-), or zero day (-00)
Extends handleDateTime() to apply the zero-component check on the date portion for DATETIME values
since TIMESTAMP only permits the full zero timestamp (0000-00-00 00:00:00), not partial zeros. 
 
 Reference: https://dev.mysql.com/doc/refman/9.6/en/datetime.html
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
