### PR TITLE
Include child primary key in fields for one-to-one joins

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/JoinMetadataEnricher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/JoinMetadataEnricher.java
@@ -13,6 +13,7 @@ package org.opensearch.dataprepper.plugins.source.rds.converter;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.JoinRelation;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.JoinType;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -114,7 +115,9 @@ public class JoinMetadataEnricher {
         final Set<String> keys = new HashSet<>();
         keys.addAll(relation.getParentKey());
         keys.addAll(relation.getChildKey());
-        if (!isParent) {
+        // For 1:N children, exclude child PK from fields since the script adds it separately.
+        // For 1:1 children, include child PK in fields since it's flattened at root like other fields.
+        if (!isParent && relation.getJoinType() != JoinType.ONE_TO_ONE) {
             keys.addAll(relation.getChildPrimaryKey());
         }
         return keys;

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/JoinMetadataEnricherTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/JoinMetadataEnricherTest.java
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.JoinMetadataEnricher.JOIN_CHILD_PK_NAME_METADATA;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.JoinMetadataEnricher.JOIN_CHILD_PK_VALUE_METADATA;
@@ -142,6 +144,42 @@ class JoinMetadataEnricherTest {
         enricher.enrich(event, "shipping", List.of("shipping_id", "order_id", "carrier"), false);
 
         assertThat(event.getMetadata().getAttribute(JOIN_TYPE_METADATA), is("one_to_one"));
+    }
+
+    @Test
+    void enrich_one_to_one_child_includes_child_primary_key_in_fields() {
+        JoinRelation relation = createRelation("orders", "shipping",
+                "order_id", "order_id", "shipping_id", "one_to_one");
+        JoinMetadataEnricher enricher = new JoinMetadataEnricher(List.of(relation));
+
+        Event event = createEvent(Map.of("shipping_id", 1, "order_id", 5, "carrier", "UPS", "tracking_number", "TRK-5"));
+
+        enricher.enrich(event, "shipping", List.of("shipping_id", "order_id", "carrier", "tracking_number"), false);
+
+        // For 1:1 joins, child PK (shipping_id) should be included in fields since it's flattened at root
+        final String fields = (String) event.getMetadata().getAttribute(JOIN_FIELDS_METADATA);
+        assertThat(fields, containsString("shipping_id"));
+        assertThat(fields, containsString("carrier"));
+        assertThat(fields, containsString("tracking_number"));
+        // order_id (join key) should still be excluded
+        assertThat(fields, not(containsString("order_id")));
+    }
+
+    @Test
+    void enrich_one_to_many_child_excludes_child_primary_key_from_fields() {
+        JoinRelation relation = createRelation("orders", "order_items",
+                "order_id", "order_id", "item_id", "one_to_many");
+        JoinMetadataEnricher enricher = new JoinMetadataEnricher(List.of(relation));
+
+        Event event = createEvent(Map.of("item_id", 10, "order_id", 1, "product_name", "Widget", "price", 9.99));
+
+        enricher.enrich(event, "order_items", List.of("item_id", "order_id", "product_name", "price"), false);
+
+        // For 1:N joins, child PK (item_id) should be excluded from fields (script adds it separately)
+        final String fields = (String) event.getMetadata().getAttribute(JOIN_FIELDS_METADATA);
+        assertThat(fields, not(containsString("item_id")));
+        assertThat(fields, containsString("product_name"));
+        assertThat(fields, containsString("price"));
     }
 
     @Test


### PR DESCRIPTION
### Description
For one-to-many joins, the child primary key (e.g., item_id) is excluded from the _fields metadata because the Painless script adds it separately via the child_pk_name parameter. However, for one-to-one joins, the script only iterates _fields to flatten child columns at the document root — it does not add the child primary key separately. This caused the child PK (e.g., shipping_id) to be missing from the denormalized OpenSearch document.

Fix: Only exclude child primary key from _fields for one-to-many joins. For one-to-one joins, the child PK is now included in _fields so it gets flattened at the document root like other child columns.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
