### PR TITLE
feat(otlp-sink): Add log signal support and configurable signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ data-prepper-main/src/test/resources/logstash-conf/logstash-filter.yaml
 *.iml
 .kiro
 .vscode
+.project
+.classpath
+org.eclipse*
 
 # Manual testing files (should not be committed)
 MANUAL_TEST.md

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsConfig.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsConfig.java
@@ -37,6 +37,9 @@ public class AwsConfig {
     @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
     private String awsStsExternalId;
 
+    @JsonProperty("service_name")
+    private String serviceName;
+
     public Region getAwsRegion() {
         return awsRegion != null ? Region.of(awsRegion) : null;
     }
@@ -51,5 +54,9 @@ public class AwsConfig {
 
     public Map<String, String> getAwsStsHeaderOverrides() {
         return awsStsHeaderOverrides;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 }

--- a/data-prepper-plugins/otlp-sink/README.md
+++ b/data-prepper-plugins/otlp-sink/README.md
@@ -8,9 +8,8 @@ to any OTLP Protobuf-compatible endpoint.
 
 ## Known Limitations
 
-- Currently, supports only trace data (spans). Support for metrics and logs will be added in future releases.
+- Currently, supports trace and log data. Support for metrics will be added in future releases.
 - No support for DQL-based loss-less delivery in this release.
-- Only AWS X-Ray-compatible OTLP endpoints are currently supported (`https://xray.<region>.amazonaws.com/v1/traces`).
 - Only OTLP over HTTP is supported; gRPC is not yet supported.
 
 ---
@@ -63,25 +62,58 @@ otlp_pipeline:
           sts_external_id: external-id-value
 ```
 
+### Log Pipeline Configuration
+
+Use this to send log events to an OTLP-compatible log ingestion endpoint.
+
+```yaml
+log_pipeline:
+  source:
+    http:
+      port: 2021
+      path: "/logs"
+
+  sink:
+    - otlp:
+        endpoint: "https://my-otlp-endpoint.example.com:443/v1/logs"
+        signal_type: logs
+        max_retries: 3
+        threshold:
+          max_events: 100
+          flush_timeout: 5s
+        aws:
+          service_name: my-service
+          region: us-east-1
+          sts_role_arn: arn:aws:iam::123456789012:role/MyRole
+        additional_headers:
+          x-custom-header: my-value
+```
+
 ---
 
 ## Configuration Options
 
-| Property                   | Type     | Required | Default               | Description                                                                                              |
-|----------------------------|----------|----------|-----------------------|----------------------------------------------------------------------------------------------------------|
-| `endpoint`                 | `String` | Yes      | —                     | AWS X-Ray OTLP endpoint where spans will be sent.                                                        |
-| `max_retries`              | `int`    | No       | `5`                   | Maximum number of retry attempts on HTTP send failures.                                                  |
-| **threshold**              | `Object` | No       | —                     | Controls batching behavior. See below for sub-properties.                                                |
-| `threshold.max_events`     | `int`    | No       | `512` (recommended)   | Maximum number of spans per batch. Use `0` to disable count-based flushing. Must be ≥ 0.                 |
-| `threshold.max_batch_size` | `String` | No       | `1mb` (recommended)   | Maximum total payload bytes per batch. Supports human-readable suffixes (`kb`, `mb`).                    |   
-| `threshold.flush_timeout`  | `String` | No       | `200ms` (recommended) | Maximum time to wait before flushing a non-empty batch. Minimum: 1ms (e.g., `200ms`, `1s`)               |
-| **aws**                    | `Object` | Yes      | —                     | AWS authentication settings. Use `{}` if no STS role is needed. See below.                               |
-| `aws.sts_role_arn`         | `String` | No       | —                     | IAM Role ARN that Data Prepper (or OSI) assumes to send spans to X-Ray on behalf of a customer account.  |
-| `aws.sts_external_id`      | `String` | No       | —                     | External ID to use when assuming the role. Required only if the target IAM role enforces sts:ExternalId. |
+| Property                   | Type              | Required | Default               | Description                                                                                              |
+|----------------------------|-------------------|----------|-----------------------|----------------------------------------------------------------------------------------------------------|
+| `endpoint`                 | `String`          | Yes      | —                     | OTLP endpoint where data will be sent.                                                                   |
+| `signal_type`              | `String`          | No       | `traces`              | Signal type to send: `traces` or `logs`.                                                                 |
+| `max_retries`              | `int`             | No       | `5`                   | Maximum number of retry attempts on HTTP send failures.                                                  |
+| **threshold**              | `Object`          | No       | —                     | Controls batching behavior. See below for sub-properties.                                                |
+| `threshold.max_events`     | `int`             | No       | `512` (recommended)   | Maximum number of events per batch. Use `0` to disable count-based flushing. Must be ≥ 0.                |
+| `threshold.max_batch_size` | `String`          | No       | `1mb` (recommended)   | Maximum total payload bytes per batch. Supports human-readable suffixes (`kb`, `mb`).                    |   
+| `threshold.flush_timeout`  | `String`          | No       | `200ms` (recommended) | Maximum time to wait before flushing a non-empty batch. Minimum: 1ms (e.g., `200ms`, `1s`)               |
+| **aws**                    | `Object`          | Yes      | —                     | AWS authentication settings. Use `{}` if no STS role is needed. See below.                               |
+| `aws.sts_role_arn`         | `String`          | No       | —                     | IAM Role ARN that Data Prepper assumes to send data to the endpoint on behalf of a customer account.     |
+| `aws.sts_external_id`      | `String`          | No       | —                     | External ID to use when assuming the role. Required only if the target IAM role enforces sts:ExternalId. |
+| `aws.region`               | `String`          | No       | parsed from endpoint  | AWS region for SigV4 signing. Falls back to parsing from the endpoint URL if not set.                    |
+| `aws.service_name`         | `String`          | No       | `xray`                | SigV4 signing service name. Override for non-X-Ray OTLP endpoints.                                      |
+| `additional_headers`       | `Map<String,String>` | No    | `{}`                  | Custom HTTP headers added to every outgoing request after SigV4 signing.                                 |
 
 **Additional Notes:**
 
-- `aws.region` is automatically derived from the endpoint.
+- `aws.region` can be set explicitly or is automatically derived from the endpoint. Explicit `aws.region` takes precedence.
+- `aws.service_name` defaults to `xray` for backward compatibility with existing X-Ray trace pipelines.
+- `additional_headers` are injected after SigV4 signing, so they are not included in the signature.
 
 ---
 

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSink.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSink.java
@@ -11,10 +11,10 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.annotations.Experimental;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;
 import org.opensearch.dataprepper.model.sink.Sink;
-import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.plugins.sink.otlp.buffer.OtlpSinkBuffer;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.otlp.metrics.OtlpSinkMetrics;
@@ -31,7 +31,7 @@ import java.util.Collection;
         pluginType = Sink.class,
         pluginConfigurationType = OtlpSinkConfig.class
 )
-public class OtlpSink extends AbstractSink<Record<Span>> {
+public class OtlpSink extends AbstractSink<Record<Event>> {
     private volatile boolean initialized = false;
 
     private final OtlpSinkBuffer buffer;
@@ -68,8 +68,8 @@ public class OtlpSink extends AbstractSink<Record<Span>> {
      * @param records Records to be output
      */
     @Override
-    public void doOutput(@Nonnull final Collection<Record<Span>> records) {
-        for (final Record<Span> record : records) {
+    public void doOutput(@Nonnull final Collection<Record<Event>> records) {
+        for (final Record<Event> record : records) {
             buffer.add(record);
         }
     }

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/buffer/OtlpSinkBuffer.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/buffer/OtlpSinkBuffer.java
@@ -6,9 +6,11 @@
 package org.opensearch.dataprepper.plugins.sink.otlp.buffer;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.MessageLite;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import lombok.Getter;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.trace.Span;
@@ -16,6 +18,7 @@ import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoStandardCodec;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.otlp.http.OtlpHttpSender;
 import org.opensearch.dataprepper.plugins.sink.otlp.metrics.OtlpSinkMetrics;
+import org.opensearch.dataprepper.plugins.sink.otlp.codec.OtlpLogEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.utils.Pair;
@@ -30,17 +33,22 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A back-pressure buffer for OTLP sink.
+ * A back-pressure buffer for OTLP sink that supports both traces and logs.
  */
 public class OtlpSinkBuffer {
     private static final Logger LOG = LoggerFactory.getLogger(OtlpSinkBuffer.class);
     private static final int SAFETY_FACTOR = 10;
     private static final int MIN_QUEUE_CAPACITY = 2000;
 
-    private final BlockingQueue<Record<Span>> queue;
-    private final OTelProtoStandardCodec.OTelProtoEncoder encoder;
+    private final BlockingQueue<Record<Event>> queue;
     private final OtlpHttpSender sender;
     private final OtlpSinkMetrics sinkMetrics;
+    private final boolean isLogSignal;
+
+    // Trace encoding (only used when isLogSignal=false)
+    private final OTelProtoStandardCodec.OTelProtoEncoder traceEncoder;
+    // Log encoding (only used when isLogSignal=true)
+    private final OtlpLogEncoder logEncoder;
 
     private final int maxEvents;
     private final long maxBatchBytes;
@@ -58,8 +66,13 @@ public class OtlpSinkBuffer {
      * @param config      the OTLP sink configuration
      * @param sinkMetrics the metrics collector to use
      */
-    public OtlpSinkBuffer(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier, @Nonnull final OtlpSinkConfig config, @Nonnull final OtlpSinkMetrics sinkMetrics) {
-        this(config, sinkMetrics, new OTelProtoStandardCodec.OTelProtoEncoder(), new OtlpHttpSender(awsCredentialsSupplier, config, sinkMetrics));
+    public OtlpSinkBuffer(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier,
+                           @Nonnull final OtlpSinkConfig config,
+                           @Nonnull final OtlpSinkMetrics sinkMetrics) {
+        this(config, sinkMetrics,
+                new OTelProtoStandardCodec.OTelProtoEncoder(),
+                new OtlpLogEncoder(),
+                new OtlpHttpSender(awsCredentialsSupplier, config, sinkMetrics));
     }
 
     /**
@@ -68,12 +81,17 @@ public class OtlpSinkBuffer {
     @VisibleForTesting
     OtlpSinkBuffer(@Nonnull final OtlpSinkConfig config,
                    @Nonnull final OtlpSinkMetrics sinkMetrics,
-                   @Nonnull final OTelProtoStandardCodec.OTelProtoEncoder encoder,
+                   @Nonnull final OTelProtoStandardCodec.OTelProtoEncoder traceEncoder,
+                   @Nonnull final OtlpLogEncoder logEncoder,
                    @Nonnull final OtlpHttpSender sender) {
 
         this.sinkMetrics = sinkMetrics;
-        this.encoder = encoder;
+        this.traceEncoder = traceEncoder;
+        this.logEncoder = logEncoder;
         this.sender = sender;
+
+        // Detect signal type from config
+        this.isLogSignal = config.isLogSignal();
 
         this.maxEvents = config.getMaxEvents();
         this.maxBatchBytes = config.getMaxBatchSize();
@@ -120,50 +138,50 @@ public class OtlpSinkBuffer {
     }
 
     /**
-     * Enqueues a span record for later batching and sending.
+     * Enqueues an event record for later batching and sending.
      * <p>
      * This will block if the internal queue is full, guaranteeing
      * lossless delivery during normal operations.
-     * On interruption, the span is still rejected and
+     * On interruption, the event is still rejected and
      * error metrics are incremented.
      *
-     * @param record the span record to enqueue
+     * @param record the event record to enqueue
      */
-    public void add(final Record<Span> record) {
+    public void add(final Record<Event> record) {
         try {
             queue.put(record);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOG.error("Interrupted while enqueuing span", e);
+            LOG.error("Interrupted while enqueuing event", e);
             sinkMetrics.incrementFailedSpansCount(1);
             sinkMetrics.incrementErrorsCount();
         }
     }
 
     /**
-     * Worker loop that batches spans by count, size, or time and then flushes them.
+     * Worker loop that batches events by count, size, or time and then flushes them.
      * <p>
      * Continues running as long as {@link #running} is true or the queue is not empty.
      * Handles encoding failures, timeout-based flush, and final flush on shutdown.
      */
     private void run() {
-        final List<Pair<ResourceSpans, EventHandle>> batch = new ArrayList<>();
+        final List<Pair<MessageLite, EventHandle>> batch = new ArrayList<>();
         long batchSize = 0;
         long lastFlush = System.currentTimeMillis();
 
         while (true) {
             try {
                 final long now = System.currentTimeMillis();
-                final Record<Span> record = queue.poll(100, TimeUnit.MILLISECONDS);
+                final Record<Event> record = queue.poll(100, TimeUnit.MILLISECONDS);
 
                 if (record != null) {
                     try {
-                        final ResourceSpans resourceSpans = encoder.convertToResourceSpans(record.getData());
+                        final MessageLite encoded = encodeRecord(record);
                         final EventHandle eventHandle = record.getData().getEventHandle();
-                        batch.add(Pair.of(resourceSpans, eventHandle));
-                        batchSize += resourceSpans.getSerializedSize();
+                        batch.add(Pair.of(encoded, eventHandle));
+                        batchSize += encoded.getSerializedSize();
                     } catch (final Exception e) {
-                        LOG.error("Failed to encode span, skipping", e);
+                        LOG.error("Failed to encode event, skipping", e);
                         sinkMetrics.incrementFailedSpansCount(1);
                         sinkMetrics.incrementErrorsCount();
                     }
@@ -173,7 +191,7 @@ public class OtlpSinkBuffer {
                 final boolean flushByTime = !batch.isEmpty() && (now - lastFlush >= flushTimeoutMillis);
 
                 if (flushBySize || flushByTime) {
-                    sender.send(batch);
+                    sender.send(batch, isLogSignal);
                     batch.clear();
                     batchSize = 0;
                     lastFlush = now;
@@ -188,15 +206,22 @@ public class OtlpSinkBuffer {
                     LOG.debug("Worker interrupted while polling, continuing...");
                     sinkMetrics.incrementErrorsCount();
                 }
-
-                // Continue to loop if still running
             }
         }
 
-        // Final flush
         if (!batch.isEmpty()) {
-            sender.send(batch);
+            sender.send(batch, isLogSignal);
             batch.clear();
         }
+    }
+
+    private MessageLite encodeRecord(final Record<Event> record) throws Exception {
+        if (isLogSignal) {
+            return logEncoder.encode(record.getData());
+        }
+        if (!(record.getData() instanceof Span)) {
+            throw new IllegalArgumentException("Expected Span event for traces signal_type, got: " + record.getData().getClass().getSimpleName());
+        }
+        return traceEncoder.convertToResourceSpans((Span) record.getData());
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/codec/OtlpLogEncoder.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/codec/OtlpLogEncoder.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.otlp.codec;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.proto.logs.v1.ScopeLogs;
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Encodes a Data Prepper Event into an OTLP ResourceLogs protobuf message.
+ */
+public class OtlpLogEncoder {
+
+    private static final String SCOPE_NAME = "data-prepper-otlp-sink";
+
+    public ResourceLogs encode(final Event event) {
+        final long nowNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
+        final LogRecord.Builder logBuilder = LogRecord.newBuilder()
+                .setObservedTimeUnixNano(nowNanos);
+
+        final Instant eventTime = event.getMetadata() != null ? event.getMetadata().getTimeReceived() : null;
+        if (eventTime != null) {
+            logBuilder.setTimeUnixNano(TimeUnit.SECONDS.toNanos(eventTime.getEpochSecond()) + eventTime.getNano());
+        } else {
+            logBuilder.setTimeUnixNano(nowNanos);
+        }
+
+        logBuilder.setBody(AnyValue.newBuilder().setStringValue(event.toJsonString()).build());
+
+        final Map<String, Object> eventData = event.toMap();
+        for (final Map.Entry<String, Object> entry : eventData.entrySet()) {
+            logBuilder.addAttributes(KeyValue.newBuilder()
+                    .setKey(entry.getKey())
+                    .setValue(toAnyValue(entry.getValue()))
+                    .build());
+        }
+
+        return ResourceLogs.newBuilder()
+                .addScopeLogs(ScopeLogs.newBuilder()
+                        .setScope(InstrumentationScope.newBuilder().setName(SCOPE_NAME).build())
+                        .addLogRecords(logBuilder.build())
+                        .build())
+                .build();
+    }
+
+    private AnyValue toAnyValue(final Object value) {
+        if (value == null) {
+            return AnyValue.getDefaultInstance();
+        }
+        if (value instanceof String) {
+            return AnyValue.newBuilder().setStringValue((String) value).build();
+        }
+        if (value instanceof Boolean) {
+            return AnyValue.newBuilder().setBoolValue((Boolean) value).build();
+        }
+        if (value instanceof Integer || value instanceof Long) {
+            return AnyValue.newBuilder().setIntValue(((Number) value).longValue()).build();
+        }
+        if (value instanceof Float || value instanceof Double) {
+            return AnyValue.newBuilder().setDoubleValue(((Number) value).doubleValue()).build();
+        }
+        return AnyValue.newBuilder().setStringValue(value.toString()).build();
+    }
+}

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfig.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfig.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.regions.Region;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -71,12 +72,39 @@ public class OtlpSinkConfig {
     @Valid
     private AwsConfig awsConfig;
 
+    @JsonProperty("additional_headers")
+    private Map<String, String> additionalHeaders = Map.of();
+
+    @Getter
+    @JsonProperty("signal_type")
+    private String signalType = "traces";
+
+    public Map<String, String> getAdditionalHeaders() {
+        return additionalHeaders;
+    }
+
+    public boolean isLogSignal() {
+        return "logs".equalsIgnoreCase(signalType);
+    }
+
+    public String getServiceName() {
+        if (awsConfig == null || awsConfig.getServiceName() == null) {
+            return null;
+        }
+        return awsConfig.getServiceName();
+    }
+
     /**
-     * Get AWS region from the provided endpoint.
-     *
-     * @return the AWS region
+     * Get AWS region from the aws config block, or fall back to parsing the endpoint.
      */
     public Region getAwsRegion() {
+        if (awsConfig != null && awsConfig.getAwsRegion() != null) {
+            return awsConfig.getAwsRegion();
+        }
+        return parseRegionFromEndpoint();
+    }
+
+    private Region parseRegionFromEndpoint() {
         try {
             final String host = URI.create(this.endpoint).getHost();
             if (host == null) {

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/http/OtlpHttpSender.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/http/OtlpHttpSender.java
@@ -5,6 +5,7 @@
 package org.opensearch.dataprepper.plugins.sink.otlp.http;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.MessageLite;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
@@ -16,8 +17,11 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.model.event.EventHandle;
@@ -31,12 +35,14 @@ import software.amazon.awssdk.utils.Pair;
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Responsible for sending signed OTLP Protobuf requests to OTLP endpoint using an Ameria client.
+ * Responsible for sending signed OTLP Protobuf requests to OTLP endpoint using an Armeria client.
+ * Supports both trace (ExportTraceServiceRequest) and log (ExportLogsServiceRequest) payloads.
  */
 public class OtlpHttpSender {
     private static final Logger LOG = LoggerFactory.getLogger(OtlpHttpSender.class);
@@ -46,6 +52,7 @@ public class OtlpHttpSender {
     private final WebClient webClient;
     private final OtlpSinkMetrics sinkMetrics;
     private final Function<byte[], byte[]> gzipCompressor;
+    private final Map<String, String> additionalHeaders;
 
     /**
      * Constructor for the OtlpHttpSender.
@@ -54,8 +61,11 @@ public class OtlpHttpSender {
      * @param config The configuration for the OTLP sink plugin.
      * @param sinkMetrics The metrics for the OTLP sink plugin.
      */
-    public OtlpHttpSender(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier, @Nonnull final OtlpSinkConfig config, @Nonnull final OtlpSinkMetrics sinkMetrics) {
-        this(sinkMetrics, new GzipCompressor(sinkMetrics), new SigV4Signer(awsCredentialsSupplier, config), buildWebClient(config));
+    public OtlpHttpSender(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier,
+                          @Nonnull final OtlpSinkConfig config,
+                          @Nonnull final OtlpSinkMetrics sinkMetrics) {
+        this(sinkMetrics, new GzipCompressor(sinkMetrics), new SigV4Signer(awsCredentialsSupplier, config),
+                buildWebClient(config), config.getAdditionalHeaders());
     }
 
     /**
@@ -64,11 +74,16 @@ public class OtlpHttpSender {
     @VisibleForTesting
     OtlpHttpSender(@Nonnull final OtlpSinkMetrics sinkMetrics, @Nonnull final Function<byte[], byte[]> gzipCompressor,
                    final SigV4Signer signer, final WebClient webClient) {
+        this(sinkMetrics, gzipCompressor, signer, webClient, Map.of());
+    }
 
+    OtlpHttpSender(@Nonnull final OtlpSinkMetrics sinkMetrics, @Nonnull final Function<byte[], byte[]> gzipCompressor,
+                   final SigV4Signer signer, final WebClient webClient, final Map<String, String> additionalHeaders) {
         this.sinkMetrics = sinkMetrics;
         this.gzipCompressor = gzipCompressor;
         this.signer = signer;
         this.webClient = webClient;
+        this.additionalHeaders = additionalHeaders != null ? additionalHeaders : Map.of();
     }
 
     /**
@@ -78,7 +93,7 @@ public class OtlpHttpSender {
      * See: <a href="https://opentelemetry.io/docs/specs/otlp/#otlphttp-response">OTLP/HTTP Response</a>
      * <p>
      * We are not using the Retry-After header for dynamic backoff because:
-     * - Armeria’s retry rule API expects a boolean decision or fixed Backoff.
+     * - Armeria's retry rule API expects a boolean decision or fixed Backoff.
      * - Applying Retry-After semantics would require a custom Backoff implementation,
      * adding complexity with minimal benefit for most OTLP endpoints.
      * - Our exponential backoff already handles typical retry intervals gracefully.
@@ -106,27 +121,41 @@ public class OtlpHttpSender {
     }
 
     /**
-     * Sends the provided OTLP Protobuf payload to the OTLP endpoint asynchronously.
-     *
-     * @param batch the batch of spans to send
+     * Sends a batch of encoded OTLP records (either ResourceSpans or ResourceLogs).
      */
-    public void send(@Nonnull final List<Pair<ResourceSpans, EventHandle>> batch) {
+    public void send(@Nonnull final List<Pair<MessageLite, EventHandle>> batch, final boolean isLogSignal) {
         if (batch.isEmpty()) {
             return;
         }
 
-        // Defensive copy to avoid ConcurrentModificationException
-        final List<Pair<ResourceSpans, EventHandle>> immutableBatch = List.copyOf(batch);
+        final List<Pair<MessageLite, EventHandle>> immutableBatch = List.copyOf(batch);
+        final int count = immutableBatch.size();
 
-        final Pair<byte[], byte[]> payloadAndCompressedPayload = getPayloadAndCompressedPayload(immutableBatch);
-        final int spans = immutableBatch.size();
-        if (payloadAndCompressedPayload.right().length == 0) {
-            sinkMetrics.incrementFailedSpansCount(spans);
+        final byte[] payload;
+        if (isLogSignal) {
+            final ExportLogsServiceRequest request = ExportLogsServiceRequest.newBuilder()
+                    .addAllResourceLogs(immutableBatch.stream()
+                            .map(p -> (ResourceLogs) p.left())
+                            .collect(Collectors.toList()))
+                    .build();
+            payload = request.toByteArray();
+        } else {
+            final ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder()
+                    .addAllResourceSpans(immutableBatch.stream()
+                            .map(p -> (ResourceSpans) p.left())
+                            .collect(Collectors.toList()))
+                    .build();
+            payload = request.toByteArray();
+        }
+
+        final byte[] compressedPayload = gzipCompressor.apply(payload);
+        if (compressedPayload.length == 0) {
+            sinkMetrics.incrementFailedSpansCount(count);
             releaseAllEventHandle(immutableBatch, false);
             return;
         }
 
-        final HttpRequest request = buildHttpRequest(payloadAndCompressedPayload.right());
+        final HttpRequest request = buildHttpRequest(compressedPayload);
         final long startTime = System.currentTimeMillis();
 
         webClient.execute(request)
@@ -134,29 +163,19 @@ public class OtlpHttpSender {
                 .thenAccept(response -> {
                     final long latency = System.currentTimeMillis() - startTime;
                     sinkMetrics.recordHttpLatency(latency);
-                    sinkMetrics.incrementPayloadSize(payloadAndCompressedPayload.left().length);
-                    sinkMetrics.incrementPayloadGzipSize(payloadAndCompressedPayload.right().length);
+                    sinkMetrics.incrementPayloadSize(payload.length);
+                    sinkMetrics.incrementPayloadGzipSize(compressedPayload.length);
 
                     final int statusCode = response.status().code();
                     final byte[] responseBytes = response.content().array();
-                    handleResponse(statusCode, responseBytes, immutableBatch);
+                    handleResponse(statusCode, responseBytes, immutableBatch, isLogSignal);
                 })
                 .exceptionally(e -> {
-                    LOG.error("Failed to send {} spans.", spans, e);
-                    sinkMetrics.incrementRejectedSpansCount(spans);
+                    LOG.error("Failed to send {} events.", count, e);
+                    sinkMetrics.incrementRejectedSpansCount(count);
                     releaseAllEventHandle(immutableBatch, false);
                     return null;
                 });
-    }
-
-    private Pair<byte[], byte[]> getPayloadAndCompressedPayload(final List<Pair<ResourceSpans, EventHandle>> batch) {
-        final ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder()
-                .addAllResourceSpans(batch.stream().map(Pair::left).collect(Collectors.toList()))
-                .build();
-        final byte[] payload = request.toByteArray();
-        final byte[] compressedPayload = gzipCompressor.apply(payload);
-
-        return Pair.of(payload, compressedPayload);
     }
 
     private HttpRequest buildHttpRequest(final byte[] compressedPayload) {
@@ -168,16 +187,20 @@ public class OtlpHttpSender {
                 .path(signedRequest.getUri().getRawPath())
                 .authority(signedRequest.getUri().getAuthority());
 
-        // ONLY use the signed headers
         signedRequest.headers().forEach((k, vList) -> vList.forEach(v -> headersBuilder.add(k, v)));
+
+        // Add user-configured additional headers (e.g. x-amzn-data-stream-name)
+        additionalHeaders.forEach(headersBuilder::add);
+
         return HttpRequest.of(headersBuilder.build(), HttpData.wrap(compressedPayload));
     }
 
-    private void handleResponse(final int statusCode, final byte[] responseBytes, final List<Pair<ResourceSpans, EventHandle>> batch) {
+    private void handleResponse(final int statusCode, final byte[] responseBytes,
+                                final List<Pair<MessageLite, EventHandle>> batch, final boolean isLogSignal) {
         sinkMetrics.recordResponseCode(statusCode);
 
         if (statusCode >= 200 && statusCode < 300) {
-            handleSuccessfulResponse(responseBytes, batch);
+            handleSuccessfulResponse(responseBytes, batch, isLogSignal);
             return;
         }
 
@@ -193,44 +216,51 @@ public class OtlpHttpSender {
     /**
      * Handles a successful OTLP response with partial success.
      */
-    private void handleSuccessfulResponse(final byte[] responseBytes, final List<Pair<ResourceSpans, EventHandle>> batch) {
-        final int spans = batch.size();
+    private void handleSuccessfulResponse(final byte[] responseBytes,
+                                          final List<Pair<MessageLite, EventHandle>> batch,
+                                          final boolean isLogSignal) {
+        final int count = batch.size();
         if (responseBytes == null) {
-            sinkMetrics.incrementRecordsOut(spans);
+            sinkMetrics.incrementRecordsOut(count);
             releaseAllEventHandle(batch, true);
             return;
         }
 
         try {
-            final ExportTraceServiceResponse otlpResponse = ExportTraceServiceResponse.parseFrom(responseBytes);
+            long rejected = 0;
+            String errorMessage = "";
 
-            if (otlpResponse.hasPartialSuccess()) {
-                final var partial = otlpResponse.getPartialSuccess();
-                final long rejectedSpans = partial.getRejectedSpans();
-                final String errorMessage = partial.getErrorMessage();
-                if (rejectedSpans > 0) {
-                    LOG.error("OTLP Partial Success: rejectedSpans={}, message={}", rejectedSpans, errorMessage);
-                    sinkMetrics.incrementRejectedSpansCount(rejectedSpans);
+            if (isLogSignal) {
+                final ExportLogsServiceResponse resp = ExportLogsServiceResponse.parseFrom(responseBytes);
+                if (resp.hasPartialSuccess()) {
+                    rejected = resp.getPartialSuccess().getRejectedLogRecords();
+                    errorMessage = resp.getPartialSuccess().getErrorMessage();
                 }
-
-                final long deliveredSpans = spans - rejectedSpans;
-                sinkMetrics.incrementRecordsOut(deliveredSpans);
-
-                // Optimistically release all as true, no per-span granularity
-                releaseAllEventHandle(batch, true);
             } else {
-                sinkMetrics.incrementRecordsOut(spans);
-                releaseAllEventHandle(batch, true);
+                final ExportTraceServiceResponse resp = ExportTraceServiceResponse.parseFrom(responseBytes);
+                if (resp.hasPartialSuccess()) {
+                    rejected = resp.getPartialSuccess().getRejectedSpans();
+                    errorMessage = resp.getPartialSuccess().getErrorMessage();
+                }
             }
+
+            if (rejected > 0) {
+                LOG.error("OTLP Partial Success: rejected={}, message={}", rejected, errorMessage);
+                sinkMetrics.incrementRejectedSpansCount(rejected);
+            }
+
+            sinkMetrics.incrementRecordsOut(count - rejected);
+            releaseAllEventHandle(batch, true);
+
         } catch (final Exception e) {
-            LOG.error("Could not parse OTLP response as ExportTraceServiceResponse: {}", e.getMessage());
+            LOG.error("Could not parse OTLP response: {}", e.getMessage());
             sinkMetrics.incrementErrorsCount();
-            sinkMetrics.incrementRecordsOut(spans);
+            sinkMetrics.incrementRecordsOut(count);
             releaseAllEventHandle(batch, true);
         }
     }
 
-    private void releaseAllEventHandle(@Nonnull final List<Pair<ResourceSpans, EventHandle>> batch, final boolean success) {
+    private void releaseAllEventHandle(@Nonnull final List<Pair<MessageLite, EventHandle>> batch, final boolean success) {
         batch.forEach(pair -> pair.right().release(success));
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4Signer.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4Signer.java
@@ -24,13 +24,14 @@ import java.net.URI;
  * before sending them to the AWS OTLP endpoint.
  */
 class SigV4Signer {
-    private static final String SERVICE_NAME = "xray";
+    private static final String DEFAULT_SERVICE_NAME = "xray";
     private static final String OTLP_PATH = "/v1/traces";
     private final Aws4Signer signer = Aws4Signer.create();
 
     private final AwsCredentialsProvider credentialsProvider;
     private final Region region;
     private final URI endpointUri;
+    private final String serviceName;
 
     /**
      * Constructs a SigV4 signer helper.
@@ -40,6 +41,7 @@ class SigV4Signer {
      */
     SigV4Signer(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier, @Nonnull final OtlpSinkConfig config) {
         this.region = config.getAwsRegion();
+        this.serviceName = config.getServiceName() != null ? config.getServiceName() : DEFAULT_SERVICE_NAME;
 
         this.credentialsProvider = awsCredentialsSupplier.getProvider(AwsCredentialsOptions.builder()
                 .withRegion(region)
@@ -69,7 +71,7 @@ class SigV4Signer {
 
         return signer.sign(unsignedRequest, Aws4SignerParams.builder()
                 .signingRegion(region)
-                .signingName(SERVICE_NAME)
+                .signingName(serviceName)
                 .awsCredentials(credentialsProvider.resolveCredentials())
                 .build());
     }

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSinkTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSinkTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.plugins.sink.otlp.buffer.OtlpSinkBuffer;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
 import software.amazon.awssdk.regions.Region;
@@ -36,7 +36,6 @@ class OtlpSinkTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        // Arrange: stub out config, metrics, setting
         mockAwsCredSupplier = mock(AwsCredentialsSupplier.class);
         mockConfig = mock(OtlpSinkConfig.class);
         when(mockConfig.getAwsRegion()).thenReturn(Region.of("us-west-2"));
@@ -48,10 +47,8 @@ class OtlpSinkTest {
         when(mockSetting.getPipelineName()).thenReturn("pipeline");
         when(mockSetting.getName()).thenReturn("otlp");
 
-        // Create the real sink
         target = new OtlpSink(mockAwsCredSupplier, mockConfig, mockMetrics, mockSetting);
 
-        // Replace its private buffer with a mock
         mockBuffer = mock(OtlpSinkBuffer.class);
         final Field bufferField = OtlpSink.class.getDeclaredField("buffer");
         bufferField.setAccessible(true);
@@ -60,23 +57,17 @@ class OtlpSinkTest {
 
     @Test
     void testInitialize_startsBuffer() {
-        // Act
         target.initialize();
-
-        // Assert
         verify(mockBuffer).start();
     }
 
     @Test
     void testOutput_addsEveryRecordToBuffer() {
-        // Arrange
-        @SuppressWarnings("unchecked") final Record<Span> r1 = mock(Record.class);
-        @SuppressWarnings("unchecked") final Record<Span> r2 = mock(Record.class);
+        @SuppressWarnings("unchecked") final Record<Event> r1 = mock(Record.class);
+        @SuppressWarnings("unchecked") final Record<Event> r2 = mock(Record.class);
 
-        // Act
         target.output(List.of(r1, r2));
 
-        // Assert
         verify(mockBuffer).add(r1);
         verify(mockBuffer).add(r2);
         verifyNoMoreInteractions(mockBuffer);
@@ -86,30 +77,23 @@ class OtlpSinkTest {
     void testIsReady_returnsTrueOnlyAfterInitialization() {
         when(mockBuffer.isRunning()).thenReturn(true);
 
-        // Not initialized yet
         assertFalse(target.isReady());
 
-        // Initialize, which sets 'initialized = true' and starts the buffer
         target.initialize();
         assertTrue(target.isReady());
 
-        // Now simulate buffer being not running
         when(mockBuffer.isRunning()).thenReturn(false);
         assertFalse(target.isReady());
     }
 
     @Test
     void testShutdown_stopsBuffer() {
-        // Act
         target.shutdown();
-
-        // Assert
         verify(mockBuffer).stop();
     }
 
     @Test
     void testConstructor_doesNotThrow() {
-        // Just ensure the three-arg constructor still works
         assertDoesNotThrow(() -> new OtlpSink(mockAwsCredSupplier, mockConfig, mockMetrics, mockSetting));
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/buffer/OtlpSinkBufferTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/buffer/OtlpSinkBufferTest.java
@@ -5,15 +5,18 @@
 
 package org.opensearch.dataprepper.plugins.sink.otlp.buffer;
 
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoStandardCodec;
+import org.opensearch.dataprepper.plugins.sink.otlp.codec.OtlpLogEncoder;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.otlp.http.OtlpHttpSender;
 import org.opensearch.dataprepper.plugins.sink.otlp.metrics.OtlpSinkMetrics;
@@ -31,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -45,7 +50,8 @@ class OtlpSinkBufferTest {
 
     private OtlpSinkConfig config;
     private OtlpSinkMetrics metrics;
-    private OTelProtoStandardCodec.OTelProtoEncoder encoder;
+    private OTelProtoStandardCodec.OTelProtoEncoder traceEncoder;
+    private OtlpLogEncoder logEncoder;
     private OtlpHttpSender sender;
     private OtlpSinkBuffer buffer;
     private AwsCredentialsSupplier mockAwsCredSupplier;
@@ -59,13 +65,15 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(1_000_000L);
         when(config.getFlushTimeoutMillis()).thenReturn(10L);
         when(config.getAwsRegion()).thenReturn(Region.of("us-west-2"));
+        when(config.isLogSignal()).thenReturn(false);
 
         metrics = mock(OtlpSinkMetrics.class);
-        encoder = mock(OTelProtoStandardCodec.OTelProtoEncoder.class);
+        traceEncoder = mock(OTelProtoStandardCodec.OTelProtoEncoder.class);
+        logEncoder = mock(OtlpLogEncoder.class);
         sender = mock(OtlpHttpSender.class);
         mockAwsCredSupplier = mock(AwsCredentialsSupplier.class);
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
     }
 
     @AfterEach
@@ -94,7 +102,7 @@ class OtlpSinkBufferTest {
     @Test
     void testQueueCapacityCalculation_withHighMaxEvents() {
         when(config.getMaxEvents()).thenReturn(500);
-        final OtlpSinkBuffer highCapacityBuffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        final OtlpSinkBuffer highCapacityBuffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         assertNotNull(highCapacityBuffer);
         highCapacityBuffer.stop();
     }
@@ -102,7 +110,7 @@ class OtlpSinkBufferTest {
     @Test
     void testQueueCapacityCalculation_withLowMaxEvents() {
         when(config.getMaxEvents()).thenReturn(1);
-        final OtlpSinkBuffer lowCapacityBuffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        final OtlpSinkBuffer lowCapacityBuffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         assertNotNull(lowCapacityBuffer);
         lowCapacityBuffer.stop();
     }
@@ -114,14 +122,14 @@ class OtlpSinkBufferTest {
 
     @Test
     void testAddHandlesInterruptedException() throws Exception {
-        @SuppressWarnings("unchecked") final BlockingQueue<Record<Span>> badQueue = mock(BlockingQueue.class);
+        @SuppressWarnings("unchecked") final BlockingQueue<Record<Event>> badQueue = mock(BlockingQueue.class);
         doThrow(new InterruptedException()).when(badQueue).put(any());
 
         final Field queueField = OtlpSinkBuffer.class.getDeclaredField("queue");
         queueField.setAccessible(true);
         queueField.set(buffer, badQueue);
 
-        final Record<Span> rec = mock(Record.class);
+        final Record<Event> rec = mock(Record.class);
         buffer.add(rec);
 
         verify(metrics).incrementFailedSpansCount(1);
@@ -130,19 +138,17 @@ class OtlpSinkBufferTest {
 
     @Test
     void testWorkerThreadHandlesEncodeException() throws Exception {
-        // First call throws exception, second call succeeds
-        when(encoder.convertToResourceSpans(any(Span.class)))
+        when(traceEncoder.convertToResourceSpans(any(Span.class)))
                 .thenThrow(new RuntimeException("boom"))
                 .thenReturn(ResourceSpans.getDefaultInstance());
 
-        final Record<Span> rec1 = createMockRecord();
-        final Record<Span> rec2 = createMockRecord();
+        final Record<Event> rec1 = createMockSpanRecord();
+        final Record<Event> rec2 = createMockSpanRecord();
 
         buffer.start();
         buffer.add(rec1);
         buffer.add(rec2);
 
-        // Wait for processing to complete
         await().atMost(2, SECONDS).untilAsserted(() -> {
             verify(metrics).incrementFailedSpansCount(1);
             verify(metrics, atLeastOnce()).incrementErrorsCount();
@@ -150,8 +156,7 @@ class OtlpSinkBufferTest {
 
         buffer.stop();
 
-        // The second record should have been processed and sent
-        await().atMost(1, SECONDS).untilAsserted(() -> verify(sender).send(anyList()));
+        await().atMost(1, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(false)));
     }
 
     @Test
@@ -160,19 +165,15 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        final ResourceSpans resourceSpans = ResourceSpans.getDefaultInstance();
-        when(encoder.convertToResourceSpans(any(Span.class))).thenReturn(resourceSpans);
+        when(traceEncoder.convertToResourceSpans(any(Span.class))).thenReturn(ResourceSpans.getDefaultInstance());
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> rec1 = createMockRecord();
-        final Record<Span> rec2 = createMockRecord();
+        buffer.add(createMockSpanRecord());
+        buffer.add(createMockSpanRecord());
 
-        buffer.add(rec1);
-        buffer.add(rec2);
-
-        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList()));
+        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(false)));
         buffer.stop();
     }
 
@@ -184,15 +185,14 @@ class OtlpSinkBufferTest {
 
         final ResourceSpans largeResourceSpans = mock(ResourceSpans.class);
         when(largeResourceSpans.getSerializedSize()).thenReturn(150);
-        when(encoder.convertToResourceSpans(any(Span.class))).thenReturn(largeResourceSpans);
+        when(traceEncoder.convertToResourceSpans(any(Span.class))).thenReturn(largeResourceSpans);
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> rec = createMockRecord();
-        buffer.add(rec);
+        buffer.add(createMockSpanRecord());
 
-        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList()));
+        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(false)));
         buffer.stop();
     }
 
@@ -202,16 +202,14 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(50L);
 
-        final ResourceSpans resourceSpans = ResourceSpans.getDefaultInstance();
-        when(encoder.convertToResourceSpans(any(Span.class))).thenReturn(resourceSpans);
+        when(traceEncoder.convertToResourceSpans(any(Span.class))).thenReturn(ResourceSpans.getDefaultInstance());
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> rec = createMockRecord();
-        buffer.add(rec);
+        buffer.add(createMockSpanRecord());
 
-        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList()));
+        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(false)));
         buffer.stop();
     }
 
@@ -221,25 +219,24 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        TimeUnit.MILLISECONDS.sleep(200); // Let it poll empty queue
+        TimeUnit.MILLISECONDS.sleep(200);
 
         buffer.stop();
-        verify(sender, never()).send(anyList());
+        verify(sender, never()).send(anyList(), anyBoolean());
     }
 
     @Test
     void testEventHandleIncludedInBatch() throws Exception {
-        final ResourceSpans resourceSpans = ResourceSpans.getDefaultInstance();
-        when(encoder.convertToResourceSpans(any(Span.class))).thenReturn(resourceSpans);
+        when(traceEncoder.convertToResourceSpans(any(Span.class))).thenReturn(ResourceSpans.getDefaultInstance());
 
         final EventHandle eventHandle = mock(EventHandle.class);
-        final Record<Span> rec = mock(Record.class);
         final Span span = mock(Span.class);
-        when(rec.getData()).thenReturn(span);
         when(span.getEventHandle()).thenReturn(eventHandle);
+        @SuppressWarnings("unchecked") final Record<Event> rec = mock(Record.class);
+        when(rec.getData()).thenReturn(span);
 
         buffer.start();
         buffer.add(rec);
@@ -247,7 +244,7 @@ class OtlpSinkBufferTest {
         TimeUnit.MILLISECONDS.sleep(100);
         buffer.stop();
 
-        await().atMost(1, SECONDS).untilAsserted(() -> verify(sender).send(anyList()));
+        await().atMost(1, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(false)));
         verify(span).getEventHandle();
     }
 
@@ -312,7 +309,7 @@ class OtlpSinkBufferTest {
         executorField.setAccessible(true);
         executorField.set(buffer, mockExecutor);
 
-        buffer.stop(); // Set running to false
+        buffer.stop();
 
         buffer.restartWorker();
 
@@ -321,10 +318,9 @@ class OtlpSinkBufferTest {
 
     @Test
     void testRunWithInterruptedException() throws Exception {
-        final OtlpSinkBuffer localBuffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        final OtlpSinkBuffer localBuffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
 
-        // Override the internal queue to throw InterruptedException
-        final BlockingQueue<Record<Span>> interruptingQueue = mock(BlockingQueue.class);
+        @SuppressWarnings("unchecked") final BlockingQueue<Record<Event>> interruptingQueue = mock(BlockingQueue.class);
         when(interruptingQueue.poll(anyLong(), any(TimeUnit.class))).thenThrow(new InterruptedException());
         when(interruptingQueue.isEmpty()).thenReturn(true);
 
@@ -334,7 +330,7 @@ class OtlpSinkBufferTest {
 
         localBuffer.start();
 
-        TimeUnit.MILLISECONDS.sleep(100); // Let the thread hit the poll
+        TimeUnit.MILLISECONDS.sleep(100);
 
         localBuffer.stop();
 
@@ -345,10 +341,9 @@ class OtlpSinkBufferTest {
 
     @Test
     void testRunWithInterruptedException_whileRunning() throws Exception {
-        final OtlpSinkBuffer localBuffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        final OtlpSinkBuffer localBuffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
 
-        // Override the internal queue to throw InterruptedException first, then return null
-        final BlockingQueue<Record<Span>> interruptingQueue = mock(BlockingQueue.class);
+        @SuppressWarnings("unchecked") final BlockingQueue<Record<Event>> interruptingQueue = mock(BlockingQueue.class);
         when(interruptingQueue.poll(anyLong(), any(TimeUnit.class)))
                 .thenThrow(new InterruptedException())
                 .thenReturn(null);
@@ -360,7 +355,7 @@ class OtlpSinkBufferTest {
 
         localBuffer.start();
 
-        TimeUnit.MILLISECONDS.sleep(200); // Let the thread hit the poll and continue
+        TimeUnit.MILLISECONDS.sleep(200);
 
         localBuffer.stop();
 
@@ -376,11 +371,10 @@ class OtlpSinkBufferTest {
             throw new AssertionError("simulated fatal crash");
         });
 
-        buffer = new OtlpSinkBuffer(config, metrics, crashingEncoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, crashingEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> record = createMockRecord();
-        buffer.add(record);
+        buffer.add(createMockSpanRecord());
 
         await().atMost(2, SECONDS).untilAsserted(() -> {
             verify(metrics, atLeastOnce()).incrementErrorsCount();
@@ -389,29 +383,23 @@ class OtlpSinkBufferTest {
 
     @Test
     void testFinalFlushAfterStopFlushesBatch() throws Exception {
-        // Configure buffer to *not* flush by size or time
-        when(config.getMaxEvents()).thenReturn(1000); // very high
-        when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE); // very high
-        when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE); // effectively disables time-based flush
+        when(config.getMaxEvents()).thenReturn(1000);
+        when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
+        when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        final ResourceSpans resourceSpans = ResourceSpans.getDefaultInstance();
-        when(encoder.convertToResourceSpans(any())).thenReturn(resourceSpans);
+        when(traceEncoder.convertToResourceSpans(any())).thenReturn(ResourceSpans.getDefaultInstance());
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> record = createMockRecord();
-        buffer.add(record);
+        buffer.add(createMockSpanRecord());
 
-        // Wait briefly to ensure the record is picked up
         TimeUnit.MILLISECONDS.sleep(100);
 
-        // Stop should trigger the final flush
         buffer.stop();
 
-        // Verify final flush triggered send
         await().atMost(1, SECONDS).untilAsserted(() ->
-                verify(sender).send(anyList())
+                verify(sender).send(anyList(), eq(false))
         );
     }
 
@@ -421,15 +409,13 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        // Don't add any records
         TimeUnit.MILLISECONDS.sleep(50);
         buffer.stop();
 
-        // Verify no send was called since batch was empty
-        verify(sender, never()).send(anyList());
+        verify(sender, never()).send(anyList(), anyBoolean());
     }
 
     @Test
@@ -438,28 +424,23 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        final ResourceSpans resourceSpans = ResourceSpans.getDefaultInstance();
-        when(encoder.convertToResourceSpans(any())).thenReturn(resourceSpans);
+        when(traceEncoder.convertToResourceSpans(any())).thenReturn(ResourceSpans.getDefaultInstance());
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> record = createMockRecord();
-        buffer.add(record);
+        buffer.add(createMockSpanRecord());
 
         TimeUnit.MILLISECONDS.sleep(100);
         buffer.stop();
 
-        // Should only flush on final flush, not by count
         await().atMost(1, SECONDS).untilAsserted(() ->
-                verify(sender, times(1)).send(anyList())
+                verify(sender, times(1)).send(anyList(), eq(false))
         );
     }
 
     @Test
     void testDaemonThreadConfiguration() {
-        // This test verifies that the thread is created as non-daemon
-        // We can't directly test this, but we can verify the thread factory is called
         buffer.start();
         assertTrue(buffer.isRunning());
         buffer.stop();
@@ -476,21 +457,17 @@ class OtlpSinkBufferTest {
         when(resourceSpans1.getSerializedSize()).thenReturn(20);
         when(resourceSpans2.getSerializedSize()).thenReturn(35);
 
-        when(encoder.convertToResourceSpans(any(Span.class)))
+        when(traceEncoder.convertToResourceSpans(any(Span.class)))
                 .thenReturn(resourceSpans1)
                 .thenReturn(resourceSpans2);
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> rec1 = createMockRecord();
-        final Record<Span> rec2 = createMockRecord();
+        buffer.add(createMockSpanRecord());
+        buffer.add(createMockSpanRecord());
 
-        buffer.add(rec1);
-        buffer.add(rec2);
-
-        // Total size: 20 + 35 = 55, which exceeds 50
-        await().atMost(1, SECONDS).untilAsserted(() -> verify(sender).send(anyList()));
+        await().atMost(1, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(false)));
         buffer.stop();
     }
 
@@ -500,51 +477,39 @@ class OtlpSinkBufferTest {
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        final ResourceSpans resourceSpans = ResourceSpans.getDefaultInstance();
-        when(encoder.convertToResourceSpans(any())).thenReturn(resourceSpans);
+        when(traceEncoder.convertToResourceSpans(any())).thenReturn(ResourceSpans.getDefaultInstance());
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> rec1 = createMockRecord();
-        final Record<Span> rec2 = createMockRecord();
-        final Record<Span> rec3 = createMockRecord();
+        buffer.add(createMockSpanRecord());
+        buffer.add(createMockSpanRecord());
+        buffer.add(createMockSpanRecord());
 
-        buffer.add(rec1);
-        buffer.add(rec2);
-        buffer.add(rec3);
-
-        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender, times(3)).send(anyList()));
+        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender, times(3)).send(anyList(), eq(false)));
         buffer.stop();
     }
 
     @Test
     void testEncodingFailureDoesNotStopProcessing() throws Exception {
-        // Configure to process multiple records
         when(config.getMaxEvents()).thenReturn(2);
         when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
         when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
 
-        // First and third succeed, second fails
-        when(encoder.convertToResourceSpans(any(Span.class)))
+        when(traceEncoder.convertToResourceSpans(any(Span.class)))
                 .thenReturn(ResourceSpans.getDefaultInstance())
                 .thenThrow(new RuntimeException("encoding error"))
                 .thenReturn(ResourceSpans.getDefaultInstance());
 
-        buffer = new OtlpSinkBuffer(config, metrics, encoder, sender);
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
         buffer.start();
 
-        final Record<Span> rec1 = createMockRecord();
-        final Record<Span> rec2 = createMockRecord();
-        final Record<Span> rec3 = createMockRecord();
+        buffer.add(createMockSpanRecord());
+        buffer.add(createMockSpanRecord());
+        buffer.add(createMockSpanRecord());
 
-        buffer.add(rec1);
-        buffer.add(rec2);
-        buffer.add(rec3);
-
-        // Should still send the batch with the 2 successful records
         await().atMost(2, SECONDS).untilAsserted(() -> {
-            verify(sender).send(anyList());
+            verify(sender).send(anyList(), eq(false));
             verify(metrics).incrementFailedSpansCount(1);
             verify(metrics, atLeastOnce()).incrementErrorsCount();
         });
@@ -552,12 +517,85 @@ class OtlpSinkBufferTest {
         buffer.stop();
     }
 
-    private Record<Span> createMockRecord() {
-        final Record<Span> record = mock(Record.class);
+    // --- Log signal tests ---
+
+    @Test
+    void testLogSignal_usesLogEncoder() throws Exception {
+        when(config.isLogSignal()).thenReturn(true);
+        when(config.getMaxEvents()).thenReturn(1);
+        when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
+        when(config.getFlushTimeoutMillis()).thenReturn(Long.MAX_VALUE);
+
+        when(logEncoder.encode(any(Event.class))).thenReturn(ResourceLogs.getDefaultInstance());
+
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
+        buffer.start();
+
+        buffer.add(createMockEventRecord());
+
+        await().atMost(2, SECONDS).untilAsserted(() -> verify(sender).send(anyList(), eq(true)));
+        verify(logEncoder).encode(any(Event.class));
+        buffer.stop();
+    }
+
+    @Test
+    void testLogSignal_encodingFailureIncrementsMetrics() throws Exception {
+        when(config.isLogSignal()).thenReturn(true);
+        when(config.getMaxEvents()).thenReturn(1);
+        when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
+        when(config.getFlushTimeoutMillis()).thenReturn(50L);
+
+        when(logEncoder.encode(any(Event.class))).thenThrow(new RuntimeException("log encode failed"));
+
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
+        buffer.start();
+
+        buffer.add(createMockEventRecord());
+
+        await().atMost(2, SECONDS).untilAsserted(() -> {
+            verify(metrics).incrementFailedSpansCount(1);
+            verify(metrics, atLeastOnce()).incrementErrorsCount();
+        });
+
+        buffer.stop();
+    }
+
+    @Test
+    void testTraceSignal_rejectsNonSpanEvent() throws Exception {
+        when(config.isLogSignal()).thenReturn(false);
+        when(config.getMaxEvents()).thenReturn(1);
+        when(config.getMaxBatchSize()).thenReturn(Long.MAX_VALUE);
+        when(config.getFlushTimeoutMillis()).thenReturn(50L);
+
+        buffer = new OtlpSinkBuffer(config, metrics, traceEncoder, logEncoder, sender);
+        buffer.start();
+
+        // Add a plain Event (not a Span) in trace mode
+        buffer.add(createMockEventRecord());
+
+        await().atMost(2, SECONDS).untilAsserted(() -> {
+            verify(metrics).incrementFailedSpansCount(1);
+            verify(metrics, atLeastOnce()).incrementErrorsCount();
+        });
+
+        buffer.stop();
+    }
+
+    private Record<Event> createMockSpanRecord() {
+        @SuppressWarnings("unchecked") final Record<Event> record = mock(Record.class);
         final Span span = mock(Span.class);
         final EventHandle eventHandle = mock(EventHandle.class);
         when(record.getData()).thenReturn(span);
         when(span.getEventHandle()).thenReturn(eventHandle);
+        return record;
+    }
+
+    private Record<Event> createMockEventRecord() {
+        @SuppressWarnings("unchecked") final Record<Event> record = mock(Record.class);
+        final Event event = mock(Event.class);
+        final EventHandle eventHandle = mock(EventHandle.class);
+        when(record.getData()).thenReturn(event);
+        when(event.getEventHandle()).thenReturn(eventHandle);
         return record;
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/codec/OtlpLogEncoderTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/codec/OtlpLogEncoderTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.otlp.codec;
+
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OtlpLogEncoderTest {
+
+    private OtlpLogEncoder encoder;
+
+    @BeforeEach
+    void setUp() {
+        encoder = new OtlpLogEncoder();
+    }
+
+    @Test
+    void testEncode_basicEvent() {
+        final Event event = mockEvent(Map.of("message", "hello"), "{\"message\":\"hello\"}", null);
+
+        final ResourceLogs result = encoder.encode(event);
+
+        assertNotNull(result);
+        assertEquals(1, result.getScopeLogsCount());
+        assertEquals(1, result.getScopeLogs(0).getLogRecordsCount());
+
+        final LogRecord logRecord = result.getScopeLogs(0).getLogRecords(0);
+        assertEquals("{\"message\":\"hello\"}", logRecord.getBody().getStringValue());
+        assertTrue(logRecord.getTimeUnixNano() > 0);
+        assertTrue(logRecord.getObservedTimeUnixNano() > 0);
+    }
+
+    @Test
+    void testEncode_setsTimeFromMetadata() {
+        final Instant eventTime = Instant.parse("2026-01-15T10:30:00Z");
+        final Event event = mockEvent(Map.of("msg", "test"), "{\"msg\":\"test\"}", eventTime);
+
+        final ResourceLogs result = encoder.encode(event);
+        final LogRecord logRecord = result.getScopeLogs(0).getLogRecords(0);
+
+        final long expectedNanos = eventTime.getEpochSecond() * 1_000_000_000L + eventTime.getNano();
+        assertEquals(expectedNanos, logRecord.getTimeUnixNano());
+    }
+
+    @Test
+    void testEncode_usesCurrentTimeWhenNoMetadata() {
+        final Event event = mockEvent(Map.of("msg", "test"), "{\"msg\":\"test\"}", null);
+        when(event.getMetadata()).thenReturn(null);
+
+        final long before = System.currentTimeMillis() * 1_000_000L;
+        final ResourceLogs result = encoder.encode(event);
+        final long after = System.currentTimeMillis() * 1_000_000L;
+
+        final LogRecord logRecord = result.getScopeLogs(0).getLogRecords(0);
+        assertTrue(logRecord.getTimeUnixNano() >= before);
+        assertTrue(logRecord.getTimeUnixNano() <= after);
+    }
+
+    @Test
+    void testEncode_typedAttributes() {
+        final Map<String, Object> data = new LinkedHashMap<>();
+        data.put("str", "value");
+        data.put("bool", true);
+        data.put("intVal", 42);
+        data.put("longVal", 100L);
+        data.put("floatVal", 1.5f);
+        data.put("doubleVal", 3.14);
+        data.put("nullVal", null);
+
+        final Event event = mockEvent(data, "{}", null);
+
+        final ResourceLogs result = encoder.encode(event);
+        final LogRecord logRecord = result.getScopeLogs(0).getLogRecords(0);
+
+        assertEquals(7, logRecord.getAttributesCount());
+
+        final Map<String, KeyValue> attrs = new LinkedHashMap<>();
+        for (final KeyValue kv : logRecord.getAttributesList()) {
+            attrs.put(kv.getKey(), kv);
+        }
+
+        assertEquals("value", attrs.get("str").getValue().getStringValue());
+        assertTrue(attrs.get("bool").getValue().getBoolValue());
+        assertEquals(42, attrs.get("intVal").getValue().getIntValue());
+        assertEquals(100L, attrs.get("longVal").getValue().getIntValue());
+        assertEquals(3.14, attrs.get("doubleVal").getValue().getDoubleValue(), 0.001);
+        assertTrue(attrs.get("floatVal").getValue().getDoubleValue() > 1.0);
+    }
+
+    @Test
+    void testEncode_unsupportedTypeUsesToString() {
+        final Map<String, Object> data = new LinkedHashMap<>();
+        data.put("list", java.util.List.of("a", "b"));
+
+        final Event event = mockEvent(data, "{}", null);
+
+        final ResourceLogs result = encoder.encode(event);
+        final LogRecord logRecord = result.getScopeLogs(0).getLogRecords(0);
+
+        assertEquals("[a, b]", logRecord.getAttributes(0).getValue().getStringValue());
+    }
+
+    @Test
+    void testEncode_scopeName() {
+        final Event event = mockEvent(Map.of(), "{}", null);
+
+        final ResourceLogs result = encoder.encode(event);
+
+        assertEquals("data-prepper-otlp-sink", result.getScopeLogs(0).getScope().getName());
+    }
+
+    @Test
+    void testEncode_bodyIsFullJson() {
+        final String json = "{\"message\":\"hello\",\"count\":5}";
+        final Event event = mockEvent(Map.of("message", "hello", "count", 5), json, null);
+
+        final ResourceLogs result = encoder.encode(event);
+        final LogRecord logRecord = result.getScopeLogs(0).getLogRecords(0);
+
+        assertFalse(logRecord.getBody().getStringValue().isEmpty());
+    }
+
+    private Event mockEvent(final Map<String, Object> data, final String json, final Instant timeReceived) {
+        final Event event = mock(Event.class);
+        when(event.toMap()).thenReturn(data);
+        when(event.toJsonString()).thenReturn(json);
+
+        final EventMetadata metadata = mock(EventMetadata.class);
+        when(metadata.getTimeReceived()).thenReturn(timeReceived);
+        when(event.getMetadata()).thenReturn(metadata);
+
+        return event;
+    }
+}

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfigTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/configuration/OtlpSinkConfigTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -263,5 +264,127 @@ class OtlpSinkConfigTest {
             final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
             config.getAwsRegion();  // must trigger parsing logic
         });
+    }
+
+    @Test
+    void testSignalType_defaultsToTraces() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws: {}"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertEquals("traces", config.getSignalType());
+        assertFalse(config.isLogSignal());
+    }
+
+    @Test
+    void testSignalType_logs() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws: {}",
+                "signal_type: logs"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertEquals("logs", config.getSignalType());
+        assertTrue(config.isLogSignal());
+    }
+
+    @Test
+    void testSignalType_logsCaseInsensitive() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws: {}",
+                "signal_type: LOGS"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertTrue(config.isLogSignal());
+    }
+
+    @Test
+    void testAdditionalHeaders_defaultsToEmpty() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws: {}"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertNotNull(config.getAdditionalHeaders());
+        assertTrue(config.getAdditionalHeaders().isEmpty());
+    }
+
+    @Test
+    void testAdditionalHeaders_deserialization() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws: {}",
+                "additional_headers:",
+                "  x-custom-header: my-value",
+                "  x-another: another-value"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertEquals(2, config.getAdditionalHeaders().size());
+        assertEquals("my-value", config.getAdditionalHeaders().get("x-custom-header"));
+        assertEquals("another-value", config.getAdditionalHeaders().get("x-another"));
+    }
+
+    @Test
+    void testGetServiceName_returnsNullWhenNotSet() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws: {}"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertNull(config.getServiceName());
+    }
+
+    @Test
+    void testGetServiceName_returnsValueWhenSet() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws:",
+                "  service_name: my-service"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertEquals("my-service", config.getServiceName());
+    }
+
+    @Test
+    void testAwsRegion_fromAwsConfigBlock() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"" + EXPECTED_ENDPOINT + "\"",
+                "aws:",
+                "  region: eu-west-1"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        assertThat(config.getAwsRegion(), equalTo(Region.EU_WEST_1));
+    }
+
+    @Test
+    void testAwsRegion_awsConfigTakesPrecedenceOverEndpoint() throws Exception {
+        final String yaml = String.join("\n",
+                "endpoint: \"https://xray.us-east-1.amazonaws.com\"",
+                "aws:",
+                "  region: eu-west-1"
+        );
+
+        final OtlpSinkConfig config = mapper.readValue(yaml, OtlpSinkConfig.class);
+
+        // aws.region should take precedence over endpoint parsing
+        assertThat(config.getAwsRegion(), equalTo(Region.EU_WEST_1));
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/OtlpHttpSenderTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/OtlpHttpSenderTest.java
@@ -5,13 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.sink.otlp.http;
 
+import com.google.protobuf.MessageLite;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.ResponseHeaders;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsPartialSuccess;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,12 +27,13 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.utils.Pair;
 
-import java.lang.reflect.Method;
 import java.net.URI;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.awaitility.Awaitility.await;
@@ -39,13 +44,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class OtlpHttpSenderTest {
 
     private static final byte[] PAYLOAD = "test-otlp".getBytes(StandardCharsets.UTF_8);
-    private static final int SPANS_COUNT = 3;
+    private static final int BATCH_COUNT = 3;
 
     private OtlpSinkMetrics metrics;
     private SigV4Signer signer;
@@ -53,7 +57,8 @@ class OtlpHttpSenderTest {
     private Function<byte[], byte[]> gzipCompressor;
     private OtlpHttpSender sender;
     private AwsCredentialsSupplier mockAwsCredSupplier;
-    private List<Pair<ResourceSpans, EventHandle>> testBatch;
+    private List<Pair<MessageLite, EventHandle>> traceBatch;
+    private List<Pair<MessageLite, EventHandle>> logBatch;
     private EventHandle mockEventHandle1;
     private EventHandle mockEventHandle2;
     private EventHandle mockEventHandle3;
@@ -70,11 +75,16 @@ class OtlpHttpSenderTest {
         mockEventHandle2 = mock(EventHandle.class);
         mockEventHandle3 = mock(EventHandle.class);
 
-        // Create test batch with ResourceSpans and EventHandles
-        testBatch = Arrays.asList(
+        traceBatch = Arrays.asList(
                 Pair.of(ResourceSpans.newBuilder().build(), mockEventHandle1),
                 Pair.of(ResourceSpans.newBuilder().build(), mockEventHandle2),
                 Pair.of(ResourceSpans.newBuilder().build(), mockEventHandle3)
+        );
+
+        logBatch = Arrays.asList(
+                Pair.of(ResourceLogs.newBuilder().build(), mockEventHandle1),
+                Pair.of(ResourceLogs.newBuilder().build(), mockEventHandle2),
+                Pair.of(ResourceLogs.newBuilder().build(), mockEventHandle3)
         );
 
         when(gzipCompressor.apply(any())).thenReturn(PAYLOAD);
@@ -89,34 +99,33 @@ class OtlpHttpSenderTest {
         sender = new OtlpHttpSender(metrics, gzipCompressor, signer, webClient);
     }
 
+    // --- Trace signal tests ---
+
     @Test
     void testSend_emptyBatch_returnsEarly() {
-        final List<Pair<ResourceSpans, EventHandle>> emptyBatch = Collections.emptyList();
+        final List<Pair<MessageLite, EventHandle>> emptyBatch = Collections.emptyList();
 
-        // Prevent accidental NPE if send logic changes
         when(webClient.execute(any(HttpRequest.class))).thenThrow(new AssertionError("Should not call execute"));
 
-        sender.send(emptyBatch);
+        sender.send(emptyBatch, false);
 
         verifyNoInteractions(metrics);
     }
 
     @Test
-    void testSend_successfulResponse() {
+    void testSend_traces_successfulResponse() {
         when(webClient.execute(any(HttpRequest.class))).thenReturn(
                 HttpResponse.of(ResponseHeaders.of(200), HttpData.empty())
         );
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
-            verify(metrics).incrementRecordsOut(SPANS_COUNT);
+            verify(metrics).incrementRecordsOut(BATCH_COUNT);
             verify(metrics).incrementPayloadSize(anyLong());
             verify(metrics).incrementPayloadGzipSize(PAYLOAD.length);
             verify(metrics).recordHttpLatency(anyLong());
             verify(metrics).recordResponseCode(200);
-
-            // Verify all event handles are released with success=true
             verify(mockEventHandle1).release(true);
             verify(mockEventHandle2).release(true);
             verify(mockEventHandle3).release(true);
@@ -124,7 +133,7 @@ class OtlpHttpSenderTest {
     }
 
     @Test
-    void testSend_partialSuccessResponse() {
+    void testSend_traces_partialSuccessResponse() {
         final ExportTraceServiceResponse proto = ExportTraceServiceResponse.newBuilder()
                 .setPartialSuccess(ExportTracePartialSuccess.newBuilder()
                         .setRejectedSpans(2)
@@ -136,14 +145,12 @@ class OtlpHttpSenderTest {
                 HttpResponse.of(ResponseHeaders.of(200), HttpData.wrap(proto.toByteArray()))
         );
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
             verify(metrics).incrementRejectedSpansCount(2);
-            verify(metrics).incrementRecordsOut(SPANS_COUNT - 2);
+            verify(metrics).incrementRecordsOut(BATCH_COUNT - 2);
             verify(metrics).recordResponseCode(200);
-
-            // All handles should still be released as true (optimistic)
             verify(mockEventHandle1).release(true);
             verify(mockEventHandle2).release(true);
             verify(mockEventHandle3).release(true);
@@ -151,7 +158,7 @@ class OtlpHttpSenderTest {
     }
 
     @Test
-    void testSend_partialSuccessWithZeroRejected() {
+    void testSend_traces_partialSuccessWithZeroRejected() {
         final ExportTraceServiceResponse proto = ExportTraceServiceResponse.newBuilder()
                 .setPartialSuccess(ExportTracePartialSuccess.newBuilder()
                         .setRejectedSpans(0)
@@ -163,17 +170,12 @@ class OtlpHttpSenderTest {
                 HttpResponse.of(ResponseHeaders.of(200), HttpData.wrap(proto.toByteArray()))
         );
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
             verify(metrics, never()).incrementRejectedSpansCount(anyLong());
-            verify(metrics).incrementRecordsOut(SPANS_COUNT);
+            verify(metrics).incrementRecordsOut(BATCH_COUNT);
             verify(metrics).recordResponseCode(200);
-
-            // All handles should be released as true
-            verify(mockEventHandle1).release(true);
-            verify(mockEventHandle2).release(true);
-            verify(mockEventHandle3).release(true);
         });
     }
 
@@ -183,17 +185,13 @@ class OtlpHttpSenderTest {
                 HttpResponse.of(ResponseHeaders.of(200), HttpData.ofUtf8("not-protobuf"))
         );
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
             verify(metrics).incrementErrorsCount();
-            verify(metrics).incrementRecordsOut(SPANS_COUNT);
+            verify(metrics).incrementRecordsOut(BATCH_COUNT);
             verify(metrics).recordResponseCode(200);
-
-            // Handles should still be released as true despite parse error
             verify(mockEventHandle1).release(true);
-            verify(mockEventHandle2).release(true);
-            verify(mockEventHandle3).release(true);
         });
     }
 
@@ -203,13 +201,11 @@ class OtlpHttpSenderTest {
                 HttpResponse.of(ResponseHeaders.of(400), HttpData.ofUtf8("{\"error\":\"bad request\"}"))
         );
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
             verify(metrics).recordResponseCode(400);
-            verify(metrics).incrementRejectedSpansCount(SPANS_COUNT);
-
-            // All handles should be released with success=false
+            verify(metrics).incrementRejectedSpansCount(BATCH_COUNT);
             verify(mockEventHandle1).release(false);
             verify(mockEventHandle2).release(false);
             verify(mockEventHandle3).release(false);
@@ -222,16 +218,12 @@ class OtlpHttpSenderTest {
                 HttpResponse.of(ResponseHeaders.of(500), HttpData.empty())
         );
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
             verify(metrics).recordResponseCode(500);
-            verify(metrics).incrementRejectedSpansCount(SPANS_COUNT);
-
-            // All handles should be released with success=false
+            verify(metrics).incrementRejectedSpansCount(BATCH_COUNT);
             verify(mockEventHandle1).release(false);
-            verify(mockEventHandle2).release(false);
-            verify(mockEventHandle3).release(false);
         });
     }
 
@@ -239,15 +231,11 @@ class OtlpHttpSenderTest {
     void testSend_skipsSendIfGzipFails() {
         sender = new OtlpHttpSender(metrics, ignored -> new byte[0], signer, webClient);
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
-        verify(metrics).incrementFailedSpansCount(SPANS_COUNT);
+        verify(metrics).incrementFailedSpansCount(BATCH_COUNT);
         verifyNoInteractions(webClient);
-
-        // All handles should be released with success=false
         verify(mockEventHandle1).release(false);
-        verify(mockEventHandle2).release(false);
-        verify(mockEventHandle3).release(false);
     }
 
     @Test
@@ -255,27 +243,155 @@ class OtlpHttpSenderTest {
         final HttpResponse failingResponse = HttpResponse.ofFailure(new RuntimeException("send failed"));
         when(webClient.execute(any(HttpRequest.class))).thenReturn(failingResponse);
 
-        sender.send(testBatch);
+        sender.send(traceBatch, false);
 
         await().untilAsserted(() -> {
-            verify(metrics).incrementRejectedSpansCount(SPANS_COUNT);
-
-            // All handles should be released with success=false
+            verify(metrics).incrementRejectedSpansCount(BATCH_COUNT);
             verify(mockEventHandle1).release(false);
-            verify(mockEventHandle2).release(false);
-            verify(mockEventHandle3).release(false);
         });
+    }
+
+    // --- Log signal tests ---
+
+    @Test
+    void testSend_logs_successfulResponse() {
+        when(webClient.execute(any(HttpRequest.class))).thenReturn(
+                HttpResponse.of(ResponseHeaders.of(200), HttpData.empty())
+        );
+
+        sender.send(logBatch, true);
+
+        await().untilAsserted(() -> {
+            verify(metrics).incrementRecordsOut(BATCH_COUNT);
+            verify(metrics).recordResponseCode(200);
+            verify(mockEventHandle1).release(true);
+            verify(mockEventHandle2).release(true);
+            verify(mockEventHandle3).release(true);
+        });
+    }
+
+    @Test
+    void testSend_logs_successfulResponseWithNullBody() {
+        // Simulate a response where content().array() returns null-like empty
+        when(webClient.execute(any(HttpRequest.class))).thenReturn(
+                HttpResponse.of(ResponseHeaders.of(200))
+        );
+
+        sender.send(logBatch, true);
+
+        await().untilAsserted(() -> {
+            verify(metrics).incrementRecordsOut(BATCH_COUNT);
+            verify(mockEventHandle1).release(true);
+        });
+    }
+
+    @Test
+    void testSend_logs_partialSuccessResponse() {
+        final ExportLogsServiceResponse proto = ExportLogsServiceResponse.newBuilder()
+                .setPartialSuccess(ExportLogsPartialSuccess.newBuilder()
+                        .setRejectedLogRecords(1)
+                        .setErrorMessage("invalid log")
+                        .build())
+                .build();
+
+        when(webClient.execute(any(HttpRequest.class))).thenReturn(
+                HttpResponse.of(ResponseHeaders.of(200), HttpData.wrap(proto.toByteArray()))
+        );
+
+        sender.send(logBatch, true);
+
+        await().untilAsserted(() -> {
+            verify(metrics).incrementRejectedSpansCount(1);
+            verify(metrics).incrementRecordsOut(BATCH_COUNT - 1);
+            verify(metrics).recordResponseCode(200);
+        });
+    }
+
+    @Test
+    void testSend_logs_nonSuccessStatus() {
+        when(webClient.execute(any(HttpRequest.class))).thenReturn(
+                HttpResponse.of(ResponseHeaders.of(403), HttpData.ofUtf8("forbidden"))
+        );
+
+        sender.send(logBatch, true);
+
+        await().untilAsserted(() -> {
+            verify(metrics).recordResponseCode(403);
+            verify(metrics).incrementRejectedSpansCount(BATCH_COUNT);
+            verify(mockEventHandle1).release(false);
+        });
+    }
+
+    // --- Additional headers test ---
+
+    @Test
+    void testSend_withAdditionalHeaders() {
+        final Map<String, String> headers = Map.of("x-custom-header", "custom-value");
+        sender = new OtlpHttpSender(metrics, gzipCompressor, signer, webClient, headers);
+
+        when(webClient.execute(any(HttpRequest.class))).thenReturn(
+                HttpResponse.of(ResponseHeaders.of(200), HttpData.empty())
+        );
+
+        sender.send(traceBatch, false);
+
+        await().untilAsserted(() -> {
+            verify(metrics).incrementRecordsOut(BATCH_COUNT);
+            verify(signer).signRequest(any());
+        });
+    }
+
+    // --- Coverage: private method paths ---
+
+    @Test
+    void testHandleSuccessfulResponse_nullBytes_logSignal() throws Exception {
+        final Method method = OtlpHttpSender.class.getDeclaredMethod(
+                "handleSuccessfulResponse", byte[].class, List.class, boolean.class);
+        method.setAccessible(true);
+
+        method.invoke(sender, null, logBatch, true);
+
+        verify(metrics).incrementRecordsOut(BATCH_COUNT);
+        verify(mockEventHandle1).release(true);
+    }
+
+    @Test
+    void testHandleSuccessfulResponse_nullBytes_traceSignal() throws Exception {
+        final Method method = OtlpHttpSender.class.getDeclaredMethod(
+                "handleSuccessfulResponse", byte[].class, List.class, boolean.class);
+        method.setAccessible(true);
+
+        method.invoke(sender, null, traceBatch, false);
+
+        verify(metrics).incrementRecordsOut(BATCH_COUNT);
+        verify(mockEventHandle1).release(true);
+    }
+
+    // --- Constructor tests ---
+
+    @Test
+    void testConstructor_withNullAdditionalHeaders() {
+        final OtlpHttpSender nullHeadersSender = new OtlpHttpSender(metrics, gzipCompressor, signer, webClient, null);
+        assertNotNull(nullHeadersSender);
+
+        when(webClient.execute(any(HttpRequest.class))).thenReturn(
+                HttpResponse.of(ResponseHeaders.of(200), HttpData.empty())
+        );
+
+        nullHeadersSender.send(traceBatch, false);
+
+        await().untilAsserted(() -> verify(metrics).incrementRecordsOut(BATCH_COUNT));
     }
 
     @Test
     void testConstructor_withDefaultConfig() {
         final OtlpSinkConfig config = mock(OtlpSinkConfig.class);
-
         when(config.getEndpoint()).thenReturn("https://localhost/v1/traces");
         when(config.getMaxBatchSize()).thenReturn(1_000_000L);
         when(config.getMaxRetries()).thenReturn(2);
         when(config.getFlushTimeoutMillis()).thenReturn(5000L);
         when(config.getAwsRegion()).thenReturn(software.amazon.awssdk.regions.Region.US_WEST_2);
+        when(config.getAdditionalHeaders()).thenReturn(Map.of());
 
         final OtlpHttpSender defaultSender = new OtlpHttpSender(mockAwsCredSupplier, config, metrics);
         assertNotNull(defaultSender);
@@ -284,158 +400,14 @@ class OtlpHttpSenderTest {
     @Test
     void testConstructor_withMinimumThresholdConfig() {
         final OtlpSinkConfig config = mock(OtlpSinkConfig.class);
-
-        // Set all threshold values to minimum valid input
         when(config.getEndpoint()).thenReturn("https://localhost/v1/traces");
         when(config.getMaxBatchSize()).thenReturn(0L);
         when(config.getMaxRetries()).thenReturn(0);
         when(config.getFlushTimeoutMillis()).thenReturn(1L);
         when(config.getAwsRegion()).thenReturn(software.amazon.awssdk.regions.Region.US_WEST_2);
+        when(config.getAdditionalHeaders()).thenReturn(Map.of());
 
-        // Should not throw or crash
         final OtlpHttpSender minimalSender = new OtlpHttpSender(mockAwsCredSupplier, config, metrics);
         assertNotNull(minimalSender);
-    }
-
-    @Test
-    void testGetPayloadAndCompressedPayload_privateMethod() throws Exception {
-        // Test the private method via reflection to ensure 100% coverage
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("getPayloadAndCompressedPayload", List.class);
-        method.setAccessible(true);
-
-        when(gzipCompressor.apply(any())).thenReturn("compressed".getBytes());
-
-        @SuppressWarnings("unchecked") final Pair<byte[], byte[]> result = (Pair<byte[], byte[]>) method.invoke(sender, testBatch);
-
-        assertNotNull(result);
-        assertNotNull(result.left()); // payload
-        assertNotNull(result.right()); // compressed payload
-        verify(gzipCompressor).apply(any());
-    }
-
-    @Test
-    void testBuildHttpRequest_privateMethod() throws Exception {
-        // Test the private method via reflection
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("buildHttpRequest", byte[].class);
-        method.setAccessible(true);
-
-        final HttpRequest result = (HttpRequest) method.invoke(sender, PAYLOAD);
-
-        assertNotNull(result);
-        verify(signer).signRequest(PAYLOAD);
-    }
-
-    @Test
-    void testHandleResponse_privateMethod_success() throws Exception {
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleResponse", int.class, byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, 200, null, testBatch);
-
-        verify(metrics).recordResponseCode(200);
-        verify(metrics).incrementRecordsOut(SPANS_COUNT);
-        verify(mockEventHandle1).release(true);
-        verify(mockEventHandle2).release(true);
-        verify(mockEventHandle3).release(true);
-    }
-
-    @Test
-    void testHandleResponse_privateMethod_failure() throws Exception {
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleResponse", int.class, byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, 400, "error".getBytes(), testBatch);
-
-        verify(metrics).recordResponseCode(400);
-        verify(metrics).incrementRejectedSpansCount(SPANS_COUNT);
-        verify(mockEventHandle1).release(false);
-        verify(mockEventHandle2).release(false);
-        verify(mockEventHandle3).release(false);
-    }
-
-    @Test
-    void testHandleSuccessfulResponse_privateMethod_withNullBody() throws Exception {
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleSuccessfulResponse", byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, null, testBatch);
-
-        verify(metrics).incrementRecordsOut(SPANS_COUNT);
-        verify(mockEventHandle1).release(true);
-        verify(mockEventHandle2).release(true);
-        verify(mockEventHandle3).release(true);
-        verifyNoMoreInteractions(metrics);
-    }
-
-    @Test
-    void testHandleSuccessfulResponse_privateMethod_withoutPartialSuccess() throws Exception {
-        // Create a response with no partial_success
-        final ExportTraceServiceResponse response = ExportTraceServiceResponse.newBuilder().build();
-        final byte[] responseBytes = response.toByteArray();
-
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleSuccessfulResponse", byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, responseBytes, testBatch);
-
-        verify(metrics).incrementRecordsOut(SPANS_COUNT);
-        verify(mockEventHandle1).release(true);
-        verify(mockEventHandle2).release(true);
-        verify(mockEventHandle3).release(true);
-        verifyNoMoreInteractions(metrics);
-    }
-
-    @Test
-    void testHandleSuccessfulResponse_privateMethod_withPartialSuccess() throws Exception {
-        final ExportTraceServiceResponse response = ExportTraceServiceResponse.newBuilder()
-                .setPartialSuccess(ExportTracePartialSuccess.newBuilder()
-                        .setRejectedSpans(1)
-                        .setErrorMessage("test error")
-                        .build())
-                .build();
-        final byte[] responseBytes = response.toByteArray();
-
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleSuccessfulResponse", byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, responseBytes, testBatch);
-
-        verify(metrics).incrementRejectedSpansCount(1);
-        verify(metrics).incrementRecordsOut(SPANS_COUNT - 1);
-        verify(mockEventHandle1).release(true);
-        verify(mockEventHandle2).release(true);
-        verify(mockEventHandle3).release(true);
-    }
-
-    @Test
-    void testHandleSuccessfulResponse_privateMethod_parseException() throws Exception {
-        final byte[] invalidBytes = "invalid protobuf".getBytes();
-
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleSuccessfulResponse", byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, invalidBytes, testBatch);
-
-        verify(metrics).incrementErrorsCount();
-        verify(metrics).incrementRecordsOut(SPANS_COUNT);
-        verify(mockEventHandle1).release(true);
-        verify(mockEventHandle2).release(true);
-        verify(mockEventHandle3).release(true);
-    }
-
-    @Test
-    void testHandleResponse_withNullResponseBody_logsNoBody() throws Exception {
-        final Method method = OtlpHttpSender.class.getDeclaredMethod("handleResponse", int.class, byte[].class, List.class);
-        method.setAccessible(true);
-
-        method.invoke(sender, 500, null, testBatch);
-
-        verify(metrics).recordResponseCode(500);
-        verify(metrics).incrementRejectedSpansCount(SPANS_COUNT);
-
-        // Verifying event handles released with success=false
-        verify(mockEventHandle1).release(false);
-        verify(mockEventHandle2).release(false);
-        verify(mockEventHandle3).release(false);
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4SignerTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4SignerTest.java
@@ -71,4 +71,31 @@ class SigV4SignerTest {
         assertEquals("application/x-protobuf", request.firstMatchingHeader("Content-Type").orElse(null));
         assertEquals("https://xray.us-west-2.amazonaws.com/v1/traces", request.getUri().toString());
     }
+
+    @Test
+    void testSignRequest_withCustomServiceName() {
+        final String endpoint = "https://my-endpoint.us-west-2.amazonaws.com/v1/logs";
+        when(mockConfig.getEndpoint()).thenReturn(endpoint);
+        when(mockConfig.getServiceName()).thenReturn("my-service");
+
+        target = new SigV4Signer(mockSupplier, mockConfig);
+        final SdkHttpFullRequest request = target.signRequest(PAYLOAD);
+
+        assertNotNull(request);
+        assertEquals("POST", request.method().name());
+        assertTrue(request.headers().containsKey("Authorization"));
+        assertEquals(endpoint, request.getUri().toString());
+    }
+
+    @Test
+    void testSignRequest_withNullServiceName_usesXrayDefault() {
+        when(mockConfig.getEndpoint()).thenReturn(null);
+        when(mockConfig.getServiceName()).thenReturn(null);
+
+        target = new SigV4Signer(mockSupplier, mockConfig);
+        final SdkHttpFullRequest request = target.signRequest(PAYLOAD);
+
+        assertNotNull(request);
+        assertEquals("https://xray.us-west-2.amazonaws.com/v1/traces", request.getUri().toString());
+    }
 }


### PR DESCRIPTION
### Description

This PR extends the OTLP sink plugin to support log ingestion alongside the existing trace support. It also adds configurable SigV4 signing service names and custom HTTP headers, making the sink usable with any OTLP/HTTP-compatible AWS endpoint.

**Configurable SigV4 signing service name**
* Added `service_name` field to `AwsConfig` (shared across plugins)
* `SigV4Signer` uses configurable service name instead of hardcoded `"xray"`
* Default remains `"xray"` — no breaking change for existing pipelines

**Log signal support**
* Added `signal_type` config option (`traces` or `logs`, default: `traces`)
* New `OtlpLogEncoder` converts Data Prepper `Event` → OTLP `ResourceLogs` protobuf
* `OtlpSinkBuffer` routes encoding based on signal type
* `OtlpHttpSender` builds `ExportLogsServiceRequest` or `ExportTraceServiceRequest`
* Response parsing handles both log and trace partial success responses

**Additional headers**
* Added `additional_headers` map config to `OtlpSinkConfig`
* Headers injected into every outgoing request after SigV4 signing

**Region from AWS config**
* `getAwsRegion()` now checks `aws.region` first, falls back to endpoint URL parsing

**Generalized event type**
* Changed `OtlpSink` from `AbstractSink<Record<Span>>` to `AbstractSink<Record<Event>>`
* Plugin is `@Experimental`, so this breaking change is acceptable

**Example config (logs):**
```yaml
otlp:
  endpoint: "https://my-otlp-endpoint.example.com:443/v1/logs"
  signal_type: logs
  aws:
    service_name: my-service
    region: us-east-1
    sts_role_arn: arn:aws:iam::123456789012:role/MyRole
  additional_headers:
    x-custom-header: my-value
  threshold:
    max_events: 100
    flush_timeout: 10s
```

### Issues Resolved
Resolves #6763

### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. [#12289](https://github.com/opensearch-project/documentation-website/issues/12289)
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
