### PR TITLE
Fixes the opensearch sink tests that run against OpenDistro

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -341,7 +341,7 @@ class OpenSearchSinkIT {
     }
 
     @Test
-    @DisabledIf(value = "isES6", disabledReason = LOG_INGESTION_TEST_DISABLED_REASON)
+    @DisabledIf(value = "isComposableIndexTemplateNotSupported", disabledReason = "Composable index templates are not supported on this version")
     @Timeout(value = 50, unit = TimeUnit.SECONDS)
     void testInstantiateSinkLogsPlainWithTemplateTypeUsesIndexType() throws IOException {
         final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfig(
@@ -2219,6 +2219,10 @@ class OpenSearchSinkIT {
 
     private static boolean isES6() {
         return DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(OpenSearchIntegrationHelper.getVersion()) >= 0;
+    }
+
+    private static boolean isComposableIndexTemplateNotSupported() {
+        return OpenSearchIntegrationHelper.getVersion().compareTo(DeclaredOpenSearchVersion.OPENDISTRO_1_9) < 0;
     }
 
     private static boolean isDataStreamNotSupported() {


### PR DESCRIPTION
### Description

The OpenDistro integration tests were broken by [`a611740`](https://github.com/opensearch-project/data-prepper/commit/a6117406211f2362760e540c5fe0b8caa1a7757c) from PR #6647. That new test disabled the composable index template tests for ES 6. But there are some versions of OpenDistro based on ES 7 that don't support composable index templates. Composable index templates were added in OpenDistro 1.9, which is ES 7.9.

### Issues Resolved

N/A

Fixes build failures
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
