### PR TITLE
Minify Painless script before sending to OpenSearch

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ScriptManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ScriptManager.java
@@ -28,10 +28,12 @@ public class ScriptManager {
 
     private final ScriptConfiguration scriptConfiguration;
     private final ExpressionEvaluator expressionEvaluator;
+    private final String minifiedSource;
 
     public ScriptManager(final ScriptConfiguration scriptConfiguration, final ExpressionEvaluator expressionEvaluator) {
         this.scriptConfiguration = scriptConfiguration;
         this.expressionEvaluator = expressionEvaluator;
+        this.minifiedSource = scriptConfiguration != null ? minifyScript(scriptConfiguration.getSource()) : null;
     }
 
     public boolean isScriptEnabled() {
@@ -61,10 +63,27 @@ public class ScriptManager {
             resolvedParams.forEach((k, v) -> scriptParams.put(k, JsonData.of(v)));
         }
         final InlineScript inlineScript = new InlineScript.Builder()
-                .source(scriptConfiguration.getSource())
+                .source(minifiedSource)
                 .lang(PAINLESS)
                 .params(scriptParams)
                 .build();
         return Script.of(s -> s.inline(inlineScript));
+    }
+
+    static String minifyScript(final String source) {
+        if (source == null) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder();
+        for (final String line : source.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.isEmpty() && !trimmed.startsWith("//")) {
+                if (sb.length() > 0) {
+                    sb.append('\n');
+                }
+                sb.append(trimmed);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ScriptManagerMinifyTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ScriptManagerMinifyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+class ScriptManagerMinifyTest {
+
+    @Test
+    void minifyScript_removes_comment_lines() {
+        final String source = "// This is a comment\nctx._source.field = params.value;\n// Another comment\nctx.op = 'none';";
+        final String result = ScriptManager.minifyScript(source);
+        assertThat(result, equalTo("ctx._source.field = params.value;\nctx.op = 'none';"));
+    }
+
+    @Test
+    void minifyScript_removes_blank_lines() {
+        final String source = "ctx._source.a = 1;\n\n\nctx._source.b = 2;";
+        final String result = ScriptManager.minifyScript(source);
+        assertThat(result, equalTo("ctx._source.a = 1;\nctx._source.b = 2;"));
+    }
+
+    @Test
+    void minifyScript_trims_leading_whitespace() {
+        final String source = "  ctx._source.a = 1;\n    ctx._source.b = 2;";
+        final String result = ScriptManager.minifyScript(source);
+        assertThat(result, equalTo("ctx._source.a = 1;\nctx._source.b = 2;"));
+    }
+
+    @Test
+    void minifyScript_handles_mixed_comments_blanks_and_code() {
+        final String source = "// Header comment\n\nString table = params.table;\n// Inline explanation\nlong version = Long.parseLong(params.version);\n\n// Footer\n";
+        final String result = ScriptManager.minifyScript(source);
+        assertThat(result, equalTo("String table = params.table;\nlong version = Long.parseLong(params.version);"));
+    }
+
+    @Test
+    void minifyScript_returns_null_for_null_input() {
+        assertThat(ScriptManager.minifyScript(null), nullValue());
+    }
+
+    @Test
+    void minifyScript_preserves_inline_comments_after_code() {
+        final String source = "ctx._source.a = 1; // keep this line";
+        final String result = ScriptManager.minifyScript(source);
+        assertThat(result, equalTo("ctx._source.a = 1; // keep this line"));
+    }
+
+    @Test
+    void minifyScript_single_line_no_comments() {
+        final String source = "ctx._source.counter += 1;";
+        final String result = ScriptManager.minifyScript(source);
+        assertThat(result, equalTo("ctx._source.counter += 1;"));
+    }
+}


### PR DESCRIPTION
### Description
Strip comment lines and blank lines from the Painless script source at initialization time. This reduces the script payload size sent to OpenSearch on every bulk request, improving network efficiency.

The minification is done once in the ScriptManager constructor and the result is reused for all subsequent buildScript calls. Only full-line comments (lines starting with //) and empty lines are removed. Inline comments after code are preserved.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
