### PR TITLE
Fix thread safety in dissect processor by eliminating mutable shared state

### DIFF
--- a/data-prepper-plugins/dissect-processor/build.gradle
+++ b/data-prepper-plugins/dissect-processor/build.gradle
@@ -29,10 +29,6 @@ test {
     useJUnitPlatform()
 }
 
-tasks.withType(Zip).configureEach {
-    zip64 = true
-}
-
 jmh {
     profilers = ['gc']
 }

--- a/data-prepper-plugins/dissect-processor/build.gradle
+++ b/data-prepper-plugins/dissect-processor/build.gradle
@@ -9,6 +9,7 @@
 
 plugins {
     id 'java'
+    id 'data-prepper.jmh'
 }
 
 
@@ -21,8 +22,17 @@ dependencies {
     testImplementation project(':data-prepper-plugins:log-generator-source')
     testImplementation project(':data-prepper-test:test-common')
     implementation libs.commons.lang3
+    jmh project(':data-prepper-api')
 }
 
 test {
     useJUnitPlatform()
+}
+
+tasks.withType(Zip).configureEach {
+    zip64 = true
+}
+
+jmh {
+    profilers = ['gc']
 }

--- a/data-prepper-plugins/dissect-processor/src/jmh/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorBenchmark.java
+++ b/data-prepper-plugins/dissect-processor/src/jmh/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorBenchmark.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(2)
+@Threads(4)
+@Warmup(iterations = 1, time = 2)
+@Measurement(iterations = 5, time = 10)
+public class DissectProcessorBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        Dissector dissector;
+        String input;
+
+        @Setup
+        public void setUp() {
+            dissector = new Dissector("%{timestamp} %{level} %{message}");
+            input = "2024-01-15 ERROR service crashed";
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public Object benchmark_dissect(BenchmarkState state) {
+        return state.dissector.dissectText(state.input);
+    }
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Delimiter.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Delimiter.java
@@ -11,46 +11,9 @@ package org.opensearch.dataprepper.plugins.processor.dissect;
 
 public class Delimiter {
     private final String delimiterString;
-    private int start = -1;
-    private int end = -1;
-    private Delimiter next = null;
-
-    private Delimiter prev = null;
 
     public Delimiter(String delimiterString) {
         this.delimiterString = delimiterString;
-    }
-
-    public int getStart() {
-        return start;
-    }
-
-    public void setStart(int ind) {
-        start = ind;
-    }
-
-    public int getEnd() {
-        return end;
-    }
-
-    public void setEnd(int ind) {
-        end = ind;
-    }
-
-    public Delimiter getNext() {
-        return next;
-    }
-
-    public void setNext(Delimiter nextDelimiter) {
-        next = nextDelimiter;
-    }
-
-    public Delimiter getPrev() {
-        return prev;
-    }
-
-    public void setPrev(Delimiter prevDelimiter) {
-        prev = prevDelimiter;
     }
 
     @Override

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
@@ -15,13 +15,11 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
-import org.opensearch.dataprepper.model.annotations.SingleThread;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.plugins.processor.dissect.Fields.Field;
 import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 import org.opensearch.dataprepper.typeconverter.TypeConverter;
 import org.slf4j.Logger;
@@ -29,12 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-
-@SingleThread
 @DataPrepperPlugin(name = "dissect", pluginType = Processor.class, pluginConfigurationType = DissectProcessorConfig.class)
 public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(DissectProcessor.class);
@@ -96,16 +91,15 @@ public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Ev
         Dissector dissector = dissectorMap.get(field);
         boolean isDeleteSourceOnSuccessfulDissect = dissectConfig.isDeleteSourceRequested();
         String text = event.get(field, String.class);
-        if (dissector.dissectText(text)) {
-            List<Field> dissectedFields = dissector.getDissectedFields();
-            for(Field disectedField: dissectedFields) {
-                String dissectFieldName = disectedField.getKey();
-                Object dissectFieldValue = convertTargetType(dissectFieldName,disectedField.getValue());
-                event.put(disectedField.getKey(), dissectFieldValue);
-            }
-            if (isDeleteSourceOnSuccessfulDissect) {
-                event.delete(field);
-            }
+        Map<String, String> dissectedFields = dissector.dissectText(text);
+        if (dissectedFields == null) {
+            return;
+        }
+        for(Map.Entry<String, String> entry: dissectedFields.entrySet()) {
+            event.put(entry.getKey(), convertTargetType(entry.getKey(), entry.getValue()));
+        }
+        if (isDeleteSourceOnSuccessfulDissect) {
+            event.delete(field);
         }
     }
 
@@ -125,8 +119,6 @@ public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Ev
             return fieldValue;
         }
     }
