### PR TITLE
Support PluginConfigVariable for Confluence/Jira bearer token.         

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/configuration/AuthenticationConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/configuration/AuthenticationConfig.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Getter;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 
 import static org.opensearch.dataprepper.plugins.source.atlassian.utils.Constants.BASIC;
 import static org.opensearch.dataprepper.plugins.source.atlassian.utils.Constants.BEARER_TOKEN;
@@ -31,13 +32,14 @@ public class AuthenticationConfig {
     private Oauth2Config oauth2Config;
 
     @JsonProperty("bearer_token")
-    private String bearerToken;
+    private PluginConfigVariable bearerToken;
 
     @AssertTrue(message = "Authentication config should have exactly one of basic, oauth2, or bearer_token")
     private boolean isValidAuthenticationConfig() {
         boolean hasBasic = basicConfig != null;
         boolean hasOauth = oauth2Config != null;
-        boolean hasBearer = bearerToken != null && !bearerToken.isEmpty();
+        boolean hasBearer = bearerToken != null && bearerToken.getValue() != null
+                && !((String) bearerToken.getValue()).isEmpty();
         int count = (hasBasic ? 1 : 0) + (hasOauth ? 1 : 0) + (hasBearer ? 1 : 0);
         return count == 1;
     }
@@ -45,7 +47,8 @@ public class AuthenticationConfig {
     public String getAuthType() {
         if (basicConfig != null) {
             return BASIC;
-        } else if (bearerToken != null && !bearerToken.isEmpty()) {
+        } else if (bearerToken != null && bearerToken.getValue() != null
+                && !((String) bearerToken.getValue()).isEmpty()) {
             return BEARER_TOKEN;
         } else {
             return OAUTH2;

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/configuration/AuthenticationConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/configuration/AuthenticationConfig.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.source.atlassian.configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
@@ -34,12 +35,24 @@ public class AuthenticationConfig {
     @JsonProperty("bearer_token")
     private PluginConfigVariable bearerToken;
 
+    @JsonIgnore
+    public String getBearerTokenValue() {
+        if (bearerToken == null || bearerToken.getValue() == null) {
+            return null;
+        }
+        final Object value = bearerToken.getValue();
+        if (value instanceof String) {
+            return (String) value;
+        }
+        return value.toString();
+    }
+
     @AssertTrue(message = "Authentication config should have exactly one of basic, oauth2, or bearer_token")
     private boolean isValidAuthenticationConfig() {
         boolean hasBasic = basicConfig != null;
         boolean hasOauth = oauth2Config != null;
-        boolean hasBearer = bearerToken != null && bearerToken.getValue() != null
-                && !((String) bearerToken.getValue()).isEmpty();
+        final String tokenValue = getBearerTokenValue();
+        boolean hasBearer = tokenValue != null && !tokenValue.isEmpty();
         int count = (hasBasic ? 1 : 0) + (hasOauth ? 1 : 0) + (hasBearer ? 1 : 0);
         return count == 1;
     }
@@ -47,11 +60,11 @@ public class AuthenticationConfig {
     public String getAuthType() {
         if (basicConfig != null) {
             return BASIC;
-        } else if (bearerToken != null && bearerToken.getValue() != null
-                && !((String) bearerToken.getValue()).isEmpty()) {
-            return BEARER_TOKEN;
-        } else {
-            return OAUTH2;
         }
+        final String tokenValue = getBearerTokenValue();
+        if (tokenValue != null && !tokenValue.isEmpty()) {
+            return BEARER_TOKEN;
+        }
+        return OAUTH2;
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfig.java
@@ -10,19 +10,25 @@
 
 package org.opensearch.dataprepper.plugins.source.atlassian.rest.auth;
 
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.source.atlassian.AtlassianSourceConfig;
+
+import java.util.Objects;
 
 public class AtlassianBearerTokenAuthConfig implements AtlassianAuthConfig {
 
-    private String accountUrl;
-    private final String bearerToken;
+    private final String accountUrl;
+    private final PluginConfigVariable bearerTokenVariable;
 
     public AtlassianBearerTokenAuthConfig(AtlassianSourceConfig sourceConfig) {
-        this.bearerToken = sourceConfig.getAuthenticationConfig().getBearerToken();
-        accountUrl = sourceConfig.getAccountUrl();
-        if (!accountUrl.endsWith("/")) {
-            accountUrl += "/";
+        Objects.requireNonNull(sourceConfig, "sourceConfig must not be null");
+        this.bearerTokenVariable = sourceConfig.getAuthenticationConfig().getBearerToken();
+        Objects.requireNonNull(bearerTokenVariable, "bearer_token must not be null");
+        String url = sourceConfig.getAccountUrl();
+        if (!url.endsWith("/")) {
+            url += "/";
         }
+        this.accountUrl = url;
     }
 
     @Override
@@ -31,11 +37,11 @@ public class AtlassianBearerTokenAuthConfig implements AtlassianAuthConfig {
     }
 
     public String getBearerToken() {
-        return bearerToken;
+        return (String) bearerTokenVariable.getValue();
     }
 
     @Override
     public void renewCredentials() {
-        // static token, no renewal needed
+        bearerTokenVariable.refresh();
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfig.java
@@ -37,11 +37,17 @@ public class AtlassianBearerTokenAuthConfig implements AtlassianAuthConfig {
     }
 
     public String getBearerToken() {
-        return (String) bearerTokenVariable.getValue();
+        final Object value = bearerTokenVariable.getValue();
+        if (value instanceof String) {
+            return (String) value;
+        }
+        return value != null ? value.toString() : null;
     }
 
     @Override
     public void renewCredentials() {
-        bearerTokenVariable.refresh();
+        if (bearerTokenVariable.isUpdatable()) {
+            bearerTokenVariable.refresh();
+        }
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfig.java
@@ -46,8 +46,6 @@ public class AtlassianBearerTokenAuthConfig implements AtlassianAuthConfig {
 
     @Override
     public void renewCredentials() {
-        if (bearerTokenVariable.isUpdatable()) {
-            bearerTokenVariable.refresh();
-        }
+        bearerTokenVariable.refresh();
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianAuthFactoryTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianAuthFactoryTest.java
@@ -46,6 +46,9 @@ public class AtlassianAuthFactoryTest {
     @Mock
     private PluginConfigVariable refreshTokenPluginConfigVariable;
 
+    @Mock
+    private PluginConfigVariable bearerTokenVariable;
+
     private AtlassianAuthFactory confluenceAuthFactory;
 
     @BeforeEach
@@ -72,10 +75,9 @@ public class AtlassianAuthFactoryTest {
 
     @Test
     void testGetObjectBearerToken() {
-        final String token = UUID.randomUUID().toString();
         when(sourceConfig.getAuthType()).thenReturn(BEARER_TOKEN);
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(token);
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
         assertInstanceOf(AtlassianBearerTokenAuthConfig.class, confluenceAuthFactory.getObject());
     }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianAuthFactoryTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianAuthFactoryTest.java
@@ -20,7 +20,6 @@ import org.opensearch.dataprepper.plugins.source.atlassian.AtlassianSourceConfig
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.AuthenticationConfig;
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.Oauth2Config;
 
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfigTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.source.atlassian.AtlassianSourceConfig;
 import org.opensearch.dataprepper.plugins.source.atlassian.configuration.AuthenticationConfig;
 
@@ -22,7 +23,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +34,9 @@ class AtlassianBearerTokenAuthConfigTest {
 
     @Mock
     private AuthenticationConfig authenticationConfig;
+
+    @Mock
+    private PluginConfigVariable bearerTokenVariable;
 
     private String token;
 
@@ -45,7 +49,7 @@ class AtlassianBearerTokenAuthConfigTest {
     void testGetUrl() {
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(token);
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
 
         AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
         assertThat(config.getUrl(), equalTo("https://confluence.opensearch.org/"));
@@ -55,7 +59,7 @@ class AtlassianBearerTokenAuthConfigTest {
     void testGetUrlWithTrailingSlash() {
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org/");
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(token);
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
 
         AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
         assertThat(config.getUrl(), equalTo("https://confluence.opensearch.org/"));
@@ -65,19 +69,22 @@ class AtlassianBearerTokenAuthConfigTest {
     void testGetBearerToken() {
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(token);
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
+        when(bearerTokenVariable.getValue()).thenReturn(token);
 
         AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
         assertThat(config.getBearerToken(), equalTo(token));
     }
 
     @Test
-    void testRenewCredentialsIsNoOp() {
+    void testRenewCredentials_calls_refresh() {
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(token);
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
 
         AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
-        assertDoesNotThrow(config::renewCredentials);
+        config.renewCredentials();
+
+        verify(bearerTokenVariable).refresh();
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfigTest.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,28 +77,14 @@ class AtlassianBearerTokenAuthConfigTest {
     }
 
     @Test
-    void testRenewCredentials_calls_refresh_when_updatable() {
+    void testRenewCredentials_calls_refresh() {
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
-        when(bearerTokenVariable.isUpdatable()).thenReturn(true);
 
         AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
         config.renewCredentials();
 
         verify(bearerTokenVariable).refresh();
-    }
-
-    @Test
-    void testRenewCredentials_does_not_call_refresh_when_not_updatable() {
-        when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
-        when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
-        when(bearerTokenVariable.isUpdatable()).thenReturn(false);
-
-        AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
-        config.renewCredentials();
-
-        verify(bearerTokenVariable, never()).refresh();
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianBearerTokenAuthConfigTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -77,14 +78,28 @@ class AtlassianBearerTokenAuthConfigTest {
     }
 
     @Test
-    void testRenewCredentials_calls_refresh() {
+    void testRenewCredentials_calls_refresh_when_updatable() {
         when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
         when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
+        when(bearerTokenVariable.isUpdatable()).thenReturn(true);
 
         AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
         config.renewCredentials();
 
         verify(bearerTokenVariable).refresh();
+    }
+
+    @Test
+    void testRenewCredentials_does_not_call_refresh_when_not_updatable() {
+        when(sourceConfig.getAccountUrl()).thenReturn("https://confluence.opensearch.org");
+        when(sourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
+        when(bearerTokenVariable.isUpdatable()).thenReturn(false);
+
+        AtlassianBearerTokenAuthConfig config = new AtlassianBearerTokenAuthConfig(sourceConfig);
+        config.renewCredentials();
+
+        verify(bearerTokenVariable, never()).refresh();
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceConfigHelper.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceConfigHelper.java
@@ -12,7 +12,6 @@ package org.opensearch.dataprepper.plugins.source.confluence.utils;
 
 
 import lombok.extern.slf4j.Slf4j;
-import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.source.confluence.ConfluenceSourceConfig;
 import org.opensearch.dataprepper.plugins.source.source_crawler.utils.AddressValidation;
 
@@ -106,9 +105,8 @@ public class ConfluenceConfigHelper {
         }
 
         if (BEARER_TOKEN.equals(authType)) {
-            PluginConfigVariable bearerToken = config.getAuthenticationConfig().getBearerToken();
-            if (bearerToken == null || bearerToken.getValue() == null
-                    || ((String) bearerToken.getValue()).isEmpty()) {
+            final String tokenValue = config.getAuthenticationConfig().getBearerTokenValue();
+            if (tokenValue == null || tokenValue.isEmpty()) {
                 throw new RuntimeException("Bearer token is required for BearerToken AuthType");
             }
         }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceConfigHelper.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/main/java/org/opensearch/dataprepper/plugins/source/confluence/utils/ConfluenceConfigHelper.java
@@ -12,6 +12,7 @@ package org.opensearch.dataprepper.plugins.source.confluence.utils;
 
 
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.dataprepper.model.plugin.PluginConfigVariable;
 import org.opensearch.dataprepper.plugins.source.confluence.ConfluenceSourceConfig;
 import org.opensearch.dataprepper.plugins.source.source_crawler.utils.AddressValidation;
 
@@ -105,8 +106,9 @@ public class ConfluenceConfigHelper {
         }
 
         if (BEARER_TOKEN.equals(authType)) {
-            String bearerToken = config.getAuthenticationConfig().getBearerToken();
-            if (bearerToken == null || bearerToken.isEmpty()) {
+            PluginConfigVariable bearerToken = config.getAuthenticationConfig().getBearerToken();
+            if (bearerToken == null || bearerToken.getValue() == null
+                    || ((String) bearerToken.getValue()).isEmpty()) {
                 throw new RuntimeException("Bearer token is required for BearerToken AuthType");
             }
         }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceConfigHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceConfigHelperTest.java
@@ -70,6 +70,9 @@ public class ConfluenceConfigHelperTest {
     @Mock
     PluginConfigVariable refreshTokenPluginConfigVariable;
 
+    @Mock
+    PluginConfigVariable bearerTokenVariable;
+
     @Test
     void testInitialization() {
         ConfluenceConfigHelper confluenceConfigHelper = new ConfluenceConfigHelper();
@@ -170,7 +173,8 @@ public class ConfluenceConfigHelperTest {
         when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://opensearch.org");
         when(confluenceSourceConfig.getAuthType()).thenReturn(BEARER_TOKEN);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn("");
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
+        when(bearerTokenVariable.getValue()).thenReturn("");
         assertThrows(RuntimeException.class, () -> ConfluenceConfigHelper.validateConfig(confluenceSourceConfig));
     }
 
@@ -179,7 +183,9 @@ public class ConfluenceConfigHelperTest {
         when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://opensearch.org");
         when(confluenceSourceConfig.getAuthType()).thenReturn(BEARER_TOKEN);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(UUID.randomUUID().toString());
+        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
+        when(bearerTokenVariable.getValue()).thenReturn(UUID.randomUUID().toString());
+        when(confluenceSourceConfig.isAllowLocalAddress()).thenReturn(false);
         assertDoesNotThrow(() -> ConfluenceConfigHelper.validateConfig(confluenceSourceConfig));
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceConfigHelperTest.java
+++ b/data-prepper-plugins/saas-source-plugins/confluence-source/src/test/java/org/opensearch/dataprepper/plugins/source/confluence/ConfluenceConfigHelperTest.java
@@ -164,7 +164,7 @@ public class ConfluenceConfigHelperTest {
         when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://opensearch.org");
         when(confluenceSourceConfig.getAuthType()).thenReturn(BEARER_TOKEN);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(null);
+        when(authenticationConfig.getBearerTokenValue()).thenReturn(null);
         assertThrows(RuntimeException.class, () -> ConfluenceConfigHelper.validateConfig(confluenceSourceConfig));
     }
 
@@ -173,8 +173,7 @@ public class ConfluenceConfigHelperTest {
         when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://opensearch.org");
         when(confluenceSourceConfig.getAuthType()).thenReturn(BEARER_TOKEN);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
-        when(bearerTokenVariable.getValue()).thenReturn("");
+        when(authenticationConfig.getBearerTokenValue()).thenReturn("");
         assertThrows(RuntimeException.class, () -> ConfluenceConfigHelper.validateConfig(confluenceSourceConfig));
     }
 
@@ -183,8 +182,7 @@ public class ConfluenceConfigHelperTest {
         when(confluenceSourceConfig.getAccountUrl()).thenReturn("https://opensearch.org");
         when(confluenceSourceConfig.getAuthType()).thenReturn(BEARER_TOKEN);
         when(confluenceSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
-        when(authenticationConfig.getBearerToken()).thenReturn(bearerTokenVariable);
-        when(bearerTokenVariable.getValue()).thenReturn(UUID.randomUUID().toString());
+        when(authenticationConfig.getBearerTokenValue()).thenReturn(UUID.randomUUID().toString());
         when(confluenceSourceConfig.isAllowLocalAddress()).thenReturn(false);
         assertDoesNotThrow(() -> ConfluenceConfigHelper.validateConfig(confluenceSourceConfig));
     }


### PR DESCRIPTION
### Description
Change `bearer_token` field in `AuthenticationConfig` from `String` to `PluginConfigVariable` to enable reading credentials from external secrets managers (e.g., AWS Secrets Manager). The `renewCredentials()` method in `AtlassianBearerTokenAuthConfig` now calls `refresh()` on the variable so externally rotated secrets are picked up on next use.
 
### Issues Resolved
Resolves #6844
https://github.com/opensearch-project/data-prepper/issues/6844
 
### Check List
- [ X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ X ] New functionality has javadoc added
- [ X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
