### PR TITLE
Fixes the opensearch sink build and tests

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -70,6 +70,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private final RestHighLevelClient restHighLevelClient;
   private final OpenSearchClient openSearchClient;
   private final OpenSearchClientRefresher openSearchClientRefresher;
+  private final ConnectionConfiguration connectionConfiguration;
   private IndexManager indexManager;
   private volatile boolean initialized;
 
@@ -93,7 +94,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     this.indexManagerFactory = new IndexManagerFactory(new ClusterSettingsParser());
     this.initialized = false;
 
-    final ConnectionConfiguration connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
+    connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
     restHighLevelClient = connectionConfiguration.createClient(awsCredentialsSupplier);
     openSearchClient = connectionConfiguration.createOpenSearchClient(restHighLevelClient, awsCredentialsSupplier);
     final Function<ConnectionConfiguration, OpenSearchClient> clientFunction =


### PR DESCRIPTION
### Description

The `ConnectionConfiguration` is missing probably from some of the merges along with recent refactoring. The fix is to create a field for it in the constructor and use it when initializing.

 
### Issues Resolved

Fixes the build
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
