### PR TITLE
Add pipeline DLQ support for rds source

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -133,7 +133,8 @@ public class RdsService {
             exportScheduler = new ExportScheduler(
                     sourceCoordinator, snapshotManager, exportTaskManager, s3Client, pluginMetrics);
             dataFileScheduler = new DataFileScheduler(
-                    sourceCoordinator, sourceConfig, s3PathPrefix, s3Client, eventFactory, buffer, pluginMetrics, acknowledgementSetManager);
+                    sourceCoordinator, sourceConfig, s3PathPrefix, s3Client, eventFactory, buffer, pluginMetrics,
+                    acknowledgementSetManager, pluginSetting, pipelineDescription, failurePipeline);
             runnableList.add(exportScheduler);
             runnableList.add(dataFileScheduler);
         }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -10,8 +10,10 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
@@ -68,6 +70,8 @@ public class RdsService {
     private final PluginConfigObservable pluginConfigObservable;
     private final RdsSourceAggregateMetrics rdsSourceAggregateMetrics;
     private final PipelineDescription pipelineDescription;
+    private final PluginSetting pluginSetting;
+    private final HeadlessPipeline failurePipeline;
     private ExecutorService executor;
     private LeaderScheduler leaderScheduler;
     private ExportScheduler exportScheduler;
@@ -82,7 +86,9 @@ public class RdsService {
                       final PluginMetrics pluginMetrics,
                       final AcknowledgementSetManager acknowledgementSetManager,
                       final PluginConfigObservable pluginConfigObservable,
-                      final PipelineDescription pipelineDescription) {
+                      final PipelineDescription pipelineDescription,
+                      final PluginSetting pluginSetting,
+                      final HeadlessPipeline failurePipeline) {
         this.sourceCoordinator = sourceCoordinator;
         this.eventFactory = eventFactory;
         this.pluginMetrics = pluginMetrics;
@@ -91,6 +97,8 @@ public class RdsService {
         this.pluginConfigObservable = pluginConfigObservable;
         this.rdsSourceAggregateMetrics = new RdsSourceAggregateMetrics();
         this.pipelineDescription = pipelineDescription;
+        this.pluginSetting = pluginSetting;
+        this.failurePipeline = failurePipeline;
 
         rdsClient = clientFactory.buildRdsClient();
         s3Client = clientFactory.buildS3Client();
@@ -141,7 +149,8 @@ public class RdsService {
             }
 
             streamScheduler = new StreamScheduler(
-                    sourceCoordinator, sourceConfig, s3PathPrefix, replicationLogClientFactory, buffer, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
+                    sourceCoordinator, sourceConfig, s3PathPrefix, replicationLogClientFactory, buffer, pluginMetrics,
+                    acknowledgementSetManager, pluginConfigObservable, pluginSetting, pipelineDescription, failurePipeline);
             runnableList.add(streamScheduler);
 
             if (sourceConfig.getEngine().isMySql()) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsSource.java
@@ -12,8 +12,10 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
@@ -41,8 +43,10 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigObservable pluginConfigObservable;
     private final PipelineDescription pipelineDescription;
+    private final PluginSetting pluginSetting;
     private EnhancedSourceCoordinator sourceCoordinator;
     private RdsService rdsService;
+    private HeadlessPipeline failurePipeline;
 
     @DataPrepperPluginConstructor
     public RdsSource(final PluginMetrics pluginMetrics,
@@ -51,13 +55,15 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
                      final AwsCredentialsSupplier awsCredentialsSupplier,
                      final AcknowledgementSetManager acknowledgementSetManager,
                      final PluginConfigObservable pluginConfigObservable,
-                     final PipelineDescription pipelineDescription) {
+                     final PipelineDescription pipelineDescription,
+                     final PluginSetting pluginSetting) {
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
         this.eventFactory = eventFactory;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginConfigObservable = pluginConfigObservable;
         this.pipelineDescription = pipelineDescription;
+        this.pluginSetting = pluginSetting;
 
         clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig);
     }
@@ -69,7 +75,7 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
         sourceCoordinator.createPartition(new LeaderPartition());
 
         rdsService = new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics,
-                acknowledgementSetManager, pluginConfigObservable, pipelineDescription);
+                acknowledgementSetManager, pluginConfigObservable, pipelineDescription, pluginSetting, failurePipeline);
 
         LOG.info("Start RDS service");
         rdsService.start(buffer);
@@ -81,6 +87,11 @@ public class RdsSource implements Source<Record<Event>>, UsesEnhancedSourceCoord
         if (Objects.nonNull(rdsService)) {
             rdsService.shutdown();
         }
+    }
+
+    @Override
+    public void setFailurePipeline(final HeadlessPipeline failurePipeline) {
+        this.failurePipeline = failurePipeline;
     }
 
     @Override

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -193,8 +193,12 @@ public class DataFileLoader implements Runnable {
                             .addArgument(objectKey)
                             .setCause(e)
                             .log();
-                    exportRecordErrorCounter.increment();
-                    sendToFailurePipeline(record.getData(), e);
+                    if (failurePipeline != null) {
+                        exportRecordErrorCounter.increment();
+                        sendToFailurePipeline(record.getData(), e);
+                    } else {
+                        throw new RuntimeException(e);
+                    }
                 }
             });
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -12,8 +12,11 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.EngineType;
@@ -71,6 +74,9 @@ public class DataFileLoader implements Runnable {
     private final Counter exportRecordErrorCounter;
     private final DistributionSummary bytesReceivedSummary;
     private final DistributionSummary bytesProcessedSummary;
+    private final PluginSetting pluginSetting;
+    private final String pipelineName;
+    private final HeadlessPipeline failurePipeline;
 
     private DataFileLoader(final DataFilePartition dataFilePartition,
                            final InputCodec codec,
@@ -81,7 +87,10 @@ public class DataFileLoader implements Runnable {
                            final EnhancedSourceCoordinator sourceCoordinator,
                            final AcknowledgementSet acknowledgementSet,
                            final Duration acknowledgmentTimeout,
-                           final DbTableMetadata dbTableMetadata) {
+                           final DbTableMetadata dbTableMetadata,
+                           final PluginSetting pluginSetting,
+                           final PipelineDescription pipelineDescription,
+                           final HeadlessPipeline failurePipeline) {
         this.dataFilePartition = dataFilePartition;
         bucket = dataFilePartition.getBucket();
         objectKey = dataFilePartition.getKey();
@@ -93,6 +102,9 @@ public class DataFileLoader implements Runnable {
         this.acknowledgementSet = acknowledgementSet;
         this.acknowledgmentTimeout = acknowledgmentTimeout;
         this.dbTableMetadata = dbTableMetadata;
+        this.pluginSetting = pluginSetting;
+        this.pipelineName = pipelineDescription.getPipelineName();
+        this.failurePipeline = failurePipeline;
 
         exportRecordsTotalCounter = pluginMetrics.counter(EXPORT_RECORDS_TOTAL_COUNT);
         exportRecordSuccessCounter = pluginMetrics.counter(EXPORT_RECORDS_PROCESSED_COUNT);
@@ -110,9 +122,13 @@ public class DataFileLoader implements Runnable {
                                         final EnhancedSourceCoordinator sourceCoordinator,
                                         final AcknowledgementSet acknowledgementSet,
                                         final Duration acknowledgmentTimeout,
-                                        final DbTableMetadata dbTableMetadata) {
+                                        final DbTableMetadata dbTableMetadata,
+                                        final PluginSetting pluginSetting,
+                                        final PipelineDescription pipelineDescription,
+                                        final HeadlessPipeline failurePipeline) {
         return new DataFileLoader(dataFilePartition, codec, buffer, objectReader, recordConverter,
-                pluginMetrics, sourceCoordinator, acknowledgementSet, acknowledgmentTimeout, dbTableMetadata);
+                pluginMetrics, sourceCoordinator, acknowledgementSet, acknowledgmentTimeout, dbTableMetadata,
+                pluginSetting, pipelineDescription, failurePipeline);
     }
 
     @Override
@@ -177,7 +193,8 @@ public class DataFileLoader implements Runnable {
                             .addArgument(objectKey)
                             .setCause(e)
                             .log();
-                    throw new RuntimeException(e);
+                    exportRecordErrorCounter.increment();
+                    sendToFailurePipeline(record.getData(), e);
                 }
             });
 
@@ -226,6 +243,22 @@ public class DataFileLoader implements Runnable {
                         entry.getValue());
                 event.put(entry.getKey(), data);
             }
