### PR TITLE
Fix typo: occured -> occurred in ml-inference processors

### DIFF
--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/BedrockBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/BedrockBatchJobCreator.java
@@ -223,7 +223,7 @@ public class BedrockBatchJobCreator extends AbstractBatchJobCreator {
                 ));
             }
         } catch (Exception ex) {
-            LOG.error(NOISY, "Exception occured during error handling: {}", ex.getMessage());
+            LOG.error(NOISY, "Exception occurred during error handling: {}", ex.getMessage());
         }
     }
 

--- a/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreator.java
+++ b/data-prepper-plugins/ml-inference-processor/src/main/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreator.java
@@ -277,7 +277,7 @@ public class SageMakerBatchJobCreator extends AbstractBatchJobCreator {
             }
             dlqPushHandler.perform(dlqObjects);
         } catch (Exception ex) {
-            LOG.error(NOISY, "Exception occured during error handling: {}", ex.getMessage());
+            LOG.error(NOISY, "Exception occurred during error handling: {}", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
### Description
Fixes 'occured' -> 'occurred' typo in two ml-inference processor classes (`BedrockBatchJobCreator.java`, `SageMakerBatchJobCreator.java`).

### Issues Resolved
N/A.

### Check List
- [ ] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

String/comment-only change, no tests required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
