### PR TITLE
Updates the triage meeting time to 11am Central / 9am Pacific.

### DIFF
--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -16,7 +16,7 @@ However, should we run out of time before your issue is discussed, you are alway
 
 ### How do I join the triage meeting?
 
-Meetings are hosted regularly Tuesdays at 2:30 PM US Central Time (12:30 PM Pacific Time) and can be joined via the links posted on the [OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events.
+Meetings are hosted regularly Tuesdays at 11:00 AM US Central Time (9:00 AM Pacific Time) and can be joined via the links posted on the [OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events.
 The event will be titled `OpenSearch Data Prepper Triage Meeting`.
 
 After joining the video meeting, you can enable your video / voice to join the discussion.


### PR DESCRIPTION
### Description

Updates the triage meeting time to 11am Central / 9am Pacific.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