+        }
+    }
+
+    private void sendToFailurePipeline(final Event event, final Exception e) {
+        if (failurePipeline == null) {
+            return;
+        }
+        try {
+            event.updateFailureMetadata()
+                    .withPluginId(pluginSetting.getName())
+                    .withPluginName(pluginSetting.getName())
+                    .withPipelineName(pipelineName)
+                    .withErrorMessage(e.getMessage());
+            failurePipeline.sendEvents(List.of(new Record<>(event)));
+        } catch (Exception ex) {
+            LOG.error(NOISY, "Failed to send event to failure pipeline", ex);
         }
     }
 }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
@@ -11,8 +11,11 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
@@ -66,6 +69,9 @@ public class DataFileScheduler implements Runnable {
     private final Buffer<Record<Event>> buffer;
     private final PluginMetrics pluginMetrics;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final PluginSetting pluginSetting;
+    private final PipelineDescription pipelineDescription;
+    private final HeadlessPipeline failurePipeline;
 
     private final Counter exportFileSuccessCounter;
     private final Counter exportFileErrorCounter;
@@ -80,7 +86,10 @@ public class DataFileScheduler implements Runnable {
                              final EventFactory eventFactory,
                              final Buffer<Record<Event>> buffer,
                              final PluginMetrics pluginMetrics,
-                             final AcknowledgementSetManager acknowledgementSetManager) {
+                             final AcknowledgementSetManager acknowledgementSetManager,
+                             final PluginSetting pluginSetting,
+                             final PipelineDescription pipelineDescription,
+                             final HeadlessPipeline failurePipeline) {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
         codec = new ParquetInputCodec(eventFactory);
@@ -94,6 +103,9 @@ public class DataFileScheduler implements Runnable {
         this.buffer = buffer;
         this.pluginMetrics = pluginMetrics;
         this.acknowledgementSetManager = acknowledgementSetManager;
+        this.pluginSetting = pluginSetting;
+        this.pipelineDescription = pipelineDescription;
+        this.failurePipeline = failurePipeline;
 
         this.exportFileSuccessCounter = pluginMetrics.counter(EXPORT_S3_OBJECTS_PROCESSED_COUNT);
         this.exportFileErrorCounter = pluginMetrics.counter(EXPORT_S3_OBJECTS_ERROR_COUNT);
@@ -162,7 +174,7 @@ public class DataFileScheduler implements Runnable {
         Runnable loader = DataFileLoader.create(
                 dataFilePartition, codec, buffer, objectReader, recordConverter, pluginMetrics,
                 sourceCoordinator, acknowledgementSet, sourceConfig.getDataFileAcknowledgmentTimeout(),
-                getDBTableMetadata());
+                getDBTableMetadata(), pluginSetting, pipelineDescription, failurePipeline);
         CompletableFuture runLoader = CompletableFuture.runAsync(loader, executor);
 
         if (isAcknowledgmentsEnabled) {

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -23,9 +23,12 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 import org.opensearch.dataprepper.plugins.source.rds.converter.StreamRecordConverter;
@@ -98,6 +101,9 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
     private final DbTableMetadata dbTableMetadata;
     private final ExecutorService binlogEventExecutorService;
     private final CascadingActionDetector cascadeActionDetector;
+    private final PluginSetting pluginSetting;
+    private final String pipelineName;
+    private final HeadlessPipeline failurePipeline;
 
     private final Counter changeEventSuccessCounter;
     private final Counter changeEventErrorCounter;
@@ -120,7 +126,10 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                                final StreamCheckpointer streamCheckpointer,
                                final AcknowledgementSetManager acknowledgementSetManager,
                                final DbTableMetadata dbTableMetadata,
-                               final CascadingActionDetector cascadeActionDetector) {
+                               final CascadingActionDetector cascadeActionDetector,
+                               final PluginSetting pluginSetting,
+                               final PipelineDescription pipelineDescription,
+                               final HeadlessPipeline failurePipeline) {
         this.streamPartition = streamPartition;
         this.buffer = buffer;
         this.binaryLogClient = binaryLogClient;
@@ -148,6 +157,10 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
         this.cascadeActionDetector = cascadeActionDetector;
         parentTableMap = cascadeActionDetector.getParentTableMap(streamPartition);
 
+        this.pluginSetting = pluginSetting;
+        this.pipelineName = pipelineDescription.getPipelineName();
+        this.failurePipeline = failurePipeline;
+
         changeEventSuccessCounter = pluginMetrics.counter(CHANGE_EVENTS_PROCESSED_COUNT);
         changeEventErrorCounter = pluginMetrics.counter(CHANGE_EVENTS_PROCESSING_ERROR_COUNT);
         bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
@@ -165,9 +178,13 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
                                              final StreamCheckpointer streamCheckpointer,
                                              final AcknowledgementSetManager acknowledgementSetManager,
                                              final DbTableMetadata dbTableMetadata,
-                                             final CascadingActionDetector cascadeActionDetector) {
+                                             final CascadingActionDetector cascadeActionDetector,
+                                             final PluginSetting pluginSetting,
+                                             final PipelineDescription pipelineDescription,
+                                             final HeadlessPipeline failurePipeline) {
         return new BinlogEventListener(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient, 
-                                       streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadeActionDetector);
+                                       streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadeActionDetector,
+                                       pluginSetting, pipelineDescription, failurePipeline);
     }
 
     @Override
@@ -429,37 +446,46 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             final Object[] rowDataArray = rows.get(rowNum);
             final OpenSearchBulkActions bulkAction = bulkActions.get(rowNum);
 
-            final Map<String, Object> rowDataMap = new HashMap<>();
-            final int columnCount = Math.min(columnNames.size(), rowDataArray.length);
-            if (rowDataArray.length != columnNames.size()) {
-                LOG.warn("Row data length ({}) does not match column names size ({}) for table {}. Extra columns will be skipped.",
-                        rowDataArray.length, columnNames.size(), tableMetadata.getFullTableName());
-            }
-            for (int i = 0; i < columnCount; i++) {
-                final Map<String, String> tbColumnDatatypeMap = dbTableMetadata.getTableColumnDataTypeMap().get(tableMetadata.getFullTableName());
-                final String columnDataType = tbColumnDatatypeMap.get(columnNames.get(i));
-                final Object data =  MySQLDataTypeHelper.getDataByColumnType(MySQLDataType.byDataType(columnDataType), columnNames.get(i),
-                        rowDataArray[i], tableMetadata);
-                rowDataMap.put(columnNames.get(i), data);
-            }
+            try {
+                final Map<String, Object> rowDataMap = new HashMap<>();
+                final int columnCount = Math.min(columnNames.size(), rowDataArray.length);
+                if (rowDataArray.length != columnNames.size()) {
+                    LOG.warn("Row data length ({}) does not match column names size ({}) for table {}. Extra columns will be skipped.",
+                            rowDataArray.length, columnNames.size(), tableMetadata.getFullTableName());
+                }
+                for (int i = 0; i < columnCount; i++) {
+                    final Map<String, String> tbColumnDatatypeMap = dbTableMetadata.getTableColumnDataTypeMap().get(tableMetadata.getFullTableName());
+                    final String columnDataType = tbColumnDatatypeMap.get(columnNames.get(i));
+                    final Object data =  MySQLDataTypeHelper.getDataByColumnType(MySQLDataType.byDataType(columnDataType), columnNames.get(i),
+                            rowDataArray[i], tableMetadata);
+                    rowDataMap.put(columnNames.get(i), data);
+                }
 
-            final Event dataPrepperEvent = JacksonEvent.builder()
-                    .withEventType(DATA_PREPPER_EVENT_TYPE)
-                    .withData(rowDataMap)
-                    .build();
+                final Event dataPrepperEvent = JacksonEvent.builder()
+                        .withEventType(DATA_PREPPER_EVENT_TYPE)
+                        .withData(rowDataMap)
+                        .build();
 
-            final Event pipelineEvent = recordConverter.convert(
-                    dataPrepperEvent,
-                    tableMetadata.getDatabaseName(),
-                    tableMetadata.getDatabaseName(),
-                    tableMetadata.getTableName(),
-                    bulkAction,
-                    primaryKeys,
-                    eventTimestampMillis,
-                    recordConverter.getVersionNumber(eventTimestampMillis),
-                    streamEventType,
-                    tableMetadata.getColumnNames());
-            pipelineEvents.add(pipelineEvent);
+                final Event pipelineEvent = recordConverter.convert(
+                        dataPrepperEvent,
+                        tableMetadata.getDatabaseName(),
+                        tableMetadata.getDatabaseName(),
+                        tableMetadata.getTableName(),
+                        bulkAction,
+                        primaryKeys,
+                        eventTimestampMillis,
+                        recordConverter.getVersionNumber(eventTimestampMillis),
+                        streamEventType,
+                        tableMetadata.getColumnNames());
+                pipelineEvents.add(pipelineEvent);
+            } catch (Exception e) {
+                LOG.error(NOISY, "Failed to process row change event", e);
+                changeEventErrorCounter.increment();
+                final Event failedEvent = JacksonEvent.builder()
+                        .withEventType(DATA_PREPPER_EVENT_TYPE)
+                        .build();
+                sendToFailurePipeline(failedEvent, e);
+            }
         }
 
         writeToBuffer(bufferAccumulator, acknowledgementSet);
@@ -493,6 +519,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             bufferAccumulator.add(record);
         } catch (Exception e) {
             LOG.error(NOISY, "Failed to add event to buffer", e);
+            sendToFailurePipeline(record.getData(), e);
         }
     }
 
@@ -505,6 +532,25 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             // otherwise bufferAccumulator will keep retrying with backoff
             LOG.error(NOISY, "Failed to flush buffer", e);
             changeEventErrorCounter.increment(eventCount);
+            for (Event event : pipelineEvents) {
+                sendToFailurePipeline(event, e);
+            }
+        }
+    }
+
+    private void sendToFailurePipeline(final Event event, final Exception e) {
+        if (failurePipeline == null) {
+            return;
+        }
+        try {
+            event.updateFailureMetadata()
+                    .withPluginId(pluginSetting.getName())
+                    .withPluginName(pluginSetting.getName())
+                    .withPipelineName(pipelineName)
+                    .withErrorMessage(e.getMessage());
+            failurePipeline.sendEvents(List.of(new Record<>(event)));
+        } catch (Exception ex) {
+            LOG.error(NOISY, "Failed to send event to failure pipeline", ex);
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
@@ -18,9 +18,12 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 import org.opensearch.dataprepper.plugins.source.rds.converter.StreamRecordConverter;
@@ -100,6 +103,9 @@ public class LogicalReplicationEventProcessor {
     private final LogicalReplicationClient logicalReplicationClient;
     private final StreamCheckpointer streamCheckpointer;
     private final StreamCheckpointManager streamCheckpointManager;
+    private final PluginSetting pluginSetting;
+    private final String pipelineName;
+    private final HeadlessPipeline failurePipeline;
 
     private final Counter changeEventSuccessCounter;
     private final Counter changeEventErrorCounter;
@@ -121,7 +127,10 @@ public class LogicalReplicationEventProcessor {
                                             final PluginMetrics pluginMetrics,
                                             final LogicalReplicationClient logicalReplicationClient,
                                             final StreamCheckpointer streamCheckpointer,
-                                            final AcknowledgementSetManager acknowledgementSetManager) {
+                                            final AcknowledgementSetManager acknowledgementSetManager,
+                                            final PluginSetting pluginSetting,
+                                            final PipelineDescription pipelineDescription,
+                                            final HeadlessPipeline failurePipeline) {
         this.streamPartition = streamPartition;
         this.sourceConfig = sourceConfig;
         recordConverter = new StreamRecordConverter(s3Prefix, sourceConfig.getPartitionCount());
@@ -141,6 +150,10 @@ public class LogicalReplicationEventProcessor {
                 sourceConfig.getEngine(), pluginMetrics);
         streamCheckpointManager.start();
 
+        this.pluginSetting = pluginSetting;
+        this.pipelineName = pipelineDescription.getPipelineName();
+        this.failurePipeline = failurePipeline;
+
         tableMetadataMap = new HashMap<>();
         pipelineEvents = new ArrayList<>();
 
@@ -159,9 +172,13 @@ public class LogicalReplicationEventProcessor {
                                                           final PluginMetrics pluginMetrics,
                                                           final LogicalReplicationClient logicalReplicationClient,
                                                           final StreamCheckpointer streamCheckpointer,
-                                                          final AcknowledgementSetManager acknowledgementSetManager) {
+                                                          final AcknowledgementSetManager acknowledgementSetManager,
+                                                          final PluginSetting pluginSetting,
+                                                          final PipelineDescription pipelineDescription,
+                                                          final HeadlessPipeline failurePipeline) {
         return new LogicalReplicationEventProcessor(streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics,
-                logicalReplicationClient, streamCheckpointer, acknowledgementSetManager);
+                logicalReplicationClient, streamCheckpointer, acknowledgementSetManager,
+                pluginSetting, pipelineDescription, failurePipeline);
     }
 
     public void process(ByteBuffer msg) {
@@ -419,23 +436,33 @@ public class LogicalReplicationEventProcessor {
 
     private void createPipelineEvent(Map<String, Object> rowDataMap, TableMetadata tableMetadata, List<String> primaryKeys,
                                      long eventTimestampMillis, OpenSearchBulkActions bulkAction, StreamEventType streamEventType) {
-        final Event dataPrepperEvent = JacksonEvent.builder()
-                .withEventType("event")
-                .withData(rowDataMap)
-                .build();
+        try {
+            final Event dataPrepperEvent = JacksonEvent.builder()
+                    .withEventType("event")
+                    .withData(rowDataMap)
+                    .build();
 
-        final Event pipelineEvent = recordConverter.convert(
-                dataPrepperEvent,
-                tableMetadata.getDatabaseName(),
-                tableMetadata.getSchemaName(),
-                tableMetadata.getTableName(),
-                bulkAction,
-                primaryKeys,
-                eventTimestampMillis,
-                recordConverter.getVersionNumber(eventTimestampMillis),
-                streamEventType,
-                tableMetadata.getColumnNames());
-        pipelineEvents.add(pipelineEvent);
+            final Event pipelineEvent = recordConverter.convert(
+                    dataPrepperEvent,
+                    tableMetadata.getDatabaseName(),
+                    tableMetadata.getSchemaName(),
+                    tableMetadata.getTableName(),
+                    bulkAction,
+                    primaryKeys,
+                    eventTimestampMillis,
+                    recordConverter.getVersionNumber(eventTimestampMillis),
+                    streamEventType,
+                    tableMetadata.getColumnNames());
+            pipelineEvents.add(pipelineEvent);
+        } catch (Exception e) {
+            LOG.error(NOISY, "Failed to process replication event", e);
+            eventProcessingErrorCounter.increment();
+            final Event failedEvent = JacksonEvent.builder()
+                    .withEventType("event")
+                    .withData(rowDataMap)
+                    .build();
+            sendToFailurePipeline(failedEvent, e);
+        }
     }
 
     private void writeToBuffer(BufferAccumulator<Record<Event>> bufferAccumulator, AcknowledgementSet acknowledgementSet) {
@@ -455,6 +482,7 @@ public class LogicalReplicationEventProcessor {
             bufferAccumulator.add(record);
         } catch (Exception e) {
             LOG.error(NOISY, "Failed to add event to buffer", e);
+            sendToFailurePipeline(record.getData(), e);
         }
     }
 
@@ -467,6 +495,25 @@ public class LogicalReplicationEventProcessor {
             // otherwise bufferAccumulator will keep retrying with backoff
             LOG.error(NOISY, "Failed to flush buffer", e);
             changeEventErrorCounter.increment(eventCount);
+            for (Event event : pipelineEvents) {
+                sendToFailurePipeline(event, e);
+            }
+        }
+    }
+
+    private void sendToFailurePipeline(final Event event, final Exception e) {
+        if (failurePipeline == null) {
+            return;
+        }
+        try {
+            event.updateFailureMetadata()
+                    .withPluginId(pluginSetting.getName())
+                    .withPluginName(pluginSetting.getName())
+                    .withPipelineName(pipelineName)
+                    .withErrorMessage(e.getMessage());
+            failurePipeline.sendEvents(List.of(new Record<>(event)));
+        } catch (Exception ex) {
+            LOG.error(NOISY, "Failed to send event to failure pipeline", ex);
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamScheduler.java
@@ -9,7 +9,10 @@ import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
@@ -39,6 +42,9 @@ public class StreamScheduler implements Runnable {
     private final PluginMetrics pluginMetrics;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigObservable pluginConfigObservable;
+    private final PluginSetting pluginSetting;
+    private final PipelineDescription pipelineDescription;
+    private final HeadlessPipeline failurePipeline;
     private StreamWorkerTaskRefresher streamWorkerTaskRefresher;
 
     private volatile boolean shutdownRequested = false;
@@ -50,7 +56,10 @@ public class StreamScheduler implements Runnable {
                            final Buffer<Record<Event>> buffer,
                            final PluginMetrics pluginMetrics,
                            final AcknowledgementSetManager acknowledgementSetManager,
-                           final PluginConfigObservable pluginConfigObservable) {
+                           final PluginConfigObservable pluginConfigObservable,
+                           final PluginSetting pluginSetting,
+                           final PipelineDescription pipelineDescription,
+                           final HeadlessPipeline failurePipeline) {
         this.sourceCoordinator = sourceCoordinator;
         this.sourceConfig = sourceConfig;
         this.s3Prefix = s3Prefix;
@@ -59,6 +68,9 @@ public class StreamScheduler implements Runnable {
         this.pluginMetrics = pluginMetrics;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginConfigObservable = pluginConfigObservable;
+        this.pluginSetting = pluginSetting;
+        this.pipelineDescription = pipelineDescription;
+        this.failurePipeline = failurePipeline;
     }
 
     @Override
@@ -86,7 +98,7 @@ public class StreamScheduler implements Runnable {
                     streamWorkerTaskRefresher = StreamWorkerTaskRefresher.create(
                             sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, replicationLogClientFactory, buffer,
                             () -> Executors.newSingleThreadExecutor(BackgroundThreadFactory.defaultExecutorThreadFactory("rds-source-stream-worker")),
-                            acknowledgementSetManager, pluginMetrics);
+                            acknowledgementSetManager, pluginMetrics, pluginSetting, pipelineDescription, failurePipeline);
 
                     streamWorkerTaskRefresher.initialize(sourceConfig);
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresher.java
@@ -10,7 +10,10 @@ import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
@@ -45,6 +48,9 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final Counter credentialsChangeCounter;
     private final Counter taskRefreshErrorsCounter;
+    private final PluginSetting pluginSetting;
+    private final PipelineDescription pipelineDescription;
+    private final HeadlessPipeline failurePipeline;
 
     private ExecutorService executorService;
     private RdsSourceConfig currentSourceConfig;
@@ -58,7 +64,10 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
                                      final Buffer<Record<Event>> buffer,
                                      final Supplier<ExecutorService> executorServiceSupplier,
                                      final AcknowledgementSetManager acknowledgementSetManager,
-                                     final PluginMetrics pluginMetrics) {
+                                     final PluginMetrics pluginMetrics,
+                                     final PluginSetting pluginSetting,
+                                     final PipelineDescription pipelineDescription,
+                                     final HeadlessPipeline failurePipeline) {
         this.sourceCoordinator = sourceCoordinator;
         this.streamPartition = streamPartition;
         this.streamCheckpointer = streamCheckpointer;
@@ -71,6 +80,9 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
         this.replicationLogClientFactory = replicationLogClientFactory;
         this.credentialsChangeCounter = pluginMetrics.counter(CREDENTIALS_CHANGED);
         this.taskRefreshErrorsCounter = pluginMetrics.counter(TASK_REFRESH_ERRORS);
+        this.pluginSetting = pluginSetting;
+        this.pipelineDescription = pipelineDescription;
+        this.failurePipeline = failurePipeline;
     }
 
     public static StreamWorkerTaskRefresher create(final EnhancedSourceCoordinator sourceCoordinator,
@@ -81,9 +93,13 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
                                                    final Buffer<Record<Event>> buffer,
                                                    final Supplier<ExecutorService> executorServiceSupplier,
                                                    final AcknowledgementSetManager acknowledgementSetManager,
-                                                   final PluginMetrics pluginMetrics) {
+                                                   final PluginMetrics pluginMetrics,
+                                                   final PluginSetting pluginSetting,
+                                                   final PipelineDescription pipelineDescription,
+                                                   final HeadlessPipeline failurePipeline) {
         return new StreamWorkerTaskRefresher(sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix,
-                binlogClientFactory, buffer, executorServiceSupplier, acknowledgementSetManager, pluginMetrics);
+                binlogClientFactory, buffer, executorServiceSupplier, acknowledgementSetManager, pluginMetrics,
+                pluginSetting, pipelineDescription, failurePipeline);
     }
 
     public void initialize(RdsSourceConfig sourceConfig) {
@@ -130,13 +146,15 @@ public class StreamWorkerTaskRefresher implements PluginConfigObserver<RdsSource
             final BinaryLogClient binaryLogClient = ((BinlogClientWrapper) replicationLogClient).getBinlogClient();
             binaryLogClient.registerEventListener(BinlogEventListener.create(
                     streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
-                    streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadeActionDetector));
+                    streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadeActionDetector,
+                    pluginSetting, pipelineDescription, failurePipeline));
             binaryLogClient.registerLifecycleListener(new BinlogClientLifecycleListener());
         } else {
             final LogicalReplicationClient logicalReplicationClient = (LogicalReplicationClient) replicationLogClient;
             logicalReplicationClient.setEventProcessor(LogicalReplicationEventProcessor.create(
                     streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics, logicalReplicationClient,
-                    streamCheckpointer, acknowledgementSetManager));
+                    streamCheckpointer, acknowledgementSetManager,
+                    pluginSetting, pipelineDescription, failurePipeline));
         }
         streamWorker = StreamWorker.create(sourceCoordinator, replicationLogClient, pluginMetrics);
         executorService.submit(() -> streamWorker.processStream(streamPartition));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -18,6 +18,8 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
@@ -98,6 +100,12 @@ class RdsServiceTest {
 
     @Mock
     private PipelineDescription pipelineDescription;
+
+    @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
 
     @BeforeEach
     void setUp() {
@@ -211,6 +219,6 @@ class RdsServiceTest {
 
     private RdsService createObjectUnderTest() {
         return new RdsService(sourceCoordinator, sourceConfig, eventFactory, clientFactory, pluginMetrics,
-                acknowledgementSetManager, pluginConfigObservable, pipelineDescription);
+                acknowledgementSetManager, pluginConfigObservable, pipelineDescription, pluginSetting, failurePipeline);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsSourceTest.java
@@ -16,6 +16,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManag
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.plugins.source.rds.configuration.AwsAuthenticationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,6 +50,9 @@ class RdsSourceTest {
     @Mock
     private PipelineDescription pipelineDescription;
 
+    @Mock
+    private PluginSetting pluginSetting;
+
     @BeforeEach
     void setUp() {
         when(sourceConfig.getAwsAuthenticationConfig()).thenReturn(awsAuthenticationConfig);
@@ -63,6 +67,6 @@ class RdsSourceTest {
     private RdsSource createObjectUnderTest() {
         return new RdsSource(
                 pluginMetrics, sourceConfig, eventFactory, awsCredentialsSupplier, acknowledgementSetManager,
-                pluginConfigObservable, pipelineDescription);
+                pluginConfigObservable, pipelineDescription, pluginSetting);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -23,11 +23,15 @@ import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.BaseEventBuilder;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventFailureMetadata;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.io.InputFile;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
@@ -40,6 +44,7 @@ import org.opensearch.dataprepper.plugins.source.rds.model.DbTableMetadata;
 
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -95,6 +100,15 @@ class DataFileLoaderTest {
     private DbTableMetadata dbTableMetadata;
 
     @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
+
+    @Mock
     private Duration acknowledgmentTimeout;
 
     @Mock
@@ -119,6 +133,7 @@ class DataFileLoaderTest {
         when(pluginMetrics.counter(EXPORT_RECORDS_PROCESSING_ERROR_COUNT)).thenReturn(exportRecordErrorCounter);
         when(pluginMetrics.summary(BYTES_RECEIVED)).thenReturn(bytesReceivedSummary);
         when(pluginMetrics.summary(BYTES_PROCESSED)).thenReturn(bytesProcessedSummary);
+        when(pipelineDescription.getPipelineName()).thenReturn("test-pipeline");
     }
 
     @ParameterizedTest
@@ -276,6 +291,112 @@ class DataFileLoaderTest {
     private DataFileLoader createObjectUnderTest() {
         final InputCodec codec = new ParquetInputCodec(eventFactory);
         return DataFileLoader.create(dataFilePartition, codec, buffer, s3ObjectReader, recordConverter,
-                pluginMetrics, sourceCoordinator, acknowledgementSet, acknowledgmentTimeout, dbTableMetadata);
+                pluginMetrics, sourceCoordinator, acknowledgementSet, acknowledgmentTimeout, dbTableMetadata,
+                pluginSetting, pipelineDescription, failurePipeline);
+    }
+
+    @ParameterizedTest
+    @EnumSource(EngineType.class)
+    void test_record_processing_failure_sends_to_dlq_and_continues(EngineType engineType) throws Exception {
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        when(dataFilePartition.getBucket()).thenReturn(bucket);
+        when(dataFilePartition.getKey()).thenReturn(key);
+        final DataFileProgressState progressState = mock(DataFileProgressState.class, RETURNS_DEEP_STUBS);
+        when(dataFilePartition.getProgressState()).thenReturn(Optional.of(progressState));
+        when(progressState.getEngineType()).thenReturn(engineType.toString());
+        when(pluginSetting.getName()).thenReturn("rds");
+
+        InputStream inputStream = mock(InputStream.class);
+        when(s3ObjectReader.readFile(bucket, key)).thenReturn(inputStream);
+
+        final Event event = mock(Event.class);
+        when(event.toJsonString()).thenReturn("test");
+        when(event.toMap()).thenReturn(Map.of());
+        final EventFailureMetadata eventFailureMetadata = mock(EventFailureMetadata.class);
+        when(event.updateFailureMetadata()).thenReturn(eventFailureMetadata);
+        when(eventFailureMetadata.withPluginId(any())).thenReturn(eventFailureMetadata);
+        when(eventFailureMetadata.withPluginName(any())).thenReturn(eventFailureMetadata);
+        when(eventFailureMetadata.withPipelineName(any())).thenReturn(eventFailureMetadata);
+        when(eventFailureMetadata.withErrorMessage(any())).thenReturn(eventFailureMetadata);
+
+        when(recordConverter.convert(any(), any(), any(), any(), any(), any(), anyLong(), anyLong(), any(), any()))
+                .thenThrow(new RuntimeException("conversion error"));
+
+        AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
+        ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
+        BufferAccumulator<Record<Event>> bufferAccumulator = mock(BufferAccumulator.class);
+        when(builder.build()).thenReturn(parquetReader);
+        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), (GenericRecord) null);
+
+        final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
+        when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
+
+        try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class);
+             MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
+
+            readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(any(Buffer.class), anyInt(), any(Duration.class))).thenReturn(bufferAccumulator);
+
+            DataFileLoader dataFileLoader = createObjectUnderTest();
+            dataFileLoader.run();
+        }
+
+        // Event was sent to DLQ
+        verify(failurePipeline).sendEvents(any());
+        verify(exportRecordErrorCounter).increment();
+        // Processing continued (flush still called)
+        verify(bufferAccumulator).flush();
+    }
+
+    @ParameterizedTest
+    @EnumSource(EngineType.class)
+    void test_record_processing_failure_with_null_failure_pipeline_does_not_throw(EngineType engineType) throws Exception {
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        when(dataFilePartition.getBucket()).thenReturn(bucket);
+        when(dataFilePartition.getKey()).thenReturn(key);
+        final DataFileProgressState progressState = mock(DataFileProgressState.class, RETURNS_DEEP_STUBS);
+        when(dataFilePartition.getProgressState()).thenReturn(Optional.of(progressState));
+        when(progressState.getEngineType()).thenReturn(engineType.toString());
+
+        InputStream inputStream = mock(InputStream.class);
+        when(s3ObjectReader.readFile(bucket, key)).thenReturn(inputStream);
+
+        final Event event = mock(Event.class);
+        when(event.toJsonString()).thenReturn("test");
+        when(event.toMap()).thenReturn(Map.of());
+
+        when(recordConverter.convert(any(), any(), any(), any(), any(), any(), anyLong(), anyLong(), any(), any()))
+                .thenThrow(new RuntimeException("conversion error"));
+
+        AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
+        ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
+        BufferAccumulator<Record<Event>> bufferAccumulator = mock(BufferAccumulator.class);
+        when(builder.build()).thenReturn(parquetReader);
+        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), (GenericRecord) null);
+
+        final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
+        when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
+
+        final InputCodec codec = new ParquetInputCodec(eventFactory);
+        DataFileLoader dataFileLoader = DataFileLoader.create(dataFilePartition, codec, buffer, s3ObjectReader, recordConverter,
+                pluginMetrics, sourceCoordinator, acknowledgementSet, acknowledgmentTimeout, dbTableMetadata,
+                pluginSetting, pipelineDescription, null);
+
+        try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class);
+             MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
+
+            readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(any(Buffer.class), anyInt(), any(Duration.class))).thenReturn(bufferAccumulator);
+
+            dataFileLoader.run();
+        }
+
+        // No exception thrown, processing continued
+        verify(exportRecordErrorCounter).increment();
+        verify(bufferAccumulator).flush();
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -352,7 +352,7 @@ class DataFileLoaderTest {
 
     @ParameterizedTest
     @EnumSource(EngineType.class)
-    void test_record_processing_failure_with_null_failure_pipeline_does_not_throw(EngineType engineType) throws Exception {
+    void test_record_processing_failure_with_null_failure_pipeline_throws(EngineType engineType) throws Exception {
         final String bucket = UUID.randomUUID().toString();
         final String key = UUID.randomUUID().toString();
         when(dataFilePartition.getBucket()).thenReturn(bucket);
@@ -392,11 +392,7 @@ class DataFileLoaderTest {
             readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(any(Buffer.class), anyInt(), any(Duration.class))).thenReturn(bufferAccumulator);
 
-            dataFileLoader.run();
+            assertThrows(RuntimeException.class, dataFileLoader::run);
         }
-
-        // No exception thrown, processing continued
-        verify(exportRecordErrorCounter).increment();
-        verify(bufferAccumulator).flush();
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileSchedulerTest.java
@@ -17,6 +17,9 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.codec.InputCodec;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.record.Record;
@@ -93,6 +96,15 @@ class DataFileSchedulerTest {
     @Mock
     private AtomicInteger activeExportS3ObjectConsumersGauge;
 
+    @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
+
     private Random random;
     private String s3Prefix;
 
@@ -144,7 +156,8 @@ class DataFileSchedulerTest {
                         dataFileLoaderMockedStatic.when(() -> DataFileLoader.create(eq(dataFilePartition), any(InputCodec.class),
                                         any(Buffer.class), any(S3ObjectReader.class),
                                         any(ExportRecordConverter.class), any(PluginMetrics.class),
-                                        any(EnhancedSourceCoordinator.class), any(), any(Duration.class), any(DbTableMetadata.class)))
+                                        any(EnhancedSourceCoordinator.class), any(), any(Duration.class), any(DbTableMetadata.class),
+                                        any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                                 .thenReturn(dataFileLoader);
                         doNothing().when(dataFileLoader).run();
                         objectUnderTest.run();
@@ -174,7 +187,8 @@ class DataFileSchedulerTest {
                 dataFileLoaderMockedStatic.when(() -> DataFileLoader.create(eq(dataFilePartition), any(InputCodec.class),
                                 any(Buffer.class), any(S3ObjectReader.class),
                                 any(ExportRecordConverter.class), any(PluginMetrics.class),
-                                any(EnhancedSourceCoordinator.class), any(), any(Duration.class), any(DbTableMetadata.class)))
+                                any(EnhancedSourceCoordinator.class), any(), any(Duration.class), any(DbTableMetadata.class),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(dataFileLoader);
                 doThrow(new RuntimeException()).when(dataFileLoader).run();
                 objectUnderTest.run();
@@ -267,7 +281,7 @@ class DataFileSchedulerTest {
     }
 
     private DataFileScheduler createObjectUnderTest() {
-        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Prefix, s3Client, eventFactory, buffer, pluginMetrics, acknowledgementSetManager);
+        return new DataFileScheduler(sourceCoordinator, sourceConfig, s3Prefix, s3Client, eventFactory, buffer, pluginMetrics, acknowledgementSetManager, pluginSetting, pipelineDescription, failurePipeline);
     }
 
     private void mockDbTableMetadata() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -29,6 +29,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFailureMetadata;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
@@ -248,6 +249,56 @@ class BinlogEventListenerTest {
 
         verifyHandlerCallHelper();
         verify(objectUnderTest).handleDeleteEvent(binlogEvent);
+    }
+
+    @Test
+    void test_sendToFailurePipeline_sends_event_with_failure_metadata() throws Exception {
+        final String pluginName = "rds";
+        final String pipelineName = "test-pipeline";
+        final String errorMessage = "test error";
+        final Event event = mock(Event.class);
+        final EventFailureMetadata failureMetadata = mock(EventFailureMetadata.class);
+
+        when(pluginSetting.getName()).thenReturn(pluginName);
+        when(event.updateFailureMetadata()).thenReturn(failureMetadata);
+        when(failureMetadata.withPluginId(pluginName)).thenReturn(failureMetadata);
+        when(failureMetadata.withPluginName(pluginName)).thenReturn(failureMetadata);
+        when(failureMetadata.withPipelineName(pipelineName)).thenReturn(failureMetadata);
+        when(failureMetadata.withErrorMessage(errorMessage)).thenReturn(failureMetadata);
+
+        // Use reflection to invoke sendToFailurePipeline
+        java.lang.reflect.Method method = BinlogEventListener.class.getDeclaredMethod("sendToFailurePipeline", Event.class, Exception.class);
+        method.setAccessible(true);
+        method.invoke(objectUnderTest, event, new RuntimeException(errorMessage));
+
+        verify(event).updateFailureMetadata();
+        verify(failureMetadata).withPluginId(pluginName);
+        verify(failureMetadata).withPluginName(pluginName);
+        verify(failureMetadata).withPipelineName(pipelineName);
+        verify(failureMetadata).withErrorMessage(errorMessage);
+        verify(failurePipeline).sendEvents(any());
+    }
+
+    @Test
+    void test_sendToFailurePipeline_does_nothing_when_failurePipeline_is_null() throws Exception {
+        // Create a listener with null failurePipeline
+        BinlogEventListener listenerWithNullDlq;
+        try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
+            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(eventListnerExecutorService);
+            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(checkpointManagerExecutorService);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenReturn(threadFactory);
+            listenerWithNullDlq = BinlogEventListener.create(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
+                    streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadingActionDetector,
+                    pluginSetting, pipelineDescription, null);
+        }
+
+        final Event event = mock(Event.class);
+
+        java.lang.reflect.Method method = BinlogEventListener.class.getDeclaredMethod("sendToFailurePipeline", Event.class, Exception.class);
+        method.setAccessible(true);
+        method.invoke(listenerWithNullDlq, event, new RuntimeException("error"));
+
+        verify(event, org.mockito.Mockito.never()).updateFailureMetadata();
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -24,6 +24,9 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
@@ -89,6 +92,15 @@ class BinlogEventListenerTest {
     private CascadingActionDetector cascadingActionDetector;
 
     @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
+
+    @Mock
     private ExecutorService eventListnerExecutorService;
 
     @Mock
@@ -120,6 +132,7 @@ class BinlogEventListenerTest {
         when(pluginMetrics.timer(REPLICATION_LOG_EVENT_PROCESSING_TIME)).thenReturn(eventProcessingTimer);
         lenient().when(pluginMetrics.counter(REPLICATION_LOG_PROCESSING_ERROR_COUNT)).thenReturn(eventProcessingErrorCounter);
         lenient().when(pluginMetrics.counter(any())).thenReturn(defaultCounter);
+        when(pipelineDescription.getPipelineName()).thenReturn("test-pipeline");
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
             executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(eventListnerExecutorService);
             executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(checkpointManagerExecutorService);
@@ -313,7 +326,8 @@ class BinlogEventListenerTest {
 
     private BinlogEventListener createObjectUnderTest() {
         return BinlogEventListener.create(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
-                streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadingActionDetector);
+                streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadingActionDetector,
+                pluginSetting, pipelineDescription, failurePipeline);
     }
 
     private void verifyHandlerCallHelper() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -21,6 +21,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -63,6 +66,15 @@ class LogicalReplicationEventProcessorTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
+    @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
+
     private ByteBuffer message;
 
     private String s3Prefix;
@@ -77,6 +89,7 @@ class LogicalReplicationEventProcessorTest {
         random = new Random();
         when(pluginMetrics.timer(anyString())).thenReturn(Metrics.timer("test-timer"));
         when(pluginMetrics.counter(anyString())).thenReturn(Metrics.counter("test-counter"));
+        when(pipelineDescription.getPipelineName()).thenReturn("test-pipeline");
 
         objectUnderTest = spy(createObjectUnderTest());
     }
@@ -176,7 +189,8 @@ class LogicalReplicationEventProcessorTest {
 
     private LogicalReplicationEventProcessor createObjectUnderTest() {
         return new LogicalReplicationEventProcessor(streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics,
-                logicalReplicationClient, streamCheckpointer, acknowledgementSetManager);
+                logicalReplicationClient, streamCheckpointer, acknowledgementSetManager,
+                pluginSetting, pipelineDescription, failurePipeline);
     }
 
     private void setMessageType(MessageType messageType) {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessorTest.java
@@ -26,6 +26,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFailureMetadata;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
 import org.opensearch.dataprepper.plugins.source.rds.coordination.partition.StreamPartition;
@@ -36,8 +37,10 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -185,6 +188,49 @@ class LogicalReplicationEventProcessorTest {
     void test_stopClient() {
         objectUnderTest.stopClient();
         verify(logicalReplicationClient).disconnect();
+    }
+
+    @Test
+    void test_sendToFailurePipeline_sends_event_with_failure_metadata() throws Exception {
+        final String pluginName = "rds";
+        final String pipelineName = "test-pipeline";
+        final String errorMessage = "test error";
+        final Event event = mock(Event.class);
+        final EventFailureMetadata failureMetadata = mock(EventFailureMetadata.class);
+
+        when(pluginSetting.getName()).thenReturn(pluginName);
+        when(event.updateFailureMetadata()).thenReturn(failureMetadata);
+        when(failureMetadata.withPluginId(pluginName)).thenReturn(failureMetadata);
+        when(failureMetadata.withPluginName(pluginName)).thenReturn(failureMetadata);
+        when(failureMetadata.withPipelineName(pipelineName)).thenReturn(failureMetadata);
+        when(failureMetadata.withErrorMessage(errorMessage)).thenReturn(failureMetadata);
+
+        java.lang.reflect.Method method = LogicalReplicationEventProcessor.class.getDeclaredMethod("sendToFailurePipeline", Event.class, Exception.class);
+        method.setAccessible(true);
+        method.invoke(objectUnderTest, event, new RuntimeException(errorMessage));
+
+        verify(event).updateFailureMetadata();
+        verify(failureMetadata).withPluginId(pluginName);
+        verify(failureMetadata).withPluginName(pluginName);
+        verify(failureMetadata).withPipelineName(pipelineName);
+        verify(failureMetadata).withErrorMessage(errorMessage);
+        verify(failurePipeline).sendEvents(any());
+    }
+
+    @Test
+    void test_sendToFailurePipeline_does_nothing_when_failurePipeline_is_null() throws Exception {
+        LogicalReplicationEventProcessor processorWithNullDlq = new LogicalReplicationEventProcessor(
+                streamPartition, sourceConfig, buffer, s3Prefix, pluginMetrics,
+                logicalReplicationClient, streamCheckpointer, acknowledgementSetManager,
+                pluginSetting, pipelineDescription, null);
+
+        final Event event = mock(Event.class);
+
+        java.lang.reflect.Method method = LogicalReplicationEventProcessor.class.getDeclaredMethod("sendToFailurePipeline", Event.class, Exception.class);
+        method.setAccessible(true);
+        method.invoke(processorWithNullDlq, event, new RuntimeException("error"));
+
+        verify(event, org.mockito.Mockito.never()).updateFailureMetadata();
     }
 
     private LogicalReplicationEventProcessor createObjectUnderTest() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamSchedulerTest.java
@@ -16,6 +16,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
@@ -69,6 +72,15 @@ class StreamSchedulerTest {
     @Mock
     private StreamWorkerTaskRefresher streamWorkerTaskRefresher;
 
+    @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
+
     private String s3Prefix;
     private StreamScheduler objectUnderTest;
 
@@ -101,7 +113,8 @@ class StreamSchedulerTest {
         executorService.submit(() -> {
             try (MockedStatic<StreamWorkerTaskRefresher> streamWorkerTaskRefresherMockedStatic = mockStatic(StreamWorkerTaskRefresher.class)) {
                 streamWorkerTaskRefresherMockedStatic.when(() -> StreamWorkerTaskRefresher.create(eq(sourceCoordinator), eq(streamPartition), any(StreamCheckpointer.class),
-                                eq(s3Prefix), eq(replicationLogClientFactory), eq(buffer), any(Supplier.class), eq(acknowledgementSetManager), eq(pluginMetrics)))
+                                eq(s3Prefix), eq(replicationLogClientFactory), eq(buffer), any(Supplier.class), eq(acknowledgementSetManager), eq(pluginMetrics),
+                                eq(pluginSetting), eq(pipelineDescription), eq(failurePipeline)))
                         .thenReturn(streamWorkerTaskRefresher);
                 objectUnderTest.run();
             }
@@ -131,6 +144,7 @@ class StreamSchedulerTest {
 
     private StreamScheduler createObjectUnderTest() {
         return new StreamScheduler(
-                sourceCoordinator, sourceConfig, s3Prefix, replicationLogClientFactory, buffer, pluginMetrics, acknowledgementSetManager, pluginConfigObservable);
+                sourceCoordinator, sourceConfig, s3Prefix, replicationLogClientFactory, buffer, pluginMetrics, acknowledgementSetManager, pluginConfigObservable,
+                pluginSetting, pipelineDescription, failurePipeline);
     }
 }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamWorkerTaskRefresherTest.java
@@ -20,7 +20,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.pipeline.HeadlessPipeline;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.rds.RdsSourceConfig;
@@ -118,6 +121,15 @@ class StreamWorkerTaskRefresherTest {
     @Mock
     private GlobalState globalState;
 
+    @Mock
+    private PluginSetting pluginSetting;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private HeadlessPipeline failurePipeline;
+
     private StreamWorkerTaskRefresher streamWorkerTaskRefresher;
 
     @Nested
@@ -144,7 +156,8 @@ class StreamWorkerTaskRefresherTest {
                         .thenReturn(streamWorker);
                 binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
                                 any(String.class), eq(pluginMetrics), eq(binaryLogClient), eq(streamCheckpointer),
-                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class)))
+                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(binlogEventListener);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
             }
@@ -184,7 +197,8 @@ class StreamWorkerTaskRefresherTest {
                         .thenReturn(streamWorker);
                 binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
                                 any(String.class), eq(pluginMetrics), eq(binaryLogClient), eq(streamCheckpointer),
-                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class)))
+                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(binlogEventListener);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
                 streamWorkerTaskRefresher.update(sourceConfig2);
@@ -222,7 +236,8 @@ class StreamWorkerTaskRefresherTest {
                         .thenReturn(streamWorker);
                 binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
                                 any(String.class), eq(pluginMetrics), eq(binaryLogClient), eq(streamCheckpointer),
-                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class)))
+                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(binlogEventListener);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
                 streamWorkerTaskRefresher.update(sourceConfig);
@@ -245,7 +260,8 @@ class StreamWorkerTaskRefresherTest {
                         .thenReturn(streamWorker);
                 binlogEventListenerMockedStatic.when(() -> BinlogEventListener.create(eq(streamPartition), eq(buffer), any(RdsSourceConfig.class),
                                 any(String.class), eq(pluginMetrics), eq(binaryLogClient), eq(streamCheckpointer),
-                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class)))
+                                eq(acknowledgementSetManager), eq(dbTableMetadata), any(CascadingActionDetector.class),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(binlogEventListener);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
             }
@@ -261,7 +277,8 @@ class StreamWorkerTaskRefresherTest {
 
             return new StreamWorkerTaskRefresher(
                     sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, replicationLogClientFactory, buffer,
-                    executorServiceSupplier, acknowledgementSetManager, pluginMetrics);
+                    executorServiceSupplier, acknowledgementSetManager, pluginMetrics,
+                    pluginSetting, pipelineDescription, failurePipeline);
         }
     }
 