-
-
 
     @Override
     public void prepareForShutdown() {

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
@@ -16,12 +16,12 @@ import org.opensearch.dataprepper.plugins.processor.dissect.Fields.IndirectField
 import org.opensearch.dataprepper.plugins.processor.dissect.Fields.NormalField;
 import org.opensearch.dataprepper.plugins.processor.dissect.Fields.SkipField;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -66,64 +66,82 @@ public class Dissector {
         setFieldsMaps();
     }
 
-    public boolean dissectText(String text){
-        try {
-            if (!setDelimiterIndexes(text)) {
-                return false;
-            }
-            Field head = fieldsList.getFirst();
-            for (final Delimiter delimiter : delimiterList) {
-                int fieldStart = 0;
-                int fieldEnd = delimiter.getStart();
-                if (delimiter.getPrev() == null && delimiter.getStart() == 0) {
-                    continue;
-                }
-                if (delimiter.getPrev() != null || delimiter.getStart() == 0) {
-                    fieldStart = delimiter.getPrev().getEnd() + 1;
-                }
-                head.setValue(text.substring(fieldStart, fieldEnd));
-                head = head.getNext();
-            }
-            if (delimiterList.getLast().getEnd() != text.length() - 1) {
-                int fieldStart = delimiterList.getLast().getEnd() + 1;
-                int fieldEnd = text.length();
-                head.setValue(text.substring(fieldStart, fieldEnd));
-            }
-            return true;
-        } catch (Exception e) {
-            return false;
+    public Map<String, String> dissectText(String text) {
+        if (text == null) {
+            return null;
         }
+        int n = delimiterList.size();
+        int[] delimStarts = new int[n];
+        int[] delimEnds = new int[n];
+        if (!computeDelimiterPositions(text, delimStarts, delimEnds, n)) {
+            return null;
+        }
+        Map<Field, String> localValues = new HashMap<>(); // keyed by identity — same Field instances used for put and get
+        Field head = fieldsList.getFirst();
+        for (int i = 0; i < n; i++) {
+            int fieldStart = 0;
+            int fieldEnd = delimStarts[i];
+            if (i == 0 && delimStarts[i] == 0) {
+                continue;
+            }
+            if (i > 0) {
+                fieldStart = delimEnds[i - 1] + 1;
+            }
+            if (head == null) {
+                return null;
+            }
+            String val = text.substring(fieldStart, fieldEnd);
+            localValues.put(head, head.isStripTrailing() ? val.stripTrailing() : val);
+            head = head.getNext();
+        }
+        if (delimEnds[n - 1] != text.length() - 1) {
+            if (head == null) {
+                return null;
+            }
+            String val = text.substring(delimEnds[n - 1] + 1);
+            localValues.put(head, head.isStripTrailing() ? val.stripTrailing() : val);
+        }
+        return getDissectedFields(localValues);
     }
 
-    public List<Field> getDissectedFields(){
-        final List<Field> dissectedFields = new ArrayList<>();
-        Map<String, AppendField> appendFieldMap = getAppendedFields(unAppendedFieldsMap);
+    private Map<String, String> getDissectedFields(Map<Field, String> localValues) {
+        final Map<String, String> results = new HashMap<>();
+        Map<String, String> appendFieldMap = getAppendedFields(localValues);
 
-        dissectedFields.addAll(normalFieldMap.values());
-        dissectedFields.addAll(appendFieldMap.values());
-
-        for(final Field indirectField : indirectFieldMap.values()){
-            if(normalFieldMap.containsKey(indirectField.getKey())){
-                indirectField.setKey(normalFieldMap.get(indirectField.getKey()).getValue());
+        for (NormalField templateField : normalFieldMap.values()) {
+            String val = localValues.get(templateField);
+            if (val != null) {
+                results.put(templateField.getKey(), val);
             }
-            if(skipFieldMap.containsKey(indirectField.getKey())){
-                indirectField.setKey(skipFieldMap.get(indirectField.getKey()).getValue());
-            }
-            if(appendFieldMap.containsKey(indirectField.getKey())){
-                indirectField.setKey(appendFieldMap
-                                             .get(indirectField.getKey()).getValue());
-            }
-            dissectedFields.add(indirectField);
         }
 
-        return dissectedFields;
+        for (Map.Entry<String, String> entry : appendFieldMap.entrySet()) {
+            results.put(entry.getKey(), entry.getValue());
+        }
+
+        for (IndirectField templateField : indirectFieldMap.values()) {
+            String templateKey = templateField.getKey();
+            String resolvedKey = null;
+            if (normalFieldMap.containsKey(templateKey)) {
+                resolvedKey = localValues.get(normalFieldMap.get(templateKey));
+            } else if (skipFieldMap.containsKey(templateKey)) {
+                resolvedKey = localValues.get(skipFieldMap.get(templateKey));
+            } else if (appendFieldMap.containsKey(templateKey)) {
+                resolvedKey = appendFieldMap.get(templateKey);
+            }
+            String val = localValues.get(templateField);
+            if (resolvedKey != null && val != null) {
+                results.put(resolvedKey, val);
+            }
+        }
+        return results;
     }
 
     private void setFieldsMaps(){
-        this.normalFieldMap = fieldHelper.getNormalFieldMap();
-        this.skipFieldMap = fieldHelper.getSkipFieldMap();
-        this.indirectFieldMap = fieldHelper.getIndirectFieldMap();
-        this.unAppendedFieldsMap = fieldHelper.getAppendFieldMap();
+        this.normalFieldMap = Collections.unmodifiableMap(fieldHelper.getNormalFieldMap());
+        this.skipFieldMap = Collections.unmodifiableMap(fieldHelper.getSkipFieldMap());
+        this.indirectFieldMap = Collections.unmodifiableMap(fieldHelper.getIndirectFieldMap());
+        this.unAppendedFieldsMap = Collections.unmodifiableMap(fieldHelper.getAppendFieldMap());
     }
 
     private void parseFields(String[] fieldsArray){
@@ -150,47 +168,45 @@ public class Dissector {
             if (delimiterString.length() == 0) {
                 continue;
             }
-            Delimiter delimiter = new Delimiter(delimiterString);
-            if (delimiterList.size() == 0) {
-                delimiterList.addLast(delimiter);
-            } else {
-                delimiterList.getLast().setNext(delimiter);
-                delimiter.setPrev(delimiterList.getLast());
-                delimiterList.addLast(delimiter);
-            }
+            delimiterList.addLast(new Delimiter(delimiterString));
         }
     }
 
-    private boolean setDelimiterIndexes(String text){
+    private boolean computeDelimiterPositions(String text, int[] starts, int[] ends, int n) {
+        int i = 0;
         for (Delimiter delimiter : delimiterList) {
             int prevEnd = 0;
-            if (delimiter.getPrev() != null) {
-                prevEnd = delimiter.getPrev().getEnd() + 1;
+            if (i > 0) {
+                prevEnd = ends[i - 1] + 1;
             }
             String delimiterString = delimiter.toString();
             int start = text.indexOf(delimiterString, prevEnd);
+            if (start < 0) {
+                return false;
+            }
             if (delimiterString.trim().isEmpty()) {
                 start = start + findLastWhitespaceIndex(text.substring(start), delimiterString.length());
             }
-            int end = start + delimiterString.length() -1;
-            if (start < 0 || end > text.length()) {
+            int end = start + delimiterString.length() - 1;
+            if (end > text.length()) {
                 return false;
             }
-            delimiter.setStart(start);
-            delimiter.setEnd(end);
+            starts[i] = start;
+            ends[i] = end;
+            i++;
         }
         return true;
     }
 
-    private Map<String, AppendField> getAppendedFields(Map<String, List<AppendField>> unAppendedFieldsMap){
-        final Map<String, AppendField> appendFieldMap = new HashMap<>();
-        for(final String key : unAppendedFieldsMap.keySet()){
-            List<AppendField> appendFields = unAppendedFieldsMap.get(key);
-            Collections.sort(appendFields);
-            String value = appendFields.stream().map(AppendField::getValue).collect(Collectors.joining());
-            AppendField sortedField = new AppendField(key);
-            sortedField.setValue(value);
-            appendFieldMap.put(sortedField.getKey(), sortedField);
+    private Map<String, String> getAppendedFields(Map<Field, String> localValues) {
+        final Map<String, String> appendFieldMap = new HashMap<>();
+        for (Map.Entry<String, List<AppendField>> entry : unAppendedFieldsMap.entrySet()) {
+            List<AppendField> copy = new ArrayList<>(entry.getValue());
+            Collections.sort(copy);
+            String value = copy.stream()
+                    .map(f -> localValues.getOrDefault(f, ""))
+                    .collect(Collectors.joining());
+            appendFieldMap.put(entry.getKey(), value);
         }
         return appendFieldMap;
     }

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
@@ -135,9 +135,15 @@ public class Dissector {
             } else if (appendFieldMap.containsKey(templateKey)) {
                 resolvedKey = appendFieldMap.get(templateKey);
             }
+            if (resolvedKey == null || resolvedKey.isEmpty()) {
+                LOG.debug("Indirect field reference %{&{}} could not be resolved; dropping value", templateKey);
+                continue;
+            }
             String val = localValues.get(templateField);
-            if (resolvedKey != null && !resolvedKey.isEmpty() && val != null) {
+            if (val != null) {
                 results.put(resolvedKey, val);
+            } else {
+                LOG.debug("Indirect field reference %{&{}} had no captured value; dropping", templateKey);
             }
         }
         return results;

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
@@ -26,7 +26,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class Dissector {
+    private static final Logger LOG = LoggerFactory.getLogger(Dissector.class);
     private Map<String, SkipField> skipFieldMap;
     private Map<String, NormalField> normalFieldMap;
     private Map<String, IndirectField> indirectFieldMap;
@@ -76,7 +80,7 @@ public class Dissector {
         if (!computeDelimiterPositions(text, delimStarts, delimEnds, n)) {
             return null;
         }
-        Map<Field, String> localValues = new HashMap<>(); // keyed by identity — same Field instances used for put and get
+        Map<Field, String> localValues = new HashMap<>(delimiterList.size());
         Field head = fieldsList.getFirst();
         for (int i = 0; i < n; i++) {
             int fieldStart = 0;
@@ -88,6 +92,7 @@ public class Dissector {
                 fieldStart = delimEnds[i - 1] + 1;
             }
             if (head == null) {
+                LOG.error("Dissect pattern has fewer fields than delimiters found in input");
                 return null;
             }
             String val = text.substring(fieldStart, fieldEnd);
@@ -96,6 +101,7 @@ public class Dissector {
         }
         if (delimEnds[n - 1] != text.length() - 1) {
             if (head == null) {
+                LOG.error("Dissect pattern has fewer fields than segments found in input");
                 return null;
             }
             String val = text.substring(delimEnds[n - 1] + 1);
@@ -105,7 +111,7 @@ public class Dissector {
     }
 
     private Map<String, String> getDissectedFields(Map<Field, String> localValues) {
-        final Map<String, String> results = new HashMap<>();
+        final Map<String, String> results = new HashMap<>(normalFieldMap.size() + unAppendedFieldsMap.size() + indirectFieldMap.size());
         Map<String, String> appendFieldMap = getAppendedFields(localValues);
 
         for (NormalField templateField : normalFieldMap.values()) {
@@ -130,7 +136,7 @@ public class Dissector {
                 resolvedKey = appendFieldMap.get(templateKey);
             }
             String val = localValues.get(templateField);
-            if (resolvedKey != null && val != null) {
+            if (resolvedKey != null && !resolvedKey.isEmpty() && val != null) {
                 results.put(resolvedKey, val);
             }
         }
@@ -141,7 +147,13 @@ public class Dissector {
         this.normalFieldMap = Collections.unmodifiableMap(fieldHelper.getNormalFieldMap());
         this.skipFieldMap = Collections.unmodifiableMap(fieldHelper.getSkipFieldMap());
         this.indirectFieldMap = Collections.unmodifiableMap(fieldHelper.getIndirectFieldMap());
-        this.unAppendedFieldsMap = Collections.unmodifiableMap(fieldHelper.getAppendFieldMap());
+        Map<String, List<AppendField>> sortedAppendMap = new HashMap<>();
+        for (Map.Entry<String, List<AppendField>> entry : fieldHelper.getAppendFieldMap().entrySet()) {
+            List<AppendField> sorted = new ArrayList<>(entry.getValue());
+            Collections.sort(sorted);
+            sortedAppendMap.put(entry.getKey(), Collections.unmodifiableList(sorted));
+        }
+        this.unAppendedFieldsMap = Collections.unmodifiableMap(sortedAppendMap);
     }
 
     private void parseFields(String[] fieldsArray){
@@ -149,14 +161,9 @@ public class Dissector {
             if(fieldString==null) {
                 return;
             }
-            Field field = fieldHelper.getField(fieldString);
-            if(fieldsList.size()==0) {
-                fieldsList.addLast(field);
-            }
-            else{
-                fieldsList.getLast().setNext(field);
-                fieldsList.addLast(field);
-            }
+            Field lastField = fieldsList.size() > 0 ? fieldsList.getLast() : null;
+            Field field = fieldHelper.getField(fieldString, lastField);
+            fieldsList.addLast(field);
         }
     }
 
@@ -201,9 +208,7 @@ public class Dissector {
     private Map<String, String> getAppendedFields(Map<Field, String> localValues) {
         final Map<String, String> appendFieldMap = new HashMap<>();
         for (Map.Entry<String, List<AppendField>> entry : unAppendedFieldsMap.entrySet()) {
-            List<AppendField> copy = new ArrayList<>(entry.getValue());
-            Collections.sort(copy);
-            String value = copy.stream()
+            String value = entry.getValue().stream()
                     .map(f -> localValues.getOrDefault(f, ""))
                     .collect(Collectors.joining());
             appendFieldMap.put(entry.getKey(), value);

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
@@ -31,10 +31,10 @@ import org.slf4j.LoggerFactory;
 
 public class Dissector {
     private static final Logger LOG = LoggerFactory.getLogger(Dissector.class);
-    private Map<String, SkipField> skipFieldMap;
-    private Map<String, NormalField> normalFieldMap;
-    private Map<String, IndirectField> indirectFieldMap;
-    private Map<String, List<AppendField>> unAppendedFieldsMap;
+    private final Map<String, SkipField> skipFieldMap;
+    private final Map<String, NormalField> normalFieldMap;
+    private final Map<String, IndirectField> indirectFieldMap;
+    private final Map<String, List<AppendField>> unAppendedFieldsMap;
     private final FieldHelper fieldHelper = new FieldHelper();
     private final LinkedList<Field> fieldsList = new LinkedList<>();
     private final LinkedList<Delimiter> delimiterList = new LinkedList<>();
@@ -67,7 +67,16 @@ public class Dissector {
         }
         parseFields(fieldsArray);
         parseDelimiters(delimiterArray);
-        setFieldsMaps();
+        this.normalFieldMap = Collections.unmodifiableMap(fieldHelper.getNormalFieldMap());
+        this.skipFieldMap = Collections.unmodifiableMap(fieldHelper.getSkipFieldMap());
+        this.indirectFieldMap = Collections.unmodifiableMap(fieldHelper.getIndirectFieldMap());
+        Map<String, List<AppendField>> sortedAppendMap = new HashMap<>();
+        for (Map.Entry<String, List<AppendField>> entry : fieldHelper.getAppendFieldMap().entrySet()) {
+            List<AppendField> sorted = new ArrayList<>(entry.getValue());
+            Collections.sort(sorted);
+            sortedAppendMap.put(entry.getKey(), Collections.unmodifiableList(sorted));
+        }
+        this.unAppendedFieldsMap = Collections.unmodifiableMap(sortedAppendMap);
     }
 
     public Map<String, String> dissectText(String text) {
@@ -80,7 +89,7 @@ public class Dissector {
         if (!computeDelimiterPositions(text, delimStarts, delimEnds, n)) {
             return null;
         }
-        Map<Field, String> localValues = new HashMap<>(delimiterList.size());
+        Map<Field, String> localValues = new HashMap<>(fieldsList.size() * 2);
         Field head = fieldsList.getFirst();
         for (int i = 0; i < n; i++) {
             int fieldStart = 0;
@@ -147,19 +156,6 @@ public class Dissector {
             }
         }
         return results;
-    }
-
-    private void setFieldsMaps(){
-        this.normalFieldMap = Collections.unmodifiableMap(fieldHelper.getNormalFieldMap());
-        this.skipFieldMap = Collections.unmodifiableMap(fieldHelper.getSkipFieldMap());
-        this.indirectFieldMap = Collections.unmodifiableMap(fieldHelper.getIndirectFieldMap());
-        Map<String, List<AppendField>> sortedAppendMap = new HashMap<>();
-        for (Map.Entry<String, List<AppendField>> entry : fieldHelper.getAppendFieldMap().entrySet()) {
-            List<AppendField> sorted = new ArrayList<>(entry.getValue());
-            Collections.sort(sorted);
-            sortedAppendMap.put(entry.getKey(), Collections.unmodifiableList(sorted));
-        }
-        this.unAppendedFieldsMap = Collections.unmodifiableMap(sortedAppendMap);
     }
 
     private void parseFields(String[] fieldsArray){

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/AppendField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/AppendField.java
@@ -12,7 +12,7 @@ package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
 public class AppendField extends Field implements Comparable<AppendField> {
     private int index;
     public AppendField(String key) {
-        this.setKey(key);
+        super(key);
     }
 
     public void setIndex(int index){

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/Field.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/Field.java
@@ -11,8 +11,12 @@ package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
 
 public abstract class Field {
     boolean stripTrailing = false;
-    private String key;
+    private final String key;
     private Field next;
+
+    Field(String key) {
+        this.key = key;
+    }
 
     public String getKey() {
         return key;
@@ -22,11 +26,10 @@ public abstract class Field {
         return next;
     }
 
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    public void setNext(Field next) {
+    void setNext(Field next) {
+        if(this.next != null) {
+            throw new IllegalStateException("Field already has a next value set");
+        }
         this.next = next;
     }
 

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/Field.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/Field.java
@@ -12,12 +12,7 @@ package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
 public abstract class Field {
     boolean stripTrailing = false;
     private String key;
-    private String value;
     private Field next;
-
-    public String getValue() {
-        return value;
-    }
 
     public String getKey() {
         return key;
@@ -35,8 +30,8 @@ public abstract class Field {
         this.next = next;
     }
 
-    public void setValue(String value) {
-        this.value = stripTrailing ? value.stripTrailing() : value;
+    public boolean isStripTrailing() {
+        return stripTrailing;
     }
 
 }

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/FieldHelper.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/FieldHelper.java
@@ -40,12 +40,16 @@ public class FieldHelper {
         return appendFieldMap;
     }
 
-    public Field getField(String fieldString) {
+    public Field getField(String fieldString, Field lastField) {
         if (fieldString == null) {
             return null;
         }
         if(fieldString.trim().isEmpty()){
-            return new AppendField("");
+            AppendField emptyField = new AppendField("");
+            if (lastField != null) {
+                lastField.setNext(emptyField);
+            }
+            return emptyField;
         }
 
         Field field = null;
@@ -53,53 +57,54 @@ public class FieldHelper {
         Matcher matcher = prefixPattern.matcher(fieldString);
         if (matcher.matches()) {
             final String notation = matcher.group(1);
-            final String key = matcher.group(2);
+            String key = matcher.group(2);
             if (Objects.equals(notation, "+")) {
+                Matcher indexMatcher = indexPattern.matcher(key);
+                int index = -1;
+                if (indexMatcher.find()) {
+                    index = Integer.parseInt(indexMatcher.group(1));
+                    key = key.substring(0, indexMatcher.start());
+                }
+                Matcher trailingMatcher = appendPattern.matcher(key);
+                boolean stripTrailing = trailingMatcher.find();
+                if (stripTrailing) {
+                    key = trailingMatcher.group(1);
+                }
                 field = new AppendField(key);
-                setAppendIndex((AppendField) field);
-                setStripTrailing(field);
+                if (index >= 0) ((AppendField) field).setIndex(index);
+                field.stripTrailing = stripTrailing;
                 putInAppendMap((AppendField) field);
             } else if (Objects.equals(notation, "?")) {
+                Matcher trailingMatcher = appendPattern.matcher(key);
+                boolean stripTrailing = trailingMatcher.find();
+                if (stripTrailing) {
+                    key = trailingMatcher.group(1);
+                }
                 field = new SkipField(key);
-                setStripTrailing(field);
+                field.stripTrailing = stripTrailing;
                 skipFieldMap.put(field.getKey(), (SkipField) field);
             } else if (Objects.equals(notation, "&")) {
+                Matcher trailingMatcher = appendPattern.matcher(key);
+                boolean stripTrailing = trailingMatcher.find();
+                if (stripTrailing) {
+                    key = trailingMatcher.group(1);
+                }
                 field = new IndirectField(key);
-                setStripTrailing(field);
+                field.stripTrailing = stripTrailing;
                 indirectFieldMap.put(field.getKey(), (IndirectField) field);
             }
         } else {
-            field = new NormalField(fieldString);
-            setStripTrailing(field);
+            Matcher trailingMatcher = appendPattern.matcher(fieldString);
+            boolean stripTrailing = trailingMatcher.find();
+            String key = stripTrailing ? trailingMatcher.group(1) : fieldString;
+            field = new NormalField(key);
+            field.stripTrailing = stripTrailing;
             normalFieldMap.put(field.getKey(), (NormalField) field);
         }
+        if (lastField != null && field != null) {
+            lastField.setNext(field);
+        }
         return field;
-    }
-
-    private void setAppendIndex(AppendField field) {
-        String fieldString = field.getKey();
-        Matcher matcher = indexPattern.matcher(fieldString);
-
-        if (matcher.find()) {
-            String key = fieldString.substring(0, matcher.start());
-            int index = Integer.parseInt(matcher.group(1));
-            field.setKey(key);
-            field.setIndex(index);
-        }
-    }
-
-    private void setStripTrailing(Field field) {
-        if (field == null) {
-            return;
-        }
-
-        String fieldString = field.getKey();
-
-        Matcher matcher = appendPattern.matcher(fieldString);
-        if (matcher.find()) {
-            field.setKey(matcher.group(1));
-            field.stripTrailing = true;
-        }
     }
 
     private void putInAppendMap(AppendField field) {

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/IndirectField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/IndirectField.java
@@ -13,7 +13,7 @@ public class IndirectField extends Field {
 
 
     public IndirectField(String key) {
-        this.setKey(key);
+        super(key);
     }
 
 }

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/NormalField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/NormalField.java
@@ -12,7 +12,7 @@ package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
 public class NormalField extends Field {
 
     public NormalField(String key) {
-        this.setKey(key);
+        super(key);
     }
 
 }

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/SkipField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/SkipField.java
@@ -12,7 +12,7 @@ package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
 public class SkipField extends Field {
 
     public SkipField(String key) {
-        this.setKey(key);
+        super(key);
     }
 
 }

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DelimiterTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DelimiterTest.java
@@ -9,7 +9,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.dissect;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,37 +16,9 @@ import static org.hamcrest.Matchers.is;
 
 class DelimiterTest {
 
-    private static final String DELIMITER_STRING = "test_string";
-    private static final int START_END_INDEX = 3;
-    private static final Delimiter DELIMITER = new Delimiter("test_delimiter");
-    private Delimiter delimiter;
-
-    @BeforeEach
-    public void setUp() {
-        delimiter = new Delimiter(DELIMITER_STRING);
-    }
-
     @Test
-    public void testSetAndGetStart() {
-        delimiter.setStart(START_END_INDEX);
-        assertThat(delimiter.getStart(), is(START_END_INDEX));
-    }
-
-    @Test
-    public void testSetAndGetEnd() {
-        delimiter.setEnd(START_END_INDEX);
-        assertThat(delimiter.getEnd(), is(START_END_INDEX));
-    }
-
-    @Test
-    public void testSetAndGetNext() {
-        delimiter.setNext(DELIMITER);
-        assertThat(delimiter.getNext(), is(DELIMITER));
-    }
-
-    @Test
-    public void testSetAndGetPrev() {
-        delimiter.setPrev(DELIMITER);
-        assertThat(delimiter.getPrev(), is(DELIMITER));
+    public void testToString() {
+        Delimiter delimiter = new Delimiter("test_string");
+        assertThat(delimiter.toString(), is("test_string"));
     }
 }

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorTest.java
@@ -20,17 +20,18 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.plugins.processor.dissect.Fields.AppendField;
-import org.opensearch.dataprepper.plugins.processor.dissect.Fields.Field;
-import org.opensearch.dataprepper.plugins.processor.dissect.Fields.IndirectField;
-import org.opensearch.dataprepper.plugins.processor.dissect.Fields.NormalField;
 import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,13 +73,7 @@ class DissectProcessorTest {
     @Test
     void test_normal_fields_dissect_succeeded() throws NoSuchFieldException, IllegalAccessException {
 
-        Field field1 = new NormalField("field1");
-        Field field2 = new NormalField("field2");
-        field1.setValue("foo");
-        field2.setValue("bar");
-
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(field1, field2));
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "foo", "field2", "bar"));
 
         final DissectProcessor processor = createObjectUnderTest();
         reflectivelySetDissectorMap(processor);
@@ -94,13 +90,7 @@ class DissectProcessorTest {
     @Test
     void test_append_fields_dissect_succeeded() throws NoSuchFieldException, IllegalAccessException {
 
-        Field field1 = new AppendField("field1");
-        Field field2 = new AppendField("field2");
-        field1.setValue("foo");
-        field2.setValue("bar");
-
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(field1, field2));
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "foo", "field2", "bar"));
 
         final DissectProcessor processor = createObjectUnderTest();
         reflectivelySetDissectorMap(processor);
@@ -117,13 +107,7 @@ class DissectProcessorTest {
     @Test
     void test_indirect_fields_dissect_succeeded() throws NoSuchFieldException, IllegalAccessException {
 
-        Field field1 = new IndirectField("field1");
-        Field field2 = new IndirectField("field2");
-        field1.setValue("foo");
-        field2.setValue("bar");
-
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(field1, field2));
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "foo", "field2", "bar"));
 
         final DissectProcessor processor = createObjectUnderTest();
         reflectivelySetDissectorMap(processor);
@@ -138,16 +122,15 @@ class DissectProcessorTest {
     }
 
     @Test
-    void test_dissectText_returns_false() throws NoSuchFieldException, IllegalAccessException {
+    void test_dissectText_returns_null_on_failure() throws NoSuchFieldException, IllegalAccessException {
 
-        when(dissector.dissectText(any(String.class))).thenReturn(false);
+        when(dissector.dissectText(any(String.class))).thenReturn(null);
 
         final DissectProcessor processor = createObjectUnderTest();
         reflectivelySetDissectorMap(processor);
         final Record<Event> record = getEvent("");
         final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
-        // assert event is not modified
         assertThat(dissectedRecords.get(0).getData(), is(record.getData()));
     }
 
@@ -160,19 +143,13 @@ class DissectProcessorTest {
         final Record<Event> record = getEvent("");
         final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
-        // assert event is not modified
         assertThat(dissectedRecords.get(0).getData(), is(record.getData()));
     }
 
     @Test
     void test_target_type_int() throws NoSuchFieldException, IllegalAccessException {
 
-        Field field1 = new IndirectField("field1");
-        Field field2 = new IndirectField("field2");
-        field1.setValue("20");
-        field2.setValue("30");
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(field1, field2));
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "20", "field2", "30"));
 
         Map<String, TargetType> targetsMap = Map.of("field1", TargetType.INTEGER);
         when(dissectConfig.getTargetTypes()).thenReturn(targetsMap);
@@ -193,12 +170,8 @@ class DissectProcessorTest {
 
     @Test
     void test_target_type_bool() throws NoSuchFieldException, IllegalAccessException {
-        Field field1 = new IndirectField("field1");
-        Field field2 = new IndirectField("field2");
-        field1.setValue("true");
-        field2.setValue("30");
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(field1, field2));
+
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "true", "field2", "30"));
 
         Map<String, TargetType> targetsMap = Map.of("field1", TargetType.BOOLEAN);
         when(dissectConfig.getTargetTypes()).thenReturn(targetsMap);
@@ -219,12 +192,8 @@ class DissectProcessorTest {
 
     @Test
     void test_target_type_double() throws NoSuchFieldException, IllegalAccessException {
-        Field field1 = new IndirectField("field1");
-        Field field2 = new IndirectField("field2");
-        field1.setValue("20.0");
-        field2.setValue("30");
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(field1, field2));
+
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "20.0", "field2", "30"));
 
         Map<String, TargetType> targetsMap = Map.of("field1", TargetType.DOUBLE);
         when(dissectConfig.getTargetTypes()).thenReturn(targetsMap);
@@ -276,11 +245,7 @@ class DissectProcessorTest {
     @Test
     void test_delete_source_requested() throws NoSuchFieldException, IllegalAccessException {
 
-        Field dissectedField = new NormalField("level");
-        dissectedField.setValue("WARN");
-
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(dissectedField));
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("level", "WARN"));
         when(dissectConfig.isDeleteSourceRequested()).thenReturn(true);
 
         final DissectProcessor processor = createObjectUnderTest();
@@ -295,11 +260,8 @@ class DissectProcessorTest {
 
     @Test
     void test_delete_source_not_requested() throws NoSuchFieldException, IllegalAccessException {
-        Field dissectedField = new NormalField("level");
-        dissectedField.setValue("WARN");
 
-        when(dissector.dissectText(any(String.class))).thenReturn(true);
-        when(dissector.getDissectedFields()).thenReturn(List.of(dissectedField));
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("level", "WARN"));
         when(dissectConfig.isDeleteSourceRequested()).thenReturn(false);
 
         final DissectProcessor processor = createObjectUnderTest();
@@ -315,7 +277,7 @@ class DissectProcessorTest {
     @Test
     void test_delete_source_requested_dissect_fail() throws NoSuchFieldException, IllegalAccessException {
 
-        when(dissector.dissectText(any(String.class))).thenReturn(false);
+        when(dissector.dissectText(any(String.class))).thenReturn(null);
         when(dissectConfig.isDeleteSourceRequested()).thenReturn(true);
 
         final DissectProcessor processor = createObjectUnderTest();
@@ -324,6 +286,91 @@ class DissectProcessorTest {
         final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(dataPrepperRecord));
 
         assertTrue(dissectedRecords.get(0).getData().containsKey("test"));
+    }
+
+    @Test
+    void test_dissect_when_condition_false_skips_event() throws NoSuchFieldException, IllegalAccessException {
+        final String dissectWhen = UUID.randomUUID().toString();
+        when(dissectConfig.getDissectWhen()).thenReturn(dissectWhen);
+        when(expressionEvaluator.isValidExpressionStatement(dissectWhen)).thenReturn(true);
+        when(expressionEvaluator.evaluateConditional(eq(dissectWhen), any())).thenReturn(false);
+
+        final DissectProcessor processor = createObjectUnderTest();
+        reflectivelySetDissectorMap(processor);
+        final Record<Event> record = getEvent("some text");
+        processor.doExecute(Collections.singletonList(record));
+
+        org.mockito.Mockito.verify(dissector, org.mockito.Mockito.never()).dissectText(any());
+    }
+
+    @Test
+    void test_dissect_when_condition_true_processes_event() throws NoSuchFieldException, IllegalAccessException {
+        final String dissectWhen = UUID.randomUUID().toString();
+        when(dissectConfig.getDissectWhen()).thenReturn(dissectWhen);
+        when(expressionEvaluator.isValidExpressionStatement(dissectWhen)).thenReturn(true);
+        when(expressionEvaluator.evaluateConditional(eq(dissectWhen), any())).thenReturn(true);
+        when(dissector.dissectText(any(String.class))).thenReturn(Map.of("field1", "foo"));
+
+        final DissectProcessor processor = createObjectUnderTest();
+        reflectivelySetDissectorMap(processor);
+        final Record<Event> record = getEvent("some text");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        org.mockito.Mockito.verify(dissector).dissectText(any());
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+    }
+
+    @Test
+    void test_concurrent_doExecute_no_cross_contamination() throws InterruptedException {
+        when(dissectConfig.getMap()).thenReturn(Map.of("message", "%{timestamp} %{level} %{content}"));
+        final DissectProcessor processor = createObjectUnderTest();
+
+        int threadCount = 10;
+        int iterationsPerThread = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        List<String> errors = Collections.synchronizedList(new ArrayList<>());
+
+        for (int t = 0; t < threadCount; t++) {
+            final String timestamp = "2024-01-" + String.format("%02d", t + 1);
+            final String level = "LEVEL" + t;
+            final String content = "content" + t;
+            final String input = timestamp + " " + level + " " + content;
+
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        final Map<String, Object> data = new HashMap<>();
+                        data.put("message", input);
+                        final Record<Event> record = new Record<>(JacksonEvent.builder()
+                                .withData(data).withEventType("event").build());
+                        final List<Record<Event>> results = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+                        final Event resultEvent = results.get(0).getData();
+                        if (!timestamp.equals(resultEvent.get("timestamp", String.class))) {
+                            errors.add("timestamp mismatch: expected " + timestamp + " got " + resultEvent.get("timestamp", String.class));
+                        }
+                        if (!level.equals(resultEvent.get("level", String.class))) {
+                            errors.add("level mismatch: expected " + level + " got " + resultEvent.get("level", String.class));
+                        }
+                        if (!content.equals(resultEvent.get("content", String.class))) {
+                            errors.add("content mismatch: expected " + content + " got " + resultEvent.get("content", String.class));
+                        }
+                    }
+                } catch (Exception e) {
+                    errors.add(e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(doneLatch.await(5, TimeUnit.SECONDS), "Test timed out");
+        executor.shutdown();
+
+        assertTrue(errors.isEmpty(), "Concurrency errors: " + errors);
     }
 
 }

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorTest.java
@@ -131,6 +131,7 @@ class DissectProcessorTest {
         final Record<Event> record = getEvent("");
         final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
+        // assert event is not modified
         assertThat(dissectedRecords.get(0).getData(), is(record.getData()));
     }
 
@@ -143,6 +144,7 @@ class DissectProcessorTest {
         final Record<Event> record = getEvent("");
         final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
+        // assert event is not modified
         assertThat(dissectedRecords.get(0).getData(), is(record.getData()));
     }
 

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectorTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectorTest.java
@@ -10,13 +10,21 @@
 package org.opensearch.dataprepper.plugins.processor.dissect;
 
 import org.junit.jupiter.api.Test;
-import org.opensearch.dataprepper.plugins.processor.dissect.Fields.Field;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DissectorTest {
@@ -24,204 +32,219 @@ class DissectorTest {
     @Test
     void test_normal_field_trailing_spaces(){
         Dissector dissector = createObjectUnderTest(" %{field1} %{field2} ");
-        boolean result = dissector.dissectText(" foo bar ");
+        Map<String, String> result = dissector.dissectText(" foo bar ");
 
-        assertTrue(result);
-
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foo"));
-        assertThat(fields.get(1).getKey(), is("field2"));
-        assertThat(fields.get(1).getValue(), is("bar"));
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertThat(result.get("field1"), is("foo"));
+        assertThat(result.get("field2"), is("bar"));
     }
 
     @Test
     void test_normal_field_without_trailing_spaces(){
         Dissector dissector = createObjectUnderTest("dm1 %{field1} %{field2} dm2");
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foo"));
-        assertThat(fields.get(1).getKey(), is("field2"));
-        assertThat(fields.get(1).getValue(), is("bar"));
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertThat(result.get("field1"), is("foo"));
+        assertThat(result.get("field2"), is("bar"));
     }
 
     @Test
     void test_normal_field_failure_without_delimiters(){
         Dissector dissector = createObjectUnderTest("dm1 %{field1} %{field2} dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar");
-        assertFalse(result);
+        assertNull(dissector.dissectText("dm1 foo bar"));
     }
 
     @Test
     void test_normal_field_failure_with_extra_whitespaces(){
         Dissector dissector = createObjectUnderTest("dm1 %{field1} %{field2} dm2");
 
-        boolean result = dissector.dissectText(" dm1 foo bar dm2");
-        assertFalse(result);
+        assertNull(dissector.dissectText(" dm1 foo bar dm2"));
     }
 
     @Test
     void test_named_skip_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{?field1} %{field2} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("field2"));
-        assertThat(fields.get(0).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field2"), is("bar"));
     }
 
     @Test
     void test_unnamed_skip_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{} %{field2} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("field2"));
-        assertThat(fields.get(0).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field2"), is("bar"));
     }
 
     @Test
     void test_indirect_field_with_skip_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{?field1} %{&field1} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("foo"));
-        assertThat(fields.get(0).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("foo"), is("bar"));
     }
 
     @Test
     void test_indirect_field_with_normal_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{field1} %{&field1} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foo"));
-        assertThat(fields.get(1).getKey(), is("foo"));
-        assertThat(fields.get(1).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.get("field1"), is("foo"));
+        assertThat(result.get("foo"), is("bar"));
     }
 
     @Test
     void test_append_field_without_index(){
         Dissector dissector = createObjectUnderTest("dm1 %{+field1} %{+field1} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foobar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field1"), is("foobar"));
     }
 
     @Test
     void test_append_field_with_index(){
         Dissector dissector = createObjectUnderTest("dm1 %{+field1/2} %{+field1/1} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("barfoo"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field1"), is("barfoo"));
     }
 
     @Test
     void test_append_whitespace_normal_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{field1->} %{field2} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo      bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo      bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foo"));
-        assertThat(fields.get(1).getKey(), is("field2"));
-        assertThat(fields.get(1).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.get("field1"), is("foo"));
+        assertThat(result.get("field2"), is("bar"));
     }
 
     @Test
     void test_append_whitespace_append_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{+field1->} %{+field1} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo      bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo      bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foobar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field1"), is("foobar"));
     }
 
     @Test
     void test_append_whitespace_indirect_field(){
         Dissector dissector = createObjectUnderTest("dm1 %{?field1->} %{&field1} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo      bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo      bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("foo"));
-        assertThat(fields.get(0).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("foo"), is("bar"));
     }
 
     @Test
     void test_skip_fields_with_padding(){
         Dissector dissector = createObjectUnderTest("dm1 %{?field1->} %{?field3} %{field2} dm2");
 
+        Map<String, String> result = dissector.dissectText("dm1 foo     skip   bar dm2");
 
-        boolean result = dissector.dissectText("dm1 foo     skip   bar dm2");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
-
-        assertThat(fields.size(), is(1));
-        assertThat(fields.get(0).getKey(), is("field2"));
-        assertThat(fields.get(0).getValue(), is("bar"));
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field2"), is("bar"));
     }
 
     @Test
     void test_indirect_field_with_append(){
         Dissector dissector = createObjectUnderTest("%{+field1->} %{+field1} %{&field1->}");
 
+        Map<String, String> result = dissector.dissectText("foo     bar result     ");
 
-        boolean result = dissector.dissectText("foo     bar result     ");
-        assertTrue(result);
-        List<Field> fields = dissector.getDissectedFields();
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(2));
+        assertThat(result.get("field1"), is("foobar"));
+        assertThat(result.get("foobar"), is("result"));
+    }
 
-        assertThat(fields.size(), is(2));
-        assertThat(fields.get(0).getKey(), is("field1"));
-        assertThat(fields.get(0).getValue(), is("foobar"));
-        assertThat(fields.get(1).getKey(), is("foobar"));
-        assertThat(fields.get(1).getValue(), is("result"));
+    @Test
+    void test_dissect_text_returns_null_on_failure(){
+        Dissector dissector = createObjectUnderTest("dm1 %{field1} %{field2} dm2");
+        assertNull(dissector.dissectText(null));
+    }
+
+    @Test
+    void test_indirect_field_unresolved(){
+        Dissector dissector = createObjectUnderTest("dm1 %{field1} %{&field2} dm2");
+        Map<String, String> result = dissector.dissectText("dm1 foo bar dm2");
+
+        assertFalse(result.isEmpty());
+        assertThat(result.size(), is(1));
+        assertThat(result.get("field1"), is("foo"));
+        assertFalse(result.containsKey("bar"));
+    }
+
+    @Test
+    void test_concurrent_dissect_no_cross_contamination() throws InterruptedException {
+        Dissector dissector = createObjectUnderTest("dm1 %{field1} %{field2} dm2");
+
+        int threadCount = 10;
+        int iterationsPerThread = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        List<String> errors = Collections.synchronizedList(new ArrayList<>());
+
+        for (int t = 0; t < threadCount; t++) {
+            final String field1Value = "value" + t;
+            final String field2Value = "data" + t;
+            final String input = "dm1 " + field1Value + " " + field2Value + " dm2";
+
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        Map<String, String> result = dissector.dissectText(input);
+                        if (!field1Value.equals(result.get("field1"))) {
+                            errors.add("field1 mismatch: expected " + field1Value + " got " + result.get("field1"));
+                        }
+                        if (!field2Value.equals(result.get("field2"))) {
+                            errors.add("field2 mismatch: expected " + field2Value + " got " + result.get("field2"));
+                        }
+                    }
+                } catch (Exception e) {
+                    errors.add(e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(doneLatch.await(5, TimeUnit.SECONDS), "Test timed out");
+        executor.shutdown();
+
+        assertTrue(errors.isEmpty(), "Concurrency errors: " + errors);
     }
 
     private Dissector createObjectUnderTest(String dissectPatternString) {

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/FieldHelperTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/FieldHelperTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FieldHelperTest {
     private FieldHelper fieldHelper;
@@ -27,19 +28,19 @@ class FieldHelperTest {
 
     @Test
     void testNullFieldString() {
-        assertThat(fieldHelper.getField(null), is(nullValue()));
+        assertThat(fieldHelper.getField(null, null), is(nullValue()));
     }
 
     @Test
     void testWhitespaces() {
-        Field field = fieldHelper.getField("  ");
+        Field field = fieldHelper.getField("  ", null);
         assertThat(field, is(instanceOf(AppendField.class)));
         assertThat(field.getKey(), is(""));
     }
 
     @Test
     void testNormalFieldString() {
-        Field field = fieldHelper.getField("field1");
+        Field field = fieldHelper.getField("field1", null);
         assertThat(field, is(instanceOf(NormalField.class)));
         assertThat(field.getKey(), is("field1"));
         assertThat(field.stripTrailing, is(false));
@@ -47,7 +48,7 @@ class FieldHelperTest {
 
     @Test
     void testNormalFieldWithSuffixString() {
-        Field field = fieldHelper.getField("field1->");
+        Field field = fieldHelper.getField("field1->", null);
         assertThat(field, is(instanceOf(NormalField.class)));
         assertThat(field.getKey(), is("field1"));
         assertThat(field.stripTrailing, is(true));
@@ -55,21 +56,21 @@ class FieldHelperTest {
 
     @Test
     void testNamedSkipFieldString() {
-        Field field = fieldHelper.getField("?field1");
+        Field field = fieldHelper.getField("?field1", null);
         assertThat(field, is(instanceOf(SkipField.class)));
         assertThat(field.getKey(), is("field1"));
     }
 
     @Test
     void testAppendFieldString() {
-        Field field = fieldHelper.getField("+field1");
+        Field field = fieldHelper.getField("+field1", null);
         assertThat(field, is(instanceOf(AppendField.class)));
         assertThat(field.getKey(), is("field1"));
     }
 
     @Test
     void testAppendFieldWithIndexString() {
-        Field field = fieldHelper.getField("+field1/1");
+        Field field = fieldHelper.getField("+field1/1", null);
         assertThat(field, is(instanceOf(AppendField.class)));
         assertThat(field.getKey(), is("field1"));
         assertThat(((AppendField)field).getIndex(), is(1));
@@ -77,8 +78,24 @@ class FieldHelperTest {
 
     @Test
     void testIndirectFieldString() {
-        Field field = fieldHelper.getField("&field1");
+        Field field = fieldHelper.getField("&field1", null);
         assertThat(field, is(instanceOf(IndirectField.class)));
         assertThat(field.getKey(), is("field1"));
+    }
+
+    @Test
+    void testGetField_wiresLinkedList_whenLastFieldProvided() {
+        Field first = fieldHelper.getField("field1", null);
+        Field second = fieldHelper.getField("field2", first);
+        assertThat(first.getNext(), is(second));
+    }
+
+    @Test
+    void testSetNext_throwsWhenCalledTwice() {
+        NormalField field = new NormalField("a");
+        NormalField next1 = new NormalField("b");
+        NormalField next2 = new NormalField("c");
+        field.setNext(next1);
+        assertThrows(IllegalStateException.class, () -> field.setNext(next2));
     }
 }


### PR DESCRIPTION
## Description
Fixes a thread-safety bug in the dissect processor by eliminating shared mutable state in `Dissector`. Previously, `dissectText()` mutated shared `Delimiter.start/end` and `Field.value` on every invocation, causing data races when multiple threads processed events concurrently. The `@SingleThread` annotation was a workaround that limited throughput unnecessarily.

### Fix
 - `dissectText()` now uses local `int[]` arrays for delimiter positions and a local `Map<Field, String>` for field values instead of mutating shared objects.
 - Template field objects (`normalFieldMap`, `indirectFieldMap`, etc.) are read-only after construction and wrapped in `Collections.unmodifiableMap()`.
 - `dissectText()` returns `Map<String, String>` directly, replacing the separate `getDissectedFields()` call.
 - `@SingleThread` is removed.
 
## Issues Resolved
Resolves #5546

## Check List

 - [x] New functionality includes testing.
 - [ ] New functionality has a documentation issue. Please link to it in this PR.
   - [ ] New functionality has javadoc added
 - [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).