### PR TITLE
Fix RDS S3 sub-pipeline folder depth calculation when partition_prefix is absent.

### DIFF
--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -427,13 +427,19 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
         return Integer.toString(getDepth(s3Prefix, 4));
     }
 
+    protected String getSourceCoordinationIdentifier() {
+        return System.getenv(SOURCE_COORDINATION_IDENTIFIER_ENVIRONMENT_VARIABLE);
+    }
+
     /**
      * Calculate s3 folder scan depth for RDS source pipeline
      * @param s3Prefix: s3 prefix defined in the source configuration
      * @return s3 folder scan depth
      */
     public String calculateDepthForRdsSource(String s3Prefix) {
-        return Integer.toString(getDepth(s3Prefix, 3));
+        String envSourceCoordinationIdentifier = getSourceCoordinationIdentifier();
+        int baseDepth = envSourceCoordinationIdentifier != null ? 3 : 2;
+        return Integer.toString(getDepth(s3Prefix, baseDepth));
     }
 
     private int getDepth(String s3Prefix, int baseDepth) {

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformerTest.java
@@ -37,8 +37,12 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 class DynamicConfigTransformerTest {
@@ -456,4 +460,23 @@ class DynamicConfigTransformerTest {
         assertThat(resultOs.get("script").get("source").asText()).isEqualTo("ctx._source.merge(params.doc)");
         assertThat(resultOs.get("script").has("custom_field")).isFalse();
     }
+
+    @Test
+    void test_calculateDepthForRdsSource_without_source_coordination_identifier() {
+        String mockPrefix = "my-bucket/path";
+        DynamicConfigTransformer transformer = spy(new DynamicConfigTransformer(mock(RuleEvaluator.class)));
+        doReturn(null).when(transformer).getSourceCoordinationIdentifier();
+        String result = transformer.calculateDepthForRdsSource(mockPrefix);
+        assertThat(result, equalTo("4"));
+    }
+
+    @Test
+    void test_calculateDepthForRdsSource_with_source_coordination_identifier() {
+        String mockPrefix = "my-bucket/path";
+        DynamicConfigTransformer transformer = spy(new DynamicConfigTransformer(mock(RuleEvaluator.class)));
+        doReturn("testValue").when(transformer).getSourceCoordinationIdentifier();
+        String result = transformer.calculateDepthForRdsSource(mockPrefix);
+        assertThat(result, equalTo("5"));
+    }
+
 }


### PR DESCRIPTION
### Description
Fix RDS S3 sub-pipeline folder depth calculation when `partition_prefix` is absent.

`calculateDepthForRdsSource` uses a hardcoded base depth of 3, assuming the S3 buffer path always contains `<partition_prefix>/buffer/<hash>`. When `SOURCE_COORDINATION_PIPELINE_IDENTIFIER` is not set, the path only has `buffer/<hash>` (2 segments), causing the depth filter in `S3ScanPartitionCreationSupplier.getPrefixWithDepth()` to reject all objects — resulting in silent data loss.

This fix checks the env var and uses base depth 2 when absent, consistent with the logic already used in `getIncludePrefixForRdsSource`.
 
### Issues Resolved
Resolves #6754 
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
