### PR TITLE
Handle MySQL ENUM value 0 in StringTypeHandler

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/StringTypeHandler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/StringTypeHandler.java
@@ -35,6 +35,9 @@ public class StringTypeHandler implements MySQLDataTypeHandler {
     }
 
     private String getEnumValue(final int numericValue, final String[] enumStrValues) {
+        if (numericValue == 0) {
+            return "";
+        }
         return enumStrValues[numericValue - 1];
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/StringTypeHandlerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/datatype/mysql/handler/StringTypeHandlerTest.java
@@ -79,6 +79,26 @@ public class StringTypeHandlerTest {
     }
 
     @Test
+    public void test_handle_enum_zero_value() {
+        StringTypeHandler handler = new StringTypeHandler();
+        String columnName = "testColumn";
+        Integer value = 0;
+        String[] enumValues = { "ENUM1", "ENUM2", "ENUM3" };
+        MySQLDataType columnType = MySQLDataType.ENUM;
+        final TableMetadata metadata = TableMetadata.builder()
+                .withTableName(UUID.randomUUID().toString())
+                .withDatabaseName(UUID.randomUUID().toString())
+                .withColumnNames(List.of(columnName))
+                .withPrimaryKeys(List.of(columnName))
+                .withEnumStrValues(Map.of(columnName, enumValues))
+                .withSetStrValues(Collections.emptyMap())
+                .build();
+        String result = handler.handle(columnType, columnName, value, metadata);
+
+        assertThat(result, is(""));
+    }
+
+    @Test
     public void test_handle_set_string() {
         StringTypeHandler handler = new StringTypeHandler();
         String columnName = "testColumn";


### PR DESCRIPTION
### Description
Handle MySQL ENUM numeric value `0` (empty/invalid sentinel) in `StringTypeHandler.getEnumValue` by returning an empty string instead of throwing `ArrayIndexOutOfBoundsException`.

MySQL uses ENUM value `0` as a reserved sentinel for empty or invalid values. The binlog includes this value in row events, but the handler computed `enumStrValues[0 - 1]` which threw an exception and caused the entire update event to be skipped.

### Issues Resolved
Resolves #6779

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).