### PR TITLE
Default OpenSearch source serverless search context to point_in_time

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
@@ -145,9 +145,9 @@ public class SearchAccessorStrategy {
 
     private SearchAccessor createSearchAccessorForServerlessCollection(final PluginComponentRefresher clientRefresher) {
         if (Objects.isNull(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
-            LOG.info("Configured with AOS serverless flag as true, defaulting to search_context_type as 'none', which uses search_after");
+            LOG.info("Configured with AOS serverless flag as true, defaulting to search_context_type as 'point_in_time'");
             return new OpenSearchAccessor(clientRefresher,
-                    SearchContextType.NONE);
+                    SearchContextType.POINT_IN_TIME);
         } else {
             if ( SearchContextType.SCROLL.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
                 throw new InvalidPluginConfigurationException("A search_context_type of scroll is not supported for serverless collections");

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
@@ -210,7 +210,7 @@ public class SearchAccessStrategyTest {
     }
 
     @Test
-    void serverless_flag_true_defaults_to_search_context_type_none() {
+    void serverless_flag_true_defaults_to_search_context_type_point_in_time() {
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
         when(awsAuthenticationConfiguration.isServerlessCollection()).thenReturn(true);
@@ -222,7 +222,7 @@ public class SearchAccessStrategyTest {
         final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
 
         assertThat(searchAccessor, notNullValue());
-        assertThat(searchAccessor.getSearchContextType(), equalTo(SearchContextType.NONE));
+        assertThat(searchAccessor.getSearchContextType(), equalTo(SearchContextType.POINT_IN_TIME));
         verifyNoInteractions(pluginConfigObservable);
     }
 
@@ -244,7 +244,7 @@ public class SearchAccessStrategyTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"NONE"})
+    @ValueSource(strings = {"NONE", "POINT_IN_TIME"})
     void serverless_flag_true_uses_search_context_type_from_config(final String searchContextType) {
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);


### PR DESCRIPTION
### Description
Changes the default search_context_type for Amazon OpenSearch Serverless collections from NONE (search_after without context) to POINT_IN_TIME. When the opensearch source was originally created, Serverless did not support PIT. Serverless now supports PIT, and this provides better pagination consistency. 
 
### Issues Resolved
Resolves #6335
https://github.com/opensearch-project/data-prepper/issues/6335
 
### Check List
- [ X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ X ] New functionality has javadoc added
- [ X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
