### PR TITLE
Add configurable sort options to opensearch source search_options

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
@@ -7,8 +7,11 @@ package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
+
+import java.util.List;
 
 public class SearchConfiguration {
 
@@ -17,6 +20,10 @@ public class SearchConfiguration {
 
     @JsonProperty("batch_size")
     private Integer batchSize = 1000;
+
+    @JsonProperty("sort")
+    @Valid
+    private List<SortConfig> sort;
 
     @JsonIgnore
     private SearchContextType searchContextTypeValue;
@@ -27,6 +34,10 @@ public class SearchConfiguration {
 
     public Integer getBatchSize() {
         return batchSize;
+    }
+
+    public List<SortConfig> getSort() {
+        return sort;
     }
 
     @AssertTrue(message = "search_context_type must be one of [ 'scroll', 'point_in_time', 'none' ]")

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Set;
+
+public class SortConfig {
+
+    private static final Set<String> VALID_ORDERS = Set.of("ascending", "descending");
+
+    @JsonProperty("name")
+    @NotBlank(message = "sort field name must not be blank")
+    private String name;
+
+    @JsonProperty("order")
+    private String order = "ascending";
+
+    public String getName() {
+        return name;
+    }
+
+    public String getOrder() {
+        return order;
+    }
+
+    @AssertTrue(message = "sort order must be one of [ 'ascending', 'descending' ]")
+    boolean isOrderValid() {
+        return order == null || VALID_ORDERS.contains(order);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfig.java
@@ -11,32 +11,22 @@
 package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 
-import java.util.Set;
-
 public class SortConfig {
-
-    private static final Set<String> VALID_ORDERS = Set.of("ascending", "descending");
 
     @JsonProperty("name")
     @NotBlank(message = "sort field name must not be blank")
     private String name;
 
     @JsonProperty("order")
-    private String order = "ascending";
+    private SortOrder order = SortOrder.ASCENDING;
 
     public String getName() {
         return name;
     }
 
-    public String getOrder() {
+    public SortOrder getOrder() {
         return order;
-    }
-
-    @AssertTrue(message = "sort order must be one of [ 'ascending', 'descending' ]")
-    boolean isOrderValid() {
-        return order == null || VALID_ORDERS.contains(order);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortOrder.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortOrder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum SortOrder {
+    ASCENDING("ascending", "asc"),
+    DESCENDING("descending", "desc");
+
+    private static final Map<String, SortOrder> NAMES_MAP = Arrays.stream(SortOrder.values())
+            .collect(Collectors.toMap(
+                    value -> value.optionName,
+                    value -> value
+            ));
+
+    private final String optionName;
+    private final String opensearchName;
+
+    SortOrder(final String optionName, final String opensearchName) {
+        this.optionName = optionName;
+        this.opensearchName = opensearchName;
+    }
+
+    @JsonValue
+    public String getOptionName() {
+        return optionName;
+    }
+
+    public String getOpensearchName() {
+        return opensearchName;
+    }
+
+    @JsonCreator
+    public static SortOrder fromOptionName(final String optionName) {
+        return NAMES_MAP.get(optionName);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortOrder.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortOrder.java
@@ -28,11 +28,11 @@ public enum SortOrder {
             ));
 
     private final String optionName;
-    private final String opensearchName;
+    private final String sortOrderValue;
 
-    SortOrder(final String optionName, final String opensearchName) {
+    SortOrder(final String optionName, final String sortOrderValue) {
         this.optionName = optionName;
-        this.opensearchName = opensearchName;
+        this.sortOrderValue = sortOrderValue;
     }
 
     @JsonValue
@@ -40,8 +40,8 @@ public enum SortOrder {
         return optionName;
     }
 
-    public String getOpensearchName() {
-        return opensearchName;
+    public String getSortOrderValue() {
+        return sortOrderValue;
     }
 
     @JsonCreator

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.Search
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,13 +148,14 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
 
         final SearchConfiguration searchConfiguration = openSearchSourceConfiguration.getSearchConfiguration();
         SearchWithSearchAfterResults searchWithSearchAfterResults = null;
+        final List<SortingOptions> sortingOptions = SortingOptions.fromSortConfigs(searchConfiguration.getSort());
 
-        // todo: Pass query and sort options from SearchConfiguration to the search request
         do {
             searchWithSearchAfterResults = searchAccessor.searchWithoutSearchContext(NoSearchContextSearchRequest.builder()
                             .withIndex(indexName)
                             .withPaginationSize(searchConfiguration.getBatchSize())
                             .withSearchAfter(getSearchAfter(openSearchIndexProgressState, searchWithSearchAfterResults))
+                            .withSortOptions(sortingOptions)
                             .build());
 
             searchWithSearchAfterResults.getDocuments().stream().map(Record::new).forEach(record -> {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -27,6 +27,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,14 +184,15 @@ public class PitWorker implements SearchWorker, Runnable {
 
         final SearchConfiguration searchConfiguration = openSearchSourceConfiguration.getSearchConfiguration();
         SearchWithSearchAfterResults searchWithSearchAfterResults = null;
+        final List<SortingOptions> sortingOptions = SortingOptions.fromSortConfigs(searchConfiguration.getSort());
 
-        // todo: Pass query and sort options from SearchConfiguration to the search request
         do {
             searchWithSearchAfterResults = searchAccessor.searchWithPit(SearchPointInTimeRequest.builder()
                     .withPitId(openSearchIndexProgressState.getPitId())
                     .withKeepAlive(EXTEND_KEEP_ALIVE_TIME)
                     .withPaginationSize(searchConfiguration.getBatchSize())
                     .withSearchAfter(getSearchAfter(openSearchIndexProgressState, searchWithSearchAfterResults))
+                    .withSortOptions(sortingOptions)
                     .build());
 
             searchWithSearchAfterResults.getDocuments().stream().map(Record::new).forEach(record -> {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -26,6 +26,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,11 +156,13 @@ public class ScrollWorker implements SearchWorker {
         LOG.info("Started processing for index: '{}'", indexName);
 
         final Integer batchSize = openSearchSourceConfiguration.getSearchConfiguration().getBatchSize();
+        final List<SortingOptions> sortingOptions = SortingOptions.fromSortConfigs(openSearchSourceConfiguration.getSearchConfiguration().getSort());
 
         final CreateScrollResponse createScrollResponse = searchAccessor.createScroll(CreateScrollRequest.builder()
                 .withScrollTime(SCROLL_TIME_PER_BATCH)
                 .withSize(openSearchSourceConfiguration.getSearchConfiguration().getBatchSize())
                 .withIndex(indexName)
+                .withSortOptions(sortingOptions)
                 .build());
 
         writeDocumentsToBuffer(createScrollResponse.getDocuments(), acknowledgementSet);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
@@ -43,6 +43,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,13 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
 
     static final String PIT_RESOURCE_LIMIT_ERROR_TYPE = "rejected_execution_exception";
     static final String INDEX_NOT_FOUND_EXCEPTION = "index_not_found_exception";
+
+    private static final List<SortOptions> DEFAULT_SORT_OPTIONS = List.of(
+            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))),
+            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.field(FieldSort.of(fieldSort -> fieldSort.field("_id").order(SortOrder.Asc)))));
+
+    private static final List<SortOptions> DEFAULT_SCROLL_SORT_OPTIONS = List.of(
+            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))));
 
     private final PluginComponentRefresher<ElasticsearchClient, OpenSearchSourceConfiguration>
             elasticsearchClientRefresher;
@@ -119,10 +127,7 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
                                 .id(searchPointInTimeRequest.getPitId())
                                 .keepAlive(Time.of(time -> time.time(searchPointInTimeRequest.getKeepAlive())))))
                 .size(searchPointInTimeRequest.getPaginationSize())
-                .sort(List.of(
-                        SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))),
-                        SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.field(FieldSort.of(fieldSortBuilder -> fieldSortBuilder.field("_id").order(SortOrder.Asc)))))
-                )
+                .sort(buildSortOptions(searchPointInTimeRequest.getSortOptions()))
                 .version(true)
                 .query(Query.of(query -> query.matchAll(MatchAllQuery.of(matchAllQuery -> matchAllQuery))));
 
@@ -161,7 +166,7 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
             searchResponse = elasticsearchClientRefresher.get()
                     .search(SearchRequest.of(request -> request
                     .scroll(Time.of(time -> time.time(createScrollRequest.getScrollTime())))
-                    .sort(SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))))
+                    .sort(buildSortOptionsForScroll(createScrollRequest.getSortOptions()))
                     .size(createScrollRequest.getSize())
                     .version(true)
                     .index(createScrollRequest.getIndex())), ObjectNode.class);
@@ -232,10 +237,7 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
             builder
                     .index(noSearchContextSearchRequest.getIndex())
                     .size(noSearchContextSearchRequest.getPaginationSize())
-                    .sort(List.of(
-                            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))),
-                            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.field(FieldSort.of(fieldSortBuilder -> fieldSortBuilder.field("_id").order(SortOrder.Asc)))))
-                    )
+                    .sort(buildSortOptions(noSearchContextSearchRequest.getSortOptions()))
                     .version(true)
                     .query(Query.of(query -> query.matchAll(MatchAllQuery.of(matchAllQuery -> matchAllQuery))));
 
