### PR TITLE
Generate JSON schemas for plugins with schema definitions for nested configurations

### DIFF
--- a/data-prepper-plugin-schema-cli/src/main/java/org/opensearch/dataprepper/schemas/DataPrepperPluginSchemaExecute.java
+++ b/data-prepper-plugin-schema-cli/src/main/java/org/opensearch/dataprepper/schemas/DataPrepperPluginSchemaExecute.java
@@ -44,6 +44,9 @@ public class DataPrepperPluginSchemaExecute implements Runnable {
     @CommandLine.Option(names = {"--output_folder"})
     private String folderPath;
 
+    @CommandLine.Option(names = {"--use_definitions"}, defaultValue = "false")
+    private boolean useDefinitions;
+
     public static void main(String[] args) {
         final int exitCode = new CommandLine(new DataPrepperPluginSchemaExecute()).execute(args);
         System.exit(exitCode);
@@ -59,8 +62,9 @@ public class DataPrepperPluginSchemaExecute implements Runnable {
         } catch (IOException e) {
             throw new RuntimeException("primary fields override filepath does not exist. ", e);
         }
+        final JsonSchemaConverterConfig converterConfig = new JsonSchemaConverterConfig(useDefinitions);
         final PluginConfigsJsonSchemaConverter pluginConfigsJsonSchemaConverter = new PluginConfigsJsonSchemaConverter(
-                pluginProvider, new JsonSchemaConverter(DataPrepperModules.dataPrepperModules(), pluginProvider),
+                pluginProvider, new JsonSchemaConverter(DataPrepperModules.dataPrepperModules(), pluginProvider, converterConfig),
                 primaryFieldsOverride, siteUrl, siteBaseUrl);
         final Class<?> pluginType = pluginConfigsJsonSchemaConverter.pluginTypeNameToPluginType(pluginTypeName);
         final Map<String, String> pluginNameToJsonSchemaMap = pluginConfigsJsonSchemaConverter.convertPluginConfigsIntoJsonSchemas(

--- a/data-prepper-plugin-schema/src/main/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterConfig.java
+++ b/data-prepper-plugin-schema/src/main/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.schemas;
+
+public class JsonSchemaConverterConfig {
+    private final boolean useDefinitions;
+
+    public JsonSchemaConverterConfig(final boolean useDefinitions) {
+        this.useDefinitions = useDefinitions;
+    }
+
+    public static JsonSchemaConverterConfig defaultConfig() {
+        return new JsonSchemaConverterConfig(false);
+    }
+
+    public boolean isUseDefinitions() {
+        return useDefinitions;
+    }
+}

--- a/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterTest.java
+++ b/data-prepper-plugin-schema/src/test/java/org/opensearch/dataprepper/schemas/JsonSchemaConverterTest.java
@@ -216,4 +216,28 @@ class JsonSchemaConverterTest {
 
         private EventKey testAttributeEventKey;
     }
+
+    @Test
+    void testConvertIntoJsonSchemaWithUseDefinitions() throws JsonProcessingException {
+        final JsonSchemaConverterConfig config = new JsonSchemaConverterConfig(true);
+        final JsonSchemaConverter jsonSchemaConverter = new JsonSchemaConverter(
+                Collections.emptyList(), pluginProvider, config);
+        final ObjectNode jsonSchemaNode = jsonSchemaConverter.convertIntoJsonSchema(
+                SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON, TestConfigWithNestedObject.class);
+        
+        assertThat(jsonSchemaNode.has("$defs"), is(true));
+        final JsonNode defsNode = jsonSchemaNode.get("$defs");
+        assertThat(defsNode, instanceOf(ObjectNode.class));
+    }
+
+    @JsonClassDescription("Test config with nested object")
+    static class TestConfigWithNestedObject {
+        @JsonProperty("nested_list")
+        private List<NestedObject> nestedList;
+    }
+
+    static class NestedObject {
+        @JsonProperty("field")
+        private String field;
+    }
 }


### PR DESCRIPTION
### Description

The current schema generation uses `object` for nested configurations. With the nested configurations, the nested configurations are not referenced. This makes it difficult to auto-generate documentation from the schemas.

This PR adds a new `--use_definitions=true` configuration to the schema generation that generates a schema instead of object.

Here is how it generates currently for the `date` processor (some parts are removed to focus on the change):

```
./gradlew :data-prepper-plugin-schema-cli:run --args='--plugin_type=processor --plugin_names=date'
```
```
{
  "$schema" : "https://json-schema.org/draft/2020-12/schema",
  "type" : "object",
  "properties" : {
    "from_time_received" : {
       ...
    },
    "match" : {
      "description" : "This option cannot be defined at the same time as <code>from_time_received</code>. The date processor will use the first pattern that matches each event's timestamp field. You must provide at least one pattern unless you have <code>from_time_received</code>.",
      "type" : "array",
      "items" : {
        "type" : "object",
        "properties" : {
          "key" : {
            "type" : "string",
            "description" : "Represents the event key against which to match patterns. Required if <code>match</code> is configured."
          },
          "patterns" : {
            "description" : "A list of possible patterns that the timestamp value of the key can have. The patterns are based on a sequence of letters and symbols. The <code>patterns</code> support all the patterns listed in the Java DateTimeFormatter (https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) reference. To match ISO 8601 formatted strings, use, <code>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</code>. To match Apache Common Log Format, use <code>dd/MMM/yyyy:HH:mm:ss Z</code>. The timestamp value also supports <code>epoch_second</code>, <code>epoch_milli</code>, and <code>epoch_nano</code> values, which represent the timestamp as the number of seconds, milliseconds, and nanoseconds since the epoch. Epoch values always use the UTC time zone.",
            "examples" : [ {
              "description" : "Matches ISO-8601 formatted strings.",
              "example" : "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
            }, {
              "description" : "Matches Apache Common Log Format.",
              "example" : "dd/MMM/yyyy:HH:mm:ss Z"
            }, {
              "description" : "Matches against strings that represent seconds since Unix epoch time.",
              "example" : "epoch_second"
            } ],
            "type" : "array",
            "items" : {
              "type" : "string"
            }
          }
        }
      }
    },
    "destination" : {
      ...
    },
...
```
 
With this change, we get this output instead (again, some parts removed):

```
./gradlew :data-prepper-plugin-schema-cli:run --args='--plugin_type=processor --plugin_names=date --use_definitions=true'
```
```
{
  "$schema" : "https://json-schema.org/draft/2020-12/schema",
  "$defs" : {
    "DateMatch" : {
      "type" : "object",
      "properties" : {
        "key" : {
          "type" : "string",
          "description" : "Represents the event key against which to match patterns. Required if <code>match</code> is configured."
        },
        "patterns" : {
          "description" : "A list of possible patterns that the timestamp value of the key can have. The patterns are based on a sequence of letters and symbols. The <code>patterns</code> support all the patterns listed in the Java DateTimeFormatter (https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) reference. To match ISO 8601 formatted strings, use, <code>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</code>. To match Apache Common Log Format, use <code>dd/MMM/yyyy:HH:mm:ss Z</code>. The timestamp value also supports <code>epoch_second</code>, <code>epoch_milli</code>, and <code>epoch_nano</code> values, which represent the timestamp as the number of seconds, milliseconds, and nanoseconds since the epoch. Epoch values always use the UTC time zone.",
          "examples" : [ {
            "description" : "Matches ISO-8601 formatted strings.",
            "example" : "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
          }, {
            "description" : "Matches Apache Common Log Format.",
            "example" : "dd/MMM/yyyy:HH:mm:ss Z"
          }, {
            "description" : "Matches against strings that represent seconds since Unix epoch time.",
            "example" : "epoch_second"
          } ],
          "type" : "array",
          "items" : {
            "type" : "string"
          }
        }
      }
    }
  },
  "type" : "object",
  "properties" : {
    "from_time_received" : {
      ...
    },
    "match" : {
      "description" : "This option cannot be defined at the same time as <code>from_time_received</code>. The date processor will use the first pattern that matches each event's timestamp field. You must provide at least one pattern unless you have <code>from_time_received</code>.",
      "type" : "array",
      "items" : {
        "$ref" : "#/$defs/DateMatch"
      }
    },
    "destination" : {
      ...
    },
...
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
