### PR TITLE
Initial support for experimental features within Data Prepper plugins.

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -28,6 +28,12 @@ dependencies {
 }
 
 
+tasks.named('validateCompatibility') {
+    methodExcludes.add('org.opensearch.dataprepper.model.annotations.Experimental#message()')
+    methodExcludes.add('org.opensearch.dataprepper.model.annotations.Experimental#groups()')
+    methodExcludes.add('org.opensearch.dataprepper.model.annotations.Experimental#payload()')
+}
+
 jacocoTestCoverageVerification {
     dependsOn(jacocoTestReport)
     violationRules {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/Experimental.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/Experimental.java
@@ -9,6 +9,9 @@
 
 package org.opensearch.dataprepper.model.annotations;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -16,18 +19,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a Data Prepper plugin as experimental.
+ * Marks a Data Prepper plugin or plugin configuration field as experimental.
  * <p>
- * Experimental plugins do not have the same compatibility guarantees as other plugins and may be unstable.
+ * Experimental features do not have the same compatibility guarantees as other features and may be unstable.
  * They may have breaking changes between minor versions and may even be removed.
  * <p>
- * Data Prepper administrators must enable experimental plugins in order to use them.
- * Otherwise, they are not available to use with pipelines.
+ * When applied to a plugin class ({@link ElementType#TYPE}), the entire plugin is experimental.
+ * When applied to a configuration field ({@link ElementType#FIELD}), only that specific
+ * feature is experimental. In both cases, the Data Prepper administrator must enable
+ * experimental features in order to use them.
  *
  * @since 2.11
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Constraint(validatedBy = {})
 public @interface Experimental {
+    String message() default "This feature is experimental. You must enable experimental features in data-prepper-config.yaml in order to use them.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryIT.java
@@ -221,6 +221,35 @@ class DefaultPluginFactoryIT {
         assertThat(actualException.getMessage(), equalTo("Unable to create experimental plugin test_experimental_plugin. You must enable experimental plugins in data-prepper-config.yaml in order to use them."));
     }
 
+    @Test
+    void loadPlugin_should_throw_when_a_non_experimental_plugin_has_an_experimental_feature_configured() {
+        pluginName = "test_plugin_with_experimental_feature";
+        final Map<String, Object> pluginSettingMap = new HashMap<>();
+        pluginSettingMap.put("experimental_option", "some_value");
+        final PluginSetting pluginSetting = createPluginSettings(pluginSettingMap);
+
+        final DefaultPluginFactory objectUnderTest = createObjectUnderTest();
+
+        final InvalidPluginConfigurationException actualException = assertThrows(InvalidPluginConfigurationException.class,
+                () -> objectUnderTest.loadPlugin(TestPluggableInterface.class, pluginSetting));
+
+        assertThat(actualException.getMessage(), notNullValue());
+        assertThat(actualException.getMessage(), equalTo(
+                "Plugin test_plugin_with_experimental_feature in pipeline " + pipelineName +
+                        " is configured incorrectly: experimentalOption " +
+                        "This feature is experimental. You must enable experimental features in data-prepper-config.yaml in order to use them."));
+    }
+
+    @Test
+    void loadPlugin_should_succeed_when_a_non_experimental_plugin_has_an_experimental_feature_not_configured() {
+        pluginName = "test_plugin_with_experimental_feature";
+        final PluginSetting pluginSetting = createPluginSettings(Collections.emptyMap());
+
+        final TestPluggableInterface plugin = createObjectUnderTest().loadPlugin(TestPluggableInterface.class, pluginSetting);
+
+        assertThat(plugin, notNullValue());
+    }
+
     private PluginSetting createPluginSettings(final Map<String, Object> pluginSettingMap) {
         final PluginSetting pluginSetting = new PluginSetting(pluginName, pluginSettingMap);
         pluginSetting.setPipelineName(pipelineName);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/parser/PipelineTransformerTests.java
@@ -75,6 +75,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -150,7 +151,7 @@ class PipelineTransformerTests {
     @AfterEach
     void tearDown() {
         verify(dataPrepperConfiguration).getEventConfiguration();
-        verify(dataPrepperConfiguration).getExperimental();
+        verify(dataPrepperConfiguration, atLeastOnce()).getExperimental();
     }
 
     private PipelineTransformer createObjectUnderTest(final String pipelineConfigurationFileLocation) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestPluginWithExperimentalFeature.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestPluginWithExperimentalFeature.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.plugin.TestPluggableInterface;
+import org.opensearch.dataprepper.plugin.TestPluginWithExperimentalFeatureConfiguration;
+
+@DataPrepperPlugin(name = "test_plugin_with_experimental_feature", pluginType = TestPluggableInterface.class, pluginConfigurationType = TestPluginWithExperimentalFeatureConfiguration.class)
+public class TestPluginWithExperimentalFeature implements TestPluggableInterface {
+    private final TestPluginWithExperimentalFeatureConfiguration configuration;
+
+    @DataPrepperPluginConstructor
+    public TestPluginWithExperimentalFeature(final TestPluginWithExperimentalFeatureConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    public TestPluginWithExperimentalFeatureConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.Validator;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
+
+import javax.inject.Named;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Gets {@link ConstraintValidator} beans from the application config and makes them
+ * available to the Hibernate {@link Validator} as created in {@link ValidatorConfiguration}.
+ * <p>
+ * This allows us to create {@link ConstraintValidator} implementations that rely on Spring
+ * dependency injection.
+ */
+@Named
+class BeanAwareConstraintValidatorFactory implements ConstraintValidatorFactory {
+    private final ConstraintValidatorFactory delegate = new ConstraintValidatorFactoryImpl();
+    private final Map<Class<?>, ConstraintValidator<?, ?>> validatorsByClass;
+
+    BeanAwareConstraintValidatorFactory(final Collection<ConstraintValidator<?, ?>> constraintValidators) {
+        this.validatorsByClass = constraintValidators.stream()
+                .collect(Collectors.toMap(Object::getClass, Function.identity()));
+    }
+
+    @Override
+    public <T extends ConstraintValidator<?, ?>> T getInstance(final Class<T> key) {
+        final ConstraintValidator<?, ?> validator = validatorsByClass.get(key);
+        if (validator != null) {
+            return key.cast(validator);
+        }
+        return delegate.getInstance(key);
+    }
+
+    @Override
+    public void releaseInstance(final ConstraintValidator<?, ?> instance) {
+        if (!validatorsByClass.containsValue(instance)) {
+            delegate.releaseInstance(instance);
+        }
+    }
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactory.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactory.java
@@ -12,9 +12,7 @@ package org.opensearch.dataprepper.plugin;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorFactory;
 import jakarta.validation.Validator;
-import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 
-import javax.inject.Named;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
@@ -27,12 +25,13 @@ import java.util.stream.Collectors;
  * This allows us to create {@link ConstraintValidator} implementations that rely on Spring
  * dependency injection.
  */
-@Named
 class BeanAwareConstraintValidatorFactory implements ConstraintValidatorFactory {
-    private final ConstraintValidatorFactory delegate = new ConstraintValidatorFactoryImpl();
+    private final ConstraintValidatorFactory delegate;
     private final Map<Class<?>, ConstraintValidator<?, ?>> validatorsByClass;
 
-    BeanAwareConstraintValidatorFactory(final Collection<ConstraintValidator<?, ?>> constraintValidators) {
+    BeanAwareConstraintValidatorFactory(final ConstraintValidatorFactory delegate,
+                                        final Collection<ConstraintValidator<?, ?>> constraintValidators) {
+        this.delegate = delegate;
         this.validatorsByClass = constraintValidators.stream()
                 .collect(Collectors.toMap(Object::getClass, Function.identity()));
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ConstraintMappingContributor.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ConstraintMappingContributor.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+
+/**
+ * This interface allows implementors to add a {@link ConstraintMapping} to the
+ * {@link HibernateValidatorConfiguration} that Data Prepper uses to validate plugins.
+ */
+@FunctionalInterface
+interface ConstraintMappingContributor {
+    void addConstraintMapping(HibernateValidatorConfiguration configuration);
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalConstraintMappingContributor.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalConstraintMappingContributor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+import org.opensearch.dataprepper.model.annotations.Experimental;
+
+import javax.inject.Named;
+
+@Named
+class ExperimentalConstraintMappingContributor implements ConstraintMappingContributor {
+    @Override
+    public void addConstraintMapping(final HibernateValidatorConfiguration configuration) {
+        final ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+        constraintMapping.constraintDefinition(Experimental.class)
+                .includeExistingValidators(false)
+                .validatedBy(ExperimentalFeatureValidator.class);
+        configuration.addMapping(constraintMapping);
+    }
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalFeatureValidator.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExperimentalFeatureValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.opensearch.dataprepper.model.annotations.Experimental;
+
+import javax.inject.Named;
+
+@Named
+class ExperimentalFeatureValidator implements ConstraintValidator<Experimental, Object> {
+    private final ExperimentalConfiguration experimentalConfiguration;
+
+    ExperimentalFeatureValidator(final ExperimentalConfigurationContainer experimentalConfigurationContainer) {
+        this.experimentalConfiguration = experimentalConfigurationContainer.getExperimental();
+    }
+
+    @Override
+    public boolean isValid(final Object value, final ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return experimentalConfiguration.isEnableAll();
+    }
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ValidatorConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ValidatorConfiguration.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorFactory;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -12,10 +13,12 @@ import jakarta.validation.ValidatorFactory;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.springframework.context.annotation.Bean;
 
 import javax.inject.Named;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -23,6 +26,11 @@ import java.util.List;
  */
 @Named
 class ValidatorConfiguration {
+    @Bean
+    ConstraintValidatorFactory constraintValidatorFactory(final Collection<ConstraintValidator<?, ?>> constraintValidators) {
+        return new BeanAwareConstraintValidatorFactory(new ConstraintValidatorFactoryImpl(), constraintValidators);
+    }
+
     @Bean
     Validator validator(final ConstraintValidatorFactory constraintValidatorFactory,
                         final List<ConstraintMappingContributor> constraintMappingContributors) {

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ValidatorConfiguration.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ValidatorConfiguration.java
@@ -5,14 +5,18 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import jakarta.validation.ConstraintValidatorFactory;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.springframework.context.annotation.Bean;
 
 import javax.inject.Named;
+import java.util.List;
 
 /**
  * Application context for internal plugin framework beans.
@@ -20,11 +24,16 @@ import javax.inject.Named;
 @Named
 class ValidatorConfiguration {
     @Bean
-    Validator validator() {
-        final ValidatorFactory validationFactory = Validation.byDefaultProvider()
+    Validator validator(final ConstraintValidatorFactory constraintValidatorFactory,
+                        final List<ConstraintMappingContributor> constraintMappingContributors) {
+        final HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class)
                 .configure()
                 .messageInterpolator(new ParameterMessageInterpolator())
-                .buildValidatorFactory();
+                .constraintValidatorFactory(constraintValidatorFactory);
+
+        constraintMappingContributors.forEach(contributor -> contributor.addConstraintMapping(configuration));
+
+        final ValidatorFactory validationFactory = configuration.buildValidatorFactory();
         return validationFactory.getValidator();
     }
 

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactoryTest.java
@@ -10,40 +10,76 @@
 package org.opensearch.dataprepper.plugin;
 
 import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class BeanAwareConstraintValidatorFactoryTest {
     @Mock
+    private ConstraintValidatorFactory delegate;
+
+    @Mock
     private ConstraintValidator<?, ?> constraintValidator;
+
+    private Collection<ConstraintValidator<?, ?>> constraintValidators;
+
+    @BeforeEach
+    void setUp() {
+        constraintValidators = Collections.emptyList();
+    }
+
+    private BeanAwareConstraintValidatorFactory createObjectUnderTest() {
+        return new BeanAwareConstraintValidatorFactory(delegate, constraintValidators);
+    }
 
     @Test
     void getInstance_returns_injected_validator_when_class_matches() {
-        final BeanAwareConstraintValidatorFactory objectUnderTest =
-                new BeanAwareConstraintValidatorFactory(List.of(constraintValidator));
+        constraintValidators = List.of(constraintValidator);
 
-        final ConstraintValidator<?, ?> instance = objectUnderTest.getInstance(constraintValidator.getClass());
+        final ConstraintValidator<?, ?> instance = createObjectUnderTest().getInstance(constraintValidator.getClass());
 
         assertThat(instance, sameInstance(constraintValidator));
+        verifyNoInteractions(delegate);
     }
 
     @Test
     void getInstance_delegates_to_default_factory_when_class_not_in_injected_list() {
-        final BeanAwareConstraintValidatorFactory objectUnderTest =
-                new BeanAwareConstraintValidatorFactory(Collections.emptyList());
+        final ConstraintValidator<?, ?> delegateResult = mock(ConstraintValidator.class);
+        doReturn(delegateResult).when(delegate).getInstance(constraintValidator.getClass());
 
-        final ConstraintValidator<?, ?> instance = objectUnderTest.getInstance(constraintValidator.getClass());
+        final ConstraintValidator<?, ?> instance = createObjectUnderTest().getInstance(constraintValidator.getClass());
 
-        assertThat(instance, notNullValue());
+        assertThat(instance, sameInstance(delegateResult));
+    }
+
+    @Test
+    void releaseInstance_does_not_delegate_when_instance_is_injected() {
+        constraintValidators = List.of(constraintValidator);
+
+        createObjectUnderTest().releaseInstance(constraintValidator);
+
+        verifyNoInteractions(delegate);
+    }
+
+    @Test
+    void releaseInstance_delegates_to_default_factory_when_instance_is_not_injected() {
+        createObjectUnderTest().releaseInstance(constraintValidator);
+
+        verify(delegate).releaseInstance(constraintValidator);
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactoryTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/BeanAwareConstraintValidatorFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import jakarta.validation.ConstraintValidator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class BeanAwareConstraintValidatorFactoryTest {
+    @Mock
+    private ConstraintValidator<?, ?> constraintValidator;
+
+    @Test
+    void getInstance_returns_injected_validator_when_class_matches() {
+        final BeanAwareConstraintValidatorFactory objectUnderTest =
+                new BeanAwareConstraintValidatorFactory(List.of(constraintValidator));
+
+        final ConstraintValidator<?, ?> instance = objectUnderTest.getInstance(constraintValidator.getClass());
+
+        assertThat(instance, sameInstance(constraintValidator));
+    }
+
+    @Test
+    void getInstance_delegates_to_default_factory_when_class_not_in_injected_list() {
+        final BeanAwareConstraintValidatorFactory objectUnderTest =
+                new BeanAwareConstraintValidatorFactory(Collections.emptyList());
+
+        final ConstraintValidator<?, ?> instance = objectUnderTest.getInstance(constraintValidator.getClass());
+
+        assertThat(instance, notNullValue());
+    }
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConstraintMappingContributorTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConstraintMappingContributorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.annotations.Experimental;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExperimentalConstraintMappingContributorTest {
+
+    @Mock
+    private ExperimentalConfigurationContainer experimentalConfigurationContainer;
+
+    @Mock
+    private ExperimentalConfiguration experimentalConfiguration;
+
+    static class ConfigWithExperimentalField {
+        @Experimental
+        private Object experimentalFeature;
+
+        ConfigWithExperimentalField(final Object experimentalFeature) {
+            this.experimentalFeature = experimentalFeature;
+        }
+    }
+
+    private Validator createValidator() {
+        when(experimentalConfigurationContainer.getExperimental()).thenReturn(experimentalConfiguration);
+
+        final ExperimentalFeatureValidator experimentalFeatureValidator =
+                new ExperimentalFeatureValidator(experimentalConfigurationContainer);
+        final BeanAwareConstraintValidatorFactory constraintValidatorFactory =
+                new BeanAwareConstraintValidatorFactory(List.of(experimentalFeatureValidator));
+
+        final HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class)
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .constraintValidatorFactory(constraintValidatorFactory);
+
+        new ExperimentalConstraintMappingContributor().addConstraintMapping(configuration);
+
+        final ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
+        return validatorFactory.getValidator();
+    }
+
+    @Test
+    void addConstraintMapping_registers_experimental_validation_that_rejects_non_null_field() {
+        final Validator validator = createValidator();
+
+        final Set<ConstraintViolation<ConfigWithExperimentalField>> violations =
+                validator.validate(new ConfigWithExperimentalField(new Object()));
+
+        assertThat(violations, hasSize(1));
+        final ConstraintViolation<ConfigWithExperimentalField> violation = violations.iterator().next();
+        assertThat(violation.getPropertyPath().toString(), equalTo("experimentalFeature"));
+        assertThat(violation.getMessage(), equalTo("This feature is experimental. You must enable experimental features in data-prepper-config.yaml in order to use them."));
+    }
+
+    @Test
+    void addConstraintMapping_registers_experimental_validation_that_allows_null_field() {
+        final Validator validator = createValidator();
+
+        final Set<ConstraintViolation<ConfigWithExperimentalField>> violations =
+                validator.validate(new ConfigWithExperimentalField(null));
+
+        assertThat(violations, empty());
+    }
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConstraintMappingContributorTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalConstraintMappingContributorTest.java
@@ -15,6 +15,7 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +56,7 @@ class ExperimentalConstraintMappingContributorTest {
         final ExperimentalFeatureValidator experimentalFeatureValidator =
                 new ExperimentalFeatureValidator(experimentalConfigurationContainer);
         final BeanAwareConstraintValidatorFactory constraintValidatorFactory =
-                new BeanAwareConstraintValidatorFactory(List.of(experimentalFeatureValidator));
+                new BeanAwareConstraintValidatorFactory(new ConstraintValidatorFactoryImpl(), List.of(experimentalFeatureValidator));
 
         final HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class)
                 .configure()

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalFeatureValidatorTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ExperimentalFeatureValidatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExperimentalFeatureValidatorTest {
+
+    @Mock
+    private ExperimentalConfigurationContainer experimentalConfigurationContainer;
+
+    @Mock
+    private ExperimentalConfiguration experimentalConfiguration;
+
+    @Mock
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        when(experimentalConfigurationContainer.getExperimental()).thenReturn(experimentalConfiguration);
+    }
+
+    private ExperimentalFeatureValidator createObjectUnderTest() {
+        return new ExperimentalFeatureValidator(experimentalConfigurationContainer);
+    }
+
+    @Test
+    void isValid_returns_true_when_value_is_null() {
+        assertThat(createObjectUnderTest().isValid(null, context), equalTo(true));
+    }
+
+    @Test
+    void isValid_returns_true_when_value_is_non_null_and_enableAll_is_true() {
+        when(experimentalConfiguration.isEnableAll()).thenReturn(true);
+
+        assertThat(createObjectUnderTest().isValid(new Object(), context), equalTo(true));
+    }
+
+    @Test
+    void isValid_returns_false_when_value_is_non_null_and_enableAll_is_false() {
+        when(experimentalConfiguration.isEnableAll()).thenReturn(false);
+
+        assertThat(createObjectUnderTest().isValid(new Object(), context), equalTo(false));
+    }
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/TestPluginWithExperimentalFeatureConfiguration.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/TestPluginWithExperimentalFeatureConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import org.opensearch.dataprepper.model.annotations.Experimental;
+
+public class TestPluginWithExperimentalFeatureConfiguration {
+
+    @Experimental
+    private String experimentalOption;
+
+    public String getExperimentalOption() {
+        return experimentalOption;
+    }
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ValidatorConfigurationTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ValidatorConfigurationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.annotations.Experimental;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ValidatorConfigurationTest {
+
+    @Mock
+    private ExperimentalConfigurationContainer experimentalConfigurationContainer;
+
+    @Mock
+    private ExperimentalConfiguration experimentalConfiguration;
+
+    private Validator createValidator() {
+        when(experimentalConfigurationContainer.getExperimental()).thenReturn(experimentalConfiguration);
+        final ExperimentalFeatureValidator experimentalFeatureValidator =
+                new ExperimentalFeatureValidator(experimentalConfigurationContainer);
+        final BeanAwareConstraintValidatorFactory constraintValidatorFactory =
+                new BeanAwareConstraintValidatorFactory(List.of(experimentalFeatureValidator));
+        final ExperimentalConstraintMappingContributor experimentalContributor =
+                new ExperimentalConstraintMappingContributor();
+        return new ValidatorConfiguration().validator(
+                constraintValidatorFactory, List.of(experimentalContributor));
+    }
+
+    static class ConfigWithExperimentalField {
+        @Experimental
+        private Object experimentalFeature;
+
+        ConfigWithExperimentalField(final Object experimentalFeature) {
+            this.experimentalFeature = experimentalFeature;
+        }
+    }
+
+    @Nested
+    class ExperimentalFieldValidation {
+        @Test
+        void validator_allows_null_experimental_field_when_experimental_is_not_enabled() {
+            final Validator validator = createValidator();
+
+            final Set<ConstraintViolation<ConfigWithExperimentalField>> violations =
+                    validator.validate(new ConfigWithExperimentalField(null));
+
+            assertThat(violations, empty());
+        }
+
+        @Test
+        void validator_rejects_non_null_experimental_field_when_experimental_is_not_enabled() {
+            final Validator validator = createValidator();
+
+            final Set<ConstraintViolation<ConfigWithExperimentalField>> violations =
+                    validator.validate(new ConfigWithExperimentalField(new Object()));
+
+            assertThat(violations, hasSize(1));
+            final ConstraintViolation<ConfigWithExperimentalField> violation = violations.iterator().next();
+            assertThat(violation.getPropertyPath().toString(), equalTo("experimentalFeature"));
+        }
+
+        @Test
+        void validator_allows_non_null_experimental_field_when_enableAll_is_true() {
+            when(experimentalConfiguration.isEnableAll()).thenReturn(true);
+            final Validator validator = createValidator();
+
+            final Set<ConstraintViolation<ConfigWithExperimentalField>> violations =
+                    validator.validate(new ConfigWithExperimentalField(new Object()));
+
+            assertThat(violations, empty());
+        }
+    }
+}

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ValidatorConfigurationTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ValidatorConfigurationTest.java
@@ -11,6 +11,7 @@ package org.opensearch.dataprepper.plugin;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ class ValidatorConfigurationTest {
         final ExperimentalFeatureValidator experimentalFeatureValidator =
                 new ExperimentalFeatureValidator(experimentalConfigurationContainer);
         final BeanAwareConstraintValidatorFactory constraintValidatorFactory =
-                new BeanAwareConstraintValidatorFactory(List.of(experimentalFeatureValidator));
+                new BeanAwareConstraintValidatorFactory(new ConstraintValidatorFactoryImpl(), List.of(experimentalFeatureValidator));
         final ExperimentalConstraintMappingContributor experimentalContributor =
                 new ExperimentalConstraintMappingContributor();
         return new ValidatorConfiguration().validator(


### PR DESCRIPTION
### Description

With this change plugin authors can add an `@Experimental` annotation to configuration fields where the default value is `null`. This works well especially for nested configurations. If the `@Experimental` has a non-default, it will violate the validation for now.

The approach to implementing this is to expand our Hibernate Validator to be able to get custom `ConstraintValidator` instances from the Spring application context. This adds an `ExperimentalFeatureValidator` which implements `ConstraintValidator` for the `@Experimental` annotation. This allows data-prepper-api to retain the `@Experimental` annotation but not have any knowledge of how the constraint is implemented.

This solution builds on the work for #2695, but extends it to features within plugins. For now, I've taken the approach that you must `enable_all` experimental plugins and features for this to work.
 
I plan to use this to implement pull-based ingestion per #6796 without creating a strict change to the `opensearch` plugin.

### Issues Resolved

N/A
 
### Note on backward compatibility

This changes adds new annotation elements to `@Experimental`. These elements were flagged by japicmp as incompatible. This is probably strictly true at a byte-code level. They generate abstract methods. However, the Java runtime automatically implements these. As these elements all have default values, Java will give expected values.

I have excluded these methods from the backward compatibility checks to resolve this.

There is a related issue for japicmp: https://github.com/siom79/japicmp/issues/249

Also, JUnit hit this problem and solved it in a similar way per [this comment](https://github.com/junit-team/junit-framework/pull/5031#issuecomment-3394269619).

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
