### PR TITLE
fix: Allow empty string coercion to null in PluginModel deserialization

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
@@ -219,8 +219,9 @@ public class PluginModel {
             } else if (jsonParser.currentToken() == JsonToken.VALUE_STRING) {
                 final String value = jsonParser.getValueAsString();
                 if (value.isEmpty()) {
-                    throw context.weirdStringException(value, Map.class,
-                            "Empty string is not allowed for plugin '" + pluginName + "'. Use null, empty (no value), or {} instead.");
+                    // Treat empty string same as null (YAML bare keys like "stdout:" may parse as "")
+                    isNull = true;
+                    jsonParser.nextToken();
                 } else {
                     throw context.weirdStringException(value, Map.class,
                             "String values not allowed for plugin '" + pluginName + "'");

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -209,6 +210,7 @@ public class PluginModel {
             Map<String, Object> data = null;
             if (jsonParser.currentToken() == JsonToken.START_OBJECT) {
                 data = mapper.readValue(jsonParser, Map.class);
+                replaceEmptyStringsWithNull(data);
                 // readValue consumed up to the inner END_OBJECT; advance to the outer END_OBJECT
                 jsonParser.nextToken();
             } else if (jsonParser.currentToken() == JsonToken.VALUE_NULL) {
@@ -236,6 +238,26 @@ public class PluginModel {
                     ? nullSettingsModelSupplier.get()
                     : SERIALIZER_OBJECT_MAPPER.convertValue(data, innerModelClass);
             return constructorFunction.apply(pluginName, innerModel);
+        }
+
+        @SuppressWarnings("unchecked")
+        private static void replaceEmptyStringsWithNull(final Map<String, Object> map) {
+            map.replaceAll((k, v) -> {
+                if ("".equals(v)) return null;
+                if (v instanceof Map) replaceEmptyStringsWithNull((Map<String, Object>) v);
+                if (v instanceof List) replaceEmptyStringsInList((List<Object>) v);
+                return v;
+            });
+        }
+
+        @SuppressWarnings("unchecked")
+        private static void replaceEmptyStringsInList(final List<Object> list) {
+            list.replaceAll(v -> {
+                if ("".equals(v)) return null;
+                if (v instanceof Map) replaceEmptyStringsWithNull((Map<String, Object>) v);
+                if (v instanceof List) replaceEmptyStringsInList((List<Object>) v);
+                return v;
+            });
         }
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginModel.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
@@ -41,6 +43,10 @@ import java.util.function.Supplier;
 public class PluginModel {
 
     private static final ObjectMapper SERIALIZER_OBJECT_MAPPER = new ObjectMapper();
+    static {
+        SERIALIZER_OBJECT_MAPPER.coercionConfigDefaults()
+                .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+    }
 
     private final String pluginName;
     private final InternalJsonModel innerModel;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginModelTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginModelTests.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
@@ -229,15 +230,12 @@ class PluginModelTests {
     }
 
     @Test
-    final void testDeserialize_emptyString_throwsException() throws IOException {
+    final void testDeserialize_emptyString_treatedAsNull() throws IOException {
         final InputStream inputStream = PluginModelTests.class.getResourceAsStream("plugin_model_empty_string.yaml");
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
-        final JsonMappingException exception = assertThrows(
-            JsonMappingException.class,
-            () -> mapper.readValue(inputStream, PluginModel.class)
-        );
-        assertThat(exception.getMessage(), containsString("Empty string is not allowed"));
+        final PluginModel result = mapper.readValue(inputStream, PluginModel.class);
+        assertThat(result.getPluginSettings(), nullValue());
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SamplePipelineConfigurationTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SamplePipelineConfigurationTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -106,6 +107,19 @@ class SamplePipelineConfigurationTest {
         assertThat(processorSettings == null || processorSettings.isEmpty(), equalTo(true));
         final Map<String, Object> sinkSettings = pipeline.getSinks().get(0).getPluginSettings();
         assertThat(sinkSettings == null || sinkSettings.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void deserialize_pipeline_withBareKeyPlugins_succeeds() throws IOException {
+        final InputStream inputStream = getClass().getResourceAsStream("sample_pipelines/sample_pipeline_plugin_bare_keys.yaml");
+
+        final PipelinesDataFlowModel result = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+
+        assertThat(result, notNullValue());
+        assertThat(result.getPipelines().containsKey("test-pipeline"), equalTo(true));
+        final PipelineModel pipeline = result.getPipelines().get("test-pipeline");
+        assertThat(pipeline.getSource().getPluginName(), equalTo("http"));
+        assertThat(pipeline.getSource().getPluginSettings(), nullValue());
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SamplePipelineConfigurationTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SamplePipelineConfigurationTest.java
@@ -129,4 +129,17 @@ class SamplePipelineConfigurationTest {
         final PipelinesDataFlowModel result = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
         assertThat(result, notNullValue());
     }
+
+    @Test
+    void deserialize_pipeline_withNestedBareKeys_treatsEmptyStringsAsNull() throws IOException {
+        final InputStream inputStream = getClass().getResourceAsStream("sample_pipelines/sample_pipeline_nested_bare_keys.yaml");
+
+        final PipelinesDataFlowModel result = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+        assertThat(result, notNullValue());
+
+        final Map<String, Object> sinkSettings = result.getPipelines().get("test-pipeline").getSinks().get(0).getPluginSettings();
+        // codec.newline: (bare key) should be deserialized as null, not ""
+        final Map<String, Object> codec = (Map<String, Object>) sinkSettings.get("codec");
+        assertThat(codec.get("newline"), nullValue());
+    }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SamplePipelineConfigurationTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SamplePipelineConfigurationTest.java
@@ -123,13 +123,10 @@ class SamplePipelineConfigurationTest {
     }
 
     @Test
-    void deserialize_pipeline_withEmptyStringPluginConfig_throwsException() {
+    void deserialize_pipeline_withEmptyStringPluginConfig_treatedAsNull() throws IOException {
         final InputStream inputStream = getClass().getResourceAsStream("sample_pipelines/sample_pipeline_plugin_empty_string.yaml");
 
-        final JsonMappingException exception = assertThrows(
-            JsonMappingException.class,
-            () -> objectMapper.readValue(inputStream, PipelinesDataFlowModel.class)
-        );
-        assertThat(exception.getMessage(), containsString("Empty string is not allowed"));
+        final PipelinesDataFlowModel result = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+        assertThat(result, notNullValue());
     }
 }

--- a/data-prepper-api/src/test/resources/org/opensearch/dataprepper/model/configuration/sample_pipelines/sample_pipeline_nested_bare_keys.yaml
+++ b/data-prepper-api/src/test/resources/org/opensearch/dataprepper/model/configuration/sample_pipelines/sample_pipeline_nested_bare_keys.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+test-pipeline:
+  source:
+    http:
+      path: "/test"
+  sink:
+  - opensearch:
+      hosts:
+      - "https://example.com"
+      codec:
+        newline:
+      aws:
+        region: "us-east-1"
+  workers: 1
+  delay: 100

--- a/data-prepper-api/src/test/resources/org/opensearch/dataprepper/model/configuration/sample_pipelines/sample_pipeline_plugin_bare_keys.yaml
+++ b/data-prepper-api/src/test/resources/org/opensearch/dataprepper/model/configuration/sample_pipelines/sample_pipeline_plugin_bare_keys.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+test-pipeline:
+  source:
+    http:
+  sink:
+  - stdout:


### PR DESCRIPTION
### Description

Configure `SERIALIZER_OBJECT_MAPPER` to coerce empty strings to null. This fixes deserialization of YAML configs where plugins have bare keys with no value (e.g., `http:` or `stdout:`) which SnakeYAML parses as empty strings inside the settings map.

Without this fix, Jackson 2.21 rejects the empty string with:
`Cannot coerce empty String ("") to InternalJsonModel value`

The existing `VALUE_STRING` handling in the custom deserializer only covers the case where the plugin itself is a bare key at the top level. This fix covers the nested case where `convertValue()` encounters empty strings within the data map.

### Issues Resolved

Follow-up to #6775 / PR #6598 — completes the Jackson 2.21 deserialization compatibility fix.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).