### PR TITLE
 Fix and extend AWS environment derivation for OTLP resource attributes

### DIFF
--- a/data-prepper-plugins/otel-apm-service-map-processor/README.md
+++ b/data-prepper-plugins/otel-apm-service-map-processor/README.md
@@ -75,6 +75,38 @@ The `metric_timestamp_granularity` option controls the truncation granularity fo
 
 In `arrival_time` mode, granularity has minimal impact since all spans in a window share the same `clock.instant()` — each window always produces one data point per label combination regardless of truncation.
 
+## Environment Derivation
+
+For every emitted `NodeOperationDetail` the processor populates `sourceNode.keyAttributes.environment` (and the matching `targetNode.keyAttributes.environment` on edge events) by inspecting OTel resource attributes — and where applicable span attributes — on the underlying spans. The same value is also written to each raw span as `attributes.derived.environment` by the companion `otel_traces` processor.
+
+Lookup precedence (first match wins):
+
+1. AWS platform detection from `cloud.platform` (and a few platform-specific signals listed below).
+2. `deployment.environment.name` from `resource.attributes`.
+3. `deployment.environment` from `resource.attributes` (legacy OTel key).
+4. Default fallback: `generic:default`.
+
+For every AWS attribute the processor checks both span-level attributes and `resource.attributes` (since most OTel SDKs emit them in the resource).
+
+| Resource (or span) attributes | `environment` value |
+|---|---|
+| `cloud.platform=aws_api_gateway` (+ optional `aws.api_gateway.stage=<s>`) | `api-gateway:<s>` |
+| `cloud.platform=aws_ec2` | `ec2:default` |
+| `cloud.platform=aws_ecs` + `aws.ecs.launchtype=fargate` | `ecs-fargate:default` |
+| `cloud.platform=aws_ecs` + `aws.ecs.launchtype=ec2` | `ecs-ec2:default` |
+| `cloud.platform=aws_ecs` (launchtype absent or other) | `ecs:default` |
+| `cloud.platform=aws_eks` | `eks:default` |
+| `cloud.platform=aws_elastic_beanstalk` | `elastic-beanstalk:default` |
+| `cloud.platform=aws_lambda` | `lambda:default` |
+| `cloud.resource_id` starts with `arn:aws:lambda:` | `lambda:default` |
+| `aws.lambda.invoked_arn` is set | `lambda:default` |
+| `cloud.provider=aws` + `faas.name=<n>` | `lambda:default` |
+| `deployment.environment.name=<env>` | `<env>` |
+| `deployment.environment=<env>` | `<env>` (legacy) |
+| (none of the above) | `generic:default` |
+
+Attribute names follow the OpenTelemetry semantic conventions for [cloud](https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/) and [AWS](https://opentelemetry.io/docs/specs/semconv/registry/attributes/aws/).
+
 ## Pipeline Examples
 
 ### Basic Pipeline

--- a/data-prepper-plugins/otel-apm-service-map-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessor.java
+++ b/data-prepper-plugins/otel-apm-service-map-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessor.java
@@ -356,9 +356,9 @@ public class OTelApmServiceMapProcessor extends AbstractProcessor<Record<Event>,
                 combinedAttributes.put("resource", resource);
             }
             final Map<String, Object> scope = span.getScope();