@@ -305,5 +307,23 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
                                         DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME, hit.version()))
                         .withEventType(EventType.DOCUMENT.toString()).build())
                 .collect(Collectors.toList());
+    }
+
+    private List<SortOptions> buildSortOptions(final List<SortingOptions> sortingOptions) {
+        if (sortingOptions == null || sortingOptions.isEmpty()) {
+            return DEFAULT_SORT_OPTIONS;
+        }
+        return sortingOptions.stream()
+                .map(opt -> SortOptions.of(b -> b.field(
+                        FieldSort.of(f -> f.field(opt.getFieldName())
+                                .order("desc".equalsIgnoreCase(opt.getOrder()) ? SortOrder.Desc : SortOrder.Asc)))))
+                .collect(Collectors.toList());
+    }
+
+    private List<SortOptions> buildSortOptionsForScroll(final List<SortingOptions> sortingOptions) {
+        if (sortingOptions == null || sortingOptions.isEmpty()) {
+            return DEFAULT_SCROLL_SORT_OPTIONS;
+        }
+        return buildSortOptions(sortingOptions);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -43,6 +43,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,13 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
     static final String PIT_RESOURCE_LIMIT_ERROR_TYPE = "rejected_execution_exception";
     static final String INDEX_NOT_FOUND_EXCEPTION = "index_not_found_exception";
     static final String SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE = "Trying to create too many scroll contexts";
+
+    private static final List<SortOptions> DEFAULT_SORT_OPTIONS = List.of(
+            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))),
+            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.field(FieldSort.of(fieldSort -> fieldSort.field("_id").order(SortOrder.Asc)))));
+
+    private static final List<SortOptions> DEFAULT_SCROLL_SORT_OPTIONS = List.of(
+            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))));
 
     private final PluginComponentRefresher<OpenSearchClient, OpenSearchSourceConfiguration> clientRefresher;
     private final SearchContextType searchContextType;
