### PR TITLE
Refactors the OpenSearch sink to split out the ingestion code from the rest

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngester.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngester.java
@@ -1,0 +1,638 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.VersionType;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
+import org.opensearch.dataprepper.expression.ExpressionEvaluationException;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.MetricNames;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.InternalEventHandle;
+import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
+import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.SinkContext;
+import org.opensearch.dataprepper.model.sink.SinkForwardRecordsContext;
+import org.opensearch.dataprepper.plugins.dlq.DlqProvider;
+import org.opensearch.dataprepper.plugins.dlq.DlqWriter;
+import org.opensearch.dataprepper.plugins.dlq.s3.S3DlqProvider;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkRequest;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkApiWrapper;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkApiWrapperFactory;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkOperationWriter;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingCompressedBulkRequest;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingUncompressedBulkRequest;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
+import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.DlqConfiguration;
+import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
+import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperationConverter;
+import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilder;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamDetector;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamIndex;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DocumentBuilder;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexCache;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
+
+/**
+ * Implementation of {@link Ingester} that uses the OpenSearch
+ * bulk APIs to ingest data.
+ */
+public class BulkIngester implements Ingester {
+    private static final Logger LOG = LoggerFactory.getLogger(BulkIngester.class);
+    private static final String PLUGIN_NAME = "opensearch";
+
+    private final OpenSearchSinkConfiguration openSearchSinkConfig;
+    private final ExpressionEvaluator expressionEvaluator;
+    private final SinkContext sinkContext;
+    private final SinkForwardRecordsContext sinkForwardRecordsContext;
+    private final PluginMetrics pluginMetrics;
+    private final String pipeline;
+    private final EventActionResolver eventActionResolver;
+
+    private final OpenSearchClient openSearchClient;
+    private final Supplier<OpenSearchClient> openSearchClientSupplier;
+    private final Supplier<IndexManager> indexManagerSupplier;
+    private final Supplier<HeadlessPipeline> failurePipelineSupplier;
+
+    private final long bulkSize;
+    private final long flushTimeout;
+    private final String documentIdField;
+    private final String documentId;
+    private final String routingField;
+    private final String routing;
+    private final String documentRootKey;
+    private final VersionType versionType;
+    private final String versionExpression;
+    private final ScriptManager scriptManager;
+    private final BulkOperationFactory bulkOperationFactory;
+    private final FailedBulkOperationConverter failedBulkOperationConverter;
+
+    private final Timer bulkRequestTimer;
+    private final Counter bulkRequestErrorsCounter;
+    private final Counter invalidActionErrorsCounter;
+    private final Counter dynamicIndexDroppedEvents;
+    private final DistributionSummary bulkRequestSizeBytesSummary;
+    private final Counter dynamicDocumentVersionDroppedEvents;
+
+    private final ConcurrentHashMap<Long, AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>> bulkRequestMap;
+    private final ConcurrentHashMap<Long, Long> lastFlushTimeMap;
+
+    private final DlqProvider dlqProvider;
+    private final String dlqFile;
+    private final ExecutorService queryExecutorService;
+    private final CustomDocumentBuilder customDocumentBuilder;
+
+    private boolean useEventInBulkOperation;
+
+    private DlqWriter dlqWriter;
+    private BufferedWriter dlqFileWriter;
+    private Supplier<AccumulatingBulkRequest> bulkRequestSupplier;
+    private BulkRetryStrategy bulkRetryStrategy;
+    private BulkApiWrapper bulkApiWrapper;
+    private DataStreamIndex dataStreamIndex;
+    private ExistingDocumentQueryManager existingDocumentQueryManager;
+    private IndexManager indexManager;
+    private String configuredIndexAlias;
+
+    public BulkIngester(final OpenSearchSinkConfiguration openSearchSinkConfig,
+                        final ExpressionEvaluator expressionEvaluator,
+                        final SinkContext sinkContext,
+                        final PluginMetrics pluginMetrics,
+                        final String pipeline,
+                        final EventActionResolver eventActionResolver,
+                        final OpenSearchClient openSearchClient,
+                        final Supplier<OpenSearchClient> openSearchClientSupplier,
+                        final Supplier<IndexManager> indexManagerSupplier,
+                        final Supplier<HeadlessPipeline> failurePipelineSupplier,
+                        final CustomDocumentBuilder customDocumentBuilder) {
+        this.openSearchSinkConfig = openSearchSinkConfig;
+        this.expressionEvaluator = expressionEvaluator;
+        this.sinkContext = sinkContext;
+        this.sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
+        this.pluginMetrics = pluginMetrics;
+        this.pipeline = pipeline;
+        this.eventActionResolver = eventActionResolver;
+
+        this.openSearchClient = openSearchClient;
+        this.openSearchClientSupplier = openSearchClientSupplier;
+        this.indexManagerSupplier = indexManagerSupplier;
+        this.failurePipelineSupplier = failurePipelineSupplier;
+
+        this.bulkSize = org.opensearch.common.unit.ByteSizeUnit.MB.toBytes(
+                openSearchSinkConfig.getIndexConfiguration().getBulkSize());
+        this.flushTimeout = openSearchSinkConfig.getIndexConfiguration().getFlushTimeout();
+        this.documentIdField = openSearchSinkConfig.getIndexConfiguration().getDocumentIdField();
+        this.documentId = openSearchSinkConfig.getIndexConfiguration().getDocumentId();
+        this.routingField = openSearchSinkConfig.getIndexConfiguration().getRoutingField();
+        this.routing = openSearchSinkConfig.getIndexConfiguration().getRouting();
+        this.documentRootKey = openSearchSinkConfig.getIndexConfiguration().getDocumentRootKey();
+        this.versionType = openSearchSinkConfig.getIndexConfiguration().getVersionType();
+        this.versionExpression = openSearchSinkConfig.getIndexConfiguration().getVersionExpression();
+        this.scriptManager = new ScriptManager(openSearchSinkConfig.getIndexConfiguration().getScriptConfiguration(),
+                expressionEvaluator);
+        this.bulkOperationFactory = new BulkOperationFactory(versionType, scriptManager, new ObjectMapper(),
+                isUsingDocumentFilters());
+        this.failedBulkOperationConverter = new FailedBulkOperationConverter(pipeline, PLUGIN_NAME);
+
+        this.bulkRequestTimer = pluginMetrics.timer(OpenSearchSink.BULKREQUEST_LATENCY);
+        this.bulkRequestErrorsCounter = pluginMetrics.counter(OpenSearchSink.BULKREQUEST_ERRORS);
+        this.invalidActionErrorsCounter = pluginMetrics.counter(OpenSearchSink.INVALID_ACTION_ERRORS);
+        this.dynamicIndexDroppedEvents = pluginMetrics.counter(OpenSearchSink.DYNAMIC_INDEX_DROPPED_EVENTS);
+        this.bulkRequestSizeBytesSummary = pluginMetrics.summary(OpenSearchSink.BULKREQUEST_SIZE_BYTES);
+        this.dynamicDocumentVersionDroppedEvents = pluginMetrics.counter(
+                OpenSearchSink.INVALID_VERSION_EXPRESSION_DROPPED_EVENTS);
+
+        this.bulkRequestMap = new ConcurrentHashMap<>();
+        this.lastFlushTimeMap = new ConcurrentHashMap<>();
+
+        final Optional<DlqConfiguration> dlqConfig = openSearchSinkConfig.getRetryConfiguration().getDlq();
+        if (dlqConfig.isPresent()) {
+            this.dlqProvider = new S3DlqProvider(dlqConfig.get().getS3DlqWriterConfig());
+        } else {
+            this.dlqProvider = null;
+        }
+        this.dlqFile = openSearchSinkConfig.getRetryConfiguration().getDlqFile();
+
+        this.customDocumentBuilder = customDocumentBuilder;
+
+        this.queryExecutorService = openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null ?
+                Executors.newSingleThreadExecutor(
+                        BackgroundThreadFactory.defaultExecutorThreadFactory("existing-document-query-manager")) : null;
+    }
+
+    @Override
+    public void initialize() throws IOException {
+        this.indexManager = indexManagerSupplier.get();
+        final HeadlessPipeline failurePipeline = failurePipelineSupplier.get();
+        this.useEventInBulkOperation = (failurePipeline != null || sinkContext.getForwardToPipelines().size() > 0);
+        this.configuredIndexAlias = openSearchSinkConfig.getIndexConfiguration().getIndexAlias();
+
+        setupDlq();
+
+        final Boolean requireAlias = indexManager.isIndexAlias(configuredIndexAlias);
+        setupBulkRequestSupplier(requireAlias);
+
+        final int maxRetries = openSearchSinkConfig.getRetryConfiguration().getMaxRetries();
+        bulkApiWrapper = BulkApiWrapperFactory.getWrapper(openSearchSinkConfig.getIndexConfiguration(),
+                openSearchClientSupplier);
+
+        if (queryExecutorService != null) {
+            existingDocumentQueryManager = new ExistingDocumentQueryManager(
+                    openSearchSinkConfig.getIndexConfiguration(), pluginMetrics, openSearchClient);
+            queryExecutorService.submit(existingDocumentQueryManager);
+        }
+
+        bulkRetryStrategy = new BulkRetryStrategy(
+                bulkRequest -> bulkApiWrapper.bulk(bulkRequest.getRequest()),
+                this::logFailureForBulkRequests,
+                this::successfulOperationsHandler,
+                pluginMetrics,
+                maxRetries,
+                bulkRequestSupplier,
+                pipeline,
+                PLUGIN_NAME,
+                openSearchSinkConfig.getIndexConfiguration().getQueryOnBulkFailures() ? existingDocumentQueryManager : null,
+                isExternalVersionType(versionType));
+
+        final IndexCache indexCache = new IndexCache();
+        final DataStreamDetector dataStreamDetector = new DataStreamDetector(openSearchClient, indexCache);
+        this.dataStreamIndex = new DataStreamIndex(dataStreamDetector, openSearchSinkConfig.getIndexConfiguration());
+
+        eventActionResolver.setDataStreamSupport(dataStreamDetector, dataStreamIndex);
+    }
+
+    @Override
+    public void output(final Collection<Record<Event>> records) {
+        final long threadId = Thread.currentThread().getId();
+        if (!bulkRequestMap.containsKey(threadId)) {
+            bulkRequestMap.put(threadId, bulkRequestSupplier.get());
+        }
+        if (!lastFlushTimeMap.containsKey(threadId)) {
+            lastFlushTimeMap.put(threadId, System.currentTimeMillis());
+        }
+
+        AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest = bulkRequestMap.get(threadId);
+        long lastFlushTime = lastFlushTimeMap.get(threadId);
+
+        Set<BulkOperationWrapper> documentsReadyForIndexing = new HashSet<>();
+        if (openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null) {
+            documentsReadyForIndexing = existingDocumentQueryManager.getAndClearBulkOperationsReadyToIndex();
+        }
+
+        if (!documentsReadyForIndexing.isEmpty()) {
+            LOG.info("Found {} documents ready for indexing from query manager", documentsReadyForIndexing.size());
+        }
+
+        for (final BulkOperationWrapper bulkOperationWrapper : documentsReadyForIndexing) {
+            bulkRequest = flushBatch(bulkRequest, bulkOperationWrapper, lastFlushTime);
+            bulkRequest.addOperation(bulkOperationWrapper);
+        }
+
+        final HeadlessPipeline failurePipeline = failurePipelineSupplier.get();
+
+        for (final Record<Event> record : records) {
+            final Event event = record.getData();
+            String indexName = configuredIndexAlias;
+            try {
+                indexName = indexManager.getIndexName(event.formatString(indexName, expressionEvaluator));
+            } catch (final Exception e) {
+                LOG.error(NOISY,
+                        "There was an exception when constructing the index name. Check the dlq if configured to see details about the affected Event: {}",
+                        e.getMessage());
+                dynamicIndexDroppedEvents.increment();
+                logFailureForDlqObjects(failurePipeline, List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
+                continue;
+            }
+
+            dataStreamIndex.ensureTimestamp(event, indexName);
+
+            if (customDocumentBuilder != null) {
+                try {
+                    final List<String> tsdbDocs = customDocumentBuilder.buildDocuments(event);
+                    final String tsdbAction = eventActionResolver.resolveAction(event, indexName);
+                    final EventHandle eventHandle = event.getEventHandle();
+                    if (tsdbDocs.size() > 1 && eventHandle instanceof InternalEventHandle) {
+                        for (int i = 0; i < tsdbDocs.size() - 1; i++) {
+                            ((InternalEventHandle) eventHandle).acquireReference();
+                        }
+                    }
+                    for (final String tsdbDoc : tsdbDocs) {
+                        final SerializedJson doc = SerializedJson.fromStringAndOptionals(tsdbDoc, null, null, null);
+                        final BulkOperation op = bulkOperationFactory.create(tsdbAction, doc, null, indexName, null);
+                        final BulkOperationWrapper wrapper = new BulkOperationWrapper(op, eventHandle, null, null);
+                        bulkRequest = flushBatch(bulkRequest, wrapper, lastFlushTime);
+                        bulkRequest.addOperation(wrapper);
+                    }
+                } catch (final Exception e) {
+                    LOG.error("Failed to build TSDB documents for event: {}", e.getMessage(), e);
+                    dynamicIndexDroppedEvents.increment();
+                    logFailureForDlqObjects(failurePipelineSupplier.get(), List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
+                }
+                continue;
+            }
+
+            final SerializedJson document = getDocument(event);
+
+            Long version = null;
+            String versionExpressionEvaluationResult = null;
+            if (versionExpression != null) {
+                try {
+                    versionExpressionEvaluationResult = event.formatString(versionExpression, expressionEvaluator);
+                    version = Long.valueOf(event.formatString(versionExpression, expressionEvaluator));
+                } catch (final NumberFormatException e) {
+                    final String errorMessage = String.format(
+                            "Unable to convert the result of evaluating document_version '%s' to Long for an Event. The evaluation result '%s' must be a valid Long type",
+                            versionExpression, versionExpressionEvaluationResult);
+                    LOG.error(errorMessage);
+                    logFailureForDlqObjects(failurePipeline, List.of(createDlqObjectFromEvent(event, indexName, errorMessage)), e);
+                    dynamicDocumentVersionDroppedEvents.increment();
+                    continue;
+                } catch (final RuntimeException e) {
+                    final String errorMessage = String.format(
+                            "There was an exception when evaluating the document_version '%s': %s",
+                            versionExpression, e.getMessage());
+                    LOG.error(errorMessage
+                            + " Check the dlq if configured to see more details about the affected Event");
+                    logFailureForDlqObjects(failurePipeline, List.of(createDlqObjectFromEvent(event, indexName, errorMessage)), e);
+                    dynamicDocumentVersionDroppedEvents.increment();
+                    continue;
+                }
+            }
+
+            final String eventAction = eventActionResolver.resolveAction(event, indexName);
+            if (!eventActionResolver.isValidAction(eventAction)) {
+                LOG.error("Unknown action {}, skipping the event", eventAction);
+                invalidActionErrorsCounter.increment();
+                continue;
+            }
+
+            SerializedJson serializedJsonNode = null;
+            if (StringUtils.equals(eventAction, OpenSearchBulkActions.UPDATE.toString()) ||
+                    StringUtils.equals(eventAction, OpenSearchBulkActions.UPSERT.toString()) ||
+                    StringUtils.equals(eventAction, OpenSearchBulkActions.DELETE.toString())) {
+                serializedJsonNode = SerializedJson.fromJsonNode(event.getJsonNode(), document);
+            }
+            BulkOperation bulkOperation;
+
+            try {
+                bulkOperation = bulkOperationFactory.create(eventAction, document, version, indexName,
+                        event.getJsonNode());
+            } catch (final Exception e) {
+                LOG.error("An exception occurred while constructing the bulk operation for a document: ", e);
+                logFailureForDlqObjects(failurePipeline, List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
+                continue;
+            }
+
+            final String queryTermKey = openSearchSinkConfig.getIndexConfiguration().getQueryTerm();
+            final String termValue = queryTermKey != null ?
+                    event.get(queryTermKey, String.class) : null;
+            BulkOperationWrapper bulkOperationWrapper = (useEventInBulkOperation) ?
+                    new BulkOperationWrapper(bulkOperation, event, serializedJsonNode, termValue) :
+                    new BulkOperationWrapper(bulkOperation, event.getEventHandle(), serializedJsonNode, termValue);
+
+            if (openSearchSinkConfig.getIndexConfiguration().getQueryWhen() != null &&
+                    expressionEvaluator.evaluateConditional(
+                            openSearchSinkConfig.getIndexConfiguration().getQueryWhen(), event)) {
+                existingDocumentQueryManager.addBulkOperation(bulkOperationWrapper);
+                continue;
+            }
+
+            bulkRequest = flushBatch(bulkRequest, bulkOperationWrapper, lastFlushTime);
+            bulkRequest.addOperation(bulkOperationWrapper);
+        }
+
+        if (System.currentTimeMillis() - lastFlushTime > flushTimeout && bulkRequest.getOperationsCount() > 0) {
+            flushBatch(bulkRequest);
+            lastFlushTime = System.currentTimeMillis();
+            bulkRequest = bulkRequestSupplier.get();
+        }
+
+        bulkRequestMap.put(threadId, bulkRequest);
+        lastFlushTimeMap.put(threadId, lastFlushTime);
+    }
+
+    @Override
+    public void shutdown() {
+        if (dlqWriter != null) {
+            try {
+                dlqWriter.close();
+            } catch (final IOException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        if (dlqFileWriter != null) {
+            try {
+                dlqFileWriter.close();
+            } catch (final IOException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        if (queryExecutorService != null && existingDocumentQueryManager != null) {
+            existingDocumentQueryManager.stop();
+            queryExecutorService.shutdown();
+        }
+    }
+
+    @VisibleForTesting
+    SerializedJson getDocument(final Event event) {
+        String docId = null;
+
+        if (documentIdField != null) {
+            docId = event.get(documentIdField, String.class);
+        } else if (documentId != null) {
+            try {
+                docId = event.formatString(documentId, expressionEvaluator);
+            } catch (final ExpressionEvaluationException | EventKeyNotFoundException e) {
+                LOG.error("Unable to construct document_id with format {}, the document_id will be generated by OpenSearch",
+                        documentId, e);
+            }
+        }
+
+        String routingValue = null;
+        if (routingField != null) {
+            routingValue = event.get(routingField, String.class);
+        } else if (routing != null) {
+            try {
+                routingValue = event.formatString(routing, expressionEvaluator);
+            } catch (final ExpressionEvaluationException | EventKeyNotFoundException e) {
+                LOG.error("Unable to construct routing with format {}, the routing will be generated by OpenSearch",
+                        routing, e);
+            }
+        }
+
+        final String document = DocumentBuilder.build(event, documentRootKey, sinkContext.getTagsTargetKey(),
+                sinkContext.getIncludeKeys(), sinkContext.getExcludeKeys());
+
+        return SerializedJson.builder()
+                .withJsonString(document)
+                .withDocumentId(docId)
+                .withRoutingField(routingValue)
+                .withResolvedScriptParameters(scriptManager.resolveParams(event))
+                .build();
+    }
+
+    @VisibleForTesting
+    void successfulOperationsHandler(final List<BulkOperationWrapper> successfulOperations) {
+        if (successfulOperations.size() == 0) {
+            return;
+        }
+        if (sinkContext.getForwardToPipelines().size() == 0) {
+            for (final BulkOperationWrapper bulkOperation : successfulOperations) {
+                if (bulkOperation.getEvent() != null) {
+                    bulkOperation.getEvent().getEventHandle().release(true);
+                } else {
+                    bulkOperation.releaseEventHandle(true);
+                }
+            }
+            return;
+        }
+        for (final BulkOperationWrapper bulkOperation : successfulOperations) {
+            sinkForwardRecordsContext.addRecord(new Record<>(bulkOperation.getEvent()));
+        }
+        sinkContext.forwardRecords(sinkForwardRecordsContext, null, null);
+    }
+
+    private void flushBatch(final AccumulatingBulkRequest accumulatingBulkRequest) {
+        bulkRequestTimer.record(() -> {
+            try {
+                LOG.debug("Sending data to OpenSearch");
+                bulkRetryStrategy.execute(accumulatingBulkRequest);
+                bulkRequestSizeBytesSummary.record(accumulatingBulkRequest.getEstimatedSizeInBytes());
+            } catch (final InterruptedException e) {
+                LOG.error("Unexpected Interrupt:", e);
+                bulkRequestErrorsCounter.increment();
+                Thread.currentThread().interrupt();
+            }
+        });
+    }
+
+    private AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> flushBatch(
+            final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest,
+            final BulkOperationWrapper bulkOperationWrapper,
+            long lastFlushTime) {
+        final long estimatedBytesBeforeAdd = bulkRequest.estimateSizeInBytesWithDocument(bulkOperationWrapper);
+        if (bulkSize >= 0 && estimatedBytesBeforeAdd >= bulkSize && bulkRequest.getOperationsCount() > 0) {
+            flushBatch(bulkRequest);
+            lastFlushTime = System.currentTimeMillis();
+            return bulkRequestSupplier.get();
+        }
+        return bulkRequest;
+    }
+
+    private void logFailureForBulkRequests(final List<FailedBulkOperation> failedBulkOperations,
+                                           final Throwable failure) {
+        final List<DlqObject> dlqObjects = failedBulkOperations.stream()
+                .map(failedBulkOperationConverter::convertToDlqObject)
+                .collect(Collectors.toList());
+        logFailureForDlqObjects(failurePipelineSupplier.get(), dlqObjects, failure);
+    }
+
+    private void logFailureForDlqObjects(final HeadlessPipeline failurePipeline,
+                                         final List<DlqObject> dlqObjects, final Throwable failure) {
+        if (failurePipeline != null) {
+            List<Record<Event>> records = new ArrayList<>();
+            for (DlqObject dlqObject : dlqObjects) {
+                Event event = dlqObject.getEvent();
+                if (event != null) {
+                    event.updateFailureMetadata()
+                            .withPluginId(dlqObject.getPluginId())
+                            .withPluginName(dlqObject.getPluginName())
+                            .withPipelineName(dlqObject.getPipelineName())
+                            .withErrorMessage(((FailedDlqData) dlqObject.getFailedData()).getMessage())
+                            .with("status", ((FailedDlqData) dlqObject.getFailedData()).getStatus())
+                            .with("index", ((FailedDlqData) dlqObject.getFailedData()).getIndex())
+                            .with("indexId", ((FailedDlqData) dlqObject.getFailedData()).getIndexId());
+                    records.add(new Record<>(event));
+                }
+            }
+            failurePipeline.sendEvents(records);
+            return;
+        }
+        if (dlqFileWriter != null) {
+            dlqObjects.forEach(dlqObject -> {
+                final FailedDlqData failedDlqData = (FailedDlqData) dlqObject.getFailedData();
+                final String message = failure == null ? failedDlqData.getMessage() : failure.getMessage();
+                try {
+                    dlqFileWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
+                            BulkOperationWriter.dlqObjectToString(dlqObject), message));
+                    dlqObject.releaseEventHandle(true);
+                } catch (final IOException e) {
+                    LOG.error(NOISY, "Failed to write a document to the DLQ", e);
+                    dlqObject.releaseEventHandle(false);
+                }
+            });
+        } else if (dlqWriter != null) {
+            try {
+                dlqWriter.write(dlqObjects, pipeline, PLUGIN_NAME);
+                dlqObjects.forEach(dlqObject -> dlqObject.releaseEventHandle(true));
+            } catch (final IOException e) {
+                dlqObjects.forEach(dlqObject -> {
+                    LOG.error(NOISY, "Failed to write a document to the DLQ", e);
+                    dlqObject.releaseEventHandle(false);
+                });
+            }
+        } else {
+            dlqObjects.forEach(dlqObject -> {
+                final FailedDlqData failedDlqData = (FailedDlqData) dlqObject.getFailedData();
+                final String message = failure == null ? failedDlqData.getMessage() : failure.getMessage();
+                LOG.warn("Document failed to write to OpenSearch with error code {}. Configure a DLQ to save failed documents. Error: {}",
+                        failedDlqData.getStatus(), message);
+                dlqObject.releaseEventHandle(false);
+            });
+        }
+    }
+
+    private DlqObject createDlqObjectFromEvent(final Event event,
+                                               final String index,
+                                               final String message) {
+        DlqObject.Builder builder = DlqObject.builder()
+                .withFailedData(FailedDlqData.builder()
+                        .withDocument(event.toJsonString())
+                        .withIndex(index)
+                        .withMessage(message != null ? message : "")
+                        .build())
+                .withPluginName(PLUGIN_NAME)
+                .withPipelineName(pipeline)
+                .withPluginId(PLUGIN_NAME);
+
+        if (useEventInBulkOperation) {
+            builder.withEvent(event);
+        } else {
+            builder.withEventHandle(event.getEventHandle());
+        }
+        return builder.build();
+    }
+
+    private boolean isUsingDocumentFilters() {
+        return documentRootKey != null ||
+                (sinkContext.getIncludeKeys() != null && !sinkContext.getIncludeKeys().isEmpty()) ||
+                (sinkContext.getExcludeKeys() != null && !sinkContext.getExcludeKeys().isEmpty()) ||
+                sinkContext.getTagsTargetKey() != null;
+    }
+
+    private static boolean isExternalVersionType(final VersionType versionType) {
+        return versionType != null && (versionType == VersionType.External || versionType == VersionType.ExternalGte);
+    }
+
+    private void setupDlq() {
+        if (dlqFile != null) {
+            try {
+                dlqFileWriter = Files.newBufferedWriter(Paths.get(dlqFile), StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
+            } catch (final IOException e) {
+                throw new RuntimeException("Failed to open DLQ file: " + dlqFile, e);
+            }
+        } else if (dlqProvider != null) {
+            Optional<DlqWriter> potentialDlq = dlqProvider.getDlqWriter(new StringJoiner(MetricNames.DELIMITER)
+                    .add(pipeline)
+                    .add(PLUGIN_NAME).toString());
+            dlqWriter = potentialDlq.isPresent() ? potentialDlq.get() : null;
+        }
+    }
+
+    private void setupBulkRequestSupplier(final Boolean requireAlias) {
+        final boolean isEstimateBulkSizeUsingCompression =
+                openSearchSinkConfig.getIndexConfiguration().isEstimateBulkSizeUsingCompression();
+        final boolean isRequestCompressionEnabled =
+                openSearchSinkConfig.getConnectionConfiguration().isRequestCompressionEnabled();
+        if (isEstimateBulkSizeUsingCompression && isRequestCompressionEnabled) {
+            final int maxLocalCompressionsForEstimation =
+                    openSearchSinkConfig.getIndexConfiguration().getMaxLocalCompressionsForEstimation();
+            bulkRequestSupplier = () -> new JavaClientAccumulatingCompressedBulkRequest(
+                    new BulkRequest.Builder().requireAlias(requireAlias), bulkSize,
+                    maxLocalCompressionsForEstimation);
+        } else {
+            if (isEstimateBulkSizeUsingCompression) {
+                LOG.warn("Estimate bulk request size using compression was enabled but request compression is disabled. "
+                        + "Estimating bulk request size without compression.");
+            }
+            bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(
+                    new BulkRequest.Builder().requireAlias(requireAlias));
+        }
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/EventActionResolver.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/EventActionResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.ActionConfiguration;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamDetector;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamIndex;
+
+import java.util.List;
+
+public class EventActionResolver {
+
+    private final String defaultAction;
+    private final List<ActionConfiguration> actions;
+    private final ExpressionEvaluator expressionEvaluator;
+    private DataStreamDetector dataStreamDetector;
+    private DataStreamIndex dataStreamIndex;
+
+    public EventActionResolver(final String defaultAction,
+                               final List<ActionConfiguration> actions,
+                               final ExpressionEvaluator expressionEvaluator) {
+        this.defaultAction = defaultAction;
+        this.actions = actions;
+        this.expressionEvaluator = expressionEvaluator;
+    }
+
+    public void setDataStreamSupport(final DataStreamDetector dataStreamDetector,
+                                     final DataStreamIndex dataStreamIndex) {
+        this.dataStreamDetector = dataStreamDetector;
+        this.dataStreamIndex = dataStreamIndex;
+    }
+
+    String resolveAction(final Event event, final String indexName) {
+        String eventAction = defaultAction;
+        if (actions != null) {
+            for (final ActionConfiguration actionEntry : actions) {
+                final String condition = actionEntry.getWhen();
+                eventAction = actionEntry.getType();
+                if (condition != null &&
+                        expressionEvaluator.evaluateConditional(condition, event)) {
+                    break;
+                }
+            }
+        }
+        if (eventAction.contains("${")) {
+            eventAction = event.formatString(eventAction, expressionEvaluator);
+        }
+
+        if (dataStreamDetector != null && dataStreamDetector.isDataStream(indexName)) {
+            eventAction = dataStreamIndex.determineAction(eventAction, indexName);
+        }
+
+        return eventAction;
+    }
+
+    public boolean isValidAction(final String action) {
+        return OpenSearchBulkActions.fromOptionValue(action) != null;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/Ingester.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/Ingester.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * An interface for a mechanism to ingest data into OpenSearch.
+ */
+public interface Ingester {
+    void initialize() throws IOException;
+
+    void output(Collection<Record<Event>> records);
+
+    void shutdown();
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -9,101 +9,43 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Timer;
-import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.VersionType;
-import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.transport.TransportOptions;
-import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
-import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
-import org.opensearch.dataprepper.expression.ExpressionEvaluationException;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
-import org.opensearch.dataprepper.model.event.InternalEventHandle;
-import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
-import org.opensearch.dataprepper.model.failures.DlqObject;
-import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.model.sink.SinkContext;
-import org.opensearch.dataprepper.model.sink.SinkForwardRecordsContext;
 import org.opensearch.dataprepper.plugins.common.opensearch.ServerlessNetworkPolicyUpdater;
 import org.opensearch.dataprepper.plugins.common.opensearch.ServerlessNetworkPolicyUpdaterFactory;
 import org.opensearch.dataprepper.plugins.common.opensearch.ServerlessOptionsFactory;
-import org.opensearch.dataprepper.plugins.dlq.DlqProvider;
-import org.opensearch.dataprepper.plugins.dlq.DlqWriter;
-import org.opensearch.dataprepper.plugins.dlq.s3.S3DlqProvider;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkRequest;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkApiWrapper;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkApiWrapperFactory;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkOperationWriter;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingCompressedBulkRequest;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingUncompressedBulkRequest;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
-import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.ActionConfiguration;
-import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.DlqConfiguration;
 import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.OpenSearchSinkConfig;
-import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
-import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperationConverter;
-import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.ClusterSettingsParser;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamDetector;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamIndex;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexCache;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.DocumentBuilder;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.ExistingDocumentQueryManager;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilderFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManagerFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapper;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexTemplateAPIWrapperFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilder;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.CustomDocumentBuilderFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateStrategy;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.ServerlessOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 
 @DataPrepperPlugin(name = "opensearch", pluginType = Sink.class, pluginConfigurationType = OpenSearchSinkConfig.class)
 public class OpenSearchSink extends AbstractSink<Record<Event>> {
@@ -113,71 +55,22 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   public static final String BULKREQUEST_SIZE_BYTES = "bulkRequestSizeBytes";
   public static final String DYNAMIC_INDEX_DROPPED_EVENTS = "dynamicIndexDroppedEvents";
   public static final String INVALID_VERSION_EXPRESSION_DROPPED_EVENTS = "dynamicDocumentVersionDroppedEvents";
-  private static final String PLUGIN_NAME = "opensearch";
 
   private static final Logger LOG = LoggerFactory.getLogger(OpenSearchSink.class);
   private static final int INITIALIZE_RETRY_WAIT_TIME_MS = 5000;
-  private final AwsCredentialsSupplier awsCredentialsSupplier;
 
-  private DlqWriter dlqWriter;
-  private BufferedWriter dlqFileWriter;
+  private final AwsCredentialsSupplier awsCredentialsSupplier;
   private final OpenSearchSinkConfiguration openSearchSinkConfig;
   private final IndexManagerFactory indexManagerFactory;
-  private RestHighLevelClient restHighLevelClient;
-  private IndexManager indexManager;
-  private Supplier<AccumulatingBulkRequest> bulkRequestSupplier;
-  private BulkRetryStrategy bulkRetryStrategy;
-  private BulkApiWrapper bulkApiWrapper;
-  private final long bulkSize;
-  private final long flushTimeout;
   private final IndexType indexType;
-  private final String documentIdField;
-  private final String documentId;
-  private final String routingField;
-  private final String routing;
-  private final String pipeline;
-  private final String action;
-  private final List<ActionConfiguration> actions;
-  private final ScriptManager scriptManager;
-  private final BulkOperationFactory bulkOperationFactory;
-  private final String documentRootKey;
-  private String configuredIndexAlias;
-  private final ReentrantLock lock;
-  private final VersionType versionType;
-  private final String versionExpression;
-
-  private final Timer bulkRequestTimer;
-  private final Counter bulkRequestErrorsCounter;
-  private final Counter invalidActionErrorsCounter;
-  private final Counter dynamicIndexDroppedEvents;
-  private final DistributionSummary bulkRequestSizeBytesSummary;
-  private final Counter dynamicDocumentVersionDroppedEvents;
-  private OpenSearchClient openSearchClient;
-  private OpenSearchClientRefresher openSearchClientRefresher;
-  private ObjectMapper objectMapper;
-  private volatile boolean initialized;
-  private final SinkContext sinkContext;
-  private final ExpressionEvaluator expressionEvaluator;
-  private boolean useEventInBulkOperation;
-
-  private FailedBulkOperationConverter failedBulkOperationConverter;
-  private DataStreamDetector dataStreamDetector;
-  private DataStreamIndex dataStreamIndex;
-  IndexCache indexCache;
-
-  private DlqProvider dlqProvider;
-  private final ConcurrentHashMap<Long, AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>> bulkRequestMap;
-  private final ConcurrentHashMap<Long, Long> lastFlushTimeMap;
   private final PluginConfigObservable pluginConfigObservable;
+  private final Ingester ingester;
 
-  private ExistingDocumentQueryManager existingDocumentQueryManager;
-
-  private final CustomDocumentBuilder customDocumentBuilder;
-
-  private final ExecutorService queryExecutorService;
-
-  private final int processWorkerThreads;
-  private final SinkForwardRecordsContext sinkForwardRecordsContext;
+  private final RestHighLevelClient restHighLevelClient;
+  private final OpenSearchClient openSearchClient;
+  private final OpenSearchClientRefresher openSearchClientRefresher;
+  private IndexManager indexManager;
+  private volatile boolean initialized;
 
   @DataPrepperPluginConstructor
   public OpenSearchSink(final PluginSetting pluginSetting,
@@ -188,60 +81,48 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
                         final PluginConfigObservable pluginConfigObservable,
                         final OpenSearchSinkConfig openSearchSinkConfiguration) {
     super(pluginSetting, Integer.MAX_VALUE, INITIALIZE_RETRY_WAIT_TIME_MS);
-    this.processWorkerThreads = pipelineDescription.getNumberOfProcessWorkers();
     this.awsCredentialsSupplier = awsCredentialsSupplier;
-    this.sinkContext = sinkContext != null ? sinkContext : new SinkContext(null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    sinkForwardRecordsContext = new SinkForwardRecordsContext(sinkContext);
-    this.expressionEvaluator = expressionEvaluator;
-    this.pipeline = pipelineDescription.getPipelineName();
-    bulkRequestTimer = pluginMetrics.timer(BULKREQUEST_LATENCY);
-    bulkRequestErrorsCounter = pluginMetrics.counter(BULKREQUEST_ERRORS);
-    invalidActionErrorsCounter = pluginMetrics.counter(INVALID_ACTION_ERRORS);
-    dynamicIndexDroppedEvents = pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS);
-    bulkRequestSizeBytesSummary = pluginMetrics.summary(BULKREQUEST_SIZE_BYTES);
-    dynamicDocumentVersionDroppedEvents = pluginMetrics.counter(INVALID_VERSION_EXPRESSION_DROPPED_EVENTS);
+    this.pluginConfigObservable = pluginConfigObservable;
+
+    final SinkContext resolvedSinkContext = sinkContext != null ? sinkContext :
+            new SinkContext(null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
 
     this.openSearchSinkConfig = OpenSearchSinkConfiguration.readOSConfig(openSearchSinkConfiguration, expressionEvaluator);
-    this.bulkSize = ByteSizeUnit.MB.toBytes(openSearchSinkConfig.getIndexConfiguration().getBulkSize());
-    this.flushTimeout = openSearchSinkConfig.getIndexConfiguration().getFlushTimeout();
     this.indexType = openSearchSinkConfig.getIndexConfiguration().getIndexType();
-    this.documentIdField = openSearchSinkConfig.getIndexConfiguration().getDocumentIdField();
-    this.documentId = openSearchSinkConfig.getIndexConfiguration().getDocumentId();
-    this.routingField = openSearchSinkConfig.getIndexConfiguration().getRoutingField();
-    this.routing = openSearchSinkConfig.getIndexConfiguration().getRouting();
-    this.action = openSearchSinkConfig.getIndexConfiguration().getAction();
-    this.actions = openSearchSinkConfig.getIndexConfiguration().getActions();
-    this.scriptManager = new ScriptManager(openSearchSinkConfig.getIndexConfiguration().getScriptConfiguration(), expressionEvaluator);
-    this.documentRootKey = openSearchSinkConfig.getIndexConfiguration().getDocumentRootKey();
-    this.versionType = openSearchSinkConfig.getIndexConfiguration().getVersionType();
-    this.versionExpression = openSearchSinkConfig.getIndexConfiguration().getVersionExpression();
     this.indexManagerFactory = new IndexManagerFactory(new ClusterSettingsParser());
-    this.failedBulkOperationConverter = new FailedBulkOperationConverter(pipeline, PLUGIN_NAME);
     this.initialized = false;
-    this.lock = new ReentrantLock(true);
-    this.bulkRequestMap = new ConcurrentHashMap<>();
-    this.lastFlushTimeMap = new ConcurrentHashMap<>();
-    this.pluginConfigObservable = pluginConfigObservable;
-    this.objectMapper = new ObjectMapper();
-    this.bulkOperationFactory = new BulkOperationFactory(versionType, scriptManager, objectMapper, isUsingDocumentFilters());
-    this.customDocumentBuilder = new CustomDocumentBuilderFactory().create(this.indexType);
-    this.queryExecutorService = openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null ?
-            Executors.newSingleThreadExecutor(BackgroundThreadFactory.defaultExecutorThreadFactory("existing-document-query-manager")) : null;
 
-    final Optional<DlqConfiguration> dlqConfig = openSearchSinkConfig.getRetryConfiguration().getDlq();
+    final ConnectionConfiguration connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
+    restHighLevelClient = connectionConfiguration.createClient(awsCredentialsSupplier);
+    openSearchClient = connectionConfiguration.createOpenSearchClient(restHighLevelClient, awsCredentialsSupplier);
+    final Function<ConnectionConfiguration, OpenSearchClient> clientFunction =
+            (connConfig) -> {
+      final RestHighLevelClient client = connConfig.createClient(awsCredentialsSupplier);
+      return connConfig.createOpenSearchClient(client, awsCredentialsSupplier).withTransportOptions(
+              TransportOptions.builder()
+                      .setParameter("filter_path", "errors,took,items.*.error,items.*.status,items.*._index,items.*._id")
+                      .build());
+    };
+    openSearchClientRefresher = new OpenSearchClientRefresher(
+            pluginMetrics, connectionConfiguration, clientFunction);
 
-    if (dlqConfig.isPresent()) {
-      dlqProvider = new S3DlqProvider(dlqConfig.get().getS3DlqWriterConfig());
-    }
+    final String pipeline = pipelineDescription.getPipelineName();
+    final EventActionResolver eventActionResolver = new EventActionResolver(
+            openSearchSinkConfig.getIndexConfiguration().getAction(),
+            openSearchSinkConfig.getIndexConfiguration().getActions(),
+            expressionEvaluator);
+
+    this.ingester = new BulkIngester(openSearchSinkConfig, expressionEvaluator, resolvedSinkContext,
+            pluginMetrics, pipeline, eventActionResolver,
+            openSearchClient, () -> openSearchClientRefresher.get(),
+            this::getIndexManager, this::getFailurePipeline,
+            new CustomDocumentBuilderFactory().create(this.indexType));
   }
 
   @Override
   public void doInitialize() {
     try {
         doInitializeInternal();
-        // getFailurePipeline() does not return valid value in the constructor. Earliest it can be used
-        // is in doInitialize()
-        useEventInBulkOperation = (getFailurePipeline() != null || sinkContext.getForwardToPipelines().size() > 0);
     } catch (IOException e) {
         LOG.warn("Failed to initialize OpenSearch sink, retrying: {} ", e.getMessage());
         this.shutdown();
@@ -261,87 +142,30 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   private void doInitializeInternal() throws IOException {
     LOG.info("Initializing OpenSearch sink");
-    final ConnectionConfiguration connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
-    restHighLevelClient = connectionConfiguration.createClient(awsCredentialsSupplier);
-    openSearchClient = connectionConfiguration.createOpenSearchClient(restHighLevelClient, awsCredentialsSupplier);
-    final Function<ConnectionConfiguration, OpenSearchClient> clientFunction =
-            (connectionConfiguration1) -> {
-      final RestHighLevelClient restHighLevelClient1 = connectionConfiguration1.createClient(awsCredentialsSupplier);
-      return connectionConfiguration1.createOpenSearchClient(restHighLevelClient1, awsCredentialsSupplier).withTransportOptions(
-              TransportOptions.builder()
-                      .setParameter("filter_path", "errors,took,items.*.error,items.*.status,items.*._index,items.*._id")
-                      .build());
-    };
-    openSearchClientRefresher = new OpenSearchClientRefresher(
-            pluginMetrics, connectionConfiguration, clientFunction);
 
     pluginConfigObservable.addPluginConfigObserver(
             newOpenSearchSinkConfig -> openSearchClientRefresher.update((OpenSearchSinkConfig) newOpenSearchSinkConfig));
-    configuredIndexAlias = openSearchSinkConfig.getIndexConfiguration().getIndexAlias();
+
+    final String configuredIndexAlias = openSearchSinkConfig.getIndexConfiguration().getIndexAlias();
     final IndexTemplateAPIWrapper indexTemplateAPIWrapper = IndexTemplateAPIWrapperFactory.getWrapper(
             openSearchSinkConfig.getIndexConfiguration(), openSearchClient);
     final TemplateStrategy templateStrategy = openSearchSinkConfig.getIndexConfiguration().getTemplateType()
             .createTemplateStrategy(indexTemplateAPIWrapper);
     indexManager = indexManagerFactory.getIndexManager(indexType, openSearchClient, restHighLevelClient,
             openSearchSinkConfig, templateStrategy, configuredIndexAlias);
-    final String dlqFile = openSearchSinkConfig.getRetryConfiguration().getDlqFile();
-     if (dlqFile != null) {
-      dlqFileWriter = Files.newBufferedWriter(Paths.get(dlqFile), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-    } else if (dlqProvider != null) {
-      Optional<DlqWriter> potentialDlq = dlqProvider.getDlqWriter(new StringJoiner(MetricNames.DELIMITER)
-          .add(pipeline)
-          .add(PLUGIN_NAME).toString());
-      dlqWriter = potentialDlq.isPresent() ? potentialDlq.get() : null;
-    }
 
-    // Attempt to update the serverless network policy if required argument are given.
     maybeUpdateServerlessNetworkPolicy();
 
     indexManager.setupIndex();
 
-    final Boolean requireAlias = indexManager.isIndexAlias(configuredIndexAlias);
-    final boolean isEstimateBulkSizeUsingCompression = openSearchSinkConfig.getIndexConfiguration().isEstimateBulkSizeUsingCompression();
-    final boolean isRequestCompressionEnabled = openSearchSinkConfig.getConnectionConfiguration().isRequestCompressionEnabled();
-    if (isEstimateBulkSizeUsingCompression && isRequestCompressionEnabled) {
-      final int maxLocalCompressionsForEstimation = openSearchSinkConfig.getIndexConfiguration().getMaxLocalCompressionsForEstimation();
-      bulkRequestSupplier = () -> new JavaClientAccumulatingCompressedBulkRequest(new BulkRequest.Builder().requireAlias(requireAlias), bulkSize, maxLocalCompressionsForEstimation);
-    } else if (isEstimateBulkSizeUsingCompression) {
-      LOG.warn("Estimate bulk request size using compression was enabled but request compression is disabled. " +
-              "Estimating bulk request size without compression.");
-      bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder().requireAlias(requireAlias));
-    } else {
-      bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder().requireAlias(requireAlias));
-    }
-
-    final int maxRetries = openSearchSinkConfig.getRetryConfiguration().getMaxRetries();
-    bulkApiWrapper = BulkApiWrapperFactory.getWrapper(openSearchSinkConfig.getIndexConfiguration(),
-            () -> openSearchClientRefresher.get());
-    bulkRetryStrategy = new BulkRetryStrategy(bulkRequest -> bulkApiWrapper.bulk(bulkRequest.getRequest()),
-            this::logFailureForBulkRequests,
-            this::successfulOperationsHandler,
-            pluginMetrics,
-            maxRetries,
-            bulkRequestSupplier,
-            pipeline,
-            PLUGIN_NAME,
-            openSearchSinkConfig.getIndexConfiguration().getQueryOnBulkFailures() ? existingDocumentQueryManager : null,
-            isExternalVersionType(openSearchSinkConfig.getIndexConfiguration().getVersionType()));
-
-    if (queryExecutorService != null) {
-      existingDocumentQueryManager = new ExistingDocumentQueryManager(openSearchSinkConfig.getIndexConfiguration(), pluginMetrics, openSearchClient);
-      queryExecutorService.submit(existingDocumentQueryManager);
-    }
-
-    this.indexCache = new IndexCache();
-    this.dataStreamDetector = new DataStreamDetector(openSearchClient, indexCache);
-    this.dataStreamIndex = new DataStreamIndex(dataStreamDetector, openSearchSinkConfig.getIndexConfiguration());
+    ingester.initialize();
 
     this.initialized = true;
     LOG.info("Initialized OpenSearch sink");
   }
 
-  double getInvalidActionErrorsCount() {
-    return invalidActionErrorsCounter.count();
+  IndexManager getIndexManager() {
+    return indexManager;
   }
 
   @Override
@@ -351,297 +175,13 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   @Override
   public void doOutput(final Collection<Record<Event>> records) {
-    final long threadId = Thread.currentThread().getId();
-    if (!bulkRequestMap.containsKey(threadId)) {
-      bulkRequestMap.put(threadId, bulkRequestSupplier.get());
-    }
-    if (!lastFlushTimeMap.containsKey(threadId)) {
-      lastFlushTimeMap.put(threadId, System.currentTimeMillis());
-    }
-
-    AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest = bulkRequestMap.get(threadId);
-    long lastFlushTime = lastFlushTimeMap.get(threadId);
-
-    Set<BulkOperationWrapper> documentsReadyForIndexing = new HashSet<>();
-    if (openSearchSinkConfig.getIndexConfiguration().getQueryTerm() != null) {
-      documentsReadyForIndexing = existingDocumentQueryManager.getAndClearBulkOperationsReadyToIndex();
-    }
-
-
-    if (!documentsReadyForIndexing.isEmpty()) {
-      LOG.info("Found {} documents ready for indexing from query manager", documentsReadyForIndexing.size());
-    }
-
-    for (final BulkOperationWrapper bulkOperationWrapper : documentsReadyForIndexing) {
-      bulkRequest = flushBatch(bulkRequest, bulkOperationWrapper, lastFlushTime);
-      bulkRequest.addOperation(bulkOperationWrapper);
-    }
-
-
-    for (final Record<Event> record : records) {
-      final Event event = record.getData();
-      String indexName = configuredIndexAlias;
-      try {
-          indexName = indexManager.getIndexName(event.formatString(indexName, expressionEvaluator));
-      } catch (final Exception e) {
-          LOG.error(NOISY, "There was an exception when constructing the index name. Check the dlq if configured to see details about the affected Event: {}", e.getMessage());
-          dynamicIndexDroppedEvents.increment();
-          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
-          continue;
-      }
-      
-      dataStreamIndex.ensureTimestamp(event, indexName);
-
-      if (customDocumentBuilder != null) {
-        try {
-          final List<String> tsdbDocs = customDocumentBuilder.buildDocuments(event);
-          final String tsdbAction = resolveEventAction(event);
-          final EventHandle eventHandle = event.getEventHandle();
-          if (tsdbDocs.size() > 1 && eventHandle instanceof InternalEventHandle) {
-            for (int i = 0; i < tsdbDocs.size() - 1; i++) {
-              ((InternalEventHandle) eventHandle).acquireReference();
-            }
-          }
-          for (final String tsdbDoc : tsdbDocs) {
-            final SerializedJson doc = SerializedJson.fromStringAndOptionals(tsdbDoc, null, null, null);
-            final BulkOperation op = bulkOperationFactory.create(tsdbAction, doc, null, indexName, null);
-            final BulkOperationWrapper wrapper = new BulkOperationWrapper(op, eventHandle, null, null);
-            bulkRequest = flushBatch(bulkRequest, wrapper, lastFlushTime);
-            bulkRequest.addOperation(wrapper);
-          }
-        } catch (final Exception e) {
-          LOG.error("Failed to build TSDB documents for event: {}", e.getMessage(), e);
-          dynamicIndexDroppedEvents.increment();
-          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
-        }
-        continue;
-      }
-
-      final SerializedJson document = getDocument(event);
-
-      Long version = null;
-      String versionExpressionEvaluationResult = null;
-      if (versionExpression != null) {
-        try {
-          versionExpressionEvaluationResult = event.formatString(versionExpression, expressionEvaluator);
-          version = Long.valueOf(event.formatString(versionExpression, expressionEvaluator));
-        } catch (final NumberFormatException e) {
-          // Skip this event from the bulk request after sending to DLQ to avoid
-          // including events with invalid versions in the OpenSearch bulk request.
-          // See https://github.com/opensearch-project/data-prepper/issues/6601
-          final String errorMessage = String.format(
-                  "Unable to convert the result of evaluating document_version '%s' to Long for an Event. The evaluation result '%s' must be a valid Long type", versionExpression, versionExpressionEvaluationResult
-          );
-          LOG.error(errorMessage);
-          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, errorMessage)), e);
-          dynamicDocumentVersionDroppedEvents.increment();
-          continue;
-        } catch (final RuntimeException e) {
-          // Skip this event from the bulk request after sending to DLQ to avoid
-          // including events with invalid versions in the OpenSearch bulk request.
-          // See https://github.com/opensearch-project/data-prepper/issues/6601
-          final String errorMessage = String.format(
-                  "There was an exception when evaluating the document_version '%s': %s", versionExpression, e.getMessage());
-          LOG.error(errorMessage + " Check the dlq if configured to see more details about the affected Event");
-          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, errorMessage)), e);
-          dynamicDocumentVersionDroppedEvents.increment();
-          continue;
-        }
-      }
-
-      String eventAction = resolveEventAction(event);
-      
-      if (dataStreamDetector.isDataStream(indexName)) {
-        eventAction = dataStreamIndex.determineAction(eventAction, indexName);
-      }
-      if (OpenSearchBulkActions.fromOptionValue(eventAction) == null) {
-        LOG.error("Unknown action {}, skipping the event", eventAction);
-        invalidActionErrorsCounter.increment();
-        continue;
-      }
-
-      SerializedJson serializedJsonNode = null;
-      if (StringUtils.equals(eventAction, OpenSearchBulkActions.UPDATE.toString()) ||
-          StringUtils.equals(eventAction, OpenSearchBulkActions.UPSERT.toString()) ||
-          StringUtils.equals(eventAction, OpenSearchBulkActions.DELETE.toString())) {
-            serializedJsonNode = SerializedJson.fromJsonNode(event.getJsonNode(), document);
-      }
-      BulkOperation bulkOperation;
-
-      try {
-        bulkOperation = bulkOperationFactory.create(eventAction, document, version, indexName, event.getJsonNode());
-      } catch (final Exception e) {
-        LOG.error("An exception occurred while constructing the bulk operation for a document: ", e);
-        logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
-        continue;
-      }
-
-      final String queryTermKey = openSearchSinkConfig.getIndexConfiguration().getQueryTerm();
-      final String termValue = queryTermKey != null ?
-              event.get(queryTermKey, String.class) : null;
-      BulkOperationWrapper bulkOperationWrapper = (useEventInBulkOperation) ?
-              new BulkOperationWrapper(bulkOperation, event, serializedJsonNode, termValue) :
-              new BulkOperationWrapper(bulkOperation, event.getEventHandle(), serializedJsonNode, termValue);
-
-      if (openSearchSinkConfig.getIndexConfiguration().getQueryWhen() != null &&
-              expressionEvaluator.evaluateConditional(openSearchSinkConfig.getIndexConfiguration().getQueryWhen(), event)) {
-        existingDocumentQueryManager.addBulkOperation(bulkOperationWrapper);
-        continue;
-      }
-
-      bulkRequest = flushBatch(bulkRequest, bulkOperationWrapper, lastFlushTime);
-      bulkRequest.addOperation(bulkOperationWrapper);
-    }
-
-    // Flush the remaining requests if flush timeout expired
-    if (System.currentTimeMillis() - lastFlushTime > flushTimeout && bulkRequest.getOperationsCount() > 0) {
-      flushBatch(bulkRequest);
-      lastFlushTime = System.currentTimeMillis();
-      bulkRequest = bulkRequestSupplier.get();
-    }
-
-    bulkRequestMap.put(threadId, bulkRequest);
-    lastFlushTimeMap.put(threadId, lastFlushTime);
+    ingester.output(records);
   }
 
-  SerializedJson getDocument(final Event event) {
-    String docId = null;
-
-    if (Objects.nonNull(documentIdField)) {
-      docId = event.get(documentIdField, String.class);
-    } else if (Objects.nonNull(documentId)) {
-      try {
-        docId = event.formatString(documentId, expressionEvaluator);
-      } catch (final ExpressionEvaluationException | EventKeyNotFoundException e) {
-        LOG.error("Unable to construct document_id with format {}, the document_id will be generated by OpenSearch", documentId, e);
-      }
-    }
-
-    String routingValue = null;
-    if (routingField != null) {
-      routingValue = event.get(routingField, String.class);
-    } else if (routing != null) {
-      try {
-        routingValue = event.formatString(routing, expressionEvaluator);
-      } catch (final ExpressionEvaluationException | EventKeyNotFoundException e) {
-        LOG.error("Unable to construct routing with format {}, the routing will be generated by OpenSearch", routing, e);
-      }
-    }
-
-    final String document = DocumentBuilder.build(event, documentRootKey, sinkContext.getTagsTargetKey(), sinkContext.getIncludeKeys(), sinkContext.getExcludeKeys());
-
-    return SerializedJson.builder()
-            .withJsonString(document)
-            .withDocumentId(docId)
-            .withRoutingField(routingValue)
-            .withResolvedScriptParameters(scriptManager.resolveParams(event))
-            .build();
-  }
-
-  private void flushBatch(AccumulatingBulkRequest accumulatingBulkRequest) {
-    bulkRequestTimer.record(() -> {
-      try {
-        LOG.debug("Sending data to OpenSearch");
-        bulkRetryStrategy.execute(accumulatingBulkRequest);
-        bulkRequestSizeBytesSummary.record(accumulatingBulkRequest.getEstimatedSizeInBytes());
-      } catch (final InterruptedException e) {
-        LOG.error("Unexpected Interrupt:", e);
-        bulkRequestErrorsCounter.increment();
-        Thread.currentThread().interrupt();
-      }
-    });
-  }
-
-  @VisibleForTesting
-  void successfulOperationsHandler(final List<BulkOperationWrapper> successfulOperations) {
-    if (successfulOperations.size() == 0) {
-        return;
-    }
-    if (sinkContext.getForwardToPipelines().size() == 0) {
-      for (final BulkOperationWrapper bulkOperation: successfulOperations) {
-        if (bulkOperation.getEvent() != null) {
-            bulkOperation.getEvent().getEventHandle().release(true);
-        } else {
-            bulkOperation.releaseEventHandle(true);
-        }
-      }
-      return;
-    }
-    for (final BulkOperationWrapper bulkOperation: successfulOperations) {
-      sinkForwardRecordsContext.addRecord(new Record<>(bulkOperation.getEvent()));
-    }
-    sinkContext.forwardRecords(sinkForwardRecordsContext, null, null);
-  }
-
-  private void logFailureForBulkRequests(final List<FailedBulkOperation> failedBulkOperations, final Throwable failure) {
-
-    final List<DlqObject> dlqObjects = failedBulkOperations.stream()
-        .map(failedBulkOperationConverter::convertToDlqObject)
-        .collect(Collectors.toList());
-
-    logFailureForDlqObjects(dlqObjects, failure);
-  }
-
-  private void logFailureForDlqObjects(final List<DlqObject> dlqObjects, final Throwable failure) {
-    if (getFailurePipeline() != null) {
-      List<Record<Event>> records = new ArrayList<>();
-      for (DlqObject dlqObject : dlqObjects) {
-        Event event = dlqObject.getEvent();
-
-        if (event != null) {
-            event.updateFailureMetadata()
-                .withPluginId(dlqObject.getPluginId())
-                .withPluginName(dlqObject.getPluginName())
-                .withPipelineName(dlqObject.getPipelineName())
-                .withErrorMessage(((FailedDlqData) dlqObject.getFailedData()).getMessage())
-                .with("status", ((FailedDlqData) dlqObject.getFailedData()).getStatus())
-                .with("index", ((FailedDlqData) dlqObject.getFailedData()).getIndex())
-                .with("indexId", ((FailedDlqData) dlqObject.getFailedData()).getIndexId());
-          records.add(new Record<>(event));
-        }
-      }
-      getFailurePipeline().sendEvents(records);
-      return;
-    }
-    if (dlqFileWriter != null) {
-      dlqObjects.forEach(dlqObject -> {
-        final FailedDlqData failedDlqData = (FailedDlqData) dlqObject.getFailedData();
-        final String message = failure == null ? failedDlqData.getMessage() : failure.getMessage();
-        try {
-          dlqFileWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
-                  BulkOperationWriter.dlqObjectToString(dlqObject), message));
-          dlqObject.releaseEventHandle(true);
-        } catch (final IOException e) {
-        LOG.error(NOISY, "Failed to write a document to the DLQ", e);
-          dlqObject.releaseEventHandle(false);
-        }
-      });
-    } else if (dlqWriter != null) {
-      try {
-        dlqWriter.write(dlqObjects, pipeline, PLUGIN_NAME);
-        dlqObjects.forEach((dlqObject) -> {
-          dlqObject.releaseEventHandle(true);
-        });
-      } catch (final IOException e) {
-        dlqObjects.forEach(dlqObject -> {
-          LOG.error(NOISY, "Failed to write a document to the DLQ", e);
-          dlqObject.releaseEventHandle(false);
-        });
-      }
-    } else {
-      dlqObjects.forEach(dlqObject -> {
-
-        final FailedDlqData failedDlqData = (FailedDlqData) dlqObject.getFailedData();
-
-        final String message = failure == null ? failedDlqData.getMessage() : failure.getMessage();
-        LOG.warn("Document failed to write to OpenSearch with error code {}. Configure a DLQ to save failed documents. Error: {}", failedDlqData.getStatus(), message);
-        dlqObject.releaseEventHandle(false);
-      });
-    }
-  }
-
-  private void closeFiles() {
-    // Close the client. This closes the low-level client which will close it for both high-level clients.
+  @Override
+  public void shutdown() {
+    super.shutdown();
+    ingester.shutdown();
     if (restHighLevelClient != null) {
       try {
         restHighLevelClient.close();
@@ -649,32 +189,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         throw new RuntimeException(e.getMessage(), e);
       }
     }
-    if (dlqWriter != null) {
-      try {
-        dlqWriter.close();
-      } catch (final IOException e) {
-        LOG.error(e.getMessage(), e);
-      }
-    }
-    if (dlqFileWriter != null) {
-      try {
-        dlqFileWriter.close();
-      } catch (final IOException e) {
-        LOG.error(e.getMessage(), e);
-      }
-    }
-  }
-
-  @Override
-  public void shutdown() {
-    super.shutdown();
-    closeFiles();
     if (openSearchClient != null) {
       openSearchClient.shutdown();
-    }
-    if (queryExecutorService != null && existingDocumentQueryManager != null) {
-      existingDocumentQueryManager.stop();
-      queryExecutorService.shutdown();
     }
   }
 
@@ -692,75 +208,5 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
           maybeServerlessOptions.get().getVpceId()
       );
     }
-  }
-
-  private static boolean isExternalVersionType(final VersionType versionType) {
-    return versionType != null && (versionType == VersionType.External || versionType == VersionType.ExternalGte);
-  }
-
-  private DlqObject createDlqObjectFromEvent(final Event event,
-                                             final String index,
-                                             final String message) {
-    DlqObject.Builder builder = DlqObject.builder()
-            .withFailedData(FailedDlqData.builder()
-                    .withDocument(event.toJsonString())
-                    .withIndex(index)
-                    .withMessage(message != null ? message : "")
-                    .build())
-            .withPluginName(PLUGIN_NAME)
-            .withPipelineName(pipeline)
-            .withPluginId(PLUGIN_NAME);
-
-    if (useEventInBulkOperation) {
-      builder.withEvent(event);
-    } else {
-      builder.withEventHandle(event.getEventHandle());
-    }
-    return builder.build();
-  }
-
-  private String resolveEventAction(final Event event) {
-    String resolvedAction = action;
-    if (actions != null) {
-      for (final ActionConfiguration actionEntry : actions) {
-        final String condition = actionEntry.getWhen();
-        resolvedAction = actionEntry.getType();
-        if (condition != null &&
-                expressionEvaluator.evaluateConditional(condition, event)) {
-          break;
-        }
-      }
-    }
-    if (resolvedAction.contains("${")) {
-      resolvedAction = event.formatString(resolvedAction, expressionEvaluator);
-    }
-    return resolvedAction;
-  }
-
-  /**
-   * This function is used for update and upsert bulk actions to determine whether the original JsonNode needs to be filtered down
-   * based on the user's sink configuration. If a new parameter manipulates the document before sending to OpenSearch, it needs to be added to
-   * this list to get applied for update and upsert actions
-   * @return whether the doc
-   */
-  private boolean isUsingDocumentFilters() {
-    return documentRootKey != null ||
-            (sinkContext.getIncludeKeys() != null && !sinkContext.getIncludeKeys().isEmpty()) ||
-            (sinkContext.getExcludeKeys() != null && !sinkContext.getExcludeKeys().isEmpty()) ||
-            sinkContext.getTagsTargetKey() != null;
-  }
-
-  private AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> flushBatch(
-          final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest,
-          final BulkOperationWrapper bulkOperationWrapper,
-          long lastFlushTime
-          ) {
-    final long estimatedBytesBeforeAdd = bulkRequest.estimateSizeInBytesWithDocument(bulkOperationWrapper);
-    if (bulkSize >= 0 && estimatedBytesBeforeAdd >= bulkSize && bulkRequest.getOperationsCount() > 0) {
-      flushBatch(bulkRequest);
-      lastFlushTime = System.currentTimeMillis();
-      return bulkRequestSupplier.get();
-    }
-   return bulkRequest;
   }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngesterTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngesterTest.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.VersionType;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.SinkContext;
+import org.opensearch.dataprepper.model.sink.SinkForwardRecordsContext;
+import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DocumentBuilder;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.BULKREQUEST_ERRORS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.BULKREQUEST_LATENCY;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.BULKREQUEST_SIZE_BYTES;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.DYNAMIC_INDEX_DROPPED_EVENTS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.INVALID_ACTION_ERRORS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.INVALID_VERSION_EXPRESSION_DROPPED_EVENTS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.configuration.OpenSearchSinkConfig.DEFAULT_BULK_SIZE;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.configuration.OpenSearchSinkConfig.DEFAULT_FLUSH_TIMEOUT;
+
+@ExtendWith(MockitoExtension.class)
+public class BulkIngesterTest {
+
+    @Mock
+    private SinkContext sinkContext;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
+    @Mock
+    private OpenSearchSinkConfiguration openSearchSinkConfiguration;
+
+    @Mock
+    private IndexConfiguration indexConfiguration;
+
+    @Mock
+    private IndexManager indexManager;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Timer bulkRequestTimer;
+
+    @Mock
+    private Counter bulkRequestErrorsCounter;
+
+    @Mock
+    private Counter invalidActionErrorsCounter;
+
+    @Mock
+    private Counter dynamicIndexDroppedEvents;
+
+    @Mock
+    private DistributionSummary bulkRequestSizeBytesSummary;
+
+    @Mock
+    private Counter dynamicDocumentVersionDroppedEvents;
+
+    @Mock
+    private EventActionResolver eventActionResolver;
+
+    private String pipeline;
+
+    @BeforeEach
+    void setup() {
+        pipeline = UUID.randomUUID().toString();
+
+        final RetryConfiguration retryConfiguration = mock(RetryConfiguration.class);
+        when(retryConfiguration.getDlq()).thenReturn(Optional.empty());
+        lenient().when(retryConfiguration.getDlqFile()).thenReturn(null);
+
+        lenient().when(indexConfiguration.getAction()).thenReturn("index");
+        lenient().when(indexConfiguration.getDocumentId()).thenReturn(null);
+        lenient().when(indexConfiguration.getDocumentIdField()).thenReturn(null);
+        lenient().when(indexConfiguration.getRouting()).thenReturn(null);
+        lenient().when(indexConfiguration.getActions()).thenReturn(null);
+        lenient().when(indexConfiguration.getDocumentRootKey()).thenReturn(null);
+        lenient().when(indexConfiguration.getVersionType()).thenReturn(null);
+        lenient().when(indexConfiguration.getVersionExpression()).thenReturn(null);
+        lenient().when(indexConfiguration.getIndexAlias()).thenReturn(UUID.randomUUID().toString());
+        lenient().when(indexConfiguration.getBulkSize()).thenReturn(DEFAULT_BULK_SIZE);
+        lenient().when(indexConfiguration.getFlushTimeout()).thenReturn(DEFAULT_FLUSH_TIMEOUT);
+
+        lenient().when(openSearchSinkConfiguration.getIndexConfiguration()).thenReturn(indexConfiguration);
+        lenient().when(openSearchSinkConfiguration.getRetryConfiguration()).thenReturn(retryConfiguration);
+
+        lenient().when(pluginMetrics.timer(BULKREQUEST_LATENCY)).thenReturn(bulkRequestTimer);
+        lenient().when(pluginMetrics.counter(BULKREQUEST_ERRORS)).thenReturn(bulkRequestErrorsCounter);
+        lenient().when(pluginMetrics.counter(INVALID_ACTION_ERRORS)).thenReturn(invalidActionErrorsCounter);
+        lenient().when(pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS)).thenReturn(dynamicIndexDroppedEvents);
+        lenient().when(pluginMetrics.counter(INVALID_VERSION_EXPRESSION_DROPPED_EVENTS)).thenReturn(dynamicDocumentVersionDroppedEvents);
+        lenient().when(pluginMetrics.summary(BULKREQUEST_SIZE_BYTES)).thenReturn(bulkRequestSizeBytesSummary);
+
+        lenient().when(sinkContext.getTagsTargetKey()).thenReturn(null);
+        lenient().when(sinkContext.getIncludeKeys()).thenReturn(null);
+        lenient().when(sinkContext.getExcludeKeys()).thenReturn(null);
+    }
+
+    private OpenSearchClient openSearchClient;
+    private Supplier<OpenSearchClient> openSearchClientSupplier;
+
+    private BulkIngester createObjectUnderTest() {
+        openSearchClient = mock(OpenSearchClient.class);
+        openSearchClientSupplier = () -> openSearchClient;
+        return new BulkIngester(openSearchSinkConfiguration, expressionEvaluator, sinkContext,
+                pluginMetrics, pipeline, eventActionResolver,
+                openSearchClient, openSearchClientSupplier,
+                () -> indexManager, () -> null, null);
+    }
+
+    @Test
+    void test_successful_records_handling_without_forwarding_pipelines_bulk_operations_with_event_handles() {
+        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of());
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        BulkOperationWrapper op1 = mock(BulkOperationWrapper.class);
+        BulkOperationWrapper op2 = mock(BulkOperationWrapper.class);
+        when(op1.getEvent()).thenReturn(null);
+        when(op2.getEvent()).thenReturn(null);
+        List<BulkOperationWrapper> operationsList = new ArrayList<>();
+        operationsList.add(op1);
+        operationsList.add(op2);
+        objectUnderTest.successfulOperationsHandler(operationsList);
+        verify(op1).releaseEventHandle(eq(true));
+        verify(op2).releaseEventHandle(eq(true));
+    }
+
+    @Test
+    void test_successful_records_handling_with_forwarding_pipelines() {
+        HeadlessPipeline forwardPipeline = mock(HeadlessPipeline.class);
+        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of("fwd_pipeline", forwardPipeline));
+        final EventHandle eventHandle = mock(EventHandle.class);
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        BulkOperationWrapper op1 = mock(BulkOperationWrapper.class);
+        BulkOperationWrapper op2 = mock(BulkOperationWrapper.class);
+        Event event = mock(Event.class);
+        when(op1.getEvent()).thenReturn(event);
+        when(op2.getEvent()).thenReturn(event);
+        List<BulkOperationWrapper> operationsList = new ArrayList<>();
+        operationsList.add(op1);
+        operationsList.add(op2);
+        objectUnderTest.successfulOperationsHandler(operationsList);
+        verify(eventHandle, times(0)).release(eq(true));
+        verify(op1, times(1)).getEvent();
+        verify(op2, times(1)).getEvent();
+        verify(sinkContext, times(1)).forwardRecords(any(SinkForwardRecordsContext.class), eq(null), eq(null));
+    }
+
+    @Test
+    void test_successful_records_handling_without_forwarding_pipelines_bulk_operations_with_events() {
+        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of());
+        final EventHandle eventHandle = mock(EventHandle.class);
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        BulkOperationWrapper op1 = mock(BulkOperationWrapper.class);
+        BulkOperationWrapper op2 = mock(BulkOperationWrapper.class);
+        Event event = mock(Event.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        when(op1.getEvent()).thenReturn(event);
+        when(op2.getEvent()).thenReturn(event);
+        List<BulkOperationWrapper> operationsList = new ArrayList<>();
+        operationsList.add(op1);
+        operationsList.add(op2);
+        objectUnderTest.successfulOperationsHandler(operationsList);
+        verify(eventHandle, times(2)).release(eq(true));
+        verify(op1, times(0)).getEventHandle();
+        verify(op2, times(0)).getEventHandle();
+    }
+
+    @Test
+    void output_with_invalid_version_expression_catches_NumberFormatException_and_creates_DLQObject() throws IOException {
+        final String versionExpression = UUID.randomUUID().toString();
+        when(indexConfiguration.getVersionExpression()).thenReturn(versionExpression);
+
+        final Event event = mock(JacksonEvent.class);
+        final String document = UUID.randomUUID().toString();
+        when(event.toJsonString()).thenReturn(document);
+        final EventHandle eventHandle = mock(EventHandle.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        final String index = UUID.randomUUID().toString();
+        when(event.formatString(versionExpression, expressionEvaluator)).thenReturn("not_a_number");
+        when(event.formatString(indexConfiguration.getIndexAlias(), expressionEvaluator)).thenReturn(index);
+        final Record<Event> eventRecord = new Record<>(event);
+
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        initializeIngester(objectUnderTest);
+        when(indexManager.getIndexName(anyString())).thenReturn(index);
+
+        final DlqObject dlqObject = mock(DlqObject.class);
+        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
+        final ArgumentCaptor<FailedDlqData> failedDlqData = ArgumentCaptor.forClass(FailedDlqData.class);
+        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withFailedData(failedDlqData.capture())).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginName("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginId("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPipelineName(pipeline)).thenReturn(dlqObjectBuilder);
+
+        when(dlqObject.getFailedData()).thenReturn(mock(FailedDlqData.class));
+        doNothing().when(dlqObject).releaseEventHandle(false);
+        when(dlqObjectBuilder.build()).thenReturn(dlqObject);
+
+        try (final MockedStatic<DocumentBuilder> documentBuilderMockedStatic = mockStatic(DocumentBuilder.class);
+             final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
+            documentBuilderMockedStatic.when(() -> DocumentBuilder.build(eq(event), eq(null), eq(null), eq(null), eq(null)))
+                    .thenReturn(UUID.randomUUID().toString());
+            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
+            objectUnderTest.output(List.of(eventRecord));
+        }
+
+        final FailedDlqData failedDlqDataResult = failedDlqData.getValue();
+        assertThat(failedDlqDataResult, notNullValue());
+        assertThat(failedDlqDataResult.getDocument(), equalTo(document));
+        assertThat(failedDlqDataResult.getIndex(), equalTo(index));
+        assertThat(failedDlqDataResult.getMessage().startsWith("Unable to convert the result of evaluating document_version"), equalTo(true));
+
+        verify(dynamicDocumentVersionDroppedEvents).increment();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidVersionExceptionProvider")
+    void output_with_invalid_version_expression_does_not_add_event_to_bulk_request(
+            final Class<? extends RuntimeException> exceptionType) throws IOException {
+        final String versionExpression = UUID.randomUUID().toString();
+        when(indexConfiguration.getVersionExpression()).thenReturn(versionExpression);
+
+        final Event event = mock(JacksonEvent.class);
+        final String document = UUID.randomUUID().toString();
+        when(event.toJsonString()).thenReturn(document);
+        final EventHandle eventHandle = mock(EventHandle.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        final String index = UUID.randomUUID().toString();
+        when(event.formatString(versionExpression, expressionEvaluator)).thenThrow(exceptionType);
+        when(event.formatString(indexConfiguration.getIndexAlias(), expressionEvaluator)).thenReturn(index);
+        final Record<Event> eventRecord = new Record<>(event);
+
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        initializeIngester(objectUnderTest);
+        when(indexManager.getIndexName(anyString())).thenReturn(index);
+
+        final DlqObject dlqObject = mock(DlqObject.class);
+        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
+        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withFailedData(any(FailedDlqData.class))).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginName("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginId("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPipelineName(pipeline)).thenReturn(dlqObjectBuilder);
+        when(dlqObject.getFailedData()).thenReturn(mock(FailedDlqData.class));
+        doNothing().when(dlqObject).releaseEventHandle(false);
+        when(dlqObjectBuilder.build()).thenReturn(dlqObject);
+
+        try (final MockedStatic<DocumentBuilder> documentBuilderMockedStatic = mockStatic(DocumentBuilder.class);
+             final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
+            documentBuilderMockedStatic.when(() -> DocumentBuilder.build(eq(event), eq(null), eq(null), eq(null), eq(null)))
+                    .thenReturn(UUID.randomUUID().toString());
+            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
+            objectUnderTest.output(List.of(eventRecord));
+        }
+
+        verify(dynamicDocumentVersionDroppedEvents).increment();
+        verify(event, times(0)).getJsonNode();
+    }
+
+    private static Stream<Arguments> invalidVersionExceptionProvider() {
+        return Stream.of(
+                Arguments.of(NumberFormatException.class),
+                Arguments.of(RuntimeException.class)
+        );
+    }
+
+    @Test
+    void test_routing_field_in_document() {
+        String routingFieldKey = UUID.randomUUID().toString();
+        String routingKey = UUID.randomUUID().toString();
+        String routingFieldValue = UUID.randomUUID().toString();
+        when(indexConfiguration.getRoutingField()).thenReturn(routingFieldKey);
+        when(indexConfiguration.getRouting()).thenReturn(routingKey);
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        final Event event = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(Collections.singletonMap(routingFieldKey, routingFieldValue))
+                .build();
+        assertThat(objectUnderTest.getDocument(event).getRoutingField(), equalTo(Optional.of(routingFieldValue)));
+    }
+
+    @Test
+    void test_routing_in_document() {
+        String routingValue = UUID.randomUUID().toString();
+        String routingKey = UUID.randomUUID().toString();
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        final Event event = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(Collections.singletonMap(routingKey, routingValue))
+                .build();
+        assertThat(objectUnderTest.getDocument(event).getRoutingField(), equalTo(Optional.empty()));
+
+        when(indexConfiguration.getRouting()).thenReturn("${" + routingKey + "}");
+        final BulkIngester objectUnderTest2 = createObjectUnderTest();
+        assertThat(objectUnderTest2.getDocument(event).getRoutingField(), equalTo(Optional.of(routingValue)));
+    }
+
+    @Test
+    void output_with_invalid_version_expression_result_catches_RuntimeException_and_creates_DLQObject() throws IOException {
+        final String versionExpression = UUID.randomUUID().toString();
+        when(indexConfiguration.getVersionExpression()).thenReturn(versionExpression);
+
+        final Event event = mock(JacksonEvent.class);
+        final String document = UUID.randomUUID().toString();
+        when(event.toJsonString()).thenReturn(document);
+        final EventHandle eventHandle = mock(EventHandle.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        final String index = UUID.randomUUID().toString();
+        when(event.formatString(versionExpression, expressionEvaluator)).thenThrow(RuntimeException.class);
+        when(event.formatString(indexConfiguration.getIndexAlias(), expressionEvaluator)).thenReturn(index);
+        final Record<Event> eventRecord = new Record<>(event);
+
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        initializeIngester(objectUnderTest);
+        when(indexManager.getIndexName(anyString())).thenReturn(index);
+
+        final DlqObject dlqObject = mock(DlqObject.class);
+        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
+        final ArgumentCaptor<FailedDlqData> failedDlqData = ArgumentCaptor.forClass(FailedDlqData.class);
+        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withFailedData(failedDlqData.capture())).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginName("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginId("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPipelineName(pipeline)).thenReturn(dlqObjectBuilder);
+
+        when(dlqObject.getFailedData()).thenReturn(mock(FailedDlqData.class));
+        doNothing().when(dlqObject).releaseEventHandle(false);
+        when(dlqObjectBuilder.build()).thenReturn(dlqObject);
+
+        try (final MockedStatic<DocumentBuilder> documentBuilderMockedStatic = mockStatic(DocumentBuilder.class);
+             final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
+            documentBuilderMockedStatic.when(() -> DocumentBuilder.build(eq(event), eq(null), eq(null), eq(null), eq(null)))
+                    .thenReturn(UUID.randomUUID().toString());
+            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
+            objectUnderTest.output(List.of(eventRecord));
+        }
+
+        final FailedDlqData failedDlqDataResult = failedDlqData.getValue();
+        assertThat(failedDlqDataResult, notNullValue());
+        assertThat(failedDlqDataResult.getDocument(), equalTo(document));
+        assertThat(failedDlqDataResult.getIndex(), equalTo(index));
+        assertThat(failedDlqDataResult.getMessage().startsWith("There was an exception when evaluating the document_version"), equalTo(true));
+
+        verify(dynamicDocumentVersionDroppedEvents).increment();
+    }
+
+    @Test
+    void createDlqObjectFromEvent_with_null_message_uses_default_message() throws Exception {
+        final Event event = mock(JacksonEvent.class);
+        final String document = UUID.randomUUID().toString();
+        when(event.toJsonString()).thenReturn(document);
+        final EventHandle eventHandle = mock(EventHandle.class);
+        when(event.getEventHandle()).thenReturn(eventHandle);
+        final String index = UUID.randomUUID().toString();
+
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+
+        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
+        final ArgumentCaptor<FailedDlqData> failedDlqData = ArgumentCaptor.forClass(FailedDlqData.class);
+        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withFailedData(failedDlqData.capture())).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginName("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPluginId("opensearch")).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.withPipelineName(pipeline)).thenReturn(dlqObjectBuilder);
+        when(dlqObjectBuilder.build()).thenReturn(mock(DlqObject.class));
+
+        try (final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
+            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
+
+            java.lang.reflect.Method method = BulkIngester.class.getDeclaredMethod("createDlqObjectFromEvent", Event.class, String.class, String.class);
+            method.setAccessible(true);
+            method.invoke(objectUnderTest, event, index, null);
+        }
+
+        final FailedDlqData failedDlqDataResult = failedDlqData.getValue();
+        assertThat(failedDlqDataResult, notNullValue());
+        assertThat(failedDlqDataResult.getDocument(), equalTo(document));
+        assertThat(failedDlqDataResult.getIndex(), equalTo(index));
+        assertThat(failedDlqDataResult.getMessage(), equalTo(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("externalVersionTypeProvider")
+    void initialize_sets_isExternalVersioning_true_on_BulkRetryStrategy_for_external_version_types(
+            final VersionType versionType) throws Exception {
+        when(indexConfiguration.getVersionType()).thenReturn(versionType);
+
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        initializeIngester(objectUnderTest);
+
+        final BulkRetryStrategy bulkRetryStrategy = getField(objectUnderTest, "bulkRetryStrategy");
+        final boolean isExternalVersioning = getField(bulkRetryStrategy, "isExternalVersioning");
+        assertThat(isExternalVersioning, equalTo(true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonExternalVersionTypeProvider")
+    void initialize_sets_isExternalVersioning_false_on_BulkRetryStrategy_for_non_external_version_types(
+            final VersionType versionType) throws Exception {
+        lenient().when(indexConfiguration.getVersionType()).thenReturn(versionType);
+
+        final BulkIngester objectUnderTest = createObjectUnderTest();
+        initializeIngester(objectUnderTest);
+
+        final BulkRetryStrategy bulkRetryStrategy = getField(objectUnderTest, "bulkRetryStrategy");
+        final boolean isExternalVersioning = getField(bulkRetryStrategy, "isExternalVersioning");
+        assertThat(isExternalVersioning, equalTo(false));
+    }
+
+    private static Stream<Arguments> externalVersionTypeProvider() {
+        return Stream.of(
+                Arguments.of(VersionType.External),
+                Arguments.of(VersionType.ExternalGte)
+        );
+    }
+
+    private static Stream<Arguments> nonExternalVersionTypeProvider() {
+        return Stream.of(
+                Arguments.of(VersionType.Internal),
+                Arguments.of((VersionType) null)
+        );
+    }
+
+    private void initializeIngester(final BulkIngester ingester) throws IOException {
+        final ConnectionConfiguration connectionConfiguration = mock(ConnectionConfiguration.class);
+        lenient().when(connectionConfiguration.isRequestCompressionEnabled()).thenReturn(false);
+        lenient().when(openSearchSinkConfiguration.getConnectionConfiguration()).thenReturn(connectionConfiguration);
+        lenient().when(indexManager.isIndexAlias(anyString())).thenReturn(false);
+        ingester.initialize();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getField(final Object target, final String fieldName) throws Exception {
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(target);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/EventActionResolverTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/EventActionResolverTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.ActionConfiguration;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamDetector;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamIndex;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EventActionResolverTest {
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private DataStreamDetector dataStreamDetector;
+
+    @Mock
+    private DataStreamIndex dataStreamIndex;
+
+    @Test
+    void resolveAction_returns_default_action() {
+        final EventActionResolver resolver = new EventActionResolver("index", null, expressionEvaluator);
+        assertThat(resolver.resolveAction(event, "my-index"), equalTo("index"));
+    }
+
+    @Test
+    void resolveAction_uses_actions_list_with_matching_condition() {
+        final ActionConfiguration actionConfig = mock(ActionConfiguration.class);
+        when(actionConfig.getType()).thenReturn("delete");
+        when(actionConfig.getWhen()).thenReturn("condition");
+        when(expressionEvaluator.evaluateConditional("condition", event)).thenReturn(true);
+
+        final EventActionResolver resolver = new EventActionResolver("index", List.of(actionConfig), expressionEvaluator);
+        assertThat(resolver.resolveAction(event, "my-index"), equalTo("delete"));
+    }
+
+    @Test
+    void resolveAction_evaluates_expression_in_action() {
+        when(event.formatString("${action_field}", expressionEvaluator)).thenReturn("update");
+        final EventActionResolver resolver = new EventActionResolver("${action_field}", null, expressionEvaluator);
+        assertThat(resolver.resolveAction(event, "my-index"), equalTo("update"));
+    }
+
+    @Test
+    void resolveAction_overrides_action_for_data_stream() {
+        final EventActionResolver resolver = new EventActionResolver("index", null, expressionEvaluator);
+        resolver.setDataStreamSupport(dataStreamDetector, dataStreamIndex);
+        when(dataStreamDetector.isDataStream("my-data-stream")).thenReturn(true);
+        when(dataStreamIndex.determineAction("index", "my-data-stream")).thenReturn("create");
+
+        assertThat(resolver.resolveAction(event, "my-data-stream"), equalTo("create"));
+    }
+
+    @Test
+    void resolveAction_does_not_override_for_non_data_stream() {
+        final EventActionResolver resolver = new EventActionResolver("index", null, expressionEvaluator);
+        resolver.setDataStreamSupport(dataStreamDetector, dataStreamIndex);
+        when(dataStreamDetector.isDataStream("my-index")).thenReturn(false);
+
+        assertThat(resolver.resolveAction(event, "my-index"), equalTo("index"));
+    }
+
+    @Test
+    void isValidAction_returns_true_for_valid_action() {
+        final EventActionResolver resolver = new EventActionResolver("index", null, expressionEvaluator);
+        assertThat(resolver.isValidAction("index"), equalTo(true));
+        assertThat(resolver.isValidAction("create"), equalTo(true));
+        assertThat(resolver.isValidAction("update"), equalTo(true));
+        assertThat(resolver.isValidAction("delete"), equalTo(true));
+    }
+
+    @Test
+    void isValidAction_returns_false_for_invalid_action() {
+        final EventActionResolver resolver = new EventActionResolver("index", null, expressionEvaluator);
+        assertThat(resolver.isValidAction("invalid_action"), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
@@ -11,59 +15,37 @@ import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.VersionType;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
-import org.opensearch.dataprepper.model.sink.SinkForwardRecordsContext;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.OpenSearchSinkConfig;
-import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.DocumentBuilder;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManagerFactory;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamDetector;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.DataStreamIndex;
-import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexCache;
-import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateStrategy;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateType;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.Collections;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -77,6 +59,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.model.sink.SinkLatencyMetrics.EXTERNAL_LATENCY;
 import static org.opensearch.dataprepper.model.sink.SinkLatencyMetrics.INTERNAL_LATENCY;
+import static org.opensearch.dataprepper.metrics.MetricNames.RECORDS_IN;
+import static org.opensearch.dataprepper.metrics.MetricNames.TIME_ELAPSED;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.BULKREQUEST_ERRORS;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.BULKREQUEST_LATENCY;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink.BULKREQUEST_SIZE_BYTES;
@@ -123,44 +107,17 @@ public class OpenSearchSinkTest {
     private PluginMetrics pluginMetrics;
 
     @Mock
-    private Timer bulkRequestTimer;
-
-    @Mock
     private OpenSearchSinkConfig openSearchSinkConfig;
 
     @Mock
-    private Counter bulkRequestErrorsCounter;
-
-    @Mock
-    private Counter invalidActionErrorsCounter;
-
-    @Mock
-    private Counter dynamicIndexDroppedEvents;
-
-    @Mock
-    private DistributionSummary bulkRequestSizeBytesSummary;
-
-    @Mock
-    private Counter dynamicDocumentVersionDroppedEvents;
-
-    @Mock
     private PluginConfigObservable pluginConfigObservable;
-
-    @Mock
-    private DataStreamDetector dataStreamDetector;
-    
-    @Mock
-    private DataStreamIndex dataStreamIndex;
-    
-    @Mock
-    private IndexCache indexCache;
 
     @BeforeEach
     void setup() {
         when(pipelineDescription.getPipelineName()).thenReturn(UUID.randomUUID().toString());
 
         final RetryConfiguration retryConfiguration = mock(RetryConfiguration.class);
-        when(retryConfiguration.getDlq()).thenReturn(Optional.empty());
+        lenient().when(retryConfiguration.getDlq()).thenReturn(Optional.empty());
         lenient().when(retryConfiguration.getDlqFile()).thenReturn(null);
 
         final ConnectionConfiguration connectionConfiguration = mock(ConnectionConfiguration.class);
@@ -168,34 +125,35 @@ public class OpenSearchSinkTest {
         lenient().when(connectionConfiguration.createClient(awsCredentialsSupplier)).thenReturn(restHighLevelClient);
         lenient().when(connectionConfiguration.createOpenSearchClient(restHighLevelClient, awsCredentialsSupplier)).thenReturn(openSearchClient);
 
-        when(indexConfiguration.getAction()).thenReturn("index");
-        when(indexConfiguration.getDocumentId()).thenReturn(null);
-        when(indexConfiguration.getDocumentIdField()).thenReturn(null);
-        when(indexConfiguration.getRouting()).thenReturn(null);
-        when(indexConfiguration.getActions()).thenReturn(null);
-        when(indexConfiguration.getDocumentRootKey()).thenReturn(null);
+        lenient().when(indexConfiguration.getAction()).thenReturn("index");
+        lenient().when(indexConfiguration.getDocumentId()).thenReturn(null);
+        lenient().when(indexConfiguration.getDocumentIdField()).thenReturn(null);
+        lenient().when(indexConfiguration.getRouting()).thenReturn(null);
+        lenient().when(indexConfiguration.getActions()).thenReturn(null);
+        lenient().when(indexConfiguration.getDocumentRootKey()).thenReturn(null);
         lenient().when(indexConfiguration.getVersionType()).thenReturn(null);
         lenient().when(indexConfiguration.getVersionExpression()).thenReturn(null);
         lenient().when(indexConfiguration.getIndexAlias()).thenReturn(UUID.randomUUID().toString());
         lenient().when(indexConfiguration.getTemplateType()).thenReturn(TemplateType.V1);
-        when(indexConfiguration.getIndexType()).thenReturn(IndexType.CUSTOM);
-        when(indexConfiguration.getBulkSize()).thenReturn(DEFAULT_BULK_SIZE);
-        when(indexConfiguration.getFlushTimeout()).thenReturn(DEFAULT_FLUSH_TIMEOUT);
+        lenient().when(indexConfiguration.getIndexType()).thenReturn(IndexType.CUSTOM);
+        lenient().when(indexConfiguration.getBulkSize()).thenReturn(DEFAULT_BULK_SIZE);
+        lenient().when(indexConfiguration.getFlushTimeout()).thenReturn(DEFAULT_FLUSH_TIMEOUT);
 
-        when(openSearchSinkConfiguration.getIndexConfiguration()).thenReturn(indexConfiguration);
-        when(openSearchSinkConfiguration.getRetryConfiguration()).thenReturn(retryConfiguration);
+        lenient().when(openSearchSinkConfiguration.getIndexConfiguration()).thenReturn(indexConfiguration);
+        lenient().when(openSearchSinkConfiguration.getRetryConfiguration()).thenReturn(retryConfiguration);
         lenient().when(openSearchSinkConfiguration.getConnectionConfiguration()).thenReturn(connectionConfiguration);
 
-        when(pluginMetrics.counter(MetricNames.RECORDS_IN)).thenReturn(mock(Counter.class));
-        when(pluginMetrics.timer(MetricNames.TIME_ELAPSED)).thenReturn(mock(Timer.class));
-        when(pluginMetrics.timer(INTERNAL_LATENCY)).thenReturn(mock(Timer.class));
-        when(pluginMetrics.timer(EXTERNAL_LATENCY)).thenReturn(mock(Timer.class));
-        when(pluginMetrics.timer(BULKREQUEST_LATENCY)).thenReturn(bulkRequestTimer);
-        when(pluginMetrics.counter(BULKREQUEST_ERRORS)).thenReturn(bulkRequestErrorsCounter);
-        when(pluginMetrics.counter(INVALID_ACTION_ERRORS)).thenReturn(invalidActionErrorsCounter);
-        when(pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS)).thenReturn(dynamicIndexDroppedEvents);
-        when(pluginMetrics.counter(INVALID_VERSION_EXPRESSION_DROPPED_EVENTS)).thenReturn(dynamicDocumentVersionDroppedEvents);
-        when(pluginMetrics.summary(BULKREQUEST_SIZE_BYTES)).thenReturn(bulkRequestSizeBytesSummary);
+        lenient().when(pluginMetrics.counter(RECORDS_IN)).thenReturn(mock(Counter.class));
+        lenient().when(pluginMetrics.timer(TIME_ELAPSED)).thenReturn(mock(Timer.class));
+        lenient().when(pluginMetrics.timer(INTERNAL_LATENCY)).thenReturn(mock(Timer.class));
+        lenient().when(pluginMetrics.timer(EXTERNAL_LATENCY)).thenReturn(mock(Timer.class));
+        lenient().when(pluginMetrics.timer(BULKREQUEST_LATENCY)).thenReturn(mock(Timer.class));
+        lenient().when(pluginMetrics.counter(BULKREQUEST_ERRORS)).thenReturn(mock(Counter.class));
+        lenient().when(pluginMetrics.counter(INVALID_ACTION_ERRORS)).thenReturn(mock(Counter.class));
+        lenient().when(pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS)).thenReturn(mock(Counter.class));
+        lenient().when(pluginMetrics.counter(INVALID_VERSION_EXPRESSION_DROPPED_EVENTS)).thenReturn(mock(Counter.class));
+        lenient().when(pluginMetrics.summary(BULKREQUEST_SIZE_BYTES)).thenReturn(mock(DistributionSummary.class));
+        lenient().when(pluginMetrics.counter(anyString())).thenReturn(mock(Counter.class));
 
         lenient().when(sinkContext.getTagsTargetKey()).thenReturn(null);
         lenient().when(sinkContext.getIncludeKeys()).thenReturn(null);
@@ -207,7 +165,8 @@ public class OpenSearchSinkTest {
              final MockedStatic<PluginMetrics> pluginMetricsMockedStatic = mockStatic(PluginMetrics.class);
              final MockedConstruction<IndexManagerFactory> indexManagerFactoryMockedConstruction = mockConstruction(IndexManagerFactory.class, (mock, context) -> {
                  indexManagerFactory = mock;
-             })) {
+             });
+             final MockedConstruction<BulkIngester> bulkIngesterMockedConstruction = mockConstruction(BulkIngester.class)) {
             pluginMetricsMockedStatic.when(() -> PluginMetrics.fromPluginSetting(pluginSetting)).thenReturn(pluginMetrics);
             openSearchSinkConfigurationMockedStatic.when(() -> OpenSearchSinkConfiguration.readOSConfig(openSearchSinkConfig, expressionEvaluator))
                     .thenReturn(openSearchSinkConfiguration);
@@ -225,12 +184,11 @@ public class OpenSearchSinkTest {
         objectUnderTest.initialize();
 
         verify(pluginConfigObservable).addPluginConfigObserver(any());
+        assertThat(objectUnderTest.isReady(), equalTo(true));
     }
 
     @Test
-    void test_initialization_with_failure_and_retry_with_query_manager() throws IOException {
-        when(openSearchSinkConfiguration.getIndexConfiguration().getQueryTerm()).thenReturn(UUID.randomUUID().toString());
-
+    void test_initialization_with_failure_and_retry() throws IOException {
         final OpenSearchSink objectUnderTest = createObjectUnderTest();
         when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
                 .thenThrow(RuntimeException.class).thenReturn(indexManager);
@@ -241,423 +199,29 @@ public class OpenSearchSinkTest {
     }
 
     @Test
-    void test_sink_successful_records_handling_without_forwarding_pipelines_bulk_operations_with_event_handles() throws Exception {
-        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of());
+    void doOutput_delegates_to_ingester() throws Exception {
         final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        BulkOperationWrapper op1 = mock(BulkOperationWrapper.class);
-        BulkOperationWrapper op2 = mock(BulkOperationWrapper.class);
-        when(op1.getEvent()).thenReturn(null);
-        when(op2.getEvent()).thenReturn(null);
-        List<BulkOperationWrapper> operationsList = new ArrayList<>();
-        operationsList.add(op1);
-        operationsList.add(op2);
-        objectUnderTest.successfulOperationsHandler(operationsList);
-        verify(op1).releaseEventHandle(eq(true));
-        verify(op2).releaseEventHandle(eq(true));
 
+        final Ingester ingester = getField(objectUnderTest, "ingester");
+        final List<Record<Event>> records = Collections.emptyList();
+        objectUnderTest.doOutput(records);
+
+        verify(ingester).output(records);
     }
 
     @Test
-    void test_sink_successful_records_handling_with_forwarding_pipelines() throws Exception {
-        HeadlessPipeline forwardPipeline = mock(HeadlessPipeline.class);
-        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of("fwd_pipeline", forwardPipeline));
-        final EventHandle eventHandle = mock(EventHandle.class);
+    void shutdown_delegates_to_ingester() throws Exception {
         final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        BulkOperationWrapper op1 = mock(BulkOperationWrapper.class);
-        BulkOperationWrapper op2 = mock(BulkOperationWrapper.class);
-        Event event = mock(Event.class);
-        when(op1.getEvent()).thenReturn(event);
-        when(op2.getEvent()).thenReturn(event);
-        List<BulkOperationWrapper> operationsList = new ArrayList<>();
-        operationsList.add(op1);
-        operationsList.add(op2);
-        objectUnderTest.successfulOperationsHandler(operationsList);
-        verify(eventHandle, times(0)).release(eq(true));
-        verify(op1, times(1)).getEvent();
-        verify(op2, times(1)).getEvent();
-        verify(sinkContext, times(1)).forwardRecords(any(SinkForwardRecordsContext.class), eq(null), eq(null));
-        
-    }
 
- 
-    @Test
-    void test_sink_successful_records_handling_without_forwarding_pipelines_bulk_operations_with_events() throws Exception {
-        when(sinkContext.getForwardToPipelines()).thenReturn(Map.of());
-        final EventHandle eventHandle = mock(EventHandle.class);
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        BulkOperationWrapper op1 = mock(BulkOperationWrapper.class);
-        BulkOperationWrapper op2 = mock(BulkOperationWrapper.class);
-        Event event = mock(Event.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        when(op1.getEvent()).thenReturn(event);
-        when(op2.getEvent()).thenReturn(event);
-        List<BulkOperationWrapper> operationsList = new ArrayList<>();
-        operationsList.add(op1);
-        operationsList.add(op2);
-        objectUnderTest.successfulOperationsHandler(operationsList);
-        verify(eventHandle, times(2)).release(eq(true));
-        verify(op1, times(0)).getEventHandle();
-        verify(op2, times(0)).getEventHandle();
-        
-    }
+        final Ingester ingester = getField(objectUnderTest, "ingester");
+        objectUnderTest.shutdown();
 
-    @Test
-    void doOutput_with_invalid_version_expression_catches_NumberFormatException_and_creates_DLQObject() throws IOException {
-        when(pluginSetting.getName()).thenReturn("opensearch");
-        final String versionExpression = UUID.randomUUID().toString();
-        when(indexConfiguration.getVersionExpression()).thenReturn(versionExpression);
-
-        final Event event = mock(JacksonEvent.class);
-        final String document = UUID.randomUUID().toString();
-        when(event.toJsonString()).thenReturn(document);
-        final EventHandle eventHandle = mock(EventHandle.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        final String index = UUID.randomUUID().toString();
-        when(event.formatString(versionExpression, expressionEvaluator)).thenReturn("not_a_number");
-        when(event.formatString(indexConfiguration.getIndexAlias(), expressionEvaluator)).thenReturn(index);
-        final Record<Event> eventRecord = new Record<>(event);
-
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-
-        when(indexManager.getIndexName(anyString())).thenReturn(index);
-
-        final DlqObject dlqObject = mock(DlqObject.class);
-
-        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
-        final ArgumentCaptor<FailedDlqData> failedDlqData = ArgumentCaptor.forClass(FailedDlqData.class);
-        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withFailedData(failedDlqData.capture())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginName(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginId(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPipelineName(pipelineDescription.getPipelineName())).thenReturn(dlqObjectBuilder);
-
-        when(dlqObject.getFailedData()).thenReturn(mock(FailedDlqData.class));
-        doNothing().when(dlqObject).releaseEventHandle(false);
-        when(dlqObjectBuilder.build()).thenReturn(dlqObject);
-
-        try (final MockedStatic<DocumentBuilder> documentBuilderMockedStatic = mockStatic(DocumentBuilder.class);
-             final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
-            documentBuilderMockedStatic.when(() -> DocumentBuilder.build(eq(event), eq(null), eq(null), eq(null), eq(null)))
-                    .thenReturn(UUID.randomUUID().toString());
-
-            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
-            objectUnderTest.doOutput(List.of(eventRecord));
-        }
-
-        final FailedDlqData failedDlqDataResult = failedDlqData.getValue();
-        assertThat(failedDlqDataResult, notNullValue());
-        assertThat(failedDlqDataResult.getDocument(), equalTo(document));
-        assertThat(failedDlqDataResult.getIndex(), equalTo(index));
-        assertThat(failedDlqDataResult.getMessage().startsWith("Unable to convert the result of evaluating document_version"), equalTo(true));
-
-        verify(dynamicDocumentVersionDroppedEvents).increment();
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidVersionExceptionProvider")
-    void doOutput_with_invalid_version_expression_does_not_add_event_to_bulk_request(
-            final Class<? extends RuntimeException> exceptionType) throws IOException {
-        when(pluginSetting.getName()).thenReturn("opensearch");
-        final String versionExpression = UUID.randomUUID().toString();
-        when(indexConfiguration.getVersionExpression()).thenReturn(versionExpression);
-
-        final Event event = mock(JacksonEvent.class);
-        final String document = UUID.randomUUID().toString();
-        when(event.toJsonString()).thenReturn(document);
-        final EventHandle eventHandle = mock(EventHandle.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        final String index = UUID.randomUUID().toString();
-        when(event.formatString(versionExpression, expressionEvaluator)).thenThrow(exceptionType);
-        when(event.formatString(indexConfiguration.getIndexAlias(), expressionEvaluator)).thenReturn(index);
-        final Record<Event> eventRecord = new Record<>(event);
-
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-
-        when(indexManager.getIndexName(anyString())).thenReturn(index);
-
-        final DlqObject dlqObject = mock(DlqObject.class);
-        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
-        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withFailedData(any(FailedDlqData.class))).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginName(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginId(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPipelineName(pipelineDescription.getPipelineName())).thenReturn(dlqObjectBuilder);
-        when(dlqObject.getFailedData()).thenReturn(mock(FailedDlqData.class));
-        doNothing().when(dlqObject).releaseEventHandle(false);
-        when(dlqObjectBuilder.build()).thenReturn(dlqObject);
-
-        try (final MockedStatic<DocumentBuilder> documentBuilderMockedStatic = mockStatic(DocumentBuilder.class);
-             final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
-            documentBuilderMockedStatic.when(() -> DocumentBuilder.build(eq(event), eq(null), eq(null), eq(null), eq(null)))
-                    .thenReturn(UUID.randomUUID().toString());
-            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
-            objectUnderTest.doOutput(List.of(eventRecord));
-        }
-
-        verify(dynamicDocumentVersionDroppedEvents).increment();
-        verify(event, times(0)).getJsonNode();
-    }
-
-    private static Stream<Arguments> invalidVersionExceptionProvider() {
-        return Stream.of(
-                Arguments.of(NumberFormatException.class),
-                Arguments.of(RuntimeException.class)
-        );
-    }
-
-    @Test
-    void test_routing_field_in_document() throws IOException {
-        String routingFieldKey = UUID.randomUUID().toString();
-        String routingKey = UUID.randomUUID().toString();
-        String routingFieldValue = UUID.randomUUID().toString();
-        when(indexConfiguration.getRoutingField()).thenReturn(routingFieldKey);
-        when(indexConfiguration.getRouting()).thenReturn(routingKey);
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        final Event event = JacksonEvent.builder()
-                .withEventType("event")
-                .withData(Collections.singletonMap(routingFieldKey, routingFieldValue))
-                .build();
-        assertThat(objectUnderTest.getDocument(event).getRoutingField(), equalTo(Optional.of(routingFieldValue)));
-    }
-
-    @Test
-    void test_routing_in_document() throws IOException {
-        String routingValue = UUID.randomUUID().toString();
-        String routingKey = UUID.randomUUID().toString();
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        final Event event = JacksonEvent.builder()
-                .withEventType("event")
-                .withData(Collections.singletonMap(routingKey, routingValue))
-                .build();
-        assertThat(objectUnderTest.getDocument(event).getRoutingField(), equalTo(Optional.empty()));
-
-        when(indexConfiguration.getRouting()).thenReturn("${"+routingKey+"}");
-        final OpenSearchSink objectUnderTest2 = createObjectUnderTest();
-        assertThat(objectUnderTest2.getDocument(event).getRoutingField(), equalTo(Optional.of(routingValue)));
-    }
-
-    @Test
-    void doOutput_with_invalid_version_expression_result_catches_RuntimeException_and_creates_DLQObject() throws IOException {
-
-        when(pluginSetting.getName()).thenReturn("opensearch");
-        final String versionExpression = UUID.randomUUID().toString();
-        when(indexConfiguration.getVersionExpression()).thenReturn(versionExpression);
-
-        final Event event = mock(JacksonEvent.class);
-        final String document = UUID.randomUUID().toString();
-        when(event.toJsonString()).thenReturn(document);
-        final EventHandle eventHandle = mock(EventHandle.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        final String index = UUID.randomUUID().toString();
-        when(event.formatString(versionExpression, expressionEvaluator)).thenThrow(RuntimeException.class);
-        when(event.formatString(indexConfiguration.getIndexAlias(), expressionEvaluator)).thenReturn(index);
-        final Record<Event> eventRecord = new Record<>(event);
-
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-
-        when(indexManager.getIndexName(anyString())).thenReturn(index);
-
-        final DlqObject dlqObject = mock(DlqObject.class);
-
-        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
-        final ArgumentCaptor<FailedDlqData> failedDlqData = ArgumentCaptor.forClass(FailedDlqData.class);
-        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withFailedData(failedDlqData.capture())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginName(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginId(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPipelineName(pipelineDescription.getPipelineName())).thenReturn(dlqObjectBuilder);
-
-        when(dlqObject.getFailedData()).thenReturn(mock(FailedDlqData.class));
-        doNothing().when(dlqObject).releaseEventHandle(false);
-        when(dlqObjectBuilder.build()).thenReturn(dlqObject);
-
-        try (final MockedStatic<DocumentBuilder> documentBuilderMockedStatic = mockStatic(DocumentBuilder.class);
-             final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
-            documentBuilderMockedStatic.when(() -> DocumentBuilder.build(eq(event), eq(null), eq(null), eq(null), eq(null)))
-                    .thenReturn(UUID.randomUUID().toString());
-
-            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
-            objectUnderTest.doOutput(List.of(eventRecord));
-        }
-
-        final FailedDlqData failedDlqDataResult = failedDlqData.getValue();
-        assertThat(failedDlqDataResult, notNullValue());
-        assertThat(failedDlqDataResult.getDocument(), equalTo(document));
-        assertThat(failedDlqDataResult.getIndex(), equalTo(index));
-        assertThat(failedDlqDataResult.getMessage().startsWith("There was an exception when evaluating the document_version"), equalTo(true));
-
-        verify(dynamicDocumentVersionDroppedEvents).increment();
-    }
-
-    @Test
-    void createDlqObjectFromEvent_with_null_message_uses_default_message() throws Exception {
-        when(pluginSetting.getName()).thenReturn("opensearch");
-        
-        final Event event = mock(JacksonEvent.class);
-        final String document = UUID.randomUUID().toString();
-        when(event.toJsonString()).thenReturn(document);
-        final EventHandle eventHandle = mock(EventHandle.class);
-        when(event.getEventHandle()).thenReturn(eventHandle);
-        final String index = UUID.randomUUID().toString();
-        
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-        
-        final DlqObject.Builder dlqObjectBuilder = mock(DlqObject.Builder.class);
-        final ArgumentCaptor<FailedDlqData> failedDlqData = ArgumentCaptor.forClass(FailedDlqData.class);
-        when(dlqObjectBuilder.withEventHandle(eventHandle)).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withFailedData(failedDlqData.capture())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginName(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPluginId(pluginSetting.getName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.withPipelineName(pipelineDescription.getPipelineName())).thenReturn(dlqObjectBuilder);
-        when(dlqObjectBuilder.build()).thenReturn(mock(DlqObject.class));
-        
-        try (final MockedStatic<DlqObject> dlqObjectMockedStatic = mockStatic(DlqObject.class)) {
-            dlqObjectMockedStatic.when(DlqObject::builder).thenReturn(dlqObjectBuilder);
-            
-            // Use reflection to call the private method with null message
-            java.lang.reflect.Method method = OpenSearchSink.class.getDeclaredMethod("createDlqObjectFromEvent", Event.class, String.class, String.class);
-            method.setAccessible(true);
-            method.invoke(objectUnderTest, event, index, null);
-        }
-        
-        final FailedDlqData failedDlqDataResult = failedDlqData.getValue();
-        assertThat(failedDlqDataResult, notNullValue());
-        assertThat(failedDlqDataResult.getDocument(), equalTo(document));
-        assertThat(failedDlqDataResult.getIndex(), equalTo(index));
-        assertThat(failedDlqDataResult.getMessage(), equalTo(""));
-    }
-
-    @Test
-    void dataStreamIndex_determineAction_returnsCreate_whenIndexIsDataStream() throws Exception {
-        when(indexConfiguration.getAction()).thenReturn("index");
-        
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-        
-        // Use ReflectivelySetField to set the dataStreamIndex
-        ReflectivelySetField.setField(OpenSearchSink.class, objectUnderTest, "dataStreamIndex", dataStreamIndex);
-        
-        // Verify the dataStreamIndex was set correctly
-        assertThat(objectUnderTest, notNullValue());
-    }
-
-    @Test
-    void dataStreamIndex_determineAction_returnsConfiguredAction_whenIndexIsNotDataStream() throws Exception {
-        when(indexConfiguration.getAction()).thenReturn("index");
-        
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-        
-        // Use ReflectivelySetField to set the dataStreamIndex
-        ReflectivelySetField.setField(OpenSearchSink.class, objectUnderTest, "dataStreamIndex", dataStreamIndex);
-        
-        // Verify the dataStreamIndex was set correctly
-        assertThat(objectUnderTest, notNullValue());
-    }
-    
-    @Test
-    void dataStreamIndex_ensureTimestamp_doesNotOverwriteExistingTimestamp() throws Exception {
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-        
-        // Use ReflectivelySetField to set the dataStreamIndex
-        ReflectivelySetField.setField(OpenSearchSink.class, objectUnderTest, "dataStreamIndex", dataStreamIndex);
-        
-        // Verify the dataStreamIndex was set correctly
-        assertThat(objectUnderTest, notNullValue());
-    }
-    
-    @Test
-    void dataStreamIndex_ensureTimestamp_setsTimestampWhenMissing() throws Exception {
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-        
-        // Use ReflectivelySetField to set the dataStreamIndex
-        ReflectivelySetField.setField(OpenSearchSink.class, objectUnderTest, "dataStreamIndex", dataStreamIndex);
-        
-        // Verify the dataStreamIndex was set correctly
-        assertThat(objectUnderTest, notNullValue());
-    }
-
-    @ParameterizedTest
-    @MethodSource("externalVersionTypeProvider")
-    void initialize_sets_isExternalVersioning_true_on_BulkRetryStrategy_for_external_version_types(
-            final VersionType versionType) throws Exception {
-        when(indexConfiguration.getVersionType()).thenReturn(versionType);
-
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-
-        final BulkRetryStrategy bulkRetryStrategy = getField(objectUnderTest, "bulkRetryStrategy");
-        final boolean isExternalVersioning = getField(bulkRetryStrategy, "isExternalVersioning");
-        assertThat(isExternalVersioning, equalTo(true));
-    }
-
-    @ParameterizedTest
-    @MethodSource("nonExternalVersionTypeProvider")
-    void initialize_sets_isExternalVersioning_false_on_BulkRetryStrategy_for_non_external_version_types(
-            final VersionType versionType) throws Exception {
-        lenient().when(indexConfiguration.getVersionType()).thenReturn(versionType);
-
-        final OpenSearchSink objectUnderTest = createObjectUnderTest();
-        when(indexManagerFactory.getIndexManager(any(IndexType.class), eq(openSearchClient), any(RestHighLevelClient.class), eq(openSearchSinkConfiguration), any(TemplateStrategy.class), any()))
-                .thenReturn(indexManager);
-        doNothing().when(indexManager).setupIndex();
-        objectUnderTest.initialize();
-
-        final BulkRetryStrategy bulkRetryStrategy = getField(objectUnderTest, "bulkRetryStrategy");
-        final boolean isExternalVersioning = getField(bulkRetryStrategy, "isExternalVersioning");
-        assertThat(isExternalVersioning, equalTo(false));
-    }
-
-    private static Stream<Arguments> externalVersionTypeProvider() {
-        return Stream.of(
-                Arguments.of(VersionType.External),
-                Arguments.of(VersionType.ExternalGte)
-        );
-    }
-
-    private static Stream<Arguments> nonExternalVersionTypeProvider() {
-        return Stream.of(
-                Arguments.of(VersionType.Internal),
-                Arguments.of((VersionType) null)
-        );
+        verify(ingester).shutdown();
     }
 
     @SuppressWarnings("unchecked")
     private static <T> T getField(final Object target, final String fieldName) throws Exception {
-        Field field = target.getClass().getDeclaredField(fieldName);
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);
         return (T) field.get(target);
     }


### PR DESCRIPTION
### Description

I'm looking to update the `opensearch` sink to support OpenSearch's pull-based indexing.

As part of this work, I'm refactoring the `OpenSearchSink` class by adding an `Ingester` interface to handle the bulk of the data ingestion work. This separates concerns of index management, action determination, and ingestion.
 
### Issues Resolved

None. But this contributes toward #6796.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