-            if (scope != null ) {
+            if (scope != null) {
                 final Map<String, Object> scopeAttributes = (Map<String, Object>)scope.get("attributes");
-                if (attributes != null) {
+                if (scopeAttributes != null) {
                     combinedAttributes.putAll(scopeAttributes);
                 }
             }

--- a/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessorTest.java
+++ b/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessorTest.java
@@ -1329,6 +1329,69 @@ class OTelApmServiceMapProcessorTest extends BaseDataPrepperPluginStandardTestSu
         spanEndProcessor.shutdown();
     }
 
+    @Test
+    void doExecute_emitsServiceMapEventWithEnvironmentFromResource_whenScopeHasNullAttributes() {
+        // Regression for issue #6786 (Bug 1): when the instrumentation scope has no
+        // "attributes" key, OTelApmServiceMapProcessor.extractSpanAttributes used to
+        // throw on putAll(null) and the catch returned an empty map, dropping the
+        // resource and its deployment.environment.name.
+        when(clock.instant())
+                .thenReturn(testTime)
+                .thenReturn(testTime)
+                .thenReturn(testTime.plusSeconds(65))
+                .thenReturn(testTime.plusSeconds(65))
+                .thenReturn(testTime.plusSeconds(65))
+                .thenReturn(testTime.plusSeconds(65))
+                .thenReturn(testTime.plusSeconds(130))
+                .thenReturn(testTime.plusSeconds(130))
+                .thenReturn(testTime.plusSeconds(130))
+                .thenReturn(testTime.plusSeconds(130));
+
+        final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
+        doAnswer((a) -> { eventMetadata = a.getArgument(0); return eventBuilder; })
+                .when(eventBuilder).withEventMetadata(any());
+        doAnswer((a) -> { eventData = a.getArgument(0); return eventBuilder; })
+                .when(eventBuilder).withData(any());
+        doAnswer((a) -> JacksonEvent.builder()
+                .withEventMetadata(eventMetadata).withData(eventData).build())
+                .when(eventBuilder).build();
+
+        final File isolatedDir = new File(tempDir, "scope-null-attrs-" + System.nanoTime());
+        isolatedDir.mkdirs();
+        final OTelApmServiceMapProcessor isolatedProcessor = new OTelApmServiceMapProcessor(
+                Duration.ofSeconds(60), isolatedDir, clock, 1, eventFactory, pluginMetrics);
+
+        final Span leafServerSpan = createMockSpanWithIds("leaf-service", "GET /api/test",
+                "SPAN_KIND_SERVER", "1111111111111111", "", "aaaaaaaaaaaaaaaa");
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("deployment.environment.name", "production");
+        final Map<String, Object> resource = new HashMap<>();
+        resource.put("attributes", resourceAttrs);
+        when(leafServerSpan.getResource()).thenReturn(resource);
+        // Scope present with NO "attributes" key — the trigger for Bug 1.
+        final Map<String, Object> scope = new HashMap<>();
+        scope.put("name", "my-tracer");
+        when(leafServerSpan.getScope()).thenReturn(scope);
+
+        try {
+            isolatedProcessor.doExecute(Collections.singletonList(new Record<>(leafServerSpan)));
+            isolatedProcessor.doExecute(Collections.emptyList());
+            final Collection<Record<Event>> result = isolatedProcessor.doExecute(Collections.emptyList());
+
+            assertNotNull(result);
+            final Record<Event> serviceMapEvent = result.stream()
+                    .filter(r -> r.getData().getMetadata() != null
+                            && "SERVICE_MAP".equals(r.getData().getMetadata().getEventType()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected at least one SERVICE_MAP event"));
+            assertThat(serviceMapEvent.getData().get("sourceNode/keyAttributes/environment", String.class),
+                    equalTo("production"));
+        } finally {
+            isolatedProcessor.shutdown();
+        }
+    }
+
     // Helper method to create mock spans
     private Span createMockSpan(String serviceName, String operationName, String spanKind) {
         Span mockSpan = mock(Span.class);

--- a/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessorTest.java
+++ b/data-prepper-plugins/otel-apm-service-map-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otel_apm_service_map/OTelApmServiceMapProcessorTest.java
@@ -1349,10 +1349,14 @@ class OTelApmServiceMapProcessorTest extends BaseDataPrepperPluginStandardTestSu
 
         final BaseEventBuilder<Event> eventBuilder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
         when(eventFactory.eventBuilder(any())).thenReturn(eventBuilder);
-        doAnswer((a) -> { eventMetadata = a.getArgument(0); return eventBuilder; })
-                .when(eventBuilder).withEventMetadata(any());
-        doAnswer((a) -> { eventData = a.getArgument(0); return eventBuilder; })
-                .when(eventBuilder).withData(any());
+        doAnswer((a) -> {
+            eventMetadata = a.getArgument(0);
+            return eventBuilder;
+        }).when(eventBuilder).withEventMetadata(any());
+        doAnswer((a) -> {
+            eventData = a.getArgument(0);
+            return eventBuilder;
+        }).when(eventBuilder).withData(any());
         doAnswer((a) -> JacksonEvent.builder()
                 .withEventMetadata(eventMetadata).withData(eventData).build())
                 .when(eventBuilder).build();

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/common/OTelSpanDerivationUtil.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/common/OTelSpanDerivationUtil.java
@@ -109,7 +109,13 @@ public class OTelSpanDerivationUtil {
                 putAttribute(span, DERIVED_REMOTE_SERVICE_ATTRIBUTE, remoteOperationAndService.getService());
             }
 
-            final String environment = computeEnvironment(spanAttributes);
+            // Build combined attributes including resource for environment derivation
+            final Map<String, Object> combinedAttributes = spanAttributes != null ? new HashMap<>(spanAttributes) : new HashMap<>();
+            final Map<String, Object> resource = span.getResource();
+            if (resource != null) {
+                combinedAttributes.put("resource", resource);
+            }
+            final String environment = computeEnvironment(combinedAttributes);
 
             // Add derived attributes using our safe attribute setting method
             putAttribute(span, DERIVED_FAULT_ATTRIBUTE, String.valueOf(errorFault.fault));

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/common/ServiceEnvironmentProviders.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/common/ServiceEnvironmentProviders.java
@@ -39,26 +39,73 @@ class ServiceEnvironmentProviders {
         return "generic:default";
     }
 
+    /**
+     * Get an attribute by checking span-level attributes first, then resource attributes.
+     */
+    private static String getAttributeFromSpanOrResource(final Map<String, Object> spanAttributes,
+                                                          final Map<String, Object> resourceAttributes,
+                                                          final String key) {
+        String value = getStringAttribute(spanAttributes, key);
+        if (value == null && resourceAttributes != null) {
+            value = getStringAttribute(resourceAttributes, key);
+        }
+        return value;
+    }
+
+    /**
+     * Try to extract resource attributes from the nested structure: spanAttributes["resource"]["attributes"]
+     */
+    private static Map<String, Object> extractResourceAttributes(final Map<String, Object> spanAttributes) {
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> resourceAttrs = (Map<String, Object>)
+                ((Map<String, Object>) spanAttributes.get("resource")).get("attributes");
+            return resourceAttrs;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
     public static String getAwsServiceEnvironment(final Map<String, Object> spanAttributes) {
         try {
-            String cloudPlatform = getStringAttribute(spanAttributes, "cloud.platform");
-            if (cloudPlatform != null && cloudPlatform.equals("aws_api_gateway")) {
-                return "api-gateway:"+getStringAttribute(spanAttributes, "aws.api_gateway.stage");
+            final Map<String, Object> resourceAttributes = extractResourceAttributes(spanAttributes);
+
+            String cloudPlatform = getAttributeFromSpanOrResource(spanAttributes, resourceAttributes, "cloud.platform");
+            if ("aws_api_gateway".equals(cloudPlatform)) {
+                String stage = getAttributeFromSpanOrResource(spanAttributes, resourceAttributes, "aws.api_gateway.stage");
+                return "api-gateway:" + stage;
             }
-            if (cloudPlatform != null && cloudPlatform.equals("aws_ec2")) {
+            if ("aws_ec2".equals(cloudPlatform)) {
                 return "ec2:default";
             }
-            String cloudResourceId = getStringAttribute(spanAttributes, "cloud.resource_id");
-            String invokedArn = getStringAttribute(spanAttributes, "aws.lambda.invoked_arn");
-            if (cloudResourceId != null && cloudResourceId.startsWith("arn:aws:lambda:") || invokedArn != null) {
+            if ("aws_ecs".equals(cloudPlatform)) {
+                String launchType = getAttributeFromSpanOrResource(spanAttributes, resourceAttributes, "aws.ecs.launchtype");
+                if ("fargate".equals(launchType)) {
+                    return "ecs-fargate:default";
+                }
+                if ("ec2".equals(launchType)) {
+                    return "ecs-ec2:default";
+                }
+                return "ecs:default";
+            }
+            if ("aws_eks".equals(cloudPlatform)) {
+                return "eks:default";
+            }
+            if ("aws_elastic_beanstalk".equals(cloudPlatform)) {
+                return "elastic-beanstalk:default";
+            }
+            if ("aws_lambda".equals(cloudPlatform)) {
                 return "lambda:default";
             }
-        
-            @SuppressWarnings("unchecked")
-            Map<String, Object> resourceAttributes = (Map<String, Object>)
-                ((Map<String, Object>) spanAttributes.get("resource")).get("attributes");
-            String cloudProvider = getStringAttribute(resourceAttributes, "cloud.provider");
-            String faasName = getStringAttribute(resourceAttributes, "faas.name");
+
+            String cloudResourceId = getAttributeFromSpanOrResource(spanAttributes, resourceAttributes, "cloud.resource_id");
+            String invokedArn = getAttributeFromSpanOrResource(spanAttributes, resourceAttributes, "aws.lambda.invoked_arn");
+            if ((cloudResourceId != null && cloudResourceId.startsWith("arn:aws:lambda:")) || invokedArn != null) {
+                return "lambda:default";
+            }
+
+            String cloudProvider = resourceAttributes != null ? getStringAttribute(resourceAttributes, "cloud.provider") : null;
+            String faasName = resourceAttributes != null ? getStringAttribute(resourceAttributes, "faas.name") : null;
             if (cloudProvider != null && cloudProvider.equals("aws") && faasName != null) {
                 return "lambda:default";
             }

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/OTelSpanDerivationUtilTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/OTelSpanDerivationUtilTest.java
@@ -10,12 +10,12 @@
 
 package org.opensearch.dataprepper.plugins.otel.common;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.trace.Span;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,12 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
 
 class OTelSpanDerivationUtilTest {
 
@@ -553,12 +551,13 @@ class OTelSpanDerivationUtilTest {
         assertEquals("10.0.0.1:8080", result.getService());
     }
 
-    // ---------------------------------------------------------------------------------
-    // deriveAttributesForSpan(Span) coverage — guards #6786 Bug 2 (resource is now
-    // included when computing environment) and the Bug 3 + #6787 paths through
-    // ServiceEnvironmentProviders.
-    // ---------------------------------------------------------------------------------
-
+    /**
+     * Builds a {@link Span} mock with {@code SPAN_KIND_SERVER} suitable for exercising
+     * {@link OTelSpanDerivationUtil#deriveAttributesForSpan(Span)}. The supplied {@code attributes}
+     * map is wired so that calls to {@code span.put("attributes", ...)} update it in place — the
+     * test can then read derived attributes such as {@code derived.environment} directly from the
+     * map.
+     */
     private static Span newServerMockSpan(final Map<String, Object> attributes,
                                           final Map<String, Object> resource) {
         return newMockSpan("SPAN_KIND_SERVER", attributes, resource);
@@ -591,6 +590,15 @@ class OTelSpanDerivationUtilTest {
         resource.put("attributes", attrs);
         return resource;
     }
+
+    /**
+     * Verifies that {@link OTelSpanDerivationUtil#deriveAttributesForSpan} (and
+     * {@link OTelSpanDerivationUtil#deriveServerSpanAttributes}) populate {@code derived.environment}
+     * by reading the span's {@code resource} attributes — guarding the Bug 2 fix from issue #6786 and
+     * the platform-detection paths added by issue #6787.
+     */
+    @Nested
+    class DeriveAttributesForSpan {
 
     @Test
     void deriveAttributesForSpan_setsDerivedEnvironmentToDeploymentEnvironmentName_fromResource() {
@@ -745,5 +753,6 @@ class OTelSpanDerivationUtilTest {
 
         assertEquals("production", serverAttributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
         verify(clientSpan, never()).put(anyString(), any());
+    }
     }
 }

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/OTelSpanDerivationUtilTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/OTelSpanDerivationUtilTest.java
@@ -11,12 +11,25 @@
 package org.opensearch.dataprepper.plugins.otel.common;
 
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.trace.Span;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
 class OTelSpanDerivationUtilTest {
 
@@ -538,5 +551,199 @@ class OTelSpanDerivationUtilTest {
 
         assertEquals("UnknownRemoteOperation", result.getOperation());
         assertEquals("10.0.0.1:8080", result.getService());
+    }
+
+    // ---------------------------------------------------------------------------------
+    // deriveAttributesForSpan(Span) coverage — guards #6786 Bug 2 (resource is now
+    // included when computing environment) and the Bug 3 + #6787 paths through
+    // ServiceEnvironmentProviders.
+    // ---------------------------------------------------------------------------------
+
+    private static Span newServerMockSpan(final Map<String, Object> attributes,
+                                          final Map<String, Object> resource) {
+        return newMockSpan("SPAN_KIND_SERVER", attributes, resource);
+    }
+
+    private static Span newMockSpan(final String kind,
+                                    final Map<String, Object> attributes,
+                                    final Map<String, Object> resource) {
+        final Span span = mock(Span.class);
+        lenient().when(span.getKind()).thenReturn(kind);
+        lenient().when(span.getName()).thenReturn("GET /api");
+        lenient().when(span.getStatus()).thenReturn(Map.of("code", "OK"));
+        lenient().when(span.getSpanId()).thenReturn("1122334455667788");
+        lenient().when(span.getAttributes()).thenReturn(attributes);
+        lenient().when(span.getResource()).thenReturn(resource);
+        if (attributes != null) {
+            lenient().doAnswer(invocation -> {
+                @SuppressWarnings("unchecked")
+                final Map<String, Object> updated = (Map<String, Object>) invocation.getArgument(1);
+                attributes.clear();
+                attributes.putAll(updated);
+                return null;
+            }).when(span).put(eq("attributes"), any(Map.class));
+        }
+        return span;
+    }
+
+    private static Map<String, Object> resourceWithAttributes(final Map<String, Object> attrs) {
+        final Map<String, Object> resource = new HashMap<>();
+        resource.put("attributes", attrs);
+        return resource;
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentToDeploymentEnvironmentName_fromResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        attributes.put("http.method", "GET");
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("deployment.environment.name", "production");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("production", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentEc2Default_whenCloudPlatformAwsEc2InResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ec2");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("ec2:default", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentApiGatewayWithStage_whenBothInResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_api_gateway");
+        resourceAttrs.put("aws.api_gateway.stage", "prod");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("api-gateway:prod", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentLambdaDefault_whenInvokedArnInResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("aws.lambda.invoked_arn", "arn:aws:lambda:us-east-1:123:function:f");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("lambda:default", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentEcsFargate_whenCloudPlatformAndLaunchTypeInResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ecs");
+        resourceAttrs.put("aws.ecs.launchtype", "fargate");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("ecs-fargate:default", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentEks_whenCloudPlatformAwsEksInResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_eks");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("eks:default", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentElasticBeanstalk_whenCloudPlatformInResource() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_elastic_beanstalk");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("elastic-beanstalk:default", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_setsDerivedEnvironmentGenericDefault_whenResourceIsNull() {
+        final Map<String, Object> attributes = new HashMap<>();
+        final Span span = newServerMockSpan(attributes, null);
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("generic:default", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveAttributesForSpan_doesNotThrow_whenSpanAttributesIsNull() {
+        // Span#getAttributes() returns null, but the resource still has the env signal.
+        // The resulting attribute map starts from a fresh HashMap rather than copying
+        // a null map, so the only expectation is that no exception escapes.
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("deployment.environment.name", "production");
+
+        final Span span = newServerMockSpan(null, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        // No assertion on attributes content (the mock has no backing map);
+        // success is reaching this line without throwing.
+        assertTrue(true);
+    }
+
+    @Test
+    void deriveAttributesForSpan_preservesExistingSpanAttributesAfterDerivation() {
+        final Map<String, Object> attributes = new HashMap<>();
+        attributes.put("http.method", "GET");
+        attributes.put("http.target", "/api/test");
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("deployment.environment.name", "production");
+
+        final Span span = newServerMockSpan(attributes, resourceWithAttributes(resourceAttrs));
+
+        OTelSpanDerivationUtil.deriveAttributesForSpan(span);
+
+        assertEquals("GET", attributes.get("http.method"));
+        assertEquals("/api/test", attributes.get("http.target"));
+        assertEquals("production", attributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+    }
+
+    @Test
+    void deriveServerSpanAttributes_skipsClientSpansAndProcessesServerSpans_withResourceEnv() {
+        final Map<String, Object> serverAttributes = new HashMap<>();
+        final Map<String, Object> clientAttributes = new HashMap<>();
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("deployment.environment.name", "production");
+        final Map<String, Object> resource = resourceWithAttributes(resourceAttrs);
+
+        final Span serverSpan = newServerMockSpan(serverAttributes, resource);
+        final Span clientSpan = newMockSpan("SPAN_KIND_CLIENT", clientAttributes, resource);
+
+        OTelSpanDerivationUtil.deriveServerSpanAttributes(Arrays.asList(serverSpan, clientSpan));
+
+        assertEquals("production", serverAttributes.get(OTelSpanDerivationUtil.DERIVED_ENVIRONMENT_ATTRIBUTE));
+        verify(clientSpan, never()).put(anyString(), any());
     }
 }

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/ServiceEnvironmentProvidersTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/ServiceEnvironmentProvidersTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.otel.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ServiceEnvironmentProvidersTest {
+
+    private static Map<String, Object> spanAttributesWithResourceAttributes(final Map<String, Object> resourceAttrs) {
+        final Map<String, Object> resource = new HashMap<>();
+        resource.put("attributes", resourceAttrs);
+        final Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("resource", resource);
+        return spanAttributes;
+    }
+
+    // -----------------------------------------------------------------------
+    // Bug-3 fix coverage (#6786): resource-attribute fallback for AWS lookups.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getAwsServiceEnvironment_returnsEc2_whenCloudPlatformInResourceAttributes() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ec2");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("ec2:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsApiGatewayWithStage_whenBothInResourceAttributes() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_api_gateway");
+        resourceAttrs.put("aws.api_gateway.stage", "prod");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("api-gateway:prod", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsLambda_whenInvokedArnInResourceAttributes() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("aws.lambda.invoked_arn", "arn:aws:lambda:us-east-1:123456789012:function:my-fn");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("lambda:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsLambda_whenCloudResourceIdLambdaArnInResourceAttributes() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.resource_id", "arn:aws:lambda:us-east-1:123456789012:function:my-fn");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("lambda:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsEc2_whenCloudPlatformAtTopLevel() {
+        // Regression: legacy callers that flatten resource attributes to the top level.
+        final Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("cloud.platform", "aws_ec2");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(spanAttributes);
+
+        assertEquals("ec2:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_prefersTopLevelOverResource_whenBothPresent() {
+        // Span-level attributes take precedence over resource attributes for the same key.
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_api_gateway");
+
+        final Map<String, Object> spanAttributes = spanAttributesWithResourceAttributes(resourceAttrs);
+        spanAttributes.put("cloud.platform", "aws_ec2");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(spanAttributes);
+
+        assertEquals("ec2:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsLambda_whenCloudProviderAndFaasNameInResourceAttributes() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.provider", "aws");
+        resourceAttrs.put("faas.name", "my-fn");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("lambda:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsNull_whenResourceMapHasNullAttributes() {
+        final Map<String, Object> resource = new HashMap<>();
+        resource.put("attributes", null);
+        final Map<String, Object> spanAttributes = new HashMap<>();
+        spanAttributes.put("resource", resource);
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(spanAttributes);
+
+        assertNull(env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsNull_whenSpanAttributesIsNull() {
+        assertNull(ServiceEnvironmentProviders.getAwsServiceEnvironment(null));
+    }
+
+    @Test
+    void getDeploymentEnvironment_unchangedAfterRefactor() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("deployment.environment.name", "staging");
+
+        final String env = ServiceEnvironmentProviders.getDeploymentEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("staging", env);
+    }
+
+    // -----------------------------------------------------------------------
+    // #6787 — additional AWS platform support.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getAwsServiceEnvironment_returnsEcsFargate_whenCloudPlatformAwsEcsAndLaunchTypeFargate() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ecs");
+        resourceAttrs.put("aws.ecs.launchtype", "fargate");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("ecs-fargate:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsEcsEc2_whenCloudPlatformAwsEcsAndLaunchTypeEc2() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ecs");
+        resourceAttrs.put("aws.ecs.launchtype", "ec2");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("ecs-ec2:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsEcsDefault_whenCloudPlatformAwsEcsAndLaunchTypeMissing() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ecs");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("ecs:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsEcsDefault_whenCloudPlatformAwsEcsAndLaunchTypeUnknown() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_ecs");
+        resourceAttrs.put("aws.ecs.launchtype", "external");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("ecs:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsEks_whenCloudPlatformAwsEks() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_eks");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("eks:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsElasticBeanstalk_whenCloudPlatformAwsElasticBeanstalk() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_elastic_beanstalk");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("elastic-beanstalk:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_returnsLambda_whenCloudPlatformAwsLambda() {
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("cloud.platform", "aws_lambda");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(
+                spanAttributesWithResourceAttributes(resourceAttrs));
+
+        assertEquals("lambda:default", env);
+    }
+
+    @Test
+    void getAwsServiceEnvironment_resourceFallbackForLaunchType_whenAwsEcsLaunchtypeInResource() {
+        // Platform at top level, launch type only in resource attributes — both must be consulted.
+        final Map<String, Object> resourceAttrs = new HashMap<>();
+        resourceAttrs.put("aws.ecs.launchtype", "fargate");
+
+        final Map<String, Object> spanAttributes = spanAttributesWithResourceAttributes(resourceAttrs);
+        spanAttributes.put("cloud.platform", "aws_ecs");
+
+        final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(spanAttributes);
+
+        assertEquals("ecs-fargate:default", env);
+    }
+}

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/ServiceEnvironmentProvidersTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/common/ServiceEnvironmentProvidersTest.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.otel.common;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -28,9 +29,13 @@ class ServiceEnvironmentProvidersTest {
         return spanAttributes;
     }
 
-    // -----------------------------------------------------------------------
-    // Bug-3 fix coverage (#6786): resource-attribute fallback for AWS lookups.
-    // -----------------------------------------------------------------------
+    /**
+     * Verifies that the AWS environment lookup falls back to {@code resource.attributes} when the
+     * relevant keys are not present at the span-attribute top level. This is the path that was
+     * broken before issue #6786.
+     */
+    @Nested
+    class ResourceAttributeFallback {
 
     @Test
     void getAwsServiceEnvironment_returnsEc2_whenCloudPlatformInResourceAttributes() {
@@ -141,10 +146,14 @@ class ServiceEnvironmentProvidersTest {
 
         assertEquals("staging", env);
     }
+    }
 
-    // -----------------------------------------------------------------------
-    // #6787 — additional AWS platform support.
-    // -----------------------------------------------------------------------
+    /**
+     * Verifies environment derivation for AWS platforms added by issue #6787 (ECS with launch
+     * type, EKS, Elastic Beanstalk, and Lambda detected via {@code cloud.platform}).
+     */
+    @Nested
+    class AdditionalAwsPlatforms {
 
     @Test
     void getAwsServiceEnvironment_returnsEcsFargate_whenCloudPlatformAwsEcsAndLaunchTypeFargate() {
@@ -238,5 +247,6 @@ class ServiceEnvironmentProvidersTest {
         final String env = ServiceEnvironmentProviders.getAwsServiceEnvironment(spanAttributes);
 
         assertEquals("ecs-fargate:default", env);
+    }
     }
 }


### PR DESCRIPTION
### Description

## Summary
- Fixes three bugs (#6786) that made `attributes.derived.environment` and `keyAttributes.environment` always resolve to `generic:default` for traces ingested via the OTLP source, even when `deployment.environment.name`, `cloud.platform=aws_ec2|aws_api_gateway`, or `aws.lambda.invoked_arn` were set as resource attributes.
- Extends `cloud.platform` detection (#6787) to cover EKS, ECS (with Fargate / EC2 launch-type distinction), Elastic Beanstalk, and Lambda-via-platform. App Runner is intentionally skipped because the AWS service is being deprecated.
- Documents the full environment-derivation precedence and supported attribute keys in the processor README.

## Bug fixes 
- `OTelApmServiceMapProcessor.extractSpanAttributes` had a variable-name typo (`if (attributes != null)`) that caused `putAll(null)` to throw whenever the instrumentation scope had no attributes — the outer catch then discarded the entire combined map, including the `resource`.
- `OTelSpanDerivationUtil.deriveAttributesForSpan` never passed the span's resource into `computeEnvironment`, so the deployment-environment fallback had no data to read.
- `ServiceEnvironmentProviders.getAwsServiceEnvironment` only inspected span-level attributes for `cloud.platform`, `cloud.resource_id`, `aws.lambda.invoked_arn`, and `aws.api_gateway.stage`; with the OTLP source these live in `resource.attributes`. Refactored to fall back through to the resource attribute map.

## New AWS platform support 
| `cloud.platform`           | `environment` value         |
|----------------------------|-----------------------------|
| `aws_ecs` + Fargate        | `ecs-fargate:default`       |
| `aws_ecs` + EC2            | `ecs-ec2:default`           |
| `aws_ecs` (launchtype absent or other) | `ecs:default`   |
| `aws_eks`                  | `eks:default`               |
| `aws_elastic_beanstalk`    | `elastic-beanstalk:default` |
| `aws_lambda`               | `lambda:default`            |

Attribute names follow the OTel semantic conventions
(https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/
and https://opentelemetry.io/docs/specs/semconv/registry/attributes/aws/).
 
### Issues Resolved
Fixes #6787
Fixes #6786
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