@@ -117,10 +125,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
             builder
                     .pit(Pit.of(pitBuilder -> pitBuilder.id(searchPointInTimeRequest.getPitId()).keepAlive(searchPointInTimeRequest.getKeepAlive())))
                     .size(searchPointInTimeRequest.getPaginationSize())
-                    .sort(List.of(
-                            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))),
-                            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.field(FieldSort.of(fieldSort -> fieldSort.field("_id").order(SortOrder.Asc)))))
-                    )
+                    .sort(buildSortOptions(searchPointInTimeRequest.getSortOptions()))
                     .version(true)
                     .query(Query.of(query -> query.matchAll(MatchAllQuery.of(matchAllQuery -> matchAllQuery))));
 
@@ -157,7 +162,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
             searchResponse = clientRefresher.get()
                     .search(SearchRequest.of(request -> request
                     .scroll(Time.of(time -> time.time(createScrollRequest.getScrollTime())))
-                    .sort(SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))))
+                    .sort(buildSortOptionsForScroll(createScrollRequest.getSortOptions()))
                     .size(createScrollRequest.getSize())
                     .version(true)
                     .index(createScrollRequest.getIndex())), ObjectNode.class);
@@ -226,10 +231,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
             builder
                     .index(noSearchContextSearchRequest.getIndex())
                     .size(noSearchContextSearchRequest.getPaginationSize())
-                    .sort(List.of(
-                            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.doc(ScoreSort.of(scoreSort -> scoreSort.order(SortOrder.Asc)))),
-                            SortOptions.of(sortOptionsBuilder -> sortOptionsBuilder.field(FieldSort.of(fieldSort -> fieldSort.field("_id").order(SortOrder.Asc)))))
-                    )
+                    .sort(buildSortOptions(noSearchContextSearchRequest.getSortOptions()))
                     .version(true)
                     .query(Query.of(query -> query.matchAll(MatchAllQuery.of(matchAllQuery -> matchAllQuery))));
 
@@ -304,5 +306,23 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
                                         DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME, hit.version()))
                         .withEventType(EventType.DOCUMENT.toString()).build())
                 .collect(Collectors.toList());