@@ -285,7 +302,8 @@ class StreamWorkerTaskRefresherTest {
                 streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(ReplicationLogClient.class), eq(pluginMetrics)))
                         .thenReturn(streamWorker);
                 logicalReplicationEventProcessorMockedStatic.when(() -> LogicalReplicationEventProcessor.create(eq(streamPartition), any(RdsSourceConfig.class),
-                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(logicalReplicationEventProcessor);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
             }
@@ -320,7 +338,8 @@ class StreamWorkerTaskRefresherTest {
                 streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(ReplicationLogClient.class), eq(pluginMetrics)))
                         .thenReturn(streamWorker);
                 logicalReplicationEventProcessorMockedStatic.when(() -> LogicalReplicationEventProcessor.create(eq(streamPartition), any(RdsSourceConfig.class),
-                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(logicalReplicationEventProcessor);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
                 streamWorkerTaskRefresher.update(sourceConfig2);
@@ -353,7 +372,8 @@ class StreamWorkerTaskRefresherTest {
                 streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(ReplicationLogClient.class), eq(pluginMetrics)))
                         .thenReturn(streamWorker);
                 logicalReplicationEventProcessorMockedStatic.when(() -> LogicalReplicationEventProcessor.create(eq(streamPartition), any(RdsSourceConfig.class),
-                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(logicalReplicationEventProcessor);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
                 streamWorkerTaskRefresher.update(sourceConfig);
@@ -372,7 +392,8 @@ class StreamWorkerTaskRefresherTest {
                 streamWorkerMockedStatic.when(() -> StreamWorker.create(eq(sourceCoordinator), any(ReplicationLogClient.class), eq(pluginMetrics)))
                         .thenReturn(streamWorker);
                 logicalReplicationEventProcessorMockedStatic.when(() -> LogicalReplicationEventProcessor.create(eq(streamPartition), any(RdsSourceConfig.class),
-                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager)))
+                                eq(buffer), any(String.class), eq(pluginMetrics), eq(logicalReplicationClient), eq(streamCheckpointer), eq(acknowledgementSetManager),
+                                any(PluginSetting.class), any(PipelineDescription.class), any(HeadlessPipeline.class)))
                         .thenReturn(logicalReplicationEventProcessor);
                 streamWorkerTaskRefresher.initialize(sourceConfig);
             }
