### PR TITLE
Correct JacksonEvent.merge() null-key handling and close InputSt…

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProvider.java
+++ b/buildSrc/src/main/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProvider.java
@@ -41,7 +41,11 @@ public class LastReleasedVersionProvider {
 
     static String getLastReleasedMajorVersion(final InputStream metadataStream, final String currentVersion) throws Exception {
         final String majorVersion = currentVersion.split("\\.")[0];
-        final Document doc = DocumentBuilderFactory.newInstance()
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        final Document doc = dbf
             .newDocumentBuilder()
             .parse(metadataStream);
         

--- a/buildSrc/src/main/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProvider.java
+++ b/buildSrc/src/main/java/org/opensearch/dataprepper/gradle/compatibility/LastReleasedVersionProvider.java
@@ -32,8 +32,8 @@ public class LastReleasedVersionProvider {
         final String groupPath = group.replace('.', '/');
         final String metadataUrl = String.format("https://repo1.maven.org/maven2/%s/%s/maven-metadata.xml", groupPath, artifactId);
         
-        try {
-            return getLastReleasedMajorVersion(new URL(metadataUrl).openStream(), currentVersion);
+        try (InputStream stream = new URL(metadataUrl).openStream()) {
+            return getLastReleasedMajorVersion(stream, currentVersion);
         } catch (final Exception e) {
             return null;
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -481,9 +481,8 @@ public class JacksonEvent implements Event {
         }
 
         for (final String key : keys) {
-            final Object value = other.get(key, Object.class);
-            if (value != null) {
-                put(key, value);
+            if (other.containsKey(key)) {
+                put(key, other.get(key, Object.class));
             }
         }
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -718,6 +718,17 @@ public class JacksonEventTest {
     }
 
     @Test
+    void merge_with_keys_overwrites_existing_value_with_null() {
+        event.put("a", "original");
+        final String jsonString = "{\"a\": null}";
+        Event otherEvent = JacksonEvent.builder().withEventType(EventType.DOCUMENT.toString()).withData(jsonString).build();
+        event.merge(otherEvent, List.of("a"));
+
+        assertThat(event.containsKey("a"), equalTo(true));
+        assertThat(event.get("a", Object.class), equalTo(null));
+    }
+
+    @Test
     void merge_with_keys_skips_missing_keys_in_other() {
         event.put("existing", "value");
         final String jsonString = "{\"a\": \"alpha\"}";


### PR DESCRIPTION

### Description

Fix two bugs identified during the Data Prepper 2.15 upgrade (see internal CR-265961021):

1. **JacksonEvent.merge(Event, Collection<String>)**: The `null` check on line 485 conflates "key doesn't exist" with "key exists with a null value." If the source event has a key explicitly set to `null`, it was silently skipped, preserving the current event's existing value. This contradicts the Javadoc which states: *"Values from `other` will overwrite existing values in this Event for matching keys."* Fixed by using `containsKey()` to distinguish the two cases.

2. **LastReleasedVersionProvider.getLastReleasedMajorVersion()**: The `InputStream` returned by `new URL(metadataUrl).openStream()` was never closed, neither on the success path nor when `getLastReleasedMajorVersion(InputStream, String)` throws. Fixed with try-with-resources.

### Issues Resolved

_N/A — discovered during internal review_
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
