### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/sink/LambdaSink.java
+++ b/data-prepper-plugins/aws-lambda/src/main/java/org/opensearch/dataprepper/plugins/lambda/sink/LambdaSink.java
@@ -270,7 +270,7 @@ public class LambdaSink extends AbstractSink<Record<Event>> {
       dlqPushHandler.perform(dlqObjects);
       releaseEventHandles(failedRecords, true);
     } catch (Exception ex) {
-      LOG.error("Exception occured during error handling");
+      LOG.error("Exception occurred during error handling");
       releaseEventHandles(failedRecords, false);
     }
   }


### PR DESCRIPTION
Corrects a typo in a log message.