### PR TITLE
Adds Xun Zhang (Zhangxunmt) to the maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @divbok @sb2k16 @san81 @srikanthjg @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh
+*   @divbok @sb2k16 @san81 @srikanthjg @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh @Zhangxunmt

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,6 +16,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Karsten Schnitter      | [KarstenSchnitter](https://github.com/KarstenSchnitter)   | SAP         |
 | David Venable          | [dlvenable](https://github.com/dlvenable)                 | Amazon      |
 | Hai Yan                | [oeyh](https://github.com/oeyh)                           | Amazon      |
+| Xun Zhang              | [Zhangxunmt](https://github.com/Zhangxunmt)               | Amazon      |
 
 
 ## Emeritus


### PR DESCRIPTION
### Description

Adds Xun Zhang ([Zhangxunmt](https://github.com/Zhangxunmt)) to the list of maintainers.

Xun Zhang ([Zhangxunmt](https://github.com/Zhangxunmt)) has contributed [15 merged PRs](https://github.com/opensearch-project/data-prepper/issues?q=is%3Apr%20state%3Aclosed%20author%3AZhangxunmt) to the project. These are significant and include two new processors. I’d like to highlight some of the major changes.
* Created the ML inference processor using OpenSearch ML Commons ([#](https://github.com/opensearch-project/data-prepper/pull/5507)[5507](https://github.com/opensearch-project/data-prepper/pull/5507)).
* Adding conditions for completed S3 objects during S3 scan ([#6624](https://github.com/opensearch-project/data-prepper/pull/6624)).
* Created the S3 Enrich processor to use S3 data for enriching events in the pipeline ([#5992](https://github.com/opensearch-project/data-prepper/pull/5992)).
* Refactoring the S3 source to share code with the S3 enrich processor ([#6404](https://github.com/opensearch-project/data-prepper/pull/6404)).
 
Additionally, he has participated in [4 PR reviews](https://github.com/opensearch-project/data-prepper/pulls?q=is%3Apr+reviewed-by%3AZhangxunmt+-author%3AZhangxunmt+is%3Aclosed). I believe this is something important for project maintainers.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
