### PR TITLE
Fixes the Docker release build on local machines that may have multiple versions

### DIFF
--- a/release/docker/build.gradle
+++ b/release/docker/build.gradle
@@ -56,6 +56,7 @@ tasks.register('dockerPrepare') {
     }
 
     doLast {
+        delete "${buildDir}/docker"
         supportedArchitectures.each { arch ->
             def archiveTask = project(':release:archives:linux').tasks.getByName("linux${arch}DistTar")
             def dockerArch = arch == 'x64' ? 'amd64' : arch


### PR DESCRIPTION
### Description

If you build the Docker task between Data Prepper versions, some files would remain that would cause the Docker build to fail. Delete the build Docker directory before running Docker build to clean out any old versions.

 
### Issues Resolved

N/A

This is something I noticed locally while working on Data Prepper.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
