### PR TITLE
Improves error handling for peer-forwarder

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/exception/NoPeerForwarderTargetException.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/exception/NoPeerForwarderTargetException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.core.peerforwarder.exception;
+
+/**
+ * This exception is thrown when the peer forwarder receives a request
+ * with a destination pipeline or plugin that is not registered.
+ */
+public class NoPeerForwarderTargetException extends RuntimeException {
+
+    public NoPeerForwarderTargetException(final String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/server/PeerForwarderHttpService.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderConfiguration;
 import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderReceiveBuffer;
 import org.opensearch.dataprepper.core.peerforwarder.codec.PeerForwarderCodec;
+import org.opensearch.dataprepper.core.peerforwarder.exception.NoPeerForwarderTargetException;
 import org.opensearch.dataprepper.core.peerforwarder.model.PeerForwardingEvents;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -126,7 +127,21 @@ public class PeerForwarderHttpService {
         final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap =
                 peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap();
 
-        return pipelinePeerForwarderReceiveBufferMap
-                .get(destinationPipelineName).get(destinationPluginId);
+        final Map<String, PeerForwarderReceiveBuffer<Record<Event>>> pluginBufferMap =
+                pipelinePeerForwarderReceiveBufferMap.get(destinationPipelineName);
+        if (pluginBufferMap == null) {
+            throw new NoPeerForwarderTargetException(
+                    "Unable to find a peer-forwarder target with destinationPluginId='" + destinationPluginId +
+                            "' and destinationPipelineName='" + destinationPipelineName + "'");
+        }
+
+        final PeerForwarderReceiveBuffer<Record<Event>> buffer = pluginBufferMap.get(destinationPluginId);
+        if (buffer == null) {
+            throw new NoPeerForwarderTargetException(
+                    "Unable to find a peer-forwarder target with destinationPluginId='" + destinationPluginId +
+                            "' and destinationPipelineName='" + destinationPipelineName + "'");
+        }
+
+        return buffer;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/server/ResponseHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/peerforwarder/server/ResponseHandler.java
@@ -13,6 +13,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.core.peerforwarder.exception.NoPeerForwarderTargetException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 
@@ -53,6 +54,11 @@ public class ResponseHandler {
         if (e instanceof TimeoutException) {
             requestTimeoutsCounter.increment();
             return HttpResponse.of(HttpStatus.REQUEST_TIMEOUT, MediaType.ANY_TYPE, message);
+        }
+
+        if (e instanceof NoPeerForwarderTargetException) {
+            badRequestsCounter.increment();
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.ANY_TYPE, e.getMessage());
         }
 
         if (e instanceof NullPointerException) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -11,9 +11,15 @@ package org.opensearch.dataprepper.core.peerforwarder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.Server;
 import io.netty.handler.ssl.NotSslRecordException;
 import org.junit.jupiter.api.AfterEach;
@@ -27,6 +33,7 @@ import org.opensearch.dataprepper.core.peerforwarder.codec.JacksonPeerForwarderC
 import org.opensearch.dataprepper.core.peerforwarder.codec.JavaPeerForwarderCodec;
 import org.opensearch.dataprepper.core.peerforwarder.codec.PeerForwarderCodec;
 import org.opensearch.dataprepper.core.peerforwarder.codec.PeerForwarderCodecAppConfig;
+import org.opensearch.dataprepper.core.peerforwarder.model.PeerForwardingEvents;
 import org.opensearch.dataprepper.core.peerforwarder.discovery.DiscoveryMode;
 import org.opensearch.dataprepper.core.peerforwarder.server.PeerForwarderHttpServerProvider;
 import org.opensearch.dataprepper.core.peerforwarder.server.PeerForwarderHttpService;
@@ -339,6 +346,65 @@ class PeerForwarder_ClientServerIT {
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());
             assertThat(receivedRecords, is(empty()));
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void send_invalid_content_type_with_valid_body_returns_ok(final boolean binaryCodec) throws Exception {
+            setUpServer(binaryCodec);
+            final PeerForwarderCodec codec = applicationContext.getBean(PeerForwarderCodec.class);
+            final List<Event> eventList = outgoingRecords.stream().map(Record::getData).collect(Collectors.toList());
+            final PeerForwardingEvents peerForwardingEvents = new PeerForwardingEvents(eventList, pluginId, pipelineName);
+            final byte[] serializedBody = codec.serialize(peerForwardingEvents);
+
+            final WebClient client = WebClient.of("http://" + LOCALHOST + ":4994");
+
+            final AggregatedHttpResponse response = client.execute(
+                    HttpRequest.of(
+                            RequestHeaders.builder()
+                                    .method(HttpMethod.POST)
+                                    .path(PeerForwarderConfiguration.DEFAULT_PEER_FORWARDING_URI)
+                                    .contentType(MediaType.parse("application/x-www-form-urlencoded"))
+                                    .build(),
+                            HttpData.wrap(serializedBody)
+                    )
+            ).aggregate().join();
+
+            assertThat(response.status(), equalTo(HttpStatus.OK));
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void send_malformed_body_returns_bad_request(final boolean binaryCodec) {
+            setUpServer(binaryCodec);
+            final String body = "this is not valid json or yaml";
+
+            final WebClient client = WebClient.of("http://" + LOCALHOST + ":4994");
+
+            final AggregatedHttpResponse response = client.execute(
+                    HttpRequest.of(
+                            RequestHeaders.builder()
+                                    .method(HttpMethod.POST)
+                                    .path(PeerForwarderConfiguration.DEFAULT_PEER_FORWARDING_URI)
+                                    .build(),
+                            HttpData.ofUtf8(body)
+                    )
+            ).aggregate().join();
+
+            assertThat(response.status(), equalTo(HttpStatus.BAD_REQUEST));
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void send_Events_to_unknown_destination_returns_bad_request(final boolean binaryCodec) throws ExecutionException, InterruptedException {
+            setUpServer(binaryCodec);
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration);
+
+            final CompletableFuture<AggregatedHttpResponse> httpResponseFuture =
+                    client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            final AggregatedHttpResponse httpResponse = httpResponseFuture.get();
+
+            assertThat(httpResponse.status(), equalTo(HttpStatus.BAD_REQUEST));
         }
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -29,6 +29,7 @@ import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderConfiguration;
 import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.core.peerforwarder.PeerForwarderReceiveBuffer;
 import org.opensearch.dataprepper.core.peerforwarder.codec.PeerForwarderCodec;
+import org.opensearch.dataprepper.core.peerforwarder.exception.NoPeerForwarderTargetException;
 import org.opensearch.dataprepper.core.peerforwarder.model.PeerForwardingEvents;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -165,6 +166,35 @@ class PeerForwarderHttpServiceTest {
         final AggregatedHttpResponse aggregatedHttpResponse = objectUnderTest.doPost(aggregatedHttpRequest).aggregate().get();
 
         assertThat(aggregatedHttpResponse.status(), equalTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    @Test
+    void test_doPost_with_unknown_pipeline_should_return_BAD_REQUEST() throws Exception {
+        lenient().when(peerForwardingEvents.getDestinationPipelineName()).thenReturn("unknown_pipeline");
+        when(responseHandler.handleException(any(NoPeerForwarderTargetException.class), anyString())).thenReturn(HttpResponse.of(HttpStatus.BAD_REQUEST));
+        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
+        when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
+
+        final PeerForwarderHttpService objectUnderTest = createObjectUnderTest();
+
+        final AggregatedHttpResponse aggregatedHttpResponse = objectUnderTest.doPost(aggregatedHttpRequest).aggregate().get();
+
+        assertThat(aggregatedHttpResponse.status(), equalTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void test_doPost_with_unknown_plugin_should_return_BAD_REQUEST() throws Exception {
+        lenient().when(peerForwardingEvents.getDestinationPluginId()).thenReturn("unknown_plugin");
+        when(responseHandler.handleException(any(NoPeerForwarderTargetException.class), anyString())).thenReturn(HttpResponse.of(HttpStatus.BAD_REQUEST));
+        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
+        pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, new HashMap<>());
+        when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
+
+        final PeerForwarderHttpService objectUnderTest = createObjectUnderTest();
+
+        final AggregatedHttpResponse aggregatedHttpResponse = objectUnderTest.doPost(aggregatedHttpRequest).aggregate().get();
+
+        assertThat(aggregatedHttpResponse.status(), equalTo(HttpStatus.BAD_REQUEST));
     }
 
     private List<Event> generateEvents(final int numEvents) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/server/ResponseHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/peerforwarder/server/ResponseHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.core.peerforwarder.exception.NoPeerForwarderTargetException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 
@@ -130,6 +131,23 @@ class ResponseHandlerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
+
+        verify(badRequestsCounter).increment();
+    }
+
+    @Test
+    void test_NoPeerForwarderTargetException() throws ExecutionException, InterruptedException {
+        final ResponseHandler objectUnderTest = createObjectUnderTest();
+        final String exceptionMessage = "Unable to find a peer-forwarder target with destinationPluginId='myPlugin' and destinationPipelineName='myPipeline'";
+        final NoPeerForwarderTargetException noPeerForwarderTargetException = new NoPeerForwarderTargetException(exceptionMessage);
+
+        final String testMessage = "test exception message";
+
+        final HttpResponse httpResponse = objectUnderTest.handleException(noPeerForwarderTargetException, testMessage);
+        final AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
+
+        assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
+        assertEquals(exceptionMessage, aggregatedHttpResponse.contentUtf8());
 
         verify(badRequestsCounter).increment();
     }


### PR DESCRIPTION
### Description

Test scenarios where the input is incorrect and verify the correct response codes. Fix a 500 error when the target pipeline and plugin do not exist by returning 400 instead.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
