### PR TITLE
Release notes for Data Prepper 2.15.1

### DIFF
--- a/release/release-notes/data-prepper.release-notes-2.15.1.md
+++ b/release/release-notes/data-prepper.release-notes-2.15.1.md
@@ -1,0 +1,8 @@
+## 2026-05-07 Version 2.15.1
+
+---
+
+### Bug Fixes
+
+* Fix `RST_STREAM` non-retryable errors by updating Armeria to 1.32.6 ([#6271](https://github.com/opensearch-project/data-prepper/issues/6271))
+* Fix `JacksonEvent.merge()` skipping keys with explicit null values ([#6819](https://github.com/opensearch-project/data-prepper/pull/6819))


### PR DESCRIPTION
### Description

Release notes for Data Prepper 2.15.1

Generated using Claude and `/generate-release-notes 2.15.1`
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
