### PR TITLE
Add SINGLE_SCAN discovery mode to OpenSearch source (#6169)

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfiguration.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.AwsAuthenticationConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.ConnectionConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
@@ -101,6 +102,12 @@ public class OpenSearchSourceConfiguration {
 
     public SchedulingParameterConfiguration getSchedulingParameterConfiguration() {
         return schedulingParameterConfiguration;
+    }
+
+    @JsonIgnore
+    public boolean isSingleScanMode() {
+        return Objects.nonNull(schedulingParameterConfiguration)
+                && schedulingParameterConfiguration.getDiscoveryMode() == DiscoveryMode.SINGLE_SCAN;
     }
 
     public SearchConfiguration getSearchConfiguration() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryMode.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryMode.java
@@ -11,29 +11,45 @@
 package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Controls how the OpenSearch source discovers indices.
  * <p>
- * {@link #PERIODIC} (default) re-runs discovery on the configured scheduling interval, allowing newly
+ * {@code periodic} (default) re-runs discovery on the configured scheduling interval, allowing newly
  * created indices to be picked up and existing indices to be re-ingested.
  * <p>
- * {@link #SINGLE_SCAN} runs discovery exactly once. Once an index has been discovered and processed it is
- * not re-scheduled. This avoids re-ingesting the same indices from the start in long-running pipelines
- * where source coordinator state (e.g. DynamoDB item TTL) could otherwise be lost.
+ * {@code single_scan} runs discovery exactly once. Once an index has been discovered and processed it
+ * is not re-scheduled. This avoids re-ingesting the same indices from the start in long-running
+ * pipelines where source coordinator state (e.g. DynamoDB item TTL) could otherwise be lost.
  */
 public enum DiscoveryMode {
-    PERIODIC,
-    SINGLE_SCAN;
+    PERIODIC("periodic"),
+    SINGLE_SCAN("single_scan");
+
+    private static final Map<String, DiscoveryMode> NAMES_MAP = Arrays.stream(DiscoveryMode.values())
+            .collect(Collectors.toMap(
+                    value -> value.optionName,
+                    value -> value
+            ));
+
+    private final String optionName;
+
+    DiscoveryMode(final String optionName) {
+        this.optionName = optionName;
+    }
+
+    @JsonValue
+    public String getOptionName() {
+        return optionName;
+    }
 
     @JsonCreator
-    public static DiscoveryMode fromString(final String value) {
-        return Arrays.stream(values())
-                .filter(mode -> mode.name().equalsIgnoreCase(value))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        String.format("Invalid discovery_mode '%s'. Supported values are: PERIODIC, SINGLE_SCAN", value)));
+    public static DiscoveryMode fromOptionName(final String optionName) {
+        return NAMES_MAP.get(optionName);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryMode.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryMode.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
+/**
+ * Controls how the OpenSearch source discovers indices.
+ * <p>
+ * {@link #PERIODIC} (default) re-runs discovery on the configured scheduling interval, allowing newly
+ * created indices to be picked up and existing indices to be re-ingested.
+ * <p>
+ * {@link #SINGLE_SCAN} runs discovery exactly once. Once an index has been discovered and processed it is
+ * not re-scheduled. This avoids re-ingesting the same indices from the start in long-running pipelines
+ * where source coordinator state (e.g. DynamoDB item TTL) could otherwise be lost.
+ */
+public enum DiscoveryMode {
+    PERIODIC,
+    SINGLE_SCAN;
+
+    @JsonCreator
+    public static DiscoveryMode fromString(final String value) {
+        return Arrays.stream(values())
+                .filter(mode -> mode.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Invalid discovery_mode '%s'. Supported values are: PERIODIC, SINGLE_SCAN", value)));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfiguration.java
@@ -25,6 +25,9 @@ public class SchedulingParameterConfiguration {
     @JsonProperty("start_time")
     private String startTime = Instant.now().toString();
 
+    @JsonProperty("discovery_mode")
+    private DiscoveryMode discoveryMode = DiscoveryMode.PERIODIC;
+
     @JsonIgnore
     private Instant startTimeInstant;
 
@@ -38,6 +41,10 @@ public class SchedulingParameterConfiguration {
 
     public Instant getStartTime() {
         return startTimeInstant;
+    }
+
+    public DiscoveryMode getDiscoveryMode() {
+        return discoveryMode;
     }
 
     @AssertTrue(message = "start_time must be a valid Java Instant format such as \"2007-12-03T10:15:30.00Z\"")

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
@@ -13,7 +13,6 @@ import org.opensearch.client.opensearch.cat.IndicesResponse;
 import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
-import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.OpenSearchIndex;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.ClusterClientFactory;
@@ -79,7 +78,7 @@ public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<St
             partitions = Collections.emptyList();
         }
 
-        if (isSingleScanMode() && Objects.nonNull(globalStateMap)) {
+        if (openSearchSourceConfiguration.isSingleScanMode() && Objects.nonNull(globalStateMap)) {
             globalStateMap.put(SINGLE_SCAN_COMPLETE, Boolean.TRUE);
             LOG.info("Discovery mode is SINGLE_SCAN. Completed one-time index discovery with {} partitions.", partitions.size());
         }
@@ -87,13 +86,8 @@ public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<St
         return partitions;
     }
 
-    private boolean isSingleScanMode() {
-        return Objects.nonNull(openSearchSourceConfiguration.getSchedulingParameterConfiguration())
-                && DiscoveryMode.SINGLE_SCAN.equals(openSearchSourceConfiguration.getSchedulingParameterConfiguration().getDiscoveryMode());
-    }
-
     private boolean isSingleScanCompleted(final Map<String, Object> globalStateMap) {
-        return isSingleScanMode()
+        return openSearchSourceConfiguration.isSingleScanMode()
                 && Objects.nonNull(globalStateMap)
                 && Boolean.TRUE.equals(globalStateMap.get(SINGLE_SCAN_COMPLETE));
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
@@ -13,6 +13,7 @@ import org.opensearch.client.opensearch.cat.IndicesResponse;
 import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.OpenSearchIndex;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.ClusterClientFactory;
@@ -31,6 +32,8 @@ import java.util.regex.Matcher;
 public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<String, Object>, List<PartitionIdentifier>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchIndexPartitionCreationSupplier.class);
+
+    public static final String SINGLE_SCAN_COMPLETE = "SINGLE_SCAN_COMPLETE";
 
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final IndexParametersConfiguration indexParametersConfiguration;
@@ -62,13 +65,37 @@ public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<St
     @Override
     public List<PartitionIdentifier> apply(final Map<String, Object> globalStateMap) {
 
-        if (Objects.nonNull(openSearchClientRefresher)) {
-            return applyForOpenSearchClient(globalStateMap);
-        } else if (Objects.nonNull(elasticsearchClientRefresher)) {
-            return applyForElasticSearchClient(globalStateMap);
+        if (isSingleScanCompleted(globalStateMap)) {
+            LOG.debug("Discovery mode is SINGLE_SCAN and indices have already been discovered. Skipping rediscovery.");
+            return Collections.emptyList();
         }
 
-        return Collections.emptyList();
+        final List<PartitionIdentifier> partitions;
+        if (Objects.nonNull(openSearchClientRefresher)) {
+            partitions = applyForOpenSearchClient(globalStateMap);
+        } else if (Objects.nonNull(elasticsearchClientRefresher)) {
+            partitions = applyForElasticSearchClient(globalStateMap);
+        } else {
+            partitions = Collections.emptyList();
+        }
+
+        if (isSingleScanMode() && Objects.nonNull(globalStateMap)) {
+            globalStateMap.put(SINGLE_SCAN_COMPLETE, Boolean.TRUE);
+            LOG.info("Discovery mode is SINGLE_SCAN. Completed one-time index discovery with {} partitions.", partitions.size());
+        }
+
+        return partitions;
+    }
+
+    private boolean isSingleScanMode() {
+        return Objects.nonNull(openSearchSourceConfiguration.getSchedulingParameterConfiguration())
+                && DiscoveryMode.SINGLE_SCAN.equals(openSearchSourceConfiguration.getSchedulingParameterConfiguration().getDiscoveryMode());
+    }
+
+    private boolean isSingleScanCompleted(final Map<String, Object> globalStateMap) {
+        return isSingleScanMode()
+                && Objects.nonNull(globalStateMap)
+                && Boolean.TRUE.equals(globalStateMap.get(SINGLE_SCAN_COMPLETE));
     }
 
     private List<PartitionIdentifier> applyForOpenSearchClient(final Map<String, Object> globalStateMap) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,11 +48,15 @@ public class WorkerCommonUtils {
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
             acknowledgementSet = acknowledgementSetManager.create((result) -> {
                 if (result == true) {
-                    sourceCoordinator.closePartition(
-                            indexPartition.getPartitionKey(),
-                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
-                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount(),
-                            true);
+                    if (isSingleScanMode(openSearchSourceConfiguration)) {
+                        sourceCoordinator.completePartition(indexPartition.getPartitionKey(), true);
+                    } else {
+                        sourceCoordinator.closePartition(
+                                indexPartition.getPartitionKey(),
+                                openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
+                                openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount(),
+                                true);
+                    }
 
                     LOG.info("Received acknowledgment of completion from sink for index {}", indexPartition.getPartitionKey());
                 } else {
@@ -70,6 +75,9 @@ public class WorkerCommonUtils {
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
             sourceCoordinator.updatePartitionForAcknowledgmentWait(indexPartition.getPartitionKey(), OWNERSHIP_TIMEOUT);
             acknowledgementSet.complete();
+        } else if (isSingleScanMode(openSearchSourceConfiguration)) {
+            sourceCoordinator.completePartition(indexPartition.getPartitionKey(), false);
+            LOG.info("Completed processing of index {} (single_scan mode; index will not be rescheduled)", indexPartition.getPartitionKey());
         } else {
             sourceCoordinator.closePartition(
                     indexPartition.getPartitionKey(),
@@ -78,6 +86,11 @@ public class WorkerCommonUtils {
                     false);
             LOG.info("Completed processing of index {}", indexPartition.getPartitionKey());
         }
+    }
+
+    private static boolean isSingleScanMode(final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
+        return java.util.Objects.nonNull(openSearchSourceConfiguration.getSchedulingParameterConfiguration())
+                && DiscoveryMode.SINGLE_SCAN.equals(openSearchSourceConfiguration.getSchedulingParameterConfiguration().getDiscoveryMode());
     }
 
     static long calculateExponentialBackoffAndJitter(final int retryCount) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -11,7 +11,6 @@ import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
-import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +47,7 @@ public class WorkerCommonUtils {
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
             acknowledgementSet = acknowledgementSetManager.create((result) -> {
                 if (result == true) {
-                    if (isSingleScanMode(openSearchSourceConfiguration)) {
+                    if (openSearchSourceConfiguration.isSingleScanMode()) {
                         sourceCoordinator.completePartition(indexPartition.getPartitionKey(), true);
                     } else {
                         sourceCoordinator.closePartition(
@@ -75,7 +74,7 @@ public class WorkerCommonUtils {
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
             sourceCoordinator.updatePartitionForAcknowledgmentWait(indexPartition.getPartitionKey(), OWNERSHIP_TIMEOUT);
             acknowledgementSet.complete();
-        } else if (isSingleScanMode(openSearchSourceConfiguration)) {
+        } else if (openSearchSourceConfiguration.isSingleScanMode()) {
             sourceCoordinator.completePartition(indexPartition.getPartitionKey(), false);
             LOG.info("Completed processing of index {} (single_scan mode; index will not be rescheduled)", indexPartition.getPartitionKey());
         } else {
@@ -86,11 +85,6 @@ public class WorkerCommonUtils {
                     false);
             LOG.info("Completed processing of index {}", indexPartition.getPartitionKey());
         }
-    }
-
-    private static boolean isSingleScanMode(final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
-        return java.util.Objects.nonNull(openSearchSourceConfiguration.getSchedulingParameterConfiguration())
-                && DiscoveryMode.SINGLE_SCAN.equals(openSearchSourceConfiguration.getSchedulingParameterConfiguration().getDiscoveryMode());
     }
 
     static long calculateExponentialBackoffAndJitter(final int retryCount) {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
@@ -274,4 +274,28 @@ public class OpenSearchSourceConfigurationTest {
         assertThrows(InvalidPluginConfigurationException.class, sourceConfiguration::validateAuthConfigConflictWithDeprecatedUsernameAndPassword);
         assertThat(sourceConfiguration.isDistributionVersionValid(), equalTo(false));
     }
+
+    @Test
+    void isSingleScanMode_returns_false_when_discovery_mode_is_default() throws JsonProcessingException {
+        final String sourceConfigurationYaml =
+                "hosts: [\"http://localhost:9200\"]\n" +
+                        "disable_authentication: true\n";
+
+        final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
+
+        assertThat(sourceConfiguration.isSingleScanMode(), equalTo(false));
+    }
+
+    @Test
+    void isSingleScanMode_returns_true_when_discovery_mode_is_single_scan() throws JsonProcessingException {
+        final String sourceConfigurationYaml =
+                "hosts: [\"http://localhost:9200\"]\n" +
+                        "disable_authentication: true\n" +
+                        "scheduling:\n" +
+                        "  discovery_mode: single_scan\n";
+
+        final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
+
+        assertThat(sourceConfiguration.isSingleScanMode(), equalTo(true));
+    }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryModeTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryModeTest.java
@@ -10,30 +10,37 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.Matchers.nullValue;
 
 public class DiscoveryModeTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"PERIODIC", "periodic", "Periodic"})
-    void fromString_resolves_periodic_case_insensitively(final String value) {
-        assertThat(DiscoveryMode.fromString(value), equalTo(DiscoveryMode.PERIODIC));
+    @CsvSource({
+            "periodic,    PERIODIC",
+            "single_scan, SINGLE_SCAN"
+    })
+    void fromOptionName_returns_expected_enum(final String optionName, final DiscoveryMode expected) {
+        assertThat(DiscoveryMode.fromOptionName(optionName), equalTo(expected));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"SINGLE_SCAN", "single_scan", "Single_Scan"})
-    void fromString_resolves_single_scan_case_insensitively(final String value) {
-        assertThat(DiscoveryMode.fromString(value), equalTo(DiscoveryMode.SINGLE_SCAN));
+    @CsvSource({
+            "PERIODIC,    periodic",
+            "SINGLE_SCAN, single_scan"
+    })
+    void getOptionName_returns_expected_string(final DiscoveryMode mode, final String expected) {
+        assertThat(mode.getOptionName(), equalTo(expected));
     }
 
-    @Test
-    void fromString_with_unknown_value_throws_IllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> DiscoveryMode.fromString("ONCE"));
+    @ParameterizedTest
+    @ValueSource(strings = {"PERIODIC", "Single_Scan", "unknown", ""})
+    void fromOptionName_returns_null_for_unknown_value(final String optionName) {
+        assertThat(DiscoveryMode.fromOptionName(optionName), nullValue());
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryModeTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/DiscoveryModeTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DiscoveryModeTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"PERIODIC", "periodic", "Periodic"})
+    void fromString_resolves_periodic_case_insensitively(final String value) {
+        assertThat(DiscoveryMode.fromString(value), equalTo(DiscoveryMode.PERIODIC));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SINGLE_SCAN", "single_scan", "Single_Scan"})
+    void fromString_resolves_single_scan_case_insensitively(final String value) {
+        assertThat(DiscoveryMode.fromString(value), equalTo(DiscoveryMode.SINGLE_SCAN));
+    }
+
+    @Test
+    void fromString_with_unknown_value_throws_IllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> DiscoveryMode.fromString("ONCE"));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
@@ -27,6 +27,16 @@ public class SchedulingParameterConfigurationTest {
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(true));
         assertThat(schedulingParameterConfiguration.getStartTime().isBefore(Instant.now()), equalTo(true));
         assertThat(schedulingParameterConfiguration.getInterval(), equalTo(Duration.ofHours(8)));
+        assertThat(schedulingParameterConfiguration.getDiscoveryMode(), equalTo(DiscoveryMode.PERIODIC));
+    }
+
+    @Test
+    void single_scan_discovery_mode_from_yaml() throws JsonProcessingException {
+        final String yaml = "  discovery_mode: SINGLE_SCAN\n";
+
+        final SchedulingParameterConfiguration config = objectMapper.readValue(yaml, SchedulingParameterConfiguration.class);
+
+        assertThat(config.getDiscoveryMode(), equalTo(DiscoveryMode.SINGLE_SCAN));
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
@@ -32,7 +32,7 @@ public class SchedulingParameterConfigurationTest {
 
     @Test
     void single_scan_discovery_mode_from_yaml() throws JsonProcessingException {
-        final String yaml = "  discovery_mode: SINGLE_SCAN\n";
+        final String yaml = "  discovery_mode: single_scan\n";
 
         final SchedulingParameterConfiguration config = objectMapper.readValue(yaml, SchedulingParameterConfiguration.class);
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsCompletionTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsCompletionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class WorkerCommonUtilsCompletionTest {
+
+    @Mock
+    private OpenSearchSourceConfiguration openSearchSourceConfiguration;
+
+    @Mock
+    private SchedulingParameterConfiguration schedulingParameterConfiguration;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
+
+    @Mock
+    private SourcePartition<OpenSearchIndexProgressState> indexPartition;
+
+    @Mock
+    private AcknowledgementSet acknowledgementSet;
+
+    private String partitionKey;
+
+    @BeforeEach
+    void setup() {
+        partitionKey = UUID.randomUUID().toString();
+        lenient().when(indexPartition.getPartitionKey()).thenReturn(partitionKey);
+        lenient().when(openSearchSourceConfiguration.getSchedulingParameterConfiguration())
+                .thenReturn(schedulingParameterConfiguration);
+    }
+
+    @Test
+    void completeIndexPartition_in_periodic_mode_without_acknowledgments_calls_closePartition() {
+        when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ofHours(8));
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
+
+        WorkerCommonUtils.completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet,
+                indexPartition, sourceCoordinator);
+
+        verify(sourceCoordinator).closePartition(eq(partitionKey), eq(Duration.ofHours(8)), eq(1), eq(false));
+        verify(sourceCoordinator, never()).completePartition(eq(partitionKey), eq(false));
+    }
+
+    @Test
+    void completeIndexPartition_in_single_scan_mode_without_acknowledgments_calls_completePartition() {
+        when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
+
+        WorkerCommonUtils.completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet,
+                indexPartition, sourceCoordinator);
+
+        verify(sourceCoordinator).completePartition(eq(partitionKey), eq(false));
+        verify(sourceCoordinator, never()).closePartition(eq(partitionKey), any(Duration.class), any(Integer.class), any(Boolean.class));
+    }
+
+    @Test
+    void completeIndexPartition_with_acknowledgments_delegates_to_ack_path_regardless_of_mode() {
+        when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
+
+        WorkerCommonUtils.completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet,
+                indexPartition, sourceCoordinator);
+
+        verify(sourceCoordinator).updatePartitionForAcknowledgmentWait(eq(partitionKey), any(Duration.class));
+        verify(acknowledgementSet).complete();
+        verify(sourceCoordinator, never()).closePartition(eq(partitionKey), any(Duration.class), any(Integer.class), any(Boolean.class));
+        verify(sourceCoordinator, never()).completePartition(eq(partitionKey), any(Boolean.class));
+    }
+
+    @Test
+    void createAcknowledgmentSet_in_periodic_mode_invokes_closePartition_on_successful_ack() {
+        when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ofHours(8));
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Consumer<Boolean>> callbackCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+        when(acknowledgementSetManager.create(callbackCaptor.capture(), any(Duration.class))).thenReturn(acknowledgementSet);
+
+        WorkerCommonUtils.createAcknowledgmentSet(acknowledgementSetManager,
+                openSearchSourceConfiguration, sourceCoordinator, indexPartition);
+
+        callbackCaptor.getValue().accept(true);
+
+        verify(sourceCoordinator).closePartition(eq(partitionKey), eq(Duration.ofHours(8)), eq(1), eq(true));
+        verify(sourceCoordinator, never()).completePartition(eq(partitionKey), any(Boolean.class));
+    }
+
+    @Test
+    void createAcknowledgmentSet_in_single_scan_mode_invokes_completePartition_on_successful_ack() {
+        when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Consumer<Boolean>> callbackCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+        when(acknowledgementSetManager.create(callbackCaptor.capture(), any(Duration.class))).thenReturn(acknowledgementSet);
+
+        WorkerCommonUtils.createAcknowledgmentSet(acknowledgementSetManager,
+                openSearchSourceConfiguration, sourceCoordinator, indexPartition);
+
+        callbackCaptor.getValue().accept(true);
+
+        verify(sourceCoordinator).completePartition(eq(partitionKey), eq(true));
+        verify(sourceCoordinator, never()).closePartition(eq(partitionKey), any(Duration.class), any(Integer.class), any(Boolean.class));
+    }
+
+    @Test
+    void createAcknowledgmentSet_on_failed_ack_gives_up_partition_regardless_of_mode() {
+        when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Consumer<Boolean>> callbackCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+        when(acknowledgementSetManager.create(callbackCaptor.capture(), any(Duration.class))).thenReturn(acknowledgementSet);
+
+        WorkerCommonUtils.createAcknowledgmentSet(acknowledgementSetManager,
+                openSearchSourceConfiguration, sourceCoordinator, indexPartition);
+
+        callbackCaptor.getValue().accept(false);
+
+        verify(sourceCoordinator).giveUpPartition(eq(partitionKey));
+        verify(sourceCoordinator, never()).completePartition(eq(partitionKey), any(Boolean.class));
+        verify(sourceCoordinator, never()).closePartition(eq(partitionKey), any(Duration.class), any(Integer.class), any(Boolean.class));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsCompletionTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsCompletionTest.java
@@ -22,7 +22,6 @@ import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
-import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
 
 import java.time.Duration;
@@ -70,7 +69,7 @@ public class WorkerCommonUtilsCompletionTest {
     @Test
     void completeIndexPartition_in_periodic_mode_without_acknowledgments_calls_closePartition() {
         when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(false);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ofHours(8));
         when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
 
@@ -84,7 +83,7 @@ public class WorkerCommonUtilsCompletionTest {
     @Test
     void completeIndexPartition_in_single_scan_mode_without_acknowledgments_calls_completePartition() {
         when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(true);
 
         WorkerCommonUtils.completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet,
                 indexPartition, sourceCoordinator);
@@ -109,7 +108,7 @@ public class WorkerCommonUtilsCompletionTest {
     @Test
     void createAcknowledgmentSet_in_periodic_mode_invokes_closePartition_on_successful_ack() {
         when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(false);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ofHours(8));
         when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
 
@@ -130,7 +129,7 @@ public class WorkerCommonUtilsCompletionTest {
     @Test
     void createAcknowledgmentSet_in_single_scan_mode_invokes_completePartition_on_successful_ack() {
         when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(true);
 
         @SuppressWarnings("unchecked")
         final ArgumentCaptor<Consumer<Boolean>> callbackCaptor = ArgumentCaptor.forClass(Consumer.class);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
@@ -24,23 +24,33 @@ import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.plugins.source.opensearch.ClientRefresher;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.OpenSearchIndex;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier.SINGLE_SCAN_COMPLETE;
 
 @ExtendWith(MockitoExtension.class)
 public class OpenSearchIndexPartitionCreationSupplierTest {
@@ -258,6 +268,104 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(Collections.emptyMap());
 
         assertThat(partitionIdentifierList, notNullValue());
+    }
+
+    @Test
+    void apply_with_single_scan_mode_returns_empty_when_flag_already_set() {
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        // Refresher is wired through the constructor but should not be used when the scan is already completed
+        when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
+        when(clusterClientFactory.getClientRefresher()).thenReturn(opensearchClientRefresher);
+
+        final OpenSearchIndexPartitionCreationSupplier objectUnderTest = createObjectUnderTest();
+
+        final Map<String, Object> globalStateMap = new HashMap<>();
+        globalStateMap.put(SINGLE_SCAN_COMPLETE, Boolean.TRUE);
+
+        final List<PartitionIdentifier> partitionIdentifierList = objectUnderTest.apply(globalStateMap);
+
+        assertThat(partitionIdentifierList, notNullValue());
+        assertThat(partitionIdentifierList.isEmpty(), equalTo(true));
+        verify(opensearchClientRefresher, never()).get();
+    }
+
+    @Test
+    void apply_with_single_scan_mode_sets_flag_after_discovering_partitions() throws IOException {
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
+        when(opensearchClientRefresher.get()).thenReturn(openSearchClient);
+        when(clusterClientFactory.getClientRefresher()).thenReturn(opensearchClientRefresher);
+
+        final OpenSearchCatClient openSearchCatClient = mock(OpenSearchCatClient.class);
+        final IndicesResponse indicesResponse = mock(IndicesResponse.class);
+        final IndicesRecord indicesRecord = mock(IndicesRecord.class);
+        when(indicesRecord.index()).thenReturn("my-index");
+        when(indicesResponse.valueBody()).thenReturn(List.of(indicesRecord));
+        when(openSearchCatClient.indices()).thenReturn(indicesResponse);
+        when(openSearchClient.cat()).thenReturn(openSearchCatClient);
+
+        final Map<String, Object> globalStateMap = new HashMap<>();
+
+        final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(globalStateMap);
+
+        assertThat(partitionIdentifierList, notNullValue());
+        assertThat(partitionIdentifierList, hasSize(1));
+        assertThat(globalStateMap, hasEntry(SINGLE_SCAN_COMPLETE, Boolean.TRUE));
+    }
+
+    @Test
+    void apply_with_periodic_mode_does_not_set_single_scan_flag() throws IOException {
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
+        when(opensearchClientRefresher.get()).thenReturn(openSearchClient);
+        when(clusterClientFactory.getClientRefresher()).thenReturn(opensearchClientRefresher);
+
+        final OpenSearchCatClient openSearchCatClient = mock(OpenSearchCatClient.class);
+        final IndicesResponse indicesResponse = mock(IndicesResponse.class);
+        when(indicesResponse.valueBody()).thenReturn(Collections.emptyList());
+        when(openSearchCatClient.indices()).thenReturn(indicesResponse);
+        when(openSearchClient.cat()).thenReturn(openSearchCatClient);
+
+        final Map<String, Object> globalStateMap = new HashMap<>();
+
+        createObjectUnderTest().apply(globalStateMap);
+
+        assertThat(globalStateMap, not(hasEntry(SINGLE_SCAN_COMPLETE, Boolean.TRUE)));
+    }
+
+    @Test
+    void apply_with_periodic_mode_and_completed_flag_still_performs_discovery() throws IOException {
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
+        when(opensearchClientRefresher.get()).thenReturn(openSearchClient);
+        when(clusterClientFactory.getClientRefresher()).thenReturn(opensearchClientRefresher);
+
+        final OpenSearchCatClient openSearchCatClient = mock(OpenSearchCatClient.class);
+        final IndicesResponse indicesResponse = mock(IndicesResponse.class);
+        when(indicesResponse.valueBody()).thenReturn(Collections.emptyList());
+        when(openSearchCatClient.indices()).thenReturn(indicesResponse);
+        when(openSearchClient.cat()).thenReturn(openSearchCatClient);
+
+        final Map<String, Object> globalStateMap = new HashMap<>();
+        // A stale flag left in state should be ignored in PERIODIC mode
+        globalStateMap.put(SINGLE_SCAN_COMPLETE, Boolean.TRUE);
+
+        createObjectUnderTest().apply(globalStateMap);
+
+        // cat/indices was actually called, confirming discovery ran despite the flag
+        verify(openSearchCatClient).indices();
     }
 
     private static Stream<Arguments> opensearchCatIndicesExceptions() {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
@@ -24,10 +24,8 @@ import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.plugins.source.opensearch.ClientRefresher;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
-import org.opensearch.dataprepper.plugins.source.opensearch.configuration.DiscoveryMode;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.OpenSearchIndex;
-import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
 
 import java.io.IOException;
@@ -272,9 +270,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
 
     @Test
     void apply_with_single_scan_mode_returns_empty_when_flag_already_set() {
-        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
-        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(true);
 
         // Refresher is wired through the constructor but should not be used when the scan is already completed
         when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
@@ -294,9 +290,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
 
     @Test
     void apply_with_single_scan_mode_sets_flag_after_discovering_partitions() throws IOException {
-        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.SINGLE_SCAN);
-        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(true);
 
         when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
         when(opensearchClientRefresher.get()).thenReturn(openSearchClient);
@@ -321,9 +315,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
 
     @Test
     void apply_with_periodic_mode_does_not_set_single_scan_flag() throws IOException {
-        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
-        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(false);
 
         when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
         when(opensearchClientRefresher.get()).thenReturn(openSearchClient);
@@ -344,9 +336,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
 
     @Test
     void apply_with_periodic_mode_and_completed_flag_still_performs_discovery() throws IOException {
-        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.PERIODIC);
-        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+        when(openSearchSourceConfiguration.isSingleScanMode()).thenReturn(false);
 
         when(opensearchClientRefresher.getComponentClass()).thenReturn(OpenSearchClient.class);
         when(opensearchClientRefresher.get()).thenReturn(openSearchClient);


### PR DESCRIPTION
### Description

Adds an optional `discovery_mode` setting to the OpenSearch source `scheduling` configuration with two values: `PERIODIC` (default, existing behavior) and `SINGLE_SCAN`.

When `SINGLE_SCAN` is configured:
- `OpenSearchIndexPartitionCreationSupplier` runs index discovery exactly once and records a `SINGLE_SCAN_COMPLETE` flag in the source coordinator's global state so subsequent supplier invocations short-circuit with an empty partition list.
- On index completion, `WorkerCommonUtils` calls `sourceCoordinator.completePartition(...)` (terminal) instead of `closePartition(...)` with a reopen interval — both in the acknowledgment callback and the non-acknowledgment path.

This avoids re-ingesting indices from the start in long-running pipelines where source coordinator state (e.g. DynamoDB item TTL) expires before ingestion finishes. `PERIODIC` remains the default so existing pipelines are unaffected.

Example configuration:

```yaml
source:
  opensearch:
    hosts: ["https://search.example.com"]
    scheduling:
      discovery_mode: SINGLE_SCAN
```

### Issues Resolved

Resolves #6169

### Check List

- [x] New functionality includes testing.
  - `DiscoveryModeTest` — enum parsing, including the error path
  - `SchedulingParameterConfigurationTest` — default `PERIODIC` and YAML parsing for `SINGLE_SCAN`
  - `OpenSearchIndexPartitionCreationSupplierTest` — short-circuit on flag set, flag set after scan, `PERIODIC` keeps discovering, stale flag ignored in `PERIODIC`
  - `WorkerCommonUtilsCompletionTest` — completion paths for both modes, with and without acknowledgments, plus failed-ack fallback
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added (on `DiscoveryMode`)
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
