### PR TITLE
Add semantic enrichment support for OpenSearch sink index creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('software.amazon.awssdk:bom:2.30.23')
+        implementation platform('software.amazon.awssdk:bom:2.39.0')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     }
 }

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:opensearchserverless'
+    implementation 'software.amazon.awssdk:opensearch'
     implementation libs.commons.lang3
     implementation libs.caffeine
     implementation 'software.amazon.awssdk:apache-client'

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -102,7 +102,7 @@ public class ConnectionConfiguration {
   private final boolean requestCompressionEnabled;
   private final AuthConfig authConfig;
 
-  List<String> getHosts() {
+  public List<String> getHosts() {
     return hosts;
   }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -117,7 +117,7 @@ public class ConnectionConfiguration {
   String getApitoken() {
     return apitoken;
   }
-
+  
   String getPassword() {
     return password;
   }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -122,7 +122,7 @@ public class ConnectionConfiguration {
     return password;
   }
 
-  boolean isAwsSigv4() {
+  public boolean isAwsSigv4() {
     return awsSigv4;
   }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -302,6 +302,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     new SemanticEnrichmentIndexManager(awsCredentialsSupplier).maybeCreateIndex(
             connectionConfiguration,
             openSearchSinkConfig.getIndexConfiguration().getSemanticEnrichmentConfig(),
+            openSearchSinkConfig.getIndexConfiguration().getSemanticEnrichmentResourceName(),
             configuredIndexAlias);
 
     indexManager.setupIndex();

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -73,6 +73,8 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManagerFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapper;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapperFactory;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.SemanticEnrichmentConfig;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.SemanticEnrichmentIndexCreator;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilder;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilderFactory;
@@ -296,6 +298,9 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
     // Attempt to update the serverless network policy if required argument are given.
     maybeUpdateServerlessNetworkPolicy();
+
+    // Create index with semantic enrichment via AOSS control plane if configured.
+    maybeCreateServerlessSemanticEnrichmentIndex();
 
     indexManager.setupIndex();
 
@@ -696,6 +701,25 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   private static boolean isExternalVersionType(final VersionType versionType) {
     return versionType != null && (versionType == VersionType.External || versionType == VersionType.ExternalGte);
+  }
+
+  private void maybeCreateServerlessSemanticEnrichmentIndex() throws IOException {
+    final ConnectionConfiguration connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
+    final SemanticEnrichmentConfig semanticConfig = openSearchSinkConfig.getIndexConfiguration()
+            .getSemanticEnrichmentConfig();
+    if (semanticConfig == null || semanticConfig.getFields() == null
+            || semanticConfig.getFields().isEmpty()) {
+      return;
+    }
+
+    if (!connectionConfiguration.isAwsSigv4()) {
+      LOG.warn("Semantic enrichment is only supported with AWS OpenSearch. Skipping index creation.");
+      return;
+    }
+
+    final SemanticEnrichmentIndexCreator indexCreator = new SemanticEnrichmentIndexCreator(
+            awsCredentialsSupplier, connectionConfiguration);
+    indexCreator.createIndex(configuredIndexAlias, semanticConfig);
   }
 
   private DlqObject createDlqObjectFromEvent(final Event event,

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -73,8 +73,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManagerFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapper;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapperFactory;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.SemanticEnrichmentConfig;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.SemanticEnrichmentIndexCreator;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.SemanticEnrichmentIndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilder;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilderFactory;
@@ -299,8 +298,11 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     // Attempt to update the serverless network policy if required argument are given.
     maybeUpdateServerlessNetworkPolicy();
 
-    // Create index with semantic enrichment via AOSS control plane if configured.
-    maybeCreateServerlessSemanticEnrichmentIndex();
+    // Create index with semantic enrichment via AWS control plane (AOSS or managed domain) if configured.
+    new SemanticEnrichmentIndexManager(awsCredentialsSupplier).maybeCreateIndex(
+            connectionConfiguration,
+            openSearchSinkConfig.getIndexConfiguration().getSemanticEnrichmentConfig(),
+            configuredIndexAlias);
 
     indexManager.setupIndex();
 
@@ -701,25 +703,6 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   private static boolean isExternalVersionType(final VersionType versionType) {
     return versionType != null && (versionType == VersionType.External || versionType == VersionType.ExternalGte);
-  }
-
-  private void maybeCreateServerlessSemanticEnrichmentIndex() throws IOException {
-    final ConnectionConfiguration connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
-    final SemanticEnrichmentConfig semanticConfig = openSearchSinkConfig.getIndexConfiguration()
-            .getSemanticEnrichmentConfig();
-    if (semanticConfig == null || semanticConfig.getFields() == null
-            || semanticConfig.getFields().isEmpty()) {
-      return;
-    }
-
-    if (!connectionConfiguration.isAwsSigv4()) {
-      LOG.warn("Semantic enrichment is only supported with AWS OpenSearch. Skipping index creation.");
-      return;
-    }
-
-    final SemanticEnrichmentIndexCreator indexCreator = new SemanticEnrichmentIndexCreator(
-            awsCredentialsSupplier, connectionConfiguration);
-    indexCreator.createIndex(configuredIndexAlias, semanticConfig);
   }
 
   private DlqObject createDlqObjectFromEvent(final Event event,

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/AwsAuthenticationConfiguration.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.configuration;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/AwsAuthenticationConfiguration.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.SemanticEnrichmentConfig;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.Map;
@@ -37,6 +38,9 @@ public class AwsAuthenticationConfiguration {
     @JsonProperty("serverless_options")
     private ServerlessOptions serverlessOptions;
 
+    @JsonProperty("semantic_enrichment")
+    private SemanticEnrichmentConfig semanticEnrichmentConfig;
+
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
     }
@@ -59,6 +63,10 @@ public class AwsAuthenticationConfiguration {
 
     public ServerlessOptions getServerlessOptions() {
         return serverlessOptions;
+    }
+
+    public SemanticEnrichmentConfig getSemanticEnrichmentConfig() {
+        return semanticEnrichmentConfig;
     }
 }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/AwsAuthenticationConfiguration.java
@@ -39,6 +39,9 @@ public class AwsAuthenticationConfiguration {
     @JsonProperty("serverless")
     private boolean serverless = false;
 
+    @JsonProperty("resource_name")
+    private String resourceName;
+
     @JsonProperty("serverless_options")
     private ServerlessOptions serverlessOptions;
 
@@ -63,6 +66,10 @@ public class AwsAuthenticationConfiguration {
 
     public boolean isServerlessCollection() {
         return serverless;
+    }
+
+    public String getResourceName() {
+        return resourceName;
     }
 
     public ServerlessOptions getServerlessOptions() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -109,6 +109,7 @@ public class IndexConfiguration {
     private final boolean normalizeIndex;
     private final ScriptConfiguration scriptConfiguration;
     private final SemanticEnrichmentConfig semanticEnrichmentConfig;
+    private final String semanticEnrichmentResourceName;
 
     private final String queryWhen;
 
@@ -139,6 +140,7 @@ public class IndexConfiguration {
         this.normalizeIndex = builder.normalizeIndex;
         this.queryOnBulkFailures = builder.queryOnIndexingFailure;
         this.semanticEnrichmentConfig = builder.semanticEnrichmentConfig;
+        this.semanticEnrichmentResourceName = builder.semanticEnrichmentResourceName;
 
         determineTemplateType(builder);
 
@@ -291,6 +293,7 @@ public class IndexConfiguration {
         final AwsAuthenticationConfiguration awsConfig = openSearchSinkConfig.getAwsAuthenticationOptions();
         if (awsConfig != null && awsConfig.getSemanticEnrichmentConfig() != null) {
             builder = builder.withSemanticEnrichmentConfig(awsConfig.getSemanticEnrichmentConfig());
+            builder = builder.withSemanticEnrichmentResourceName(awsConfig.getResourceName());
         }
 
 
@@ -342,6 +345,10 @@ public class IndexConfiguration {
 
     public SemanticEnrichmentConfig getSemanticEnrichmentConfig() {
         return semanticEnrichmentConfig;
+    }
+
+    public String getSemanticEnrichmentResourceName() {
+        return semanticEnrichmentResourceName;
     }
 
     public IndexType getIndexType() {
@@ -557,6 +564,7 @@ public class IndexConfiguration {
 
         private SemanticEnrichmentConfig semanticEnrichmentConfig;
         private Integer queryAsyncLimit;
+        private String semanticEnrichmentResourceName;
 
         public Builder withIndexAlias(final String indexAlias) {
             checkArgument(indexAlias != null, "indexAlias cannot be null.");
@@ -799,6 +807,11 @@ public class IndexConfiguration {
 
         public Builder withSemanticEnrichmentConfig(final SemanticEnrichmentConfig semanticEnrichmentConfig) {
             this.semanticEnrichmentConfig = semanticEnrichmentConfig;
+            return this;
+        }
+
+        public Builder withSemanticEnrichmentResourceName(final String resourceName) {
+            this.semanticEnrichmentResourceName = resourceName;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -103,8 +103,8 @@ public class IndexConfiguration {
     private final String versionExpression;
     private final VersionType versionType;
     private final boolean normalizeIndex;
-
     private final ScriptConfiguration scriptConfiguration;
+    private final SemanticEnrichmentConfig semanticEnrichmentConfig;
 
     private final String queryWhen;
 
@@ -134,6 +134,7 @@ public class IndexConfiguration {
         this.versionType = builder.versionType;
         this.normalizeIndex = builder.normalizeIndex;
         this.queryOnBulkFailures = builder.queryOnIndexingFailure;
+        this.semanticEnrichmentConfig = builder.semanticEnrichmentConfig;
 
         determineTemplateType(builder);
 
@@ -179,6 +180,7 @@ public class IndexConfiguration {
         this.actions = builder.actions;
         this.scriptConfiguration = builder.scriptConfiguration;
         this.documentRootKey = builder.documentRootKey;
+
         this.queryWhen = builder.queryWhen;
         this.queryTerm = builder.queryTerm;
         this.queryActionOnFound = builder.actionOnFound;
@@ -282,6 +284,11 @@ public class IndexConfiguration {
                 .withDocumentRootKey(openSearchSinkConfig.getDocumentRootKey())
                 .withDistributionVersion(openSearchSinkConfig.getDistributionVersion());
 
+        final AwsAuthenticationConfiguration awsConfig = openSearchSinkConfig.getAwsAuthenticationOptions();
+        if (awsConfig != null && awsConfig.getSemanticEnrichmentConfig() != null) {
+            builder = builder.withSemanticEnrichmentConfig(awsConfig.getSemanticEnrichmentConfig());
+        }
+
 
         final String versionExpression = openSearchSinkConfig.getVersionExpression();
         builder = builder.withVersionExpression(versionExpression);
@@ -329,6 +336,9 @@ public class IndexConfiguration {
         return builder.build();
     }
 
+    public SemanticEnrichmentConfig getSemanticEnrichmentConfig() {
+        return semanticEnrichmentConfig;
+    }
 
     public IndexType getIndexType() {
         return indexType;
@@ -541,6 +551,7 @@ public class IndexConfiguration {
         private Duration queryDuration;
         private boolean queryOnIndexingFailure;
 
+        private SemanticEnrichmentConfig semanticEnrichmentConfig;
         private Integer queryAsyncLimit;
 
         public Builder withIndexAlias(final String indexAlias) {
@@ -779,6 +790,11 @@ public class IndexConfiguration {
 
         public Builder withQueryAsyncLimit(final Integer queryAsyncLimit) {
             this.queryAsyncLimit = queryAsyncLimit;
+            return this;
+        }
+
+        public Builder withSemanticEnrichmentConfig(final SemanticEnrichmentConfig semanticEnrichmentConfig) {
+            this.semanticEnrichmentConfig = semanticEnrichmentConfig;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/OpenSearchEndpointIdentifier.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/OpenSearchEndpointIdentifier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import java.net.URI;
+import java.util.List;
+
+public class OpenSearchEndpointIdentifier {
+
+    private OpenSearchEndpointIdentifier() {
+    }
+
+    public static String extractCollectionId(final List<String> hosts) {
+        final String hostname = getHostname(hosts);
+        return hostname.split("\\.")[0];
+    }
+
+    public static String extractDomainName(final List<String> hosts) {
+        final String hostname = getHostname(hosts);
+        final String prefix = hostname.split("\\.")[0];
+        final String withoutSearchPrefix = prefix.replaceFirst("^(search-|vpc-)", "");
+        final int lastHyphen = withoutSearchPrefix.lastIndexOf('-');
+        if (lastHyphen <= 0) {
+            throw new IllegalArgumentException(
+                    "Unable to extract domain name from host: " + hostname +
+                            ". Please set the 'domain_name' option in semantic_enrichment config.");
+        }
+        return withoutSearchPrefix.substring(0, lastHyphen);
+    }
+
+    static String getHostname(final List<String> hosts) {
+        if (hosts == null || hosts.isEmpty()) {
+            throw new IllegalArgumentException("Hosts list is empty, cannot extract endpoint identifier");
+        }
+        final String hostname = URI.create(hosts.get(0)).getHost();
+        if (hostname == null) {
+            throw new IllegalArgumentException("Unable to parse hostname from: " + hosts.get(0));
+        }
+        return hostname;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
@@ -12,35 +12,14 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 public class SemanticEnrichmentConfig {
-    static final String DEFAULT_LANGUAGE = "english";
 
     @JsonProperty("fields")
-    private List<String> fields;
+    private List<Map<String, SemanticEnrichmentLanguage>> fields;
 
-    @JsonProperty("language")
-    private String language = DEFAULT_LANGUAGE;
-
-    @JsonProperty("collection_name")
-    private String collectionName;
-
-    @JsonProperty("domain_name")
-    private String domainName;
-
-    public List<String> getFields() {
+    public List<Map<String, SemanticEnrichmentLanguage>> getFields() {
         return fields;
-    }
-
-    public String getLanguage() {
-        return language;
-    }
-
-    public String getCollectionName() {
-        return collectionName;
-    }
-
-    public String getDomainName() {
-        return domainName;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SemanticEnrichmentConfig {
+    static final String DEFAULT_LANGUAGE = "english";
+
+    @JsonProperty("fields")
+    private List<String> fields;
+
+    @JsonProperty("language")
+    private String language = DEFAULT_LANGUAGE;
+
+    public List<String> getFields() {
+        return fields;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfig.java
@@ -22,11 +22,25 @@ public class SemanticEnrichmentConfig {
     @JsonProperty("language")
     private String language = DEFAULT_LANGUAGE;
 
+    @JsonProperty("collection_name")
+    private String collectionName;
+
+    @JsonProperty("domain_name")
+    private String domainName;
+
     public List<String> getFields() {
         return fields;
     }
 
     public String getLanguage() {
         return language;
+    }
+
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    public String getDomainName() {
+        return domainName;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
@@ -21,7 +21,6 @@ import software.amazon.awssdk.services.opensearch.OpenSearchClient;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,42 +36,36 @@ public class SemanticEnrichmentIndexCreator {
 
     public SemanticEnrichmentIndexCreator(final AwsCredentialsSupplier awsCredentialsSupplier,
                                           final ConnectionConfiguration connectionConfiguration,
-                                          final SemanticEnrichmentConfig semanticConfig) {
+                                          final String resourceName) {
         final AwsCredentialsOptions awsCredentialsOptions = connectionConfiguration.createAwsCredentialsOptions();
         this.credentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
         this.region = awsCredentialsOptions.getRegion();
         this.serverless = connectionConfiguration.isServerless();
         this.collectionIdOrDomainName = resolveCollectionIdOrDomainName(
-                semanticConfig, connectionConfiguration.getHosts());
+                resourceName, connectionConfiguration.getHosts());
     }
 
-    private String resolveCollectionIdOrDomainName(final SemanticEnrichmentConfig semanticConfig,
-                                                   final List<String> hosts) {
+    private String resolveCollectionIdOrDomainName(final String resourceName, final List<String> hosts) {
+        if (resourceName != null && !resourceName.isEmpty()) {
+            LOG.info("Using configured resource_name: {}", resourceName);
+            return resourceName;
+        }
+
         if (serverless) {
-            if (semanticConfig.getCollectionName() != null && !semanticConfig.getCollectionName().isEmpty()) {
-                LOG.info("Using configured collection_name: {}", semanticConfig.getCollectionName());
-                return semanticConfig.getCollectionName();
-            }
-
-            LOG.info("collection_name not configured, extracting from host URL");
-            return extractCollectionId(hosts);
+            LOG.info("resource_name not configured, extracting collection ID from host URL");
+            return OpenSearchEndpointIdentifier.extractCollectionId(hosts);
         }
 
-        if (semanticConfig.getDomainName() != null && !semanticConfig.getDomainName().isEmpty()) {
-            LOG.info("Using configured domain_name: {}", semanticConfig.getDomainName());
-            return semanticConfig.getDomainName();
-        }
-
-        LOG.info("domain_name not configured, extracting from host URL");
-        return extractDomainName(hosts);
+        LOG.info("resource_name not configured, extracting domain name from host URL");
+        return OpenSearchEndpointIdentifier.extractDomainName(hosts);
     }
 
     public void createIndex(final String indexName, final SemanticEnrichmentConfig semanticConfig) throws IOException {
         if (serverless) {
             createServerlessIndex(indexName, semanticConfig);
-        } else {
-            createManagedDomainIndex(indexName, semanticConfig);
+            return;
         }
+        createManagedDomainIndex(indexName, semanticConfig);
     }
 
     private void createServerlessIndex(final String indexName,
@@ -154,44 +147,18 @@ public class SemanticEnrichmentIndexCreator {
 
     Map<String, Object> buildIndexSchema(final SemanticEnrichmentConfig semanticConfig) {
         final Map<String, Object> properties = new LinkedHashMap<>();
-        for (final String field : semanticConfig.getFields()) {
-            final Map<String, Object> fieldMapping = new LinkedHashMap<>();
-            fieldMapping.put("type", "text");
-            final Map<String, String> semanticEnrichment = new LinkedHashMap<>();
-            semanticEnrichment.put("status", "ENABLED");
-            semanticEnrichment.put("language_options", semanticConfig.getLanguage());
-            fieldMapping.put("semantic_enrichment", semanticEnrichment);
-            properties.put(field, fieldMapping);
+        for (final Map<String, SemanticEnrichmentLanguage> fieldEntry : semanticConfig.getFields()) {
+            for (final Map.Entry<String, SemanticEnrichmentLanguage> entry : fieldEntry.entrySet()) {
+                final Map<String, Object> fieldMapping = new LinkedHashMap<>();
+                fieldMapping.put("type", "text");
+                final Map<String, String> semanticEnrichment = new LinkedHashMap<>();
+                semanticEnrichment.put("status", "ENABLED");
+                semanticEnrichment.put("language_options", entry.getValue().getValue());
+                fieldMapping.put("semantic_enrichment", semanticEnrichment);
+                properties.put(entry.getKey(), fieldMapping);
+            }
         }
         return Map.of("mappings", Map.of("properties", properties));
     }
 
-    static String extractCollectionId(final List<String> hosts) {
-        final String hostname = getHostname(hosts);
-        return hostname.split("\\.")[0];
-    }
-
-    static String extractDomainName(final List<String> hosts) {
-        final String hostname = getHostname(hosts);
-        final String prefix = hostname.split("\\.")[0];
-        final String withoutSearchPrefix = prefix.replaceFirst("^(search-|vpc-)", "");
-        final int lastHyphen = withoutSearchPrefix.lastIndexOf('-');
-        if (lastHyphen <= 0) {
-            throw new IllegalArgumentException(
-                    "Unable to extract domain name from host: " + hostname +
-                            ". Please set the 'domain_name' option in semantic_enrichment config.");
-        }
-        return withoutSearchPrefix.substring(0, lastHyphen);
-    }
-
-    private static String getHostname(final List<String> hosts) {
-        if (hosts == null || hosts.isEmpty()) {
-            throw new IllegalArgumentException("Hosts list is empty, cannot extract endpoint identifier");
-        }
-        final String hostname = URI.create(hosts.get(0)).getHost();
-        if (hostname == null) {
-            throw new IllegalArgumentException("Unable to parse hostname from: " + hosts.get(0));
-        }
-        return hostname;
-    }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
@@ -9,28 +9,19 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
-import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
-import software.amazon.awssdk.http.HttpExecuteRequest;
-import software.amazon.awssdk.http.HttpExecuteResponse;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpResponse;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.opensearch.OpenSearchClient;
+import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,14 +29,6 @@ import java.util.Map;
 public class SemanticEnrichmentIndexCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SemanticEnrichmentIndexCreator.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String AOSS_SERVICE_NAME = "aoss";
-    private static final String ES_SERVICE_NAME = "es";
-    private static final String AOSS_ENDPOINT_FORMAT = "https://aoss.%s.amazonaws.com/";
-    private static final String ES_ENDPOINT_FORMAT = "https://es.%s.amazonaws.com/2021-01-01/opensearch/domain/%s/index";
-    private static final String AOSS_CREATE_INDEX_TARGET = "OpenSearchServerless.CreateIndex";
-    private static final String AOSS_CONTENT_TYPE = "application/x-amz-json-1.0";
-    private static final String ES_CONTENT_TYPE = "application/json";
 
     private final AwsCredentialsProvider credentialsProvider;
     private final Region region;
@@ -53,14 +36,35 @@ public class SemanticEnrichmentIndexCreator {
     private final String collectionIdOrDomainName;
 
     public SemanticEnrichmentIndexCreator(final AwsCredentialsSupplier awsCredentialsSupplier,
-                                          final ConnectionConfiguration connectionConfiguration) {
+                                          final ConnectionConfiguration connectionConfiguration,
+                                          final SemanticEnrichmentConfig semanticConfig) {
         final AwsCredentialsOptions awsCredentialsOptions = connectionConfiguration.createAwsCredentialsOptions();
         this.credentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
         this.region = awsCredentialsOptions.getRegion();
         this.serverless = connectionConfiguration.isServerless();
-        this.collectionIdOrDomainName = serverless
-                ? extractCollectionId(connectionConfiguration.getHosts())
-                : extractDomainName(connectionConfiguration.getHosts());
+        this.collectionIdOrDomainName = resolveCollectionIdOrDomainName(
+                semanticConfig, connectionConfiguration.getHosts());
+    }
+
+    private String resolveCollectionIdOrDomainName(final SemanticEnrichmentConfig semanticConfig,
+                                                   final List<String> hosts) {
+        if (serverless) {
+            if (semanticConfig.getCollectionName() != null && !semanticConfig.getCollectionName().isEmpty()) {
+                LOG.info("Using configured collection_name: {}", semanticConfig.getCollectionName());
+                return semanticConfig.getCollectionName();
+            }
+
+            LOG.info("collection_name not configured, extracting from host URL");
+            return extractCollectionId(hosts);
+        }
+
+        if (semanticConfig.getDomainName() != null && !semanticConfig.getDomainName().isEmpty()) {
+            LOG.info("Using configured domain_name: {}", semanticConfig.getDomainName());
+            return semanticConfig.getDomainName();
+        }
+
+        LOG.info("domain_name not configured, extracting from host URL");
+        return extractDomainName(hosts);
     }
 
     public void createIndex(final String indexName, final SemanticEnrichmentConfig semanticConfig) throws IOException {
@@ -73,87 +77,82 @@ public class SemanticEnrichmentIndexCreator {
 
     private void createServerlessIndex(final String indexName,
                                        final SemanticEnrichmentConfig semanticConfig) throws IOException {
-        LOG.info("Creating index [{}] with semantic enrichment via AOSS control plane for fields {}",
+        LOG.info("Creating serverless index [{}] with semantic enrichment for fields {}",
                 indexName, semanticConfig.getFields());
 
-        final Map<String, Object> body = new LinkedHashMap<>();
-        body.put("id", collectionIdOrDomainName);
-        body.put("indexName", indexName);
-        body.put("indexSchema", buildIndexSchema(semanticConfig));
+        try (final OpenSearchServerlessClient client = OpenSearchServerlessClient.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .build()) {
 
-        final URI endpoint = URI.create(String.format(AOSS_ENDPOINT_FORMAT, region.id()));
-        final SdkHttpFullRequest request = SdkHttpFullRequest.builder()
-                .uri(endpoint)
-                .method(SdkHttpMethod.POST)
-                .putHeader("Content-Type", AOSS_CONTENT_TYPE)
-                .putHeader("X-Amz-Target", AOSS_CREATE_INDEX_TARGET)
-                .contentStreamProvider(() -> toStream(body))
-                .build();
+            client.createIndex(software.amazon.awssdk.services.opensearchserverless.model.CreateIndexRequest.builder()
+                    .id(collectionIdOrDomainName)
+                    .indexName(indexName)
+                    .indexSchema(Document.fromMap(toDocumentMap(buildIndexSchema(semanticConfig))))
+                    .build());
 
-        executeSignedRequest(request, AOSS_SERVICE_NAME, indexName, "AOSS control plane");
+            LOG.info("Successfully created serverless index [{}] with semantic enrichment", indexName);
+
+        } catch (final software.amazon.awssdk.services.opensearchserverless.model.ConflictException e) {
+            LOG.info("Index [{}] already exists, skipping creation", indexName);
+        } catch (final software.amazon.awssdk.core.exception.SdkException e) {
+            throw new IOException(String.format(
+                    "Failed to create index [%s] via serverless control plane: %s", indexName, e.getMessage()), e);
+        }
     }
 
     private void createManagedDomainIndex(final String indexName,
                                           final SemanticEnrichmentConfig semanticConfig) throws IOException {
-        LOG.info("Creating index [{}] with semantic enrichment via OpenSearch Service control plane for fields {}",
+        LOG.info("Creating managed domain index [{}] with semantic enrichment for fields {}",
                 indexName, semanticConfig.getFields());
 
-        final Map<String, Object> body = new LinkedHashMap<>();
-        body.put("IndexName", indexName);
-        body.put("IndexSchema", buildIndexSchema(semanticConfig));
+        try (final OpenSearchClient client = OpenSearchClient.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .build()) {
 
-        final URI endpoint = URI.create(String.format(ES_ENDPOINT_FORMAT, region.id(), collectionIdOrDomainName));
-        final SdkHttpFullRequest request = SdkHttpFullRequest.builder()
-                .uri(endpoint)
-                .method(SdkHttpMethod.POST)
-                .putHeader("Content-Type", ES_CONTENT_TYPE)
-                .contentStreamProvider(() -> toStream(body))
-                .build();
+            client.createIndex(software.amazon.awssdk.services.opensearch.model.CreateIndexRequest.builder()
+                    .domainName(collectionIdOrDomainName)
+                    .indexName(indexName)
+                    .indexSchema(Document.fromMap(toDocumentMap(buildIndexSchema(semanticConfig))))
+                    .build());
 
-        executeSignedRequest(request, ES_SERVICE_NAME, indexName, "OpenSearch Service control plane");
-    }
+            LOG.info("Successfully created managed domain index [{}] with semantic enrichment", indexName);
 
-    private void executeSignedRequest(final SdkHttpFullRequest request,
-                                      final String serviceName,
-                                      final String indexName,
-                                      final String apiDescription) throws IOException {
-        final Aws4Signer signer = Aws4Signer.create();
-        final Aws4SignerParams signerParams = Aws4SignerParams.builder()
-                .awsCredentials(credentialsProvider.resolveCredentials())
-                .signingName(serviceName)
-                .signingRegion(region)
-                .build();
-
-        final SdkHttpFullRequest signedRequest = signer.sign(request, signerParams);
-
-        try (final SdkHttpClient httpClient = ApacheHttpClient.builder().build()) {
-            final HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
-                    .request(signedRequest)
-                    .contentStreamProvider(signedRequest.contentStreamProvider().orElse(null))
-                    .build();
-
-            final HttpExecuteResponse response = httpClient.prepareRequest(executeRequest).call();
-            final SdkHttpResponse httpResponse = response.httpResponse();
-            final int statusCode = httpResponse.statusCode();
-
-            String responseBody = "";
-            if (response.responseBody().isPresent()) {
-                responseBody = new String(response.responseBody().get().readAllBytes(), StandardCharsets.UTF_8);
-            }
-
-            if (statusCode >= 200 && statusCode < 300) {
-                LOG.info("Successfully created index [{}] with semantic enrichment via {}", indexName, apiDescription);
-            } else if (responseBody.contains("ConflictException") || responseBody.contains("ResourceAlreadyExistsException")) {
-                LOG.info("Index [{}] already exists, skipping creation", indexName);
-            } else {
-                throw new IOException(String.format(
-                        "Failed to create index [%s] via %s. Status: %d, Response: %s",
-                        indexName, apiDescription, statusCode, responseBody));
-            }
+        } catch (final software.amazon.awssdk.services.opensearch.model.ResourceAlreadyExistsException e) {
+            LOG.info("Index [{}] already exists, skipping creation", indexName);
+        } catch (final software.amazon.awssdk.services.opensearch.model.ConflictException e) {
+            LOG.info("Index [{}] already exists, skipping creation", indexName);
+        } catch (final software.amazon.awssdk.core.exception.SdkException e) {
+            throw new IOException(String.format(
+                    "Failed to create index [%s] via managed domain control plane: %s", indexName, e.getMessage()), e);
         }
     }
 
-    private Map<String, Object> buildIndexSchema(final SemanticEnrichmentConfig semanticConfig) {
+    @SuppressWarnings("unchecked")
+    private Map<String, Document> toDocumentMap(final Map<String, Object> map) {
+        final Map<String, Document> result = new LinkedHashMap<>();
+        for (final Map.Entry<String, Object> entry : map.entrySet()) {
+            result.put(entry.getKey(), toDocument(entry.getValue()));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Document toDocument(final Object value) {
+        if (value instanceof Map) {
+            return Document.fromMap(toDocumentMap((Map<String, Object>) value));
+        } else if (value instanceof String) {
+            return Document.fromString((String) value);
+        } else if (value instanceof Integer || value instanceof Long || value instanceof Double || value instanceof Float) {
+            return Document.fromNumber(value.toString());
+        } else if (value instanceof Boolean) {
+            return Document.fromBoolean((Boolean) value);
+        }
+        return Document.fromString(String.valueOf(value));
+    }
+
+    Map<String, Object> buildIndexSchema(final SemanticEnrichmentConfig semanticConfig) {
         final Map<String, Object> properties = new LinkedHashMap<>();
         for (final String field : semanticConfig.getFields()) {
             final Map<String, Object> fieldMapping = new LinkedHashMap<>();
@@ -167,40 +166,20 @@ public class SemanticEnrichmentIndexCreator {
         return Map.of("mappings", Map.of("properties", properties));
     }
 
-    private ByteArrayInputStream toStream(final Map<String, Object> body) {
-        try {
-            return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(body));
-        } catch (final IOException e) {
-            throw new RuntimeException("Failed to serialize request body", e);
-        }
-    }
-
     static String extractCollectionId(final List<String> hosts) {
         final String hostname = getHostname(hosts);
-        if (!hostname.contains(".aoss.")) {
-            throw new IllegalArgumentException(
-                    "Host does not appear to be an AOSS endpoint: " + hostname +
-                            ". Semantic enrichment via AOSS control plane requires a serverless collection.");
-        }
         return hostname.split("\\.")[0];
     }
 
     static String extractDomainName(final List<String> hosts) {
         final String hostname = getHostname(hosts);
-        // Managed domain format: search-{domain-name}-{random}.{region}.es.amazonaws.com
-        // or vpc-{domain-name}-{random}.{region}.es.amazonaws.com
-        if (!hostname.contains(".es.amazonaws.com")) {
-            throw new IllegalArgumentException(
-                    "Host does not appear to be a managed OpenSearch domain: " + hostname +
-                            ". Expected format: search-{domain}-{id}.{region}.es.amazonaws.com");
-        }
-        final String prefix = hostname.split("\\.")[0]; // e.g., search-my-domain-abc123
+        final String prefix = hostname.split("\\.")[0];
         final String withoutSearchPrefix = prefix.replaceFirst("^(search-|vpc-)", "");
-        // Remove the trailing random ID: last hyphen-separated segment
         final int lastHyphen = withoutSearchPrefix.lastIndexOf('-');
         if (lastHyphen <= 0) {
             throw new IllegalArgumentException(
-                    "Unable to extract domain name from host: " + hostname);
+                    "Unable to extract domain name from host: " + hostname +
+                            ". Please set the 'domain_name' option in semantic_enrichment config.");
         }
         return withoutSearchPrefix.substring(0, lastHyphen);
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
@@ -90,7 +90,7 @@ public class SemanticEnrichmentIndexCreator {
             LOG.info("Index [{}] already exists, skipping creation", indexName);
         } catch (final software.amazon.awssdk.core.exception.SdkException e) {
             throw new IOException(String.format(
-                    "Failed to create index [%s] via serverless control plane: %s", indexName, e.getMessage()), e);
+                    "Failed to create index [%s] via Amazon OpenSearch Serverless APIs: %s", indexName, e.getMessage()), e);
         }
     }
 
@@ -118,7 +118,7 @@ public class SemanticEnrichmentIndexCreator {
             LOG.info("Index [{}] already exists, skipping creation", indexName);
         } catch (final software.amazon.awssdk.core.exception.SdkException e) {
             throw new IOException(String.format(
-                    "Failed to create index [%s] via managed domain control plane: %s", indexName, e.getMessage()), e);
+                    "Failed to create index [%s] via Amazon OpenSearch Service APIs: %s", indexName, e.getMessage()), e);
         }
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SemanticEnrichmentIndexCreator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SemanticEnrichmentIndexCreator.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String AOSS_SERVICE_NAME = "aoss";
+    private static final String ES_SERVICE_NAME = "es";
+    private static final String AOSS_ENDPOINT_FORMAT = "https://aoss.%s.amazonaws.com/";
+    private static final String ES_ENDPOINT_FORMAT = "https://es.%s.amazonaws.com/2021-01-01/opensearch/domain/%s/index";
+    private static final String AOSS_CREATE_INDEX_TARGET = "OpenSearchServerless.CreateIndex";
+    private static final String AOSS_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String ES_CONTENT_TYPE = "application/json";
+
+    private final AwsCredentialsProvider credentialsProvider;
+    private final Region region;
+    private final boolean serverless;
+    private final String collectionIdOrDomainName;
+
+    public SemanticEnrichmentIndexCreator(final AwsCredentialsSupplier awsCredentialsSupplier,
+                                          final ConnectionConfiguration connectionConfiguration) {
+        final AwsCredentialsOptions awsCredentialsOptions = connectionConfiguration.createAwsCredentialsOptions();
+        this.credentialsProvider = awsCredentialsSupplier.getProvider(awsCredentialsOptions);
+        this.region = awsCredentialsOptions.getRegion();
+        this.serverless = connectionConfiguration.isServerless();
+        this.collectionIdOrDomainName = serverless
+                ? extractCollectionId(connectionConfiguration.getHosts())
+                : extractDomainName(connectionConfiguration.getHosts());
+    }
+
+    public void createIndex(final String indexName, final SemanticEnrichmentConfig semanticConfig) throws IOException {
+        if (serverless) {
+            createServerlessIndex(indexName, semanticConfig);
+        } else {
+            createManagedDomainIndex(indexName, semanticConfig);
+        }
+    }
+
+    private void createServerlessIndex(final String indexName,
+                                       final SemanticEnrichmentConfig semanticConfig) throws IOException {
+        LOG.info("Creating index [{}] with semantic enrichment via AOSS control plane for fields {}",
+                indexName, semanticConfig.getFields());
+
+        final Map<String, Object> body = new LinkedHashMap<>();
+        body.put("id", collectionIdOrDomainName);
+        body.put("indexName", indexName);
+        body.put("indexSchema", buildIndexSchema(semanticConfig));
+
+        final URI endpoint = URI.create(String.format(AOSS_ENDPOINT_FORMAT, region.id()));
+        final SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                .uri(endpoint)
+                .method(SdkHttpMethod.POST)
+                .putHeader("Content-Type", AOSS_CONTENT_TYPE)
+                .putHeader("X-Amz-Target", AOSS_CREATE_INDEX_TARGET)
+                .contentStreamProvider(() -> toStream(body))
+                .build();
+
+        executeSignedRequest(request, AOSS_SERVICE_NAME, indexName, "AOSS control plane");
+    }
+
+    private void createManagedDomainIndex(final String indexName,
+                                          final SemanticEnrichmentConfig semanticConfig) throws IOException {
+        LOG.info("Creating index [{}] with semantic enrichment via OpenSearch Service control plane for fields {}",
+                indexName, semanticConfig.getFields());
+
+        final Map<String, Object> body = new LinkedHashMap<>();
+        body.put("IndexName", indexName);
+        body.put("IndexSchema", buildIndexSchema(semanticConfig));
+
+        final URI endpoint = URI.create(String.format(ES_ENDPOINT_FORMAT, region.id(), collectionIdOrDomainName));
+        final SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                .uri(endpoint)
+                .method(SdkHttpMethod.POST)
+                .putHeader("Content-Type", ES_CONTENT_TYPE)
+                .contentStreamProvider(() -> toStream(body))
+                .build();
+
+        executeSignedRequest(request, ES_SERVICE_NAME, indexName, "OpenSearch Service control plane");
+    }
+
+    private void executeSignedRequest(final SdkHttpFullRequest request,
+                                      final String serviceName,
+                                      final String indexName,
+                                      final String apiDescription) throws IOException {
+        final Aws4Signer signer = Aws4Signer.create();
+        final Aws4SignerParams signerParams = Aws4SignerParams.builder()
+                .awsCredentials(credentialsProvider.resolveCredentials())
+                .signingName(serviceName)
+                .signingRegion(region)
+                .build();
+
+        final SdkHttpFullRequest signedRequest = signer.sign(request, signerParams);
+
+        try (final SdkHttpClient httpClient = ApacheHttpClient.builder().build()) {
+            final HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
+                    .request(signedRequest)
+                    .contentStreamProvider(signedRequest.contentStreamProvider().orElse(null))
+                    .build();
+
+            final HttpExecuteResponse response = httpClient.prepareRequest(executeRequest).call();
+            final SdkHttpResponse httpResponse = response.httpResponse();
+            final int statusCode = httpResponse.statusCode();
+
+            String responseBody = "";
+            if (response.responseBody().isPresent()) {
+                responseBody = new String(response.responseBody().get().readAllBytes(), StandardCharsets.UTF_8);
+            }
+
+            if (statusCode >= 200 && statusCode < 300) {
+                LOG.info("Successfully created index [{}] with semantic enrichment via {}", indexName, apiDescription);
+            } else if (responseBody.contains("ConflictException") || responseBody.contains("ResourceAlreadyExistsException")) {
+                LOG.info("Index [{}] already exists, skipping creation", indexName);
+            } else {
+                throw new IOException(String.format(
+                        "Failed to create index [%s] via %s. Status: %d, Response: %s",
+                        indexName, apiDescription, statusCode, responseBody));
+            }
+        }
+    }
+
+    private Map<String, Object> buildIndexSchema(final SemanticEnrichmentConfig semanticConfig) {
+        final Map<String, Object> properties = new LinkedHashMap<>();
+        for (final String field : semanticConfig.getFields()) {
+            final Map<String, Object> fieldMapping = new LinkedHashMap<>();
+            fieldMapping.put("type", "text");
+            final Map<String, String> semanticEnrichment = new LinkedHashMap<>();
+            semanticEnrichment.put("status", "ENABLED");
+            semanticEnrichment.put("language_options", semanticConfig.getLanguage());
+            fieldMapping.put("semantic_enrichment", semanticEnrichment);
+            properties.put(field, fieldMapping);
+        }
+        return Map.of("mappings", Map.of("properties", properties));
+    }
+
+    private ByteArrayInputStream toStream(final Map<String, Object> body) {
+        try {
+            return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(body));
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to serialize request body", e);
+        }
+    }
+
+    static String extractCollectionId(final List<String> hosts) {
+        final String hostname = getHostname(hosts);
+        if (!hostname.contains(".aoss.")) {
+            throw new IllegalArgumentException(
+                    "Host does not appear to be an AOSS endpoint: " + hostname +
+                            ". Semantic enrichment via AOSS control plane requires a serverless collection.");
+        }
+        return hostname.split("\\.")[0];
+    }
+
+    static String extractDomainName(final List<String> hosts) {
+        final String hostname = getHostname(hosts);
+        // Managed domain format: search-{domain-name}-{random}.{region}.es.amazonaws.com
+        // or vpc-{domain-name}-{random}.{region}.es.amazonaws.com
+        if (!hostname.contains(".es.amazonaws.com")) {
+            throw new IllegalArgumentException(
+                    "Host does not appear to be a managed OpenSearch domain: " + hostname +
+                            ". Expected format: search-{domain}-{id}.{region}.es.amazonaws.com");
+        }
+        final String prefix = hostname.split("\\.")[0]; // e.g., search-my-domain-abc123
+        final String withoutSearchPrefix = prefix.replaceFirst("^(search-|vpc-)", "");
+        // Remove the trailing random ID: last hyphen-separated segment
+        final int lastHyphen = withoutSearchPrefix.lastIndexOf('-');
+        if (lastHyphen <= 0) {
+            throw new IllegalArgumentException(
+                    "Unable to extract domain name from host: " + hostname);
+        }
+        return withoutSearchPrefix.substring(0, lastHyphen);
+    }
+
+    private static String getHostname(final List<String> hosts) {
+        if (hosts == null || hosts.isEmpty()) {
+            throw new IllegalArgumentException("Hosts list is empty, cannot extract endpoint identifier");
+        }
+        final String hostname = URI.create(hosts.get(0)).getHost();
+        if (hostname == null) {
+            throw new IllegalArgumentException("Unable to parse hostname from: " + hosts.get(0));
+        }
+        return hostname;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreator.java
@@ -147,16 +147,14 @@ public class SemanticEnrichmentIndexCreator {
 
     Map<String, Object> buildIndexSchema(final SemanticEnrichmentConfig semanticConfig) {
         final Map<String, Object> properties = new LinkedHashMap<>();
-        for (final Map<String, SemanticEnrichmentLanguage> fieldEntry : semanticConfig.getFields()) {
-            for (final Map.Entry<String, SemanticEnrichmentLanguage> entry : fieldEntry.entrySet()) {
-                final Map<String, Object> fieldMapping = new LinkedHashMap<>();
-                fieldMapping.put("type", "text");
-                final Map<String, String> semanticEnrichment = new LinkedHashMap<>();
-                semanticEnrichment.put("status", "ENABLED");
-                semanticEnrichment.put("language_options", entry.getValue().getValue());
-                fieldMapping.put("semantic_enrichment", semanticEnrichment);
-                properties.put(entry.getKey(), fieldMapping);
-            }
+        for (final SemanticFieldMapping fieldMapping : semanticConfig.getFields()) {
+            final Map<String, Object> fieldProps = new LinkedHashMap<>();
+            fieldProps.put("type", "text");
+            final Map<String, String> semanticEnrichment = new LinkedHashMap<>();
+            semanticEnrichment.put("status", "ENABLED");
+            semanticEnrichment.put("language_options", fieldMapping.getLanguage().getValue());
+            fieldProps.put("semantic_enrichment", semanticEnrichment);
+            properties.put(fieldMapping.getName(), fieldProps);
         }
         return Map.of("mappings", Map.of("properties", properties));
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
@@ -36,7 +36,7 @@ public class SemanticEnrichmentIndexManager {
         }
 
         if (!connectionConfiguration.isAwsSigv4()) {
-            LOG.warn("Semantic enrichment is only supported with AWS OpenSearch. Skipping index creation.");
+            LOG.warn("Semantic enrichment is only supported with Amazon OpenSearchService. Skipping index creation.");
             return;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class SemanticEnrichmentIndexManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SemanticEnrichmentIndexManager.class);
+
+    private final AwsCredentialsSupplier awsCredentialsSupplier;
+
+    public SemanticEnrichmentIndexManager(final AwsCredentialsSupplier awsCredentialsSupplier) {
+        this.awsCredentialsSupplier = awsCredentialsSupplier;
+    }
+
+    public void maybeCreateIndex(final ConnectionConfiguration connectionConfiguration,
+                                 final SemanticEnrichmentConfig semanticConfig,
+                                 final String indexAlias) throws IOException {
+        if (semanticConfig == null || semanticConfig.getFields() == null
+                || semanticConfig.getFields().isEmpty()) {
+            return;
+        }
+
+        if (!connectionConfiguration.isAwsSigv4()) {
+            LOG.warn("Semantic enrichment is only supported with AWS OpenSearch. Skipping index creation.");
+            return;
+        }
+
+        final SemanticEnrichmentIndexCreator indexCreator = new SemanticEnrichmentIndexCreator(
+                awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+        indexCreator.createIndex(indexAlias, semanticConfig);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
@@ -36,7 +36,7 @@ public class SemanticEnrichmentIndexManager {
         }
 
         if (!connectionConfiguration.isAwsSigv4()) {
-            LOG.warn("Semantic enrichment is only supported with Amazon OpenSearchService. Skipping index creation.");
+            LOG.warn("Semantic enrichment is only supported with Amazon OpenSearch Service. Skipping index creation.");
             return;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexManager.java
@@ -28,6 +28,7 @@ public class SemanticEnrichmentIndexManager {
 
     public void maybeCreateIndex(final ConnectionConfiguration connectionConfiguration,
                                  final SemanticEnrichmentConfig semanticConfig,
+                                 final String resourceName,
                                  final String indexAlias) throws IOException {
         if (semanticConfig == null || semanticConfig.getFields() == null
                 || semanticConfig.getFields().isEmpty()) {
@@ -40,7 +41,7 @@ public class SemanticEnrichmentIndexManager {
         }
 
         final SemanticEnrichmentIndexCreator indexCreator = new SemanticEnrichmentIndexCreator(
-                awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+                awsCredentialsSupplier, connectionConfiguration, resourceName);
         indexCreator.createIndex(indexAlias, semanticConfig);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentLanguage.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentLanguage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum SemanticEnrichmentLanguage {
+    ENGLISH("english"),
+    MULTILINGUAL("multilingual");
+
+    private final String value;
+
+    SemanticEnrichmentLanguage(final String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static SemanticEnrichmentLanguage fromValue(final String value) {
+        return Arrays.stream(values())
+                .filter(lang -> lang.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Invalid semantic enrichment language: " + value + ". Valid values are: english, multilingual"));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticFieldMapping.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticFieldMapping.java
@@ -11,14 +11,19 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.List;
+public class SemanticFieldMapping {
 
-public class SemanticEnrichmentConfig {
+    @JsonProperty("name")
+    private String name;
 
-    @JsonProperty("fields")
-    private List<SemanticFieldMapping> fields;
+    @JsonProperty("language")
+    private SemanticEnrichmentLanguage language;
 
-    public List<SemanticFieldMapping> getFields() {
-        return fields;
+    public String getName() {
+        return name;
+    }
+
+    public SemanticEnrichmentLanguage getLanguage() {
+        return language;
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/OpenSearchEndpointIdentifierTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/OpenSearchEndpointIdentifierTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OpenSearchEndpointIdentifierTest {
+
+    @Nested
+    class ExtractCollectionIdTests {
+
+        @Test
+        void test_extractCollectionId_returnsFirstSegmentOfHostname() {
+            final String collectionId = "fh1ves1t1dbd0n9i51nh";
+            final List<String> hosts = List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com");
+
+            final String result = OpenSearchEndpointIdentifier.extractCollectionId(hosts);
+
+            assertThat(result, equalTo(collectionId));
+        }
+
+        @Test
+        void test_extractCollectionId_randomId_returnsFirstSegment() {
+            final String collectionId = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
+            final List<String> hosts = List.of("https://" + collectionId + ".eu-west-1.aoss.amazonaws.com");
+
+            final String result = OpenSearchEndpointIdentifier.extractCollectionId(hosts);
+
+            assertThat(result, equalTo(collectionId));
+        }
+
+        @Test
+        void test_extractCollectionId_multipleHosts_usesFirstHost() {
+            final String collectionId = "abc123def456ghi789jk";
+            final List<String> hosts = List.of(
+                    "https://" + collectionId + ".us-east-1.aoss.amazonaws.com",
+                    "https://other12345678901234.us-east-1.aoss.amazonaws.com"
+            );
+
+            final String result = OpenSearchEndpointIdentifier.extractCollectionId(hosts);
+
+            assertThat(result, equalTo(collectionId));
+        }
+
+        @Test
+        void test_extractCollectionId_nullHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractCollectionId(null));
+        }
+
+        @Test
+        void test_extractCollectionId_emptyHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractCollectionId(Collections.emptyList()));
+        }
+
+        @Test
+        void test_extractCollectionId_unparsableHost_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractCollectionId(List.of("not-a-valid-uri")));
+        }
+    }
+
+    @Nested
+    class ExtractDomainNameTests {
+
+        @ParameterizedTest
+        @CsvSource({
+                "search-mydomain-abc123def.us-west-2.es.amazonaws.com, mydomain",
+                "search-my-domain-abc123def.us-west-2.es.amazonaws.com, my-domain",
+                "search-my-cool-domain-abc123def.us-west-2.es.amazonaws.com, my-cool-domain",
+                "vpc-mydomain-abc123def.us-west-2.es.amazonaws.com, mydomain",
+                "vpc-my-domain-abc123def.us-west-2.es.amazonaws.com, my-domain",
+                "vpc-multi-hyphen-domain-name-xyz789.eu-west-1.es.amazonaws.com, multi-hyphen-domain-name"
+        })
+        void test_extractDomainName_validHost_returnsDomainName(final String hostname, final String expectedDomain) {
+            final List<String> hosts = List.of("https://" + hostname);
+
+            final String result = OpenSearchEndpointIdentifier.extractDomainName(hosts);
+
+            assertThat(result, equalTo(expectedDomain));
+        }
+
+        @Test
+        void test_extractDomainName_multipleHosts_usesFirstHost() {
+            final List<String> hosts = List.of(
+                    "https://search-firstdomain-abc123.us-west-2.es.amazonaws.com",
+                    "https://search-seconddomain-def456.us-west-2.es.amazonaws.com"
+            );
+
+            final String result = OpenSearchEndpointIdentifier.extractDomainName(hosts);
+
+            assertThat(result, equalTo("firstdomain"));
+        }
+
+        @Test
+        void test_extractDomainName_nullHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractDomainName(null));
+        }
+
+        @Test
+        void test_extractDomainName_emptyHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractDomainName(Collections.emptyList()));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "https://search-x.us-west-2.es.amazonaws.com",
+                "https://vpc-x.us-west-2.es.amazonaws.com"
+        })
+        void test_extractDomainName_noHyphenAfterPrefixStrip_throwsIllegalArgumentException(final String host) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractDomainName(List.of(host)));
+        }
+
+        @Test
+        void test_extractDomainName_noPrefixNoHyphen_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.extractDomainName(
+                            List.of("https://singlesegment.us-west-2.es.amazonaws.com")));
+        }
+    }
+
+    @Nested
+    class GetHostnameTests {
+
+        @Test
+        void test_getHostname_validUrl_returnsHostname() {
+            final String expected = "myhost.us-west-2.aoss.amazonaws.com";
+            final List<String> hosts = List.of("https://" + expected);
+
+            final String result = OpenSearchEndpointIdentifier.getHostname(hosts);
+
+            assertThat(result, equalTo(expected));
+        }
+
+        @Test
+        void test_getHostname_urlWithPort_returnsHostnameWithoutPort() {
+            final String expected = "myhost.us-west-2.es.amazonaws.com";
+            final List<String> hosts = List.of("https://" + expected + ":443");
+
+            final String result = OpenSearchEndpointIdentifier.getHostname(hosts);
+
+            assertThat(result, equalTo(expected));
+        }
+
+        @Test
+        void test_getHostname_urlWithPath_returnsHostname() {
+            final String expected = "myhost.us-west-2.es.amazonaws.com";
+            final List<String> hosts = List.of("https://" + expected + "/some/path");
+
+            final String result = OpenSearchEndpointIdentifier.getHostname(hosts);
+
+            assertThat(result, equalTo(expected));
+        }
+
+        @Test
+        void test_getHostname_nullHosts_throwsIllegalArgumentException() {
+            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.getHostname(null));
+
+            assertThat(exception.getMessage(), equalTo("Hosts list is empty, cannot extract endpoint identifier"));
+        }
+
+        @Test
+        void test_getHostname_emptyHosts_throwsIllegalArgumentException() {
+            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.getHostname(Collections.emptyList()));
+
+            assertThat(exception.getMessage(), equalTo("Hosts list is empty, cannot extract endpoint identifier"));
+        }
+
+        @Test
+        void test_getHostname_unparsableHostname_throwsIllegalArgumentException() {
+            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> OpenSearchEndpointIdentifier.getHostname(List.of("not-a-valid-uri")));
+
+            assertThat(exception.getMessage(), equalTo("Unable to parse hostname from: not-a-valid-uri"));
+        }
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/OpenSearchEndpointIdentifierTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/OpenSearchEndpointIdentifierTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class SemanticEnrichmentConfigTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void testDeserialize_withFieldsAndLanguage_success() throws Exception {
+        final String field1 = UUID.randomUUID().toString();
+        final String field2 = UUID.randomUUID().toString();
+        final String language = UUID.randomUUID().toString();
+        final String json = String.format(
+                "{\"fields\":[\"%s\",\"%s\"],\"language\":\"%s\"}", field1, field2, language);
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getFields(), notNullValue());
+        assertThat(config.getFields().size(), equalTo(2));
+        assertThat(config.getFields().get(0), equalTo(field1));
+        assertThat(config.getFields().get(1), equalTo(field2));
+        assertThat(config.getLanguage(), equalTo(language));
+    }
+
+    @Test
+    void testDeserialize_withFieldsOnly_usesDefaultLanguage() throws Exception {
+        final String field = UUID.randomUUID().toString();
+        final String json = String.format("{\"fields\":[\"%s\"]}", field);
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getFields(), notNullValue());
+        assertThat(config.getFields().size(), equalTo(1));
+        assertThat(config.getFields().get(0), equalTo(field));
+        assertThat(config.getLanguage(), equalTo(SemanticEnrichmentConfig.DEFAULT_LANGUAGE));
+    }
+
+    @Test
+    void testDeserialize_withEmptyFields_success() throws Exception {
+        final String json = "{\"fields\":[]}";
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getFields(), notNullValue());
+        assertThat(config.getFields().size(), equalTo(0));
+        assertThat(config.getLanguage(), equalTo(SemanticEnrichmentConfig.DEFAULT_LANGUAGE));
+    }
+
+    @Test
+    void testDeserialize_withNoFields_returnsNull() throws Exception {
+        final String json = "{}";
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getFields(), nullValue());
+        assertThat(config.getLanguage(), equalTo(SemanticEnrichmentConfig.DEFAULT_LANGUAGE));
+    }
+
+    @Test
+    void testDefaultLanguage_isEnglish() {
+        assertThat(SemanticEnrichmentConfig.DEFAULT_LANGUAGE, equalTo("english"));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
@@ -1,10 +1,6 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
@@ -77,5 +73,43 @@ class SemanticEnrichmentConfigTest {
     @Test
     void testDefaultLanguage_isEnglish() {
         assertThat(SemanticEnrichmentConfig.DEFAULT_LANGUAGE, equalTo("english"));
+    }
+
+    @Test
+    void testDeserialize_withDomainName_success() throws Exception {
+        final String domainName = UUID.randomUUID().toString();
+        final String json = String.format("{\"fields\":[\"text\"],\"domain_name\":\"%s\"}", domainName);
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getDomainName(), equalTo(domainName));
+    }
+
+    @Test
+    void testDeserialize_withoutDomainName_returnsNull() throws Exception {
+        final String json = "{\"fields\":[\"text\"]}";
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getDomainName(), nullValue());
+    }
+
+    @Test
+    void testDeserialize_withCollectionName_success() throws Exception {
+        final String collectionName = UUID.randomUUID().toString();
+        final String json = String.format("{\"fields\":[\"text\"],\"collection_name\":\"%s\"}", collectionName);
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getCollectionName(), equalTo(collectionName));
+    }
+
+    @Test
+    void testDeserialize_withoutCollectionName_returnsNull() throws Exception {
+        final String json = "{\"fields\":[\"text\"]}";
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        assertThat(config.getCollectionName(), nullValue());
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,33 +22,30 @@ class SemanticEnrichmentConfigTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
-    void testDeserialize_withFieldsAndLanguage_success() throws Exception {
+    void testDeserialize_withFieldsAndMixedLanguages_success() throws Exception {
         final String field1 = UUID.randomUUID().toString();
         final String field2 = UUID.randomUUID().toString();
-        final String language = UUID.randomUUID().toString();
         final String json = String.format(
-                "{\"fields\":[\"%s\",\"%s\"],\"language\":\"%s\"}", field1, field2, language);
+                "{\"fields\":[{\"%s\":\"english\"},{\"%s\":\"multilingual\"}]}", field1, field2);
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
         assertThat(config.getFields(), notNullValue());
         assertThat(config.getFields().size(), equalTo(2));
-        assertThat(config.getFields().get(0), equalTo(field1));
-        assertThat(config.getFields().get(1), equalTo(field2));
-        assertThat(config.getLanguage(), equalTo(language));
+        assertThat(config.getFields().get(0).get(field1), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+        assertThat(config.getFields().get(1).get(field2), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
     }
 
     @Test
-    void testDeserialize_withFieldsOnly_usesDefaultLanguage() throws Exception {
+    void testDeserialize_withSingleField_success() throws Exception {
         final String field = UUID.randomUUID().toString();
-        final String json = String.format("{\"fields\":[\"%s\"]}", field);
+        final String json = String.format("{\"fields\":[{\"%s\":\"english\"}]}", field);
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
         assertThat(config.getFields(), notNullValue());
         assertThat(config.getFields().size(), equalTo(1));
-        assertThat(config.getFields().get(0), equalTo(field));
-        assertThat(config.getLanguage(), equalTo(SemanticEnrichmentConfig.DEFAULT_LANGUAGE));
+        assertThat(config.getFields().get(0).get(field), equalTo(SemanticEnrichmentLanguage.ENGLISH));
     }
 
     @Test
@@ -57,7 +56,6 @@ class SemanticEnrichmentConfigTest {
 
         assertThat(config.getFields(), notNullValue());
         assertThat(config.getFields().size(), equalTo(0));
-        assertThat(config.getLanguage(), equalTo(SemanticEnrichmentConfig.DEFAULT_LANGUAGE));
     }
 
     @Test
@@ -67,49 +65,34 @@ class SemanticEnrichmentConfigTest {
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
         assertThat(config.getFields(), nullValue());
-        assertThat(config.getLanguage(), equalTo(SemanticEnrichmentConfig.DEFAULT_LANGUAGE));
     }
 
     @Test
-    void testDefaultLanguage_isEnglish() {
-        assertThat(SemanticEnrichmentConfig.DEFAULT_LANGUAGE, equalTo("english"));
-    }
-
-    @Test
-    void testDeserialize_withDomainName_success() throws Exception {
-        final String domainName = UUID.randomUUID().toString();
-        final String json = String.format("{\"fields\":[\"text\"],\"domain_name\":\"%s\"}", domainName);
+    void testDeserialize_multipleFieldsInSingleMap_success() throws Exception {
+        final String field1 = UUID.randomUUID().toString();
+        final String field2 = UUID.randomUUID().toString();
+        final String json = String.format(
+                "{\"fields\":[{\"%s\":\"english\",\"%s\":\"multilingual\"}]}", field1, field2);
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
-        assertThat(config.getDomainName(), equalTo(domainName));
+        assertThat(config.getFields(), notNullValue());
+        assertThat(config.getFields().size(), equalTo(1));
+        final Map<String, SemanticEnrichmentLanguage> entry = config.getFields().get(0);
+        assertThat(entry.get(field1), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+        assertThat(entry.get(field2), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
     }
 
     @Test
-    void testDeserialize_withoutDomainName_returnsNull() throws Exception {
-        final String json = "{\"fields\":[\"text\"]}";
+    void testGetFields_returnsCorrectType() throws Exception {
+        final String json = "{\"fields\":[{\"title\":\"english\"},{\"body\":\"multilingual\"}]}";
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
-        assertThat(config.getDomainName(), nullValue());
-    }
-
-    @Test
-    void testDeserialize_withCollectionName_success() throws Exception {
-        final String collectionName = UUID.randomUUID().toString();
-        final String json = String.format("{\"fields\":[\"text\"],\"collection_name\":\"%s\"}", collectionName);
-
-        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
-
-        assertThat(config.getCollectionName(), equalTo(collectionName));
-    }
-
-    @Test
-    void testDeserialize_withoutCollectionName_returnsNull() throws Exception {
-        final String json = "{\"fields\":[\"text\"]}";
-
-        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
-
-        assertThat(config.getCollectionName(), nullValue());
+        final List<Map<String, SemanticEnrichmentLanguage>> fields = config.getFields();
+        assertThat(fields, notNullValue());
+        assertThat(fields.size(), equalTo(2));
+        assertThat(fields.get(0).get("title"), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+        assertThat(fields.get(1).get("body"), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentConfigTest.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,30 +21,34 @@ class SemanticEnrichmentConfigTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
-    void testDeserialize_withFieldsAndMixedLanguages_success() throws Exception {
+    void testDeserialize_withMultipleFields_success() throws Exception {
         final String field1 = UUID.randomUUID().toString();
         final String field2 = UUID.randomUUID().toString();
         final String json = String.format(
-                "{\"fields\":[{\"%s\":\"english\"},{\"%s\":\"multilingual\"}]}", field1, field2);
+                "{\"fields\":[{\"name\":\"%s\",\"language\":\"english\"},{\"name\":\"%s\",\"language\":\"multilingual\"}]}",
+                field1, field2);
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
         assertThat(config.getFields(), notNullValue());
         assertThat(config.getFields().size(), equalTo(2));
-        assertThat(config.getFields().get(0).get(field1), equalTo(SemanticEnrichmentLanguage.ENGLISH));
-        assertThat(config.getFields().get(1).get(field2), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+        assertThat(config.getFields().get(0).getName(), equalTo(field1));
+        assertThat(config.getFields().get(0).getLanguage(), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+        assertThat(config.getFields().get(1).getName(), equalTo(field2));
+        assertThat(config.getFields().get(1).getLanguage(), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
     }
 
     @Test
     void testDeserialize_withSingleField_success() throws Exception {
         final String field = UUID.randomUUID().toString();
-        final String json = String.format("{\"fields\":[{\"%s\":\"english\"}]}", field);
+        final String json = String.format("{\"fields\":[{\"name\":\"%s\",\"language\":\"english\"}]}", field);
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
         assertThat(config.getFields(), notNullValue());
         assertThat(config.getFields().size(), equalTo(1));
-        assertThat(config.getFields().get(0).get(field), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+        assertThat(config.getFields().get(0).getName(), equalTo(field));
+        assertThat(config.getFields().get(0).getLanguage(), equalTo(SemanticEnrichmentLanguage.ENGLISH));
     }
 
     @Test
@@ -68,31 +71,36 @@ class SemanticEnrichmentConfigTest {
     }
 
     @Test
-    void testDeserialize_multipleFieldsInSingleMap_success() throws Exception {
-        final String field1 = UUID.randomUUID().toString();
-        final String field2 = UUID.randomUUID().toString();
-        final String json = String.format(
-                "{\"fields\":[{\"%s\":\"english\",\"%s\":\"multilingual\"}]}", field1, field2);
+    void testDeserialize_withMixedLanguages_success() throws Exception {
+        final String json = "{\"fields\":["
+                + "{\"name\":\"title\",\"language\":\"english\"},"
+                + "{\"name\":\"body\",\"language\":\"multilingual\"},"
+                + "{\"name\":\"summary\",\"language\":\"english\"}"
+                + "]}";
+
+        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
+
+        final List<SemanticFieldMapping> fields = config.getFields();
+        assertThat(fields, notNullValue());
+        assertThat(fields.size(), equalTo(3));
+        assertThat(fields.get(0).getName(), equalTo("title"));
+        assertThat(fields.get(0).getLanguage(), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+        assertThat(fields.get(1).getName(), equalTo("body"));
+        assertThat(fields.get(1).getLanguage(), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+        assertThat(fields.get(2).getName(), equalTo("summary"));
+        assertThat(fields.get(2).getLanguage(), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+    }
+
+    @Test
+    void testDeserialize_fieldWithoutLanguage_languageIsNull() throws Exception {
+        final String name = UUID.randomUUID().toString();
+        final String json = String.format("{\"fields\":[{\"name\":\"%s\"}]}", name);
 
         final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
 
         assertThat(config.getFields(), notNullValue());
         assertThat(config.getFields().size(), equalTo(1));
-        final Map<String, SemanticEnrichmentLanguage> entry = config.getFields().get(0);
-        assertThat(entry.get(field1), equalTo(SemanticEnrichmentLanguage.ENGLISH));
-        assertThat(entry.get(field2), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
-    }
-
-    @Test
-    void testGetFields_returnsCorrectType() throws Exception {
-        final String json = "{\"fields\":[{\"title\":\"english\"},{\"body\":\"multilingual\"}]}";
-
-        final SemanticEnrichmentConfig config = OBJECT_MAPPER.readValue(json, SemanticEnrichmentConfig.class);
-
-        final List<Map<String, SemanticEnrichmentLanguage>> fields = config.getFields();
-        assertThat(fields, notNullValue());
-        assertThat(fields.size(), equalTo(2));
-        assertThat(fields.get(0).get("title"), equalTo(SemanticEnrichmentLanguage.ENGLISH));
-        assertThat(fields.get(1).get("body"), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+        assertThat(config.getFields().get(0).getName(), equalTo(name));
+        assertThat(config.getFields().get(0).getLanguage(), nullValue());
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
@@ -8,17 +8,13 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -27,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,226 +35,92 @@ class SemanticEnrichmentIndexCreatorTest {
     @Mock
     private ConnectionConfiguration connectionConfiguration;
 
-    @Mock
-    private AwsCredentialsProvider awsCredentialsProvider;
-
-    @Nested
-    class ExtractCollectionIdTests {
-
-        @Test
-        void extractCollectionId_returnsFirstSegmentOfHostname() {
-            final String collectionId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
-            final List<String> hosts = List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com");
-
-            final String result = SemanticEnrichmentIndexCreator.extractCollectionId(hosts);
-
-            assertThat(result, equalTo(collectionId));
-        }
-
-        @Test
-        void extractCollectionId_multipleHosts_usesFirstHost() {
-            final String collectionId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
-            final List<String> hosts = List.of(
-                    "https://" + collectionId + ".us-east-1.aoss.amazonaws.com",
-                    "https://other.us-east-1.aoss.amazonaws.com"
-            );
-
-            final String result = SemanticEnrichmentIndexCreator.extractCollectionId(hosts);
-
-            assertThat(result, equalTo(collectionId));
-        }
-
-        @Test
-        void extractCollectionId_nullHosts_throwsIllegalArgumentException() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(null));
-        }
-
-        @Test
-        void extractCollectionId_emptyHosts_throwsIllegalArgumentException() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(Collections.emptyList()));
-        }
-    }
-
-    @Nested
-    class ExtractDomainNameTests {
-
-        @Test
-        void extractDomainName_validSearchPrefix_returnsDomainName() {
-            final List<String> hosts = List.of("https://search-mydomain-abc123def.us-west-2.es.amazonaws.com");
-
-            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
-
-            assertThat(result, equalTo("mydomain"));
-        }
-
-        @Test
-        void extractDomainName_validVpcPrefix_returnsDomainName() {
-            final List<String> hosts = List.of("https://vpc-mydomain-abc123def.us-west-2.es.amazonaws.com");
-
-            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
-
-            assertThat(result, equalTo("mydomain"));
-        }
-
-        @Test
-        void extractDomainName_domainWithHyphens_returnsDomainName() {
-            final List<String> hosts = List.of("https://search-my-cool-domain-abc123def.us-west-2.es.amazonaws.com");
-
-            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
-
-            assertThat(result, equalTo("my-cool-domain"));
-        }
-
-        @Test
-        void extractDomainName_multipleHosts_usesFirstHost() {
-            final List<String> hosts = List.of(
-                    "https://search-firstdomain-abc123.us-west-2.es.amazonaws.com",
-                    "https://search-seconddomain-def456.us-west-2.es.amazonaws.com"
-            );
-
-            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
-
-            assertThat(result, equalTo("firstdomain"));
-        }
-
-        @Test
-        void extractDomainName_nullHosts_throwsIllegalArgumentException() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractDomainName(null));
-        }
-
-        @Test
-        void extractDomainName_emptyHosts_throwsIllegalArgumentException() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractDomainName(Collections.emptyList()));
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {
-                "https://search-x.us-west-2.es.amazonaws.com",
-                "https://vpc-x.us-west-2.es.amazonaws.com"
-        })
-        void extractDomainName_noHyphenInDomainPart_throwsIllegalArgumentException(final String host) {
-            final List<String> hosts = List.of(host);
-
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractDomainName(hosts));
-        }
-    }
-
     @Nested
     class ConstructorTests {
 
         @Test
-        void constructor_serverlessTrue_extractsCollectionId() {
+        void test_constructor_serverless_usesProvidedResourceName() {
+            final String resourceName = UUID.randomUUID().toString();
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_WEST_2)
+                    .build();
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(connectionConfiguration.isServerless()).thenReturn(true);
+            when(connectionConfiguration.getHosts()).thenReturn(List.of("https://dummy.us-west-2.aoss.amazonaws.com"));
+
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, resourceName);
+
+            assertThat(creator, notNullValue());
+        }
+
+        @Test
+        void test_constructor_serverless_extractsFromHost_whenResourceNameNull() {
             final String collectionId = "abc123def456";
+            final List<String> hosts = List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com");
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_WEST_2)
                     .build();
-            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
             when(connectionConfiguration.isServerless()).thenReturn(true);
-            when(connectionConfiguration.getHosts()).thenReturn(
-                    List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com"));
+            when(connectionConfiguration.getHosts()).thenReturn(hosts);
 
             final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, null);
 
             assertThat(creator, notNullValue());
         }
 
         @Test
-        void constructor_serverless_usesConfiguredCollectionName() {
-            final String collectionName = UUID.randomUUID().toString();
+        void test_constructor_serverless_extractsFromHost_whenResourceNameEmpty() {
+            final String collectionId = "abc123def456";
+            final List<String> hosts = List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com");
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_WEST_2)
                     .build();
-            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
-            when(semanticConfig.getCollectionName()).thenReturn(collectionName);
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
             when(connectionConfiguration.isServerless()).thenReturn(true);
+            when(connectionConfiguration.getHosts()).thenReturn(hosts);
 
             final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, "");
 
             assertThat(creator, notNullValue());
         }
 
         @Test
-        void constructor_serverless_fallsBackToHostnameExtraction_whenCollectionNameEmpty() {
-            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
-                    .withRegion(Region.US_WEST_2)
-                    .build();
-            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
-            when(semanticConfig.getCollectionName()).thenReturn("");
-
-            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-            when(connectionConfiguration.isServerless()).thenReturn(true);
-            when(connectionConfiguration.getHosts()).thenReturn(
-                    List.of("https://abc123def456.us-west-2.aoss.amazonaws.com"));
-
-            final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
-
-            assertThat(creator, notNullValue());
-        }
-
-        @Test
-        void constructor_managedDomain_usesConfiguredDomainName() {
-            final String domainName = UUID.randomUUID().toString();
+        void test_constructor_managedDomain_usesProvidedResourceName() {
+            final String resourceName = UUID.randomUUID().toString();
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_EAST_1)
                     .build();
-            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
-            when(semanticConfig.getDomainName()).thenReturn(domainName);
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
             when(connectionConfiguration.isServerless()).thenReturn(false);
+            when(connectionConfiguration.getHosts()).thenReturn(List.of("https://search-test-abc.us-east-1.es.amazonaws.com"));
 
             final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, resourceName);
 
             assertThat(creator, notNullValue());
         }
 
         @Test
-        void constructor_managedDomain_fallsBackToHostnameExtraction_whenDomainNameNotConfigured() {
+        void test_constructor_managedDomain_extractsFromHost_whenResourceNameNull() {
+            final List<String> hosts = List.of("https://search-mydomain-abc123.us-east-1.es.amazonaws.com");
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_EAST_1)
                     .build();
-            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
-            when(semanticConfig.getDomainName()).thenReturn(null);
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
             when(connectionConfiguration.isServerless()).thenReturn(false);
-            when(connectionConfiguration.getHosts()).thenReturn(
-                    List.of("https://search-mydomain-abc123.us-east-1.es.amazonaws.com"));
+            when(connectionConfiguration.getHosts()).thenReturn(hosts);
 
             final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
-
-            assertThat(creator, notNullValue());
-        }
-
-        @Test
-        void constructor_managedDomain_fallsBackToHostnameExtraction_whenDomainNameEmpty() {
-            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
-                    .withRegion(Region.US_WEST_2)
-                    .build();
-            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
-            when(semanticConfig.getDomainName()).thenReturn("");
-
-            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-            when(connectionConfiguration.isServerless()).thenReturn(false);
-            when(connectionConfiguration.getHosts()).thenReturn(
-                    List.of("https://search-testdomain-abc123.us-west-2.es.amazonaws.com"));
-
-            final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, null);
 
             assertThat(creator, notNullValue());
         }
@@ -269,11 +130,10 @@ class SemanticEnrichmentIndexCreatorTest {
     class BuildIndexSchemaTests {
 
         @Test
-        void buildIndexSchema_singleField_createsCorrectMapping() {
+        void test_buildIndexSchema_singleField_english_createsCorrectMapping() {
             final String fieldName = UUID.randomUUID().toString();
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
-            when(config.getFields()).thenReturn(List.of(fieldName));
-            when(config.getLanguage()).thenReturn("english");
+            when(config.getFields()).thenReturn(List.of(Map.of(fieldName, SemanticEnrichmentLanguage.ENGLISH)));
 
             final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
@@ -295,30 +155,10 @@ class SemanticEnrichmentIndexCreatorTest {
         }
 
         @Test
-        void buildIndexSchema_multipleFields_createsAllMappings() {
-            final String field1 = UUID.randomUUID().toString();
-            final String field2 = UUID.randomUUID().toString();
-            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
-            when(config.getFields()).thenReturn(List.of(field1, field2));
-            when(config.getLanguage()).thenReturn("english");
-
-            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
-
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
-            assertThat(properties, hasKey(field1));
-            assertThat(properties, hasKey(field2));
-        }
-
-        @Test
-        void buildIndexSchema_customLanguage_usesCustomLanguage() {
+        void test_buildIndexSchema_singleField_multilingual_createsCorrectMapping() {
             final String fieldName = UUID.randomUUID().toString();
-            final String language = UUID.randomUUID().toString();
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
-            when(config.getFields()).thenReturn(List.of(fieldName));
-            when(config.getLanguage()).thenReturn(language);
+            when(config.getFields()).thenReturn(List.of(Map.of(fieldName, SemanticEnrichmentLanguage.MULTILINGUAL)));
 
             final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
@@ -330,21 +170,50 @@ class SemanticEnrichmentIndexCreatorTest {
             final Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
             @SuppressWarnings("unchecked")
             final Map<String, String> semanticEnrichment = (Map<String, String>) fieldMapping.get("semantic_enrichment");
-            assertThat(semanticEnrichment.get("language_options"), equalTo(language));
+            assertThat(semanticEnrichment.get("language_options"), equalTo("multilingual"));
+        }
+
+        @Test
+        void test_buildIndexSchema_multipleFields_differentLanguages_createsAllMappings() {
+            final String field1 = UUID.randomUUID().toString();
+            final String field2 = UUID.randomUUID().toString();
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(
+                    Map.of(field1, SemanticEnrichmentLanguage.ENGLISH),
+                    Map.of(field2, SemanticEnrichmentLanguage.MULTILINGUAL)));
+
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            assertThat(properties, hasKey(field1));
+            assertThat(properties, hasKey(field2));
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> field1Mapping = (Map<String, Object>) properties.get(field1);
+            @SuppressWarnings("unchecked")
+            final Map<String, String> field1Enrichment = (Map<String, String>) field1Mapping.get("semantic_enrichment");
+            assertThat(field1Enrichment.get("language_options"), equalTo("english"));
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> field2Mapping = (Map<String, Object>) properties.get(field2);
+            @SuppressWarnings("unchecked")
+            final Map<String, String> field2Enrichment = (Map<String, String>) field2Mapping.get("semantic_enrichment");
+            assertThat(field2Enrichment.get("language_options"), equalTo("multilingual"));
         }
     }
-
 
     private SemanticEnrichmentIndexCreator createDefaultCreator() {
         final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                 .withRegion(Region.US_WEST_2)
                 .build();
-        final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
-        when(semanticConfig.getDomainName()).thenReturn("testdomain");
 
         when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
         when(connectionConfiguration.isServerless()).thenReturn(false);
+        when(connectionConfiguration.getHosts()).thenReturn(List.of("https://search-testdomain-abc123.us-west-2.es.amazonaws.com"));
 
-        return new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+        return new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, "testdomain");
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SemanticEnrichmentIndexCreatorTest {
+
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
+    @Mock
+    private ConnectionConfiguration connectionConfiguration;
+
+    @Mock
+    private AwsCredentialsProvider awsCredentialsProvider;
+
+    @Nested
+    class ExtractCollectionIdTests {
+
+        @Test
+        void extractCollectionId_validAossEndpoint_returnsCollectionId() {
+            final String collectionId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+            final List<String> hosts = List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com");
+
+            final String result = SemanticEnrichmentIndexCreator.extractCollectionId(hosts);
+
+            assertThat(result, equalTo(collectionId));
+        }
+
+        @Test
+        void extractCollectionId_multipleHosts_usesFirstHost() {
+            final String collectionId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+            final List<String> hosts = List.of(
+                    "https://" + collectionId + ".us-east-1.aoss.amazonaws.com",
+                    "https://other.us-east-1.aoss.amazonaws.com"
+            );
+
+            final String result = SemanticEnrichmentIndexCreator.extractCollectionId(hosts);
+
+            assertThat(result, equalTo(collectionId));
+        }
+
+        @Test
+        void extractCollectionId_nonAossEndpoint_throwsIllegalArgumentException() {
+            final List<String> hosts = List.of("https://search-mydomain-abc123.us-west-2.es.amazonaws.com");
+
+            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(hosts));
+
+            assertThat(exception.getMessage(), notNullValue());
+        }
+
+        @Test
+        void extractCollectionId_nullHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(null));
+        }
+
+        @Test
+        void extractCollectionId_emptyHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(Collections.emptyList()));
+        }
+
+        @Test
+        void extractCollectionId_invalidUri_throwsException() {
+            final List<String> hosts = List.of("not-a-valid-uri");
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(hosts));
+        }
+    }
+
+    @Nested
+    class ExtractDomainNameTests {
+
+        @Test
+        void extractDomainName_validSearchPrefix_returnsDomainName() {
+            final List<String> hosts = List.of("https://search-mydomain-abc123def.us-west-2.es.amazonaws.com");
+
+            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
+
+            assertThat(result, equalTo("mydomain"));
+        }
+
+        @Test
+        void extractDomainName_validVpcPrefix_returnsDomainName() {
+            final List<String> hosts = List.of("https://vpc-mydomain-abc123def.us-west-2.es.amazonaws.com");
+
+            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
+
+            assertThat(result, equalTo("mydomain"));
+        }
+
+        @Test
+        void extractDomainName_domainWithHyphens_returnsDomainName() {
+            final List<String> hosts = List.of("https://search-my-cool-domain-abc123def.us-west-2.es.amazonaws.com");
+
+            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
+
+            assertThat(result, equalTo("my-cool-domain"));
+        }
+
+        @Test
+        void extractDomainName_multipleHosts_usesFirstHost() {
+            final List<String> hosts = List.of(
+                    "https://search-firstdomain-abc123.us-west-2.es.amazonaws.com",
+                    "https://search-seconddomain-def456.us-west-2.es.amazonaws.com"
+            );
+
+            final String result = SemanticEnrichmentIndexCreator.extractDomainName(hosts);
+
+            assertThat(result, equalTo("firstdomain"));
+        }
+
+        @Test
+        void extractDomainName_nonEsEndpoint_throwsIllegalArgumentException() {
+            final List<String> hosts = List.of("https://abc123.us-west-2.aoss.amazonaws.com");
+
+            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractDomainName(hosts));
+
+            assertThat(exception.getMessage(), notNullValue());
+        }
+
+        @Test
+        void extractDomainName_nullHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractDomainName(null));
+        }
+
+        @Test
+        void extractDomainName_emptyHosts_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractDomainName(Collections.emptyList()));
+        }
+
+        @Test
+        void extractDomainName_invalidUri_throwsException() {
+            final List<String> hosts = List.of("not-a-valid-uri");
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractDomainName(hosts));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "https://search-x.us-west-2.es.amazonaws.com",
+                "https://vpc-x.us-west-2.es.amazonaws.com"
+        })
+        void extractDomainName_noHyphenInDomainPart_throwsIllegalArgumentException(final String host) {
+            final List<String> hosts = List.of(host);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> SemanticEnrichmentIndexCreator.extractDomainName(hosts));
+        }
+    }
+
+    @Nested
+    class ConstructorTests {
+
+        @Test
+        void constructor_serverlessTrue_extractsCollectionId() {
+            final String collectionId = "abc123def456";
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_WEST_2)
+                    .build();
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
+            when(connectionConfiguration.isServerless()).thenReturn(true);
+            when(connectionConfiguration.getHosts()).thenReturn(
+                    List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com"));
+
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration);
+
+            assertThat(creator, notNullValue());
+        }
+
+        @Test
+        void constructor_serverlessFalse_extractsDomainName() {
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_EAST_1)
+                    .build();
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
+            when(connectionConfiguration.isServerless()).thenReturn(false);
+            when(connectionConfiguration.getHosts()).thenReturn(
+                    List.of("https://search-mydomain-abc123.us-east-1.es.amazonaws.com"));
+
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration);
+
+            assertThat(creator, notNullValue());
+        }
+
+        @Test
+        void constructor_serverlessWithInvalidHost_throwsException() {
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_WEST_2)
+                    .build();
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
+            when(connectionConfiguration.isServerless()).thenReturn(true);
+            when(connectionConfiguration.getHosts()).thenReturn(
+                    List.of("https://search-mydomain-abc123.us-west-2.es.amazonaws.com"));
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration));
+        }
+
+        @Test
+        void constructor_managedWithInvalidHost_throwsException() {
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_WEST_2)
+                    .build();
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
+            when(connectionConfiguration.isServerless()).thenReturn(false);
+            when(connectionConfiguration.getHosts()).thenReturn(
+                    List.of("https://abc123.us-west-2.aoss.amazonaws.com"));
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration));
+        }
+    }
+
+    @Nested
+    class BuildIndexSchemaTests {
+
+        @Test
+        void buildIndexSchema_singleField_createsCorrectMapping() throws Exception {
+            final String fieldName = UUID.randomUUID().toString();
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(fieldName));
+            when(config.getLanguage()).thenReturn("english");
+
+            final Map<String, Object> result = invokeBuildIndexSchema(config);
+
+            assertThat(result, hasKey("mappings"));
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            assertThat(mappings, hasKey("properties"));
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            assertThat(properties, hasKey(fieldName));
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
+            assertThat(fieldMapping.get("type"), equalTo("text"));
+            assertThat(fieldMapping, hasKey("semantic_enrichment"));
+            @SuppressWarnings("unchecked")
+            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldMapping.get("semantic_enrichment");
+            assertThat(semanticEnrichment.get("status"), equalTo("ENABLED"));
+            assertThat(semanticEnrichment.get("language_options"), equalTo("english"));
+        }
+
+        @Test
+        void buildIndexSchema_multipleFields_createsAllMappings() throws Exception {
+            final String field1 = UUID.randomUUID().toString();
+            final String field2 = UUID.randomUUID().toString();
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(field1, field2));
+            when(config.getLanguage()).thenReturn("english");
+
+            final Map<String, Object> result = invokeBuildIndexSchema(config);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            assertThat(properties, hasKey(field1));
+            assertThat(properties, hasKey(field2));
+        }
+
+        @Test
+        void buildIndexSchema_customLanguage_usesCustomLanguage() throws Exception {
+            final String fieldName = UUID.randomUUID().toString();
+            final String language = UUID.randomUUID().toString();
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(fieldName));
+            when(config.getLanguage()).thenReturn(language);
+
+            final Map<String, Object> result = invokeBuildIndexSchema(config);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
+            @SuppressWarnings("unchecked")
+            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldMapping.get("semantic_enrichment");
+            assertThat(semanticEnrichment.get("language_options"), equalTo(language));
+        }
+
+        @SuppressWarnings("unchecked")
+        private Map<String, Object> invokeBuildIndexSchema(final SemanticEnrichmentConfig config) throws Exception {
+            final Method method = SemanticEnrichmentIndexCreator.class
+                    .getDeclaredMethod("buildIndexSchema", SemanticEnrichmentConfig.class);
+            method.setAccessible(true);
+            try {
+                return (Map<String, Object>) method.invoke(createDefaultCreator(), config);
+            } catch (final InvocationTargetException e) {
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+                throw e;
+            }
+        }
+    }
+
+    @Nested
+    class ToStreamTests {
+
+        @Test
+        void toStream_validBody_producesValidJson() throws Exception {
+            final Method method = SemanticEnrichmentIndexCreator.class
+                    .getDeclaredMethod("toStream", Map.class);
+            method.setAccessible(true);
+
+            final Map<String, Object> body = Map.of("key", "value", "number", 42);
+
+            final java.io.ByteArrayInputStream stream =
+                    (java.io.ByteArrayInputStream) method.invoke(createDefaultCreator(), body);
+
+            final String json = new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            assertThat(json, notNullValue());
+
+            final com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> parsed = mapper.readValue(json, Map.class);
+            assertThat(parsed.get("key"), equalTo("value"));
+            assertThat(parsed.get("number"), equalTo(42));
+        }
+    }
+
+    private SemanticEnrichmentIndexCreator createDefaultCreator() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_WEST_2)
+                .build();
+
+        when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+        when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
+        when(connectionConfiguration.isServerless()).thenReturn(false);
+        when(connectionConfiguration.getHosts()).thenReturn(
+                List.of("https://search-testdomain-abc123.us-west-2.es.amazonaws.com"));
+
+        return new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
@@ -132,8 +132,9 @@ class SemanticEnrichmentIndexCreatorTest {
         @Test
         void test_buildIndexSchema_singleField_english_createsCorrectMapping() {
             final String fieldName = UUID.randomUUID().toString();
+            final SemanticFieldMapping fieldMapping = createMockFieldMapping(fieldName, SemanticEnrichmentLanguage.ENGLISH);
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
-            when(config.getFields()).thenReturn(List.of(Map.of(fieldName, SemanticEnrichmentLanguage.ENGLISH)));
+            when(config.getFields()).thenReturn(List.of(fieldMapping));
 
             final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
@@ -145,11 +146,11 @@ class SemanticEnrichmentIndexCreatorTest {
             final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
             assertThat(properties, hasKey(fieldName));
             @SuppressWarnings("unchecked")
-            final Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
-            assertThat(fieldMapping.get("type"), equalTo("text"));
-            assertThat(fieldMapping, hasKey("semantic_enrichment"));
+            final Map<String, Object> fieldProps = (Map<String, Object>) properties.get(fieldName);
+            assertThat(fieldProps.get("type"), equalTo("text"));
+            assertThat(fieldProps, hasKey("semantic_enrichment"));
             @SuppressWarnings("unchecked")
-            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldMapping.get("semantic_enrichment");
+            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldProps.get("semantic_enrichment");
             assertThat(semanticEnrichment.get("status"), equalTo("ENABLED"));
             assertThat(semanticEnrichment.get("language_options"), equalTo("english"));
         }
@@ -157,8 +158,9 @@ class SemanticEnrichmentIndexCreatorTest {
         @Test
         void test_buildIndexSchema_singleField_multilingual_createsCorrectMapping() {
             final String fieldName = UUID.randomUUID().toString();
+            final SemanticFieldMapping fieldMapping = createMockFieldMapping(fieldName, SemanticEnrichmentLanguage.MULTILINGUAL);
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
-            when(config.getFields()).thenReturn(List.of(Map.of(fieldName, SemanticEnrichmentLanguage.MULTILINGUAL)));
+            when(config.getFields()).thenReturn(List.of(fieldMapping));
 
             final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
@@ -167,9 +169,9 @@ class SemanticEnrichmentIndexCreatorTest {
             @SuppressWarnings("unchecked")
             final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
             @SuppressWarnings("unchecked")
-            final Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
+            final Map<String, Object> fieldProps = (Map<String, Object>) properties.get(fieldName);
             @SuppressWarnings("unchecked")
-            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldMapping.get("semantic_enrichment");
+            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldProps.get("semantic_enrichment");
             assertThat(semanticEnrichment.get("language_options"), equalTo("multilingual"));
         }
 
@@ -177,10 +179,10 @@ class SemanticEnrichmentIndexCreatorTest {
         void test_buildIndexSchema_multipleFields_differentLanguages_createsAllMappings() {
             final String field1 = UUID.randomUUID().toString();
             final String field2 = UUID.randomUUID().toString();
+            final SemanticFieldMapping mapping1 = createMockFieldMapping(field1, SemanticEnrichmentLanguage.ENGLISH);
+            final SemanticFieldMapping mapping2 = createMockFieldMapping(field2, SemanticEnrichmentLanguage.MULTILINGUAL);
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
-            when(config.getFields()).thenReturn(List.of(
-                    Map.of(field1, SemanticEnrichmentLanguage.ENGLISH),
-                    Map.of(field2, SemanticEnrichmentLanguage.MULTILINGUAL)));
+            when(config.getFields()).thenReturn(List.of(mapping1, mapping2));
 
             final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
@@ -192,17 +194,85 @@ class SemanticEnrichmentIndexCreatorTest {
             assertThat(properties, hasKey(field2));
 
             @SuppressWarnings("unchecked")
-            final Map<String, Object> field1Mapping = (Map<String, Object>) properties.get(field1);
+            final Map<String, Object> field1Props = (Map<String, Object>) properties.get(field1);
             @SuppressWarnings("unchecked")
-            final Map<String, String> field1Enrichment = (Map<String, String>) field1Mapping.get("semantic_enrichment");
+            final Map<String, String> field1Enrichment = (Map<String, String>) field1Props.get("semantic_enrichment");
             assertThat(field1Enrichment.get("language_options"), equalTo("english"));
 
             @SuppressWarnings("unchecked")
-            final Map<String, Object> field2Mapping = (Map<String, Object>) properties.get(field2);
+            final Map<String, Object> field2Props = (Map<String, Object>) properties.get(field2);
             @SuppressWarnings("unchecked")
-            final Map<String, String> field2Enrichment = (Map<String, String>) field2Mapping.get("semantic_enrichment");
+            final Map<String, String> field2Enrichment = (Map<String, String>) field2Props.get("semantic_enrichment");
             assertThat(field2Enrichment.get("language_options"), equalTo("multilingual"));
         }
+
+        @Test
+        void test_buildIndexSchema_allFieldsSameLanguage_createsCorrectMappings() {
+            final String field1 = UUID.randomUUID().toString();
+            final String field2 = UUID.randomUUID().toString();
+            final String field3 = UUID.randomUUID().toString();
+            final SemanticFieldMapping mapping1 = createMockFieldMapping(field1, SemanticEnrichmentLanguage.ENGLISH);
+            final SemanticFieldMapping mapping2 = createMockFieldMapping(field2, SemanticEnrichmentLanguage.ENGLISH);
+            final SemanticFieldMapping mapping3 = createMockFieldMapping(field3, SemanticEnrichmentLanguage.ENGLISH);
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(mapping1, mapping2, mapping3));
+
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            assertThat(properties.size(), equalTo(3));
+            assertThat(properties, hasKey(field1));
+            assertThat(properties, hasKey(field2));
+            assertThat(properties, hasKey(field3));
+        }
+
+        @Test
+        void test_buildIndexSchema_fieldMapping_hasTypeText() {
+            final String fieldName = UUID.randomUUID().toString();
+            final SemanticFieldMapping fieldMapping = createMockFieldMapping(fieldName, SemanticEnrichmentLanguage.ENGLISH);
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(fieldMapping));
+
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> fieldProps = (Map<String, Object>) properties.get(fieldName);
+            assertThat(fieldProps.get("type"), equalTo("text"));
+        }
+
+        @Test
+        void test_buildIndexSchema_semanticEnrichment_hasStatusEnabled() {
+            final String fieldName = UUID.randomUUID().toString();
+            final SemanticFieldMapping fieldMapping = createMockFieldMapping(fieldName, SemanticEnrichmentLanguage.MULTILINGUAL);
+            final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
+            when(config.getFields()).thenReturn(List.of(fieldMapping));
+
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> fieldProps = (Map<String, Object>) properties.get(fieldName);
+            @SuppressWarnings("unchecked")
+            final Map<String, String> semanticEnrichment = (Map<String, String>) fieldProps.get("semantic_enrichment");
+            assertThat(semanticEnrichment.get("status"), equalTo("ENABLED"));
+        }
+    }
+
+    private SemanticFieldMapping createMockFieldMapping(final String name, final SemanticEnrichmentLanguage language) {
+        final SemanticFieldMapping fieldMapping = mock(SemanticFieldMapping.class);
+        when(fieldMapping.getName()).thenReturn(name);
+        when(fieldMapping.getLanguage()).thenReturn(language);
+        return fieldMapping;
     }
 
     private SemanticEnrichmentIndexCreator createDefaultCreator() {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
@@ -1,10 +1,6 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
@@ -22,8 +18,6 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguratio
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +47,7 @@ class SemanticEnrichmentIndexCreatorTest {
     class ExtractCollectionIdTests {
 
         @Test
-        void extractCollectionId_validAossEndpoint_returnsCollectionId() {
+        void extractCollectionId_returnsFirstSegmentOfHostname() {
             final String collectionId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
             final List<String> hosts = List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com");
 
@@ -76,16 +70,6 @@ class SemanticEnrichmentIndexCreatorTest {
         }
 
         @Test
-        void extractCollectionId_nonAossEndpoint_throwsIllegalArgumentException() {
-            final List<String> hosts = List.of("https://search-mydomain-abc123.us-west-2.es.amazonaws.com");
-
-            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(hosts));
-
-            assertThat(exception.getMessage(), notNullValue());
-        }
-
-        @Test
         void extractCollectionId_nullHosts_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class,
                     () -> SemanticEnrichmentIndexCreator.extractCollectionId(null));
@@ -95,14 +79,6 @@ class SemanticEnrichmentIndexCreatorTest {
         void extractCollectionId_emptyHosts_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class,
                     () -> SemanticEnrichmentIndexCreator.extractCollectionId(Collections.emptyList()));
-        }
-
-        @Test
-        void extractCollectionId_invalidUri_throwsException() {
-            final List<String> hosts = List.of("not-a-valid-uri");
-
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractCollectionId(hosts));
         }
     }
 
@@ -149,16 +125,6 @@ class SemanticEnrichmentIndexCreatorTest {
         }
 
         @Test
-        void extractDomainName_nonEsEndpoint_throwsIllegalArgumentException() {
-            final List<String> hosts = List.of("https://abc123.us-west-2.aoss.amazonaws.com");
-
-            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractDomainName(hosts));
-
-            assertThat(exception.getMessage(), notNullValue());
-        }
-
-        @Test
         void extractDomainName_nullHosts_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class,
                     () -> SemanticEnrichmentIndexCreator.extractDomainName(null));
@@ -168,14 +134,6 @@ class SemanticEnrichmentIndexCreatorTest {
         void extractDomainName_emptyHosts_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class,
                     () -> SemanticEnrichmentIndexCreator.extractDomainName(Collections.emptyList()));
-        }
-
-        @Test
-        void extractDomainName_invalidUri_throwsException() {
-            final List<String> hosts = List.of("not-a-valid-uri");
-
-            assertThrows(IllegalArgumentException.class,
-                    () -> SemanticEnrichmentIndexCreator.extractDomainName(hosts));
         }
 
         @ParameterizedTest
@@ -200,67 +158,110 @@ class SemanticEnrichmentIndexCreatorTest {
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_WEST_2)
                     .build();
+            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
             when(connectionConfiguration.isServerless()).thenReturn(true);
             when(connectionConfiguration.getHosts()).thenReturn(
                     List.of("https://" + collectionId + ".us-west-2.aoss.amazonaws.com"));
 
             final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration);
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
 
             assertThat(creator, notNullValue());
         }
 
         @Test
-        void constructor_serverlessFalse_extractsDomainName() {
+        void constructor_serverless_usesConfiguredCollectionName() {
+            final String collectionName = UUID.randomUUID().toString();
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_WEST_2)
+                    .build();
+            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
+            when(semanticConfig.getCollectionName()).thenReturn(collectionName);
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(connectionConfiguration.isServerless()).thenReturn(true);
+
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+
+            assertThat(creator, notNullValue());
+        }
+
+        @Test
+        void constructor_serverless_fallsBackToHostnameExtraction_whenCollectionNameEmpty() {
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_WEST_2)
+                    .build();
+            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
+            when(semanticConfig.getCollectionName()).thenReturn("");
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
+            when(connectionConfiguration.isServerless()).thenReturn(true);
+            when(connectionConfiguration.getHosts()).thenReturn(
+                    List.of("https://abc123def456.us-west-2.aoss.amazonaws.com"));
+
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+
+            assertThat(creator, notNullValue());
+        }
+
+        @Test
+        void constructor_managedDomain_usesConfiguredDomainName() {
+            final String domainName = UUID.randomUUID().toString();
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_EAST_1)
                     .build();
+            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
+            when(semanticConfig.getDomainName()).thenReturn(domainName);
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
+            when(connectionConfiguration.isServerless()).thenReturn(false);
+
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+
+            assertThat(creator, notNullValue());
+        }
+
+        @Test
+        void constructor_managedDomain_fallsBackToHostnameExtraction_whenDomainNameNotConfigured() {
+            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                    .withRegion(Region.US_EAST_1)
+                    .build();
+            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
+            when(semanticConfig.getDomainName()).thenReturn(null);
+
+            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
             when(connectionConfiguration.isServerless()).thenReturn(false);
             when(connectionConfiguration.getHosts()).thenReturn(
                     List.of("https://search-mydomain-abc123.us-east-1.es.amazonaws.com"));
 
             final SemanticEnrichmentIndexCreator creator =
-                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration);
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
 
             assertThat(creator, notNullValue());
         }
 
         @Test
-        void constructor_serverlessWithInvalidHost_throwsException() {
+        void constructor_managedDomain_fallsBackToHostnameExtraction_whenDomainNameEmpty() {
             final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                     .withRegion(Region.US_WEST_2)
                     .build();
+            final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
+            when(semanticConfig.getDomainName()).thenReturn("");
 
             when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
-            when(connectionConfiguration.isServerless()).thenReturn(true);
-            when(connectionConfiguration.getHosts()).thenReturn(
-                    List.of("https://search-mydomain-abc123.us-west-2.es.amazonaws.com"));
-
-            assertThrows(IllegalArgumentException.class,
-                    () -> new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration));
-        }
-
-        @Test
-        void constructor_managedWithInvalidHost_throwsException() {
-            final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
-                    .withRegion(Region.US_WEST_2)
-                    .build();
-
-            when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-            when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
             when(connectionConfiguration.isServerless()).thenReturn(false);
             when(connectionConfiguration.getHosts()).thenReturn(
-                    List.of("https://abc123.us-west-2.aoss.amazonaws.com"));
+                    List.of("https://search-testdomain-abc123.us-west-2.es.amazonaws.com"));
 
-            assertThrows(IllegalArgumentException.class,
-                    () -> new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration));
+            final SemanticEnrichmentIndexCreator creator =
+                    new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
+
+            assertThat(creator, notNullValue());
         }
     }
 
@@ -268,13 +269,13 @@ class SemanticEnrichmentIndexCreatorTest {
     class BuildIndexSchemaTests {
 
         @Test
-        void buildIndexSchema_singleField_createsCorrectMapping() throws Exception {
+        void buildIndexSchema_singleField_createsCorrectMapping() {
             final String fieldName = UUID.randomUUID().toString();
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
             when(config.getFields()).thenReturn(List.of(fieldName));
             when(config.getLanguage()).thenReturn("english");
 
-            final Map<String, Object> result = invokeBuildIndexSchema(config);
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
             assertThat(result, hasKey("mappings"));
             @SuppressWarnings("unchecked")
@@ -294,14 +295,14 @@ class SemanticEnrichmentIndexCreatorTest {
         }
 
         @Test
-        void buildIndexSchema_multipleFields_createsAllMappings() throws Exception {
+        void buildIndexSchema_multipleFields_createsAllMappings() {
             final String field1 = UUID.randomUUID().toString();
             final String field2 = UUID.randomUUID().toString();
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
             when(config.getFields()).thenReturn(List.of(field1, field2));
             when(config.getLanguage()).thenReturn("english");
 
-            final Map<String, Object> result = invokeBuildIndexSchema(config);
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
             @SuppressWarnings("unchecked")
             final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
@@ -312,14 +313,14 @@ class SemanticEnrichmentIndexCreatorTest {
         }
 
         @Test
-        void buildIndexSchema_customLanguage_usesCustomLanguage() throws Exception {
+        void buildIndexSchema_customLanguage_usesCustomLanguage() {
             final String fieldName = UUID.randomUUID().toString();
             final String language = UUID.randomUUID().toString();
             final SemanticEnrichmentConfig config = mock(SemanticEnrichmentConfig.class);
             when(config.getFields()).thenReturn(List.of(fieldName));
             when(config.getLanguage()).thenReturn(language);
 
-            final Map<String, Object> result = invokeBuildIndexSchema(config);
+            final Map<String, Object> result = createDefaultCreator().buildIndexSchema(config);
 
             @SuppressWarnings("unchecked")
             final Map<String, Object> mappings = (Map<String, Object>) result.get("mappings");
@@ -331,59 +332,19 @@ class SemanticEnrichmentIndexCreatorTest {
             final Map<String, String> semanticEnrichment = (Map<String, String>) fieldMapping.get("semantic_enrichment");
             assertThat(semanticEnrichment.get("language_options"), equalTo(language));
         }
-
-        @SuppressWarnings("unchecked")
-        private Map<String, Object> invokeBuildIndexSchema(final SemanticEnrichmentConfig config) throws Exception {
-            final Method method = SemanticEnrichmentIndexCreator.class
-                    .getDeclaredMethod("buildIndexSchema", SemanticEnrichmentConfig.class);
-            method.setAccessible(true);
-            try {
-                return (Map<String, Object>) method.invoke(createDefaultCreator(), config);
-            } catch (final InvocationTargetException e) {
-                if (e.getCause() instanceof RuntimeException) {
-                    throw (RuntimeException) e.getCause();
-                }
-                throw e;
-            }
-        }
     }
 
-    @Nested
-    class ToStreamTests {
-
-        @Test
-        void toStream_validBody_producesValidJson() throws Exception {
-            final Method method = SemanticEnrichmentIndexCreator.class
-                    .getDeclaredMethod("toStream", Map.class);
-            method.setAccessible(true);
-
-            final Map<String, Object> body = Map.of("key", "value", "number", 42);
-
-            final java.io.ByteArrayInputStream stream =
-                    (java.io.ByteArrayInputStream) method.invoke(createDefaultCreator(), body);
-
-            final String json = new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
-            assertThat(json, notNullValue());
-
-            final com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> parsed = mapper.readValue(json, Map.class);
-            assertThat(parsed.get("key"), equalTo("value"));
-            assertThat(parsed.get("number"), equalTo(42));
-        }
-    }
 
     private SemanticEnrichmentIndexCreator createDefaultCreator() {
         final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                 .withRegion(Region.US_WEST_2)
                 .build();
+        final SemanticEnrichmentConfig semanticConfig = mock(SemanticEnrichmentConfig.class);
+        when(semanticConfig.getDomainName()).thenReturn("testdomain");
 
         when(connectionConfiguration.createAwsCredentialsOptions()).thenReturn(awsCredentialsOptions);
-        when(awsCredentialsSupplier.getProvider(awsCredentialsOptions)).thenReturn(awsCredentialsProvider);
         when(connectionConfiguration.isServerless()).thenReturn(false);
-        when(connectionConfiguration.getHosts()).thenReturn(
-                List.of("https://search-testdomain-abc123.us-west-2.es.amazonaws.com"));
 
-        return new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration);
+        return new SemanticEnrichmentIndexCreator(awsCredentialsSupplier, connectionConfiguration, semanticConfig);
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentIndexCreatorTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentLanguageTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentLanguageTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SemanticEnrichmentLanguageTest {
+
+    @Test
+    void test_english_hasCorrectValue() {
+        assertThat(SemanticEnrichmentLanguage.ENGLISH.getValue(), equalTo("english"));
+    }
+
+    @Test
+    void test_multilingual_hasCorrectValue() {
+        assertThat(SemanticEnrichmentLanguage.MULTILINGUAL.getValue(), equalTo("multilingual"));
+    }
+
+    @Test
+    void test_fromValue_english_returnsEnglish() {
+        assertThat(SemanticEnrichmentLanguage.fromValue("english"), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+    }
+
+    @Test
+    void test_fromValue_multilingual_returnsMultilingual() {
+        assertThat(SemanticEnrichmentLanguage.fromValue("multilingual"), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+    }
+
+    @Test
+    void test_fromValue_caseInsensitive_english() {
+        assertThat(SemanticEnrichmentLanguage.fromValue("ENGLISH"), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+    }
+
+    @Test
+    void test_fromValue_caseInsensitive_multilingual() {
+        assertThat(SemanticEnrichmentLanguage.fromValue("Multilingual"), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid", "spanish", "", "eng"})
+    void test_fromValue_invalidValue_throwsException(final String value) {
+        assertThrows(IllegalArgumentException.class, () -> SemanticEnrichmentLanguage.fromValue(value));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentLanguageTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticEnrichmentLanguageTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticFieldMappingTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticFieldMappingTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class SemanticFieldMappingTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void testDeserialize_withNameAndEnglishLanguage() throws Exception {
+        final String name = UUID.randomUUID().toString();
+        final String json = String.format("{\"name\":\"%s\",\"language\":\"english\"}", name);
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping, notNullValue());
+        assertThat(mapping.getName(), equalTo(name));
+        assertThat(mapping.getLanguage(), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+    }
+
+    @Test
+    void testDeserialize_withNameAndMultilingualLanguage() throws Exception {
+        final String name = UUID.randomUUID().toString();
+        final String json = String.format("{\"name\":\"%s\",\"language\":\"multilingual\"}", name);
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping, notNullValue());
+        assertThat(mapping.getName(), equalTo(name));
+        assertThat(mapping.getLanguage(), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+    }
+
+    @Test
+    void testDeserialize_withOnlyName_languageIsNull() throws Exception {
+        final String name = UUID.randomUUID().toString();
+        final String json = String.format("{\"name\":\"%s\"}", name);
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping.getName(), equalTo(name));
+        assertThat(mapping.getLanguage(), nullValue());
+    }
+
+    @Test
+    void testDeserialize_withOnlyLanguage_nameIsNull() throws Exception {
+        final String json = "{\"language\":\"english\"}";
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping.getName(), nullValue());
+        assertThat(mapping.getLanguage(), equalTo(SemanticEnrichmentLanguage.ENGLISH));
+    }
+
+    @Test
+    void testDeserialize_emptyJson_allFieldsNull() throws Exception {
+        final String json = "{}";
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping, notNullValue());
+        assertThat(mapping.getName(), nullValue());
+        assertThat(mapping.getLanguage(), nullValue());
+    }
+
+    @Test
+    void testGetName_returnsCorrectValue() throws Exception {
+        final String name = "my_text_field";
+        final String json = String.format("{\"name\":\"%s\",\"language\":\"english\"}", name);
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping.getName(), equalTo(name));
+    }
+
+    @Test
+    void testGetLanguage_returnsCorrectEnumValue() throws Exception {
+        final String json = "{\"name\":\"field1\",\"language\":\"multilingual\"}";
+
+        final SemanticFieldMapping mapping = OBJECT_MAPPER.readValue(json, SemanticFieldMapping.class);
+
+        assertThat(mapping.getLanguage(), equalTo(SemanticEnrichmentLanguage.MULTILINGUAL));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticFieldMappingTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/SemanticFieldMappingTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;


### PR DESCRIPTION
### Description
This PR adds support for creating OpenSearch indices with semantic enrichment via the AWS OpenSearch Service 
and AOSS (OpenSearch Serverless) control plane APIs. When configured, Data Prepper will create indices with 
semantic enrichment-enabled field mappings before the normal index setup, allowing OpenSearch to automatically 
generate vector embeddings for specified text fields.

Problem
Currently, Data Prepper's OpenSearch sink creates indices using the standard OpenSearch REST API. However, 
enabling 
⧉ semantic enrichment https://docs.aws.amazon.com/opensearch-service/latest/developerguide/semantic-search.html
on index fields requires using the AWS control plane APIs (es:CreateIndex for managed domains, 
OpenSearchServerless.CreateIndex for AOSS), which are not accessible through the standard OpenSearch client. 
Users had to manually pre-create indices with semantic enrichment before running Data Prepper pipelines.

Solution
Introduced a new semantic_enrichment configuration block under aws settings that allows users to specify which 
fields should have semantic enrichment enabled:

```
sink:
  - opensearch:
      aws:
        sts_role_arn: "arn:aws:iam::123456789012:role/MyRole"
        region: "us-west-2"
        semantic_enrichment:
          fields: ["title", "description"]
          language: "english"  # optional, defaults to "english"
```

How it works
1. During sink initialization, if semantic_enrichment.fields is configured and AWS SigV4 auth is enabled, the sink creates a SemanticEnrichmentIndexCreator
2. The creator auto-detects whether the target is a managed domain or serverless collection from the host URL
3. It builds an index schema with semantic_enrichment: { status: ENABLED, language_options: <language> } on each specified field
4. The request is SigV4-signed and sent to the appropriate AWS control plane endpoint
5. If the index already exists (ConflictException / ResourceAlreadyExistsException), creation is silently skipped
6. Normal index setup via indexManager.setupIndex() proceeds afterward
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
