### PR TITLE
Build the whole data-prepper-test project as part of releases.

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -16,8 +16,7 @@ ext.coreProjects = [
         project(':data-prepper-main'),
         project(':data-prepper-pipeline-parser'),
         project(':data-prepper-plugins'),
-        project(':data-prepper-test:test-common'),
-        project(':data-prepper-test:test-event'),
+        project(':data-prepper-test'),
         project(':data-prepper-plugin-framework'),
         project(':data-prepper-plugin-schema'),
         project(':data-prepper-plugin-schema-cli')


### PR DESCRIPTION
### Description

Build the whole `data-prepper-test` project as part of releases.

When the original projects were moved into data-prepper-test (commit `65fab21f`, PR #5726) the whole sub-project should have been included. Then when new projects were added, they did not get included.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
