### PR TITLE
Update OpenTelemetry javaagent to 2.26.1 in trace analytics sample app

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/Dockerfile
+++ b/examples/trace-analytics-sample-app/sample-app/Dockerfile
@@ -20,7 +20,7 @@ COPY analytics-service /home/gradle/src/
 WORKDIR /home/gradle/src
 RUN gradle bootJar --daemon
 
-RUN wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.30.0/opentelemetry-javaagent.jar
+RUN wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.26.1/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:21-jre-jammy
 

--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/Dockerfile
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/Dockerfile
@@ -20,7 +20,7 @@ COPY . /home/gradle/src/
 WORKDIR /home/gradle/src
 RUN gradle bootJar --daemon
 
-RUN wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.30.0/opentelemetry-javaagent.jar
+RUN wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.26.1/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:21-jre-jammy
 EXPOSE 8087


### PR DESCRIPTION
### Description

Update OpenTelemetry javaagent to 2.26.1 in trace analytics sample app to fix CVE-2026-33701.
 
### Issues Resolved

N/A

Fixes CVE-2026-33701
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
