### PR TITLE
Adds Divyansh Bokadia (divbok) to the maintainers group.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @sb2k16 @engechas @san81 @srikanthjg @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh
+*   @divbok @sb2k16 @engechas @san81 @srikanthjg @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer             | GitHub ID                                                 | Affiliation |
 | ---------------------- | --------------------------------------------------------- | ----------- |
+| Divyansh Bokadia       | [divbok](https://github.com/divbok)               | Amazon      |
 | Souvik Bose            | [sb2k16](https://github.com/sb2k16)               | Amazon      |
 | Chase Engelbrecht      | [engechas](https://github.com/engechas)                   | Amazon      |
 | Santhosh Gandhe        | [san81](https://github.com/san81)             | Amazon      |


### PR DESCRIPTION
### Description

Divyansh Bokadia ([divbok](https://github.com/divbok)) has contributed [17 merged PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is%3Apr+author%3Adivbok+is%3Aclosed) to the project. Many of these have been for the RDS source. A couple significant PRs include:

* [#](https://github.com/opensearch-project/data-prepper/pull/6671)[6671](https://github.com/opensearch-project/data-prepper/pull/6671) - supporting HTTP headers as event metadata in the http source.
* [#6415](https://github.com/opensearch-project/data-prepper/pull/6415) - reading from a Kinesis stream from a specific timestamp.

I also want to highlight that he has participated in [47 merged PRs as a reviewer](https://github.com/opensearch-project/data-prepper/pulls?q=is%3Apr+reviewed-by%3Adivbok+is%3Aclosed). I believe this is significant as maintainers play an important role in reviewing PRs.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