+    }
+
+    private List<SortOptions> buildSortOptions(final List<SortingOptions> sortingOptions) {
+        if (sortingOptions == null || sortingOptions.isEmpty()) {
+            return DEFAULT_SORT_OPTIONS;
+        }
+        return sortingOptions.stream()
+                .map(opt -> SortOptions.of(b -> b.field(
+                        FieldSort.of(f -> f.field(opt.getFieldName())
+                                .order("desc".equalsIgnoreCase(opt.getOrder()) ? SortOrder.Desc : SortOrder.Asc)))))
+                .collect(Collectors.toList());
+    }
+
+    private List<SortOptions> buildSortOptionsForScroll(final List<SortingOptions> sortingOptions) {
+        if (sortingOptions == null || sortingOptions.isEmpty()) {
+            return DEFAULT_SCROLL_SORT_OPTIONS;
+        }
+        return buildSortOptions(sortingOptions);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/CreateScrollRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/CreateScrollRequest.java
@@ -4,11 +4,14 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
 
+import java.util.List;
+
 public class CreateScrollRequest {
 
     private final String index;
     private final String scrollTime;
     private final Integer size;
+    private final List<SortingOptions> sortingOptions;
 
     public String getIndex() {
         return index;
@@ -18,10 +21,13 @@ public class CreateScrollRequest {
 
     public String getScrollTime() { return scrollTime; }
 
+    public List<SortingOptions> getSortOptions() { return sortingOptions; }
+
     private CreateScrollRequest(final CreateScrollRequest.Builder builder) {
         this.index = builder.index;
         this.size = builder.size;
         this.scrollTime = builder.scrollTime;
+        this.sortingOptions = builder.sortingOptions;
     }
 
     public static CreateScrollRequest.Builder builder() {
@@ -33,6 +39,7 @@ public class CreateScrollRequest {
         private String index;
         private Integer size;
         private String scrollTime;
+        private List<SortingOptions> sortingOptions;
 
         public Builder() {
 
@@ -50,6 +57,11 @@ public class CreateScrollRequest {
 
         public CreateScrollRequest.Builder withScrollTime(final String scrollTime) {
             this.scrollTime = scrollTime;
+            return this;
+        }
+
+        public CreateScrollRequest.Builder withSortOptions(final List<SortingOptions> sortingOptions) {
+            this.sortingOptions = sortingOptions;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/NoSearchContextSearchRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/NoSearchContextSearchRequest.java
@@ -12,11 +12,13 @@ public class NoSearchContextSearchRequest {
     private final String index;
     private final List<String> searchAfter;
     private final Integer paginationSize;
+    private final List<SortingOptions> sortingOptions;
 
     private NoSearchContextSearchRequest(final NoSearchContextSearchRequest.Builder builder) {
         this.index = builder.index;
         this.searchAfter = builder.searchAfter;
         this.paginationSize = builder.paginationSize;
+        this.sortingOptions = builder.sortingOptions;
     }
 
     public static NoSearchContextSearchRequest.Builder builder() {
@@ -35,11 +37,16 @@ public class NoSearchContextSearchRequest {
         return paginationSize;
     }
 
+    public List<SortingOptions> getSortOptions() {
+        return sortingOptions;
+    }
+
     public static class Builder {
 
         private String index;
         private List<String> searchAfter;
         private Integer paginationSize;
+        private List<SortingOptions> sortingOptions;
 
 
         public Builder() {
@@ -58,6 +65,11 @@ public class NoSearchContextSearchRequest {
 
         public NoSearchContextSearchRequest.Builder withIndex(final String index) {
             this.index = index;
+            return this;
+        }
+
+        public NoSearchContextSearchRequest.Builder withSortOptions(final List<SortingOptions> sortingOptions) {
+            this.sortingOptions = sortingOptions;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptions.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptions.java
@@ -7,12 +7,16 @@ package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SortConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class SortingOptions {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SortingOptions.class);
 
     private String fieldName;
 
@@ -45,15 +49,24 @@ public class SortingOptions {
         if (sortConfigs == null || sortConfigs.isEmpty()) {
             return Collections.emptyList();
         }
-        return sortConfigs.stream()
+        final List<SortingOptions> result = sortConfigs.stream()
                 .map(SortingOptions::fromSortConfig)
                 .collect(Collectors.toList());
+
+        final boolean hasIdField = result.stream()
+                .anyMatch(opt -> "_id".equals(opt.getFieldName()));
+        if (!hasIdField) {
+            LOG.warn("Custom sort does not include _id. Pagination results may contain duplicates " +
+                    "or miss documents when sort values are not unique.");
+        }
+
+        return result;
     }
 
     private static SortingOptions fromSortConfig(final SortConfig sortConfig) {
         final SortingOptions sortingOptions = new SortingOptions();
         sortingOptions.fieldName = sortConfig.getName();
-        sortingOptions.order = "descending".equalsIgnoreCase(sortConfig.getOrder()) ? "desc" : "asc";
+        sortingOptions.order = sortConfig.getOrder().getOpensearchName();
         return sortingOptions;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptions.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptions.java
@@ -6,8 +6,12 @@
 package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SortConfig;
 
-// TODO: Convert the queryMap sort value from SearchConfiguration to this class to be passed to SearchWithPit or SearchWithScroll
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class SortingOptions {
 
     private String fieldName;
@@ -35,5 +39,21 @@ public class SortingOptions {
 
     public String getMode() {
         return mode;
+    }
+
+    public static List<SortingOptions> fromSortConfigs(final List<SortConfig> sortConfigs) {
+        if (sortConfigs == null || sortConfigs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return sortConfigs.stream()
+                .map(SortingOptions::fromSortConfig)
+                .collect(Collectors.toList());
+    }
+
+    private static SortingOptions fromSortConfig(final SortConfig sortConfig) {
+        final SortingOptions sortingOptions = new SortingOptions();
+        sortingOptions.fieldName = sortConfig.getName();
+        sortingOptions.order = "descending".equalsIgnoreCase(sortConfig.getOrder()) ? "desc" : "asc";
+        return sortingOptions;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptions.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptions.java
@@ -66,7 +66,7 @@ public class SortingOptions {
     private static SortingOptions fromSortConfig(final SortConfig sortConfig) {
         final SortingOptions sortingOptions = new SortingOptions();
         sortingOptions.fieldName = sortConfig.getName();
-        sortingOptions.order = sortConfig.getOrder().getOpensearchName();
+        sortingOptions.order = sortConfig.getOrder().getSortOrderValue();
         return sortingOptions;
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfigurationTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -28,6 +30,7 @@ public class SearchConfigurationTest {
 
         assertThat(searchConfiguration.getBatchSize(), equalTo(1000));
         assertThat(searchConfiguration.getSearchContextType(), nullValue());
+        assertThat(searchConfiguration.getSort(), nullValue());
     }
 
     @Test
@@ -55,5 +58,38 @@ public class SearchConfigurationTest {
 
         assertThat(searchConfiguration.isSearchContextTypeValid(), equalTo(false));
         assertThat(searchConfiguration.getSearchContextType(), nullValue());
+    }
+
+    @Test
+    void search_configuration_with_sort_fields() {
+        final Map<String, Object> pluginSettings = new HashMap<>();
+        pluginSettings.put("sort", List.of(
+                Map.of("name", "@timestamp", "order", "descending"),
+                Map.of("name", "_id", "order", "ascending")
+        ));
+
+        final SearchConfiguration searchConfiguration = objectMapper.convertValue(pluginSettings, SearchConfiguration.class);
+
+        assertThat(searchConfiguration.getSort(), notNullValue());
+        assertThat(searchConfiguration.getSort().size(), equalTo(2));
+        assertThat(searchConfiguration.getSort().get(0).getName(), equalTo("@timestamp"));
+        assertThat(searchConfiguration.getSort().get(0).getOrder(), equalTo("descending"));
+        assertThat(searchConfiguration.getSort().get(1).getName(), equalTo("_id"));
+        assertThat(searchConfiguration.getSort().get(1).getOrder(), equalTo("ascending"));
+    }
+
+    @Test
+    void search_configuration_with_single_sort_field_defaults_to_ascending() {
+        final Map<String, Object> pluginSettings = new HashMap<>();
+        pluginSettings.put("sort", List.of(
+                Map.of("name", "created_at")
+        ));
+
+        final SearchConfiguration searchConfiguration = objectMapper.convertValue(pluginSettings, SearchConfiguration.class);
+
+        assertThat(searchConfiguration.getSort(), notNullValue());
+        assertThat(searchConfiguration.getSort().size(), equalTo(1));
+        assertThat(searchConfiguration.getSort().get(0).getName(), equalTo("created_at"));
+        assertThat(searchConfiguration.getSort().get(0).getOrder(), equalTo("ascending"));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfigurationTest.java
@@ -73,9 +73,9 @@ public class SearchConfigurationTest {
         assertThat(searchConfiguration.getSort(), notNullValue());
         assertThat(searchConfiguration.getSort().size(), equalTo(2));
         assertThat(searchConfiguration.getSort().get(0).getName(), equalTo("@timestamp"));
-        assertThat(searchConfiguration.getSort().get(0).getOrder(), equalTo("descending"));
+        assertThat(searchConfiguration.getSort().get(0).getOrder(), equalTo(SortOrder.DESCENDING));
         assertThat(searchConfiguration.getSort().get(1).getName(), equalTo("_id"));
-        assertThat(searchConfiguration.getSort().get(1).getOrder(), equalTo("ascending"));
+        assertThat(searchConfiguration.getSort().get(1).getOrder(), equalTo(SortOrder.ASCENDING));
     }
 
     @Test
@@ -90,6 +90,6 @@ public class SearchConfigurationTest {
         assertThat(searchConfiguration.getSort(), notNullValue());
         assertThat(searchConfiguration.getSort().size(), equalTo(1));
         assertThat(searchConfiguration.getSort().get(0).getName(), equalTo("created_at"));
-        assertThat(searchConfiguration.getSort().get(0).getOrder(), equalTo("ascending"));
+        assertThat(searchConfiguration.getSort().get(0).getOrder(), equalTo(SortOrder.ASCENDING));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfigTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class SortConfigTest {
@@ -31,7 +32,7 @@ class SortConfigTest {
 
         assertThat(sortConfig, notNullValue());
         assertThat(sortConfig.getName(), equalTo("@timestamp"));
-        assertThat(sortConfig.getOrder(), equalTo("ascending"));
+        assertThat(sortConfig.getOrder(), equalTo(SortOrder.ASCENDING));
     }
 
     @Test
@@ -42,7 +43,7 @@ class SortConfigTest {
 
         assertThat(sortConfig, notNullValue());
         assertThat(sortConfig.getName(), equalTo("@timestamp"));
-        assertThat(sortConfig.getOrder(), equalTo("descending"));
+        assertThat(sortConfig.getOrder(), equalTo(SortOrder.DESCENDING));
     }
 
     @Test
@@ -53,33 +54,15 @@ class SortConfigTest {
 
         assertThat(sortConfig, notNullValue());
         assertThat(sortConfig.getName(), equalTo("_id"));
-        assertThat(sortConfig.getOrder(), equalTo("ascending"));
+        assertThat(sortConfig.getOrder(), equalTo(SortOrder.ASCENDING));
     }
 
     @Test
-    void valid_order_ascending_returns_true() throws Exception {
-        final String yaml = "name: \"@timestamp\"\norder: ascending\n";
-
-        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
-
-        assertThat(sortConfig.isOrderValid(), equalTo(true));
-    }
-
-    @Test
-    void valid_order_descending_returns_true() throws Exception {
-        final String yaml = "name: \"@timestamp\"\norder: descending\n";
-
-        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
-
-        assertThat(sortConfig.isOrderValid(), equalTo(true));
-    }
-
-    @Test
-    void invalid_order_returns_false() throws Exception {
+    void invalid_order_deserializes_to_null() throws Exception {
         final String yaml = "name: \"@timestamp\"\norder: invalid\n";
 
         final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
 
-        assertThat(sortConfig.isOrderValid(), equalTo(false));
+        assertThat(sortConfig.getOrder(), nullValue());
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SortConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class SortConfigTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
+
+    @Test
+    void default_order_is_ascending() throws Exception {
+        final String yaml = "name: \"@timestamp\"\n";
+
+        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
+
+        assertThat(sortConfig, notNullValue());
+        assertThat(sortConfig.getName(), equalTo("@timestamp"));
+        assertThat(sortConfig.getOrder(), equalTo("ascending"));
+    }
+
+    @Test
+    void deserialization_with_descending_order() throws Exception {
+        final String yaml = "name: \"@timestamp\"\norder: descending\n";
+
+        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
+
+        assertThat(sortConfig, notNullValue());
+        assertThat(sortConfig.getName(), equalTo("@timestamp"));
+        assertThat(sortConfig.getOrder(), equalTo("descending"));
+    }
+
+    @Test
+    void deserialization_with_ascending_order() throws Exception {
+        final String yaml = "name: \"_id\"\norder: ascending\n";
+
+        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
+
+        assertThat(sortConfig, notNullValue());
+        assertThat(sortConfig.getName(), equalTo("_id"));
+        assertThat(sortConfig.getOrder(), equalTo("ascending"));
+    }
+
+    @Test
+    void valid_order_ascending_returns_true() throws Exception {
+        final String yaml = "name: \"@timestamp\"\norder: ascending\n";
+
+        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
+
+        assertThat(sortConfig.isOrderValid(), equalTo(true));
+    }
+
+    @Test
+    void valid_order_descending_returns_true() throws Exception {
+        final String yaml = "name: \"@timestamp\"\norder: descending\n";
+
+        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
+
+        assertThat(sortConfig.isOrderValid(), equalTo(true));
+    }
+
+    @Test
+    void invalid_order_returns_false() throws Exception {
+        final String yaml = "name: \"@timestamp\"\norder: invalid\n";
+
+        final SortConfig sortConfig = objectMapper.readValue(yaml, SortConfig.class);
+
+        assertThat(sortConfig.isOrderValid(), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
@@ -46,6 +46,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -604,5 +605,83 @@ public class ElasticsearchAccessorTest {
         assertThat(searchScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchScrollResponse.getDocuments().get(1), notNullValue());
         assertThat(searchScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+    }
+
+    @Test
+    void search_with_pit_with_custom_sort_options_uses_configured_sort() throws IOException {
+        final String pitId = UUID.randomUUID().toString();
+        final Integer paginationSize = new Random().nextInt();
+
+        final SortingOptions timestampSort = mock(SortingOptions.class);
+        when(timestampSort.getFieldName()).thenReturn("@timestamp");
+        when(timestampSort.getOrder()).thenReturn("desc");
+
+        final SearchPointInTimeRequest searchPointInTimeRequest = mock(SearchPointInTimeRequest.class);
+        when(searchPointInTimeRequest.getPitId()).thenReturn(pitId);
+        when(searchPointInTimeRequest.getPaginationSize()).thenReturn(paginationSize);
+        when(searchPointInTimeRequest.getSearchAfter()).thenReturn(null);
+        when(searchPointInTimeRequest.getKeepAlive()).thenReturn("5m");
+        when(searchPointInTimeRequest.getSortOptions()).thenReturn(List.of(timestampSort));
+
+        final SearchResponse<ObjectNode> searchResponse = mock(SearchResponse.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final Hit<ObjectNode> hit = mock(Hit.class);
+        when(hit.id()).thenReturn(UUID.randomUUID().toString());
+        when(hit.index()).thenReturn(UUID.randomUUID().toString());
+        when(hit.source()).thenReturn(mock(ObjectNode.class));
+        when(hit.version()).thenReturn(1L);
+        when(hit.sort()).thenReturn(Collections.singletonList("2024-01-01T00:00:00Z"));
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+        final ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        when(elasticSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final SearchWithSearchAfterResults results = createObjectUnderTest().searchWithPit(searchPointInTimeRequest);
+
+        assertThat(results, notNullValue());
+        assertThat(results.getDocuments().size(), equalTo(1));
+
+        final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
+        assertThat(searchRequest.sort().size(), equalTo(1));
+        assertThat(searchRequest.sort().get(0).field().field(), equalTo("@timestamp"));
+    }
+
+    @Test
+    void search_without_search_context_with_custom_sort_options_uses_configured_sort() throws IOException {
+        final Integer paginationSize = new Random().nextInt();
+        final String index = UUID.randomUUID().toString();
+
+        final SortingOptions timestampSort = mock(SortingOptions.class);
+        when(timestampSort.getFieldName()).thenReturn("@timestamp");
+        when(timestampSort.getOrder()).thenReturn("asc");
+
+        final NoSearchContextSearchRequest noSearchContextSearchRequest = mock(NoSearchContextSearchRequest.class);
+        when(noSearchContextSearchRequest.getPaginationSize()).thenReturn(paginationSize);
+        when(noSearchContextSearchRequest.getIndex()).thenReturn(index);
+        when(noSearchContextSearchRequest.getSearchAfter()).thenReturn(null);
+        when(noSearchContextSearchRequest.getSortOptions()).thenReturn(List.of(timestampSort));
+
+        final SearchResponse<ObjectNode> searchResponse = mock(SearchResponse.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final Hit<ObjectNode> hit = mock(Hit.class);
+        when(hit.id()).thenReturn(UUID.randomUUID().toString());
+        when(hit.index()).thenReturn(UUID.randomUUID().toString());
+        when(hit.source()).thenReturn(mock(ObjectNode.class));
+        when(hit.version()).thenReturn(1L);
+        when(hit.sort()).thenReturn(Collections.singletonList("2024-01-01T00:00:00Z"));
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+        final ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        when(elasticSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final SearchWithSearchAfterResults results = createObjectUnderTest().searchWithoutSearchContext(noSearchContextSearchRequest);
+
+        assertThat(results, notNullValue());
+
+        final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
+        assertThat(searchRequest.sort().size(), equalTo(1));
+        assertThat(searchRequest.sort().get(0).field().field(), equalTo("@timestamp"));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -46,6 +46,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SortingOptions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -540,5 +541,82 @@ public class OpenSearchAccessorTest {
         assertThat(searchScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchScrollResponse.getDocuments().get(1), notNullValue());
         assertThat(searchScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+    }
+
+    @Test
+    void search_with_pit_with_custom_sort_options_uses_configured_sort() throws IOException {
+        final String pitId = UUID.randomUUID().toString();
+        final Integer paginationSize = new Random().nextInt();
+
+        final SortingOptions timestampSort = mock(SortingOptions.class);
+        when(timestampSort.getFieldName()).thenReturn("@timestamp");
+        when(timestampSort.getOrder()).thenReturn("desc");
+
+        final SearchPointInTimeRequest searchPointInTimeRequest = mock(SearchPointInTimeRequest.class);
+        when(searchPointInTimeRequest.getPitId()).thenReturn(pitId);
+        when(searchPointInTimeRequest.getPaginationSize()).thenReturn(paginationSize);
+        when(searchPointInTimeRequest.getSearchAfter()).thenReturn(null);
+        when(searchPointInTimeRequest.getSortOptions()).thenReturn(List.of(timestampSort));
+
+        final SearchResponse<ObjectNode> searchResponse = mock(SearchResponse.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final Hit<ObjectNode> hit = mock(Hit.class);
+        when(hit.id()).thenReturn(UUID.randomUUID().toString());
+        when(hit.index()).thenReturn(UUID.randomUUID().toString());
+        when(hit.source()).thenReturn(mock(ObjectNode.class));
+        when(hit.version()).thenReturn(1L);
+        when(hit.sort()).thenReturn(Collections.singletonList("2024-01-01T00:00:00Z"));
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+        final ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        when(openSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final SearchWithSearchAfterResults results = createObjectUnderTest().searchWithPit(searchPointInTimeRequest);
+
+        assertThat(results, notNullValue());
+        assertThat(results.getDocuments().size(), equalTo(1));
+
+        final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
+        assertThat(searchRequest.sort().size(), equalTo(1));
+        assertThat(searchRequest.sort().get(0).field().field(), equalTo("@timestamp"));
+    }
+
+    @Test
+    void search_without_search_context_with_custom_sort_options_uses_configured_sort() throws IOException {
+        final Integer paginationSize = new Random().nextInt();
+        final String index = UUID.randomUUID().toString();
+
+        final SortingOptions timestampSort = mock(SortingOptions.class);
+        when(timestampSort.getFieldName()).thenReturn("@timestamp");
+        when(timestampSort.getOrder()).thenReturn("asc");
+
+        final NoSearchContextSearchRequest noSearchContextSearchRequest = mock(NoSearchContextSearchRequest.class);
+        when(noSearchContextSearchRequest.getPaginationSize()).thenReturn(paginationSize);
+        when(noSearchContextSearchRequest.getIndex()).thenReturn(index);
+        when(noSearchContextSearchRequest.getSearchAfter()).thenReturn(null);
+        when(noSearchContextSearchRequest.getSortOptions()).thenReturn(List.of(timestampSort));
+
+        final SearchResponse<ObjectNode> searchResponse = mock(SearchResponse.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final Hit<ObjectNode> hit = mock(Hit.class);
+        when(hit.id()).thenReturn(UUID.randomUUID().toString());
+        when(hit.index()).thenReturn(UUID.randomUUID().toString());
+        when(hit.source()).thenReturn(mock(ObjectNode.class));
+        when(hit.version()).thenReturn(1L);
+        when(hit.sort()).thenReturn(Collections.singletonList("2024-01-01T00:00:00Z"));
+        when(hitsMetadata.hits()).thenReturn(List.of(hit));
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+        final ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        when(openSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final SearchWithSearchAfterResults results = createObjectUnderTest().searchWithoutSearchContext(noSearchContextSearchRequest);
+
+        assertThat(results, notNullValue());
+
+        final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
+        assertThat(searchRequest.sort().size(), equalTo(1));
+        assertThat(searchRequest.sort().get(0).field().field(), equalTo("@timestamp"));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptionsTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptionsTest.java
@@ -12,6 +12,7 @@ package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SortConfig;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SortOrder;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +46,7 @@ class SortingOptionsTest {
     void fromSortConfigs_with_ascending_order() {
         final SortConfig sortConfig = mock(SortConfig.class);
         when(sortConfig.getName()).thenReturn("@timestamp");
-        when(sortConfig.getOrder()).thenReturn("ascending");
+        when(sortConfig.getOrder()).thenReturn(SortOrder.ASCENDING);
 
         final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(sortConfig));
 
@@ -58,7 +59,7 @@ class SortingOptionsTest {
     void fromSortConfigs_with_descending_order() {
         final SortConfig sortConfig = mock(SortConfig.class);
         when(sortConfig.getName()).thenReturn("@timestamp");
-        when(sortConfig.getOrder()).thenReturn("descending");
+        when(sortConfig.getOrder()).thenReturn(SortOrder.DESCENDING);
 
         final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(sortConfig));
 
@@ -68,14 +69,14 @@ class SortingOptionsTest {
     }
 
     @Test
-    void fromSortConfigs_with_multiple_configs() {
+    void fromSortConfigs_with_multiple_configs_including_id() {
         final SortConfig timestampConfig = mock(SortConfig.class);
         when(timestampConfig.getName()).thenReturn("@timestamp");
-        when(timestampConfig.getOrder()).thenReturn("descending");
+        when(timestampConfig.getOrder()).thenReturn(SortOrder.DESCENDING);
 
         final SortConfig idConfig = mock(SortConfig.class);
         when(idConfig.getName()).thenReturn("_id");
-        when(idConfig.getOrder()).thenReturn("ascending");
+        when(idConfig.getOrder()).thenReturn(SortOrder.ASCENDING);
 
         final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(timestampConfig, idConfig));
 
@@ -84,5 +85,17 @@ class SortingOptionsTest {
         assertThat(result.get(0).getOrder(), equalTo("desc"));
         assertThat(result.get(1).getFieldName(), equalTo("_id"));
         assertThat(result.get(1).getOrder(), equalTo("asc"));
+    }
+
+    @Test
+    void fromSortConfigs_without_id_logs_warning() {
+        final SortConfig timestampConfig = mock(SortConfig.class);
+        when(timestampConfig.getName()).thenReturn("@timestamp");
+        when(timestampConfig.getOrder()).thenReturn(SortOrder.DESCENDING);
+
+        final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(timestampConfig));
+
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).getFieldName(), equalTo("@timestamp"));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptionsTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SortingOptionsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SortConfig;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SortingOptionsTest {
+
+    @Test
+    void fromSortConfigs_with_null_returns_empty_list() {
+        final List<SortingOptions> result = SortingOptions.fromSortConfigs(null);
+
+        assertThat(result, notNullValue());
+        assertThat(result, empty());
+    }
+
+    @Test
+    void fromSortConfigs_with_empty_list_returns_empty_list() {
+        final List<SortingOptions> result = SortingOptions.fromSortConfigs(Collections.emptyList());
+
+        assertThat(result, notNullValue());
+        assertThat(result, empty());
+    }
+
+    @Test
+    void fromSortConfigs_with_ascending_order() {
+        final SortConfig sortConfig = mock(SortConfig.class);
+        when(sortConfig.getName()).thenReturn("@timestamp");
+        when(sortConfig.getOrder()).thenReturn("ascending");
+
+        final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(sortConfig));
+
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).getFieldName(), equalTo("@timestamp"));
+        assertThat(result.get(0).getOrder(), equalTo("asc"));
+    }
+
+    @Test
+    void fromSortConfigs_with_descending_order() {
+        final SortConfig sortConfig = mock(SortConfig.class);
+        when(sortConfig.getName()).thenReturn("@timestamp");
+        when(sortConfig.getOrder()).thenReturn("descending");
+
+        final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(sortConfig));
+
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).getFieldName(), equalTo("@timestamp"));
+        assertThat(result.get(0).getOrder(), equalTo("desc"));
+    }
+
+    @Test
+    void fromSortConfigs_with_multiple_configs() {
+        final SortConfig timestampConfig = mock(SortConfig.class);
+        when(timestampConfig.getName()).thenReturn("@timestamp");
+        when(timestampConfig.getOrder()).thenReturn("descending");
+
+        final SortConfig idConfig = mock(SortConfig.class);
+        when(idConfig.getName()).thenReturn("_id");
+        when(idConfig.getOrder()).thenReturn("ascending");
+
+        final List<SortingOptions> result = SortingOptions.fromSortConfigs(List.of(timestampConfig, idConfig));
+
+        assertThat(result.size(), equalTo(2));
+        assertThat(result.get(0).getFieldName(), equalTo("@timestamp"));
+        assertThat(result.get(0).getOrder(), equalTo("desc"));
+        assertThat(result.get(1).getFieldName(), equalTo("_id"));
+        assertThat(result.get(1).getOrder(), equalTo("asc"));
+    }
+}


### PR DESCRIPTION
### Description
Adds configurable sort option to the opensearch source's search_options, allowing pipeline authors to specify custom sort fields for pagination instead of the hardcoded [_doc asc, _id asc] default.                                                                                             
                                                            
  Example configuration:                                                                                                                            
 ```
 source:                                                   
    opensearch:                                                                                                                                     
      search_options:                                                                                                                               
        sort:                                                                                                                                       
          - name: "@timestamp"                                                                                                                      
            order: descending                                                                                                                       
          - name: "_id"                                                                                                                             
            order: ascending                                                                                                                        

```                                                                                                                                                    
When no sort is configured, behavior is unchanged, defaults to _doc ascending + _id ascending for PIT/no-context searches, and _doc ascending for scroll.                                                                                                                                          
                                                                                                                                                    
  Changes include:                                                                                                                                  
  - New SortConfig configuration model with name/order fields and validation
  - Wired sort options through SearchConfiguration --> workers --> request models --> both OpenSearchAccessor and ElasticsearchAccessor                   
  - Resolved existing TODO comments in PitWorker and NoSearchContextWorker for passing sort options                              
  - Connected the pre-existing but unused `SortingOptions` model and `SearchPointInTimeRequest.sortingOptions` field
 
### Issues Resolved
Resolves #6332
https://github.com/opensearch-project/data-prepper/issues/6332 
 
### Check List
- [ X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ X ] New functionality has javadoc added
- [ X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
