### PR TITLE
Fix RDS joins: set workers=1 on main pipeline to prevent event reordering

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-joins-template.yaml
+++ b/data-prepper-plugins/rds-source/src/main/resources/org/opensearch/dataprepper/transforms/templates/rds-joins-template.yaml
@@ -8,7 +8,7 @@
 #
 
 "<<pipeline-name>>":
-  workers: "<<$.<<pipeline-name>>.workers>>"
+  workers: 1
   delay: "<<$.<<pipeline-name>>.delay>>"
   buffer: "<<$.<<pipeline-name>>.buffer>>"
   source:


### PR DESCRIPTION
### Description
The joins template inherited the user-configured workers count (default 2) for the main pipeline. With workers > 1, multiple threads write to the S3 sink concurrently. The S3 sink's ReentrantLock serializes writes but does not guarantee ordering — thread 2 can write item2 before thread 1 writes item1 for the same parent document.

When the S3 sub-pipeline reads these out-of-order events and sends them to OpenSearch, the per-table version check in the Painless script rejects the lower-versioned item (noop), causing data loss for 1:N child records.

Setting workers=1 ensures events are written to S3 in binlog order. This has no throughput impact since the S3 sink's ReentrantLock already serializes writes to a single thread at a time.

Tested with 200 threads, 5M orders: 0 failures with workers=1 vs ~0.09% failure rate with workers=2.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