@@ -388,7 +409,8 @@ class StreamWorkerTaskRefresherTest {
 
             return new StreamWorkerTaskRefresher(
                     sourceCoordinator, streamPartition, streamCheckpointer, s3Prefix, replicationLogClientFactory, buffer,
-                    executorServiceSupplier, acknowledgementSetManager, pluginMetrics);
+                    executorServiceSupplier, acknowledgementSetManager, pluginMetrics,
+                    pluginSetting, pipelineDescription, failurePipeline);
         }
     }
 


### PR DESCRIPTION
### Description

Adds pipeline DLQ support to the RDS source plugin for both the stream path (binlog/WAL) and the export path.

When a `dlq_pipeline` is configured, failed events are sent to it with `_failure_metadata` containing `pluginId`, `pluginName`, `pipelineName`, and `errorMessage`.

**Stream path** (BinlogEventListener / LogicalReplicationEventProcessor):
- Row processing failures (data type conversion, record conversion)
- Buffer write/flush failures

**Export path** (DataFileLoader):
- Record processing failures during parquet file loading

When no `dlq_pipeline` is configured, behavior is unchanged — errors are logged and counters incremented.

### Testing

Tested end-to-end locally against Aurora MySQL with a `dlq_pipeline` configured with a stdout sink.

**Stream path:**
- Verified normal INSERT/UPDATE/DELETE events flow to the main pipeline with no DLQ output
- Triggered row processing error and confirmed the failed event was sent to the DLQ with correct `_failure_metadata`

**Export path:**
- Ran a full RDS export and verified records are processed normally
- Triggered row processing error and confirmed failed events were sent to the DLQ with correct `_failure_metadata`

**No DLQ configured:**
- Verified that when no `dlq_pipeline` is defined, `failurePipeline` is null and `sendToFailurePipeline` returns immediately with no side effects

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed off
