### PR TITLE
Fix IndexOutOfBoundsException in binlog event processing when row data and column names have different lengths

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -324,12 +324,15 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             childKeyIndices = null;
         }
 
+        final List<String> columnNames = tableMetadata.getColumnNames();
+
         for (int rowNum = 0; rowNum < data.getRows().size(); rowNum++) {
             // `row` contains data before update as key and data after update as value
             Map.Entry<Serializable[], Serializable[]> row = data.getRows().get(rowNum);
 
-            for (int i = 0; i < row.getKey().length; i++) {
-                if (tableMetadata.getPrimaryKeys().contains(tableMetadata.getColumnNames().get(i)) &&
+            final int columnCount = Math.min(columnNames.size(), row.getKey().length);
+            for (int i = 0; i < columnCount; i++) {
+                if (tableMetadata.getPrimaryKeys().contains(columnNames.get(i)) &&
                         !row.getKey()[i].equals(row.getValue()[i])) {
                     LOG.debug("Primary keys were updated");
                     // add delete event for the old row data
@@ -427,7 +430,12 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             final OpenSearchBulkActions bulkAction = bulkActions.get(rowNum);
 
             final Map<String, Object> rowDataMap = new HashMap<>();
-            for (int i = 0; i < rowDataArray.length; i++) {
+            final int columnCount = Math.min(columnNames.size(), rowDataArray.length);
+            if (rowDataArray.length != columnNames.size()) {
+                LOG.warn("Row data length ({}) does not match column names size ({}) for table {}. Extra columns will be skipped.",
+                        rowDataArray.length, columnNames.size(), tableMetadata.getFullTableName());
+            }
+            for (int i = 0; i < columnCount; i++) {
                 final Map<String, String> tbColumnDatatypeMap = dbTableMetadata.getTableColumnDataTypeMap().get(tableMetadata.getFullTableName());
                 final String columnDataType = tbColumnDatatypeMap.get(columnNames.get(i));
                 final Object data =  MySQLDataTypeHelper.getDataByColumnType(MySQLDataType.byDataType(columnDataType), columnNames.get(i),

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -237,6 +237,80 @@ class BinlogEventListenerTest {
         verify(objectUnderTest).handleDeleteEvent(binlogEvent);
     }
 
+    @ParameterizedTest
+    @EnumSource(names = {"UPDATE_ROWS", "EXT_UPDATE_ROWS"})
+    void test_handleUpdateEvent_does_not_throw_when_row_data_has_extra_columns(EventType eventType) throws NoSuchFieldException, IllegalAccessException {
+        // Simulate expression index: row data has 4 values but only 2 visible column names
+        final UpdateRowsEventData data = mock(UpdateRowsEventData.class);
+        final Serializable[] oldData = new Serializable[]{1, "a", "hidden1", "hidden2"};
+        final Serializable[] newData = new Serializable[]{1, "b", "hidden1", "hidden2"};
+        final List<Map.Entry<Serializable[], Serializable[]>> rows = List.of(Map.entry(oldData, newData));
+        final long tableId = 1234L;
+        when(binlogEvent.getHeader().getEventType()).thenReturn(eventType);
+        when(binlogEvent.getData()).thenReturn(data);
+        when(data.getTableId()).thenReturn(tableId);
+        when(objectUnderTest.isValidTableId(tableId)).thenReturn(true);
+        when(data.getRows()).thenReturn(rows);
+
+        final TableMetadata tableMetadata = mock(TableMetadata.class);
+        final Map<Long, TableMetadata> tableMetadataMap = Map.of(tableId, tableMetadata);
+        Field tableMetadataMapField = BinlogEventListener.class.getDeclaredField("tableMetadataMap");
+        tableMetadataMapField.setAccessible(true);
+        tableMetadataMapField.set(objectUnderTest, tableMetadataMap);
+        when(tableMetadata.getPrimaryKeys()).thenReturn(List.of("col1"));
+        when(tableMetadata.getColumnNames()).thenReturn(List.of("col1", "col2"));
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verifyHandlerCallHelper();
+        verify(objectUnderTest).handleUpdateEvent(binlogEvent);
+
+        ArgumentCaptor<List<Serializable[]>> rowListCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<OpenSearchBulkActions>> bulkActionCaptor = ArgumentCaptor.forClass(List.class);
+        verify(objectUnderTest).handleRowChangeEvent(eq(binlogEvent), eq(tableId), rowListCaptor.capture(), bulkActionCaptor.capture(), eq(StreamEventType.UPDATE));
+
+        // No primary key change, so only the INDEX action for the new row
+        assertThat(rowListCaptor.getValue().size(), is(1));
+        assertThat(bulkActionCaptor.getValue().get(0), is(OpenSearchBulkActions.INDEX));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"UPDATE_ROWS", "EXT_UPDATE_ROWS"})
+    void test_handleUpdateEvent_detects_primary_key_change_with_extra_columns(EventType eventType) throws NoSuchFieldException, IllegalAccessException {
+        // Row data has extra expression index columns, but primary key still changes
+        final UpdateRowsEventData data = mock(UpdateRowsEventData.class);
+        final Serializable[] oldData = new Serializable[]{1, "a", "hidden1"};
+        final Serializable[] newData = new Serializable[]{2, "a", "hidden1"};
+        final List<Map.Entry<Serializable[], Serializable[]>> rows = List.of(Map.entry(oldData, newData));
+        final long tableId = 1234L;
+        when(binlogEvent.getHeader().getEventType()).thenReturn(eventType);
+        when(binlogEvent.getData()).thenReturn(data);
+        when(data.getTableId()).thenReturn(tableId);
+        when(objectUnderTest.isValidTableId(tableId)).thenReturn(true);
+        when(data.getRows()).thenReturn(rows);
+
+        final TableMetadata tableMetadata = mock(TableMetadata.class);
+        final Map<Long, TableMetadata> tableMetadataMap = Map.of(tableId, tableMetadata);
+        Field tableMetadataMapField = BinlogEventListener.class.getDeclaredField("tableMetadataMap");
+        tableMetadataMapField.setAccessible(true);
+        tableMetadataMapField.set(objectUnderTest, tableMetadataMap);
+        when(tableMetadata.getPrimaryKeys()).thenReturn(List.of("col1"));
+        when(tableMetadata.getColumnNames()).thenReturn(List.of("col1", "col2"));
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verifyHandlerCallHelper();
+
+        ArgumentCaptor<List<Serializable[]>> rowListCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<OpenSearchBulkActions>> bulkActionCaptor = ArgumentCaptor.forClass(List.class);
+        verify(objectUnderTest).handleRowChangeEvent(eq(binlogEvent), eq(tableId), rowListCaptor.capture(), bulkActionCaptor.capture(), eq(StreamEventType.UPDATE));
+
+        // Primary key changed: DELETE old + INDEX new
+        assertThat(rowListCaptor.getValue().size(), is(2));
+        assertThat(bulkActionCaptor.getValue().get(0), is(OpenSearchBulkActions.DELETE));
+        assertThat(bulkActionCaptor.getValue().get(1), is(OpenSearchBulkActions.INDEX));
+    }
+
     private BinlogEventListener createObjectUnderTest() {
         return BinlogEventListener.create(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
                 streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadingActionDetector);


### PR DESCRIPTION
### Description

Fixes `IndexOutOfBoundsException` in the RDS source binlog stream processor when the number of values in binlog row data does not match the number of column names from `TableMapEventMetadata`.

This mismatch has been observed in certain use cases but the root cause is still unknown. This PR adds a defensive fix and additional logging so we can collect more information for troubleshooting next time this is observed.

**Changes:**
- In `handleUpdateEvent`: bound the primary key check loop by `Math.min(columnNames.size(), row.getKey().length)` instead of `row.getKey().length`
- In `handleRowChangeEvent`: bound the column mapping loop by `Math.min(columnNames.size(), rowDataArray.length)` instead of `rowDataArray.length`
- Added a WARN log when row data length and column names size do not match
- Added unit tests covering the mismatch scenario

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).