### PR TITLE
Reject external versioning when script is configured in OpenSearch sink

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -302,6 +302,13 @@ public class IndexConfiguration {
             builder = builder.withScriptConfiguration(scriptConfiguration);
         }
 
+        if (scriptConfiguration != null && openSearchSinkConfig.getVersionType() != null
+                && VersionType.External.jsonValue().equals(openSearchSinkConfig.getVersionType())) {
+            throw new InvalidPluginConfigurationException(
+                    "document_version_type 'external' is incompatible with script configuration. " +
+                    "OpenSearch does not support external versioning with scripted upserts.");
+        }
+
         AwsAuthenticationConfiguration awsAuthenticationConfiguration = openSearchSinkConfig.getAwsAuthenticationOptions();
         if (awsAuthenticationConfiguration != null) {
             builder = builder.withServerless(awsAuthenticationConfiguration.isServerlessCollection());

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -653,4 +653,26 @@ public class IndexConfigurationTests {
                 "\"mappings\":{\"properties\":{\"timestamp\":{\"type\":\"date\",\"format\":\"yyyy-MM-ddHH:mm:ss||yyyy-MM-dd||epoch_millis\"}," +
                 "\"value\":{\"type\":\"double\"}}}}}";
     }
+
+    @Test
+    public void testReadIndexConfig_withExternalVersionAndScript_throws_InvalidPluginConfigurationException() throws JsonProcessingException {
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put("index_type", "custom");
+        metadata.put("index", "test-index");
+        metadata.put("document_version_type", "external");
+        metadata.put("script", Map.of("source", "ctx._source.counter += 1"));
+        final OpenSearchSinkConfig openSearchSinkConfig = getOpenSearchSinkConfig(metadata);
+        assertThrows(InvalidPluginConfigurationException.class, () -> IndexConfiguration.readIndexConfig(openSearchSinkConfig));
+    }
+
+    @Test
+    public void testReadIndexConfig_withScriptAndNoExternalVersion_doesNotThrow() throws JsonProcessingException {
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put("index_type", "custom");
+        metadata.put("index", "test-index");
+        metadata.put("script", Map.of("source", "ctx._source.counter += 1"));
+        final OpenSearchSinkConfig openSearchSinkConfig = getOpenSearchSinkConfig(metadata);
+        final IndexConfiguration config = IndexConfiguration.readIndexConfig(openSearchSinkConfig);
+        assertThat(config.getScriptConfiguration(), notNullValue());
+    }
 }


### PR DESCRIPTION
### Description
OpenSearch does not support external versioning with scripted upserts. Add config-time validation in IndexConfiguration to fail fast with a clear error message instead of getting runtime 400 errors from OpenSearch.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
