### PR TITLE
Renew partition lease in DataFileLoader to prevent reprocessing

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -204,6 +204,7 @@ public class DataFileLoader implements Runnable {
         } catch (Exception e) {
             LOG.error(NOISY, "Failed to write events to buffer", e);
             exportRecordErrorCounter.increment(eventCount.get());
+            throw new RuntimeException(e);
         } finally {
             leaseRenewalScheduler.shutdownNow();
         }

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -32,6 +32,9 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
@@ -44,6 +47,8 @@ public class DataFileLoader implements Runnable {
     static final Duration VERSION_OVERLAP_TIME_FOR_EXPORT = Duration.ofMinutes(5);
     static final Duration BUFFER_TIMEOUT = Duration.ofSeconds(60);
     static final int DEFAULT_BUFFER_BATCH_SIZE = 1_000;
+    static final Duration LEASE_RENEWAL_INTERVAL = Duration.ofMinutes(5);
+    static final Duration LEASE_RENEWAL_DURATION = Duration.ofMinutes(15);
     static final String EXPORT_RECORDS_TOTAL_COUNT = "exportRecordsTotal";
     static final String EXPORT_RECORDS_PROCESSED_COUNT = "exportRecordsProcessed";
     static final String EXPORT_RECORDS_PROCESSING_ERROR_COUNT = "exportRecordsProcessingErrors";
@@ -113,6 +118,16 @@ public class DataFileLoader implements Runnable {
     @Override
     public void run() {
         LOG.info(SENSITIVE, "Start loading s3://{}/{}", bucket, objectKey);
+
+        final ScheduledExecutorService leaseRenewalScheduler = Executors.newSingleThreadScheduledExecutor();
+        leaseRenewalScheduler.scheduleAtFixedRate(() -> {
+            try {
+                sourceCoordinator.saveProgressStateForPartition(dataFilePartition, LEASE_RENEWAL_DURATION);
+                LOG.debug(SENSITIVE, "Successfully renewed lease for partition {}", objectKey);
+            } catch (Exception e) {
+                LOG.warn(SENSITIVE, "Failed to renew lease for partition {}", objectKey, e);
+            }
+        }, LEASE_RENEWAL_INTERVAL.toMillis(), LEASE_RENEWAL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
 
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
 
@@ -189,6 +204,8 @@ public class DataFileLoader implements Runnable {
         } catch (Exception e) {
             LOG.error(NOISY, "Failed to write events to buffer", e);
             exportRecordErrorCounter.increment(eventCount.get());
+        } finally {
+            leaseRenewalScheduler.shutdownNow();
         }
     }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -208,7 +209,7 @@ class DataFileLoaderTest {
             readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(any(Buffer.class), anyInt(), any(Duration.class))).thenReturn(bufferAccumulator);
 
-            dataFileLoader.run();
+            assertThrows(RuntimeException.class, () -> dataFileLoader.run());
         }
 
         verify(bufferAccumulator).add(any(Record.class));

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -11,6 +11,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -41,10 +42,14 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -216,6 +221,55 @@ class DataFileLoaderTest {
         verify(bytesProcessedSummary).record(sizeBytes);
         verify(exportRecordSuccessCounter, never()).increment(1);
         verify(exportRecordErrorCounter).increment(1);
+    }
+
+    @Test
+    void test_run_schedules_lease_renewal() throws Exception {
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        when(dataFilePartition.getBucket()).thenReturn(bucket);
+        when(dataFilePartition.getKey()).thenReturn(key);
+        final DataFileProgressState progressState = mock(DataFileProgressState.class, RETURNS_DEEP_STUBS);
+        when(dataFilePartition.getProgressState()).thenReturn(Optional.of(progressState));
+        when(progressState.getEngineType()).thenReturn(EngineType.MYSQL.toString());
+
+        InputStream inputStream = mock(InputStream.class);
+        when(s3ObjectReader.readFile(bucket, key)).thenReturn(inputStream);
+
+        final String randomString = UUID.randomUUID().toString();
+        final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        final Event event = mock(Event.class);
+        when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
+        when(eventBuilder.withEventType(any()).withData(any()).build()).thenReturn(event);
+        when(event.toJsonString()).thenReturn(randomString);
+        when(recordConverter.convert(any(), any(), any(), any(), any(), any(), anyLong(), anyLong(), any(), any())).thenReturn(event);
+
+        AvroParquetReader.Builder<GenericRecord> builder = mock(AvroParquetReader.Builder.class);
+        ParquetReader<GenericRecord> parquetReader = mock(ParquetReader.class);
+        BufferAccumulator<Record<Event>> bufferAccumulator = mock(BufferAccumulator.class);
+        when(builder.build()).thenReturn(parquetReader);
+        when(parquetReader.read()).thenReturn(mock(GenericRecord.class, RETURNS_DEEP_STUBS), (GenericRecord) null);
+
+        try (MockedStatic<AvroParquetReader> readerMockedStatic = mockStatic(AvroParquetReader.class);
+             MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class);
+             MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
+
+            ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor).thenReturn(mockScheduler);
+
+            readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(any(Buffer.class), anyInt(), any(Duration.class))).thenReturn(bufferAccumulator);
+
+            DataFileLoader dataFileLoader = createObjectUnderTest();
+            dataFileLoader.run();
+
+            verify(mockScheduler).scheduleAtFixedRate(
+                    any(Runnable.class),
+                    eq(DataFileLoader.LEASE_RENEWAL_INTERVAL.toMillis()),
+                    eq(DataFileLoader.LEASE_RENEWAL_INTERVAL.toMillis()),
+                    eq(TimeUnit.MILLISECONDS));
+            verify(mockScheduler).shutdownNow();
+        }
     }
 
     private DataFileLoader createObjectUnderTest() {


### PR DESCRIPTION
### Description
When the circuit breaker is open for an extended period, the `DataFileLoader` in RDS source cannot flush records to the buffer in time. The partition lease (default 10 minutes) expires before flush completes, causing the partition to be re-acquired by another node and reprocessed repeatedly. This results in the pipeline making no forward progress.

This change adds a `ScheduledExecutorService` in `DataFileLoader.run()` that periodically renews the `DataFilePartition` lease by calling `saveProgressStateForPartition` every 5 minutes with a 15-minute lease extension. The scheduler is shut down in a `finally` block after processing completes.

### Issues Resolved
Resolves #6212

### Testing

**Unit test:** Verifies the lease renewal scheduler is configured with the correct interval and duration.

**End-to-end verification:** Ran the RDS source export pipeline against an Aurora MySQL cluster with a file-based flush block mechanism to simulate the circuit breaker scenario:

1. Started the pipeline with export enabled against a database with ~465 MB of data (16 parquet files)
2. Blocked the `DataFileLoader` flush using a file-based toggle (`-Ddataprepper.test.blockFlushFile`)
3. Observed the partition lease being renewed every 5 minutes while flush was blocked:
   - First renewal at t+5min
   - Second renewal at t+10min (past the default 10-min lease timeout)
4. Unblocked the flush after 12 minutes — the partition completed successfully
5. Subsequent data file partitions continued processing normally

Without the fix, the partition would have expired at t+10min and been reprocessed.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).