### PR TITLE
Fix KafkaSourceJsonTypeIT ClassCastException on kafka_headers

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -113,9 +113,9 @@ public class KafkaSourceJsonTypeIT {
     private String testTopic;
     private String testGroup;
     private String headerKey1;
-    private byte[] headerValue1;
+    private String headerValue1;
     private String headerKey2;
-    private byte[] headerValue2;
+    private String headerValue2;
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription,
@@ -125,9 +125,9 @@ public class KafkaSourceJsonTypeIT {
     @BeforeEach
     public void setup() throws Throwable {
         headerKey1 = RandomStringUtils.randomAlphabetic(6);
-        headerValue1 = RandomStringUtils.randomAlphabetic(10).getBytes(StandardCharsets.UTF_8);
+        headerValue1 = RandomStringUtils.randomAlphabetic(10);
         headerKey2 = RandomStringUtils.randomAlphabetic(5);
-        headerValue2 = RandomStringUtils.randomAlphabetic(15).getBytes(StandardCharsets.UTF_8);
+        headerValue2 = RandomStringUtils.randomAlphabetic(15);
         sourceConfig = mock(KafkaSourceConfig.class);
         pluginMetrics = mock(PluginMetrics.class);
         counter = mock(Counter.class);
@@ -235,7 +235,7 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("kafka_key"), equalTo(null));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
+            Map<String, String> kafkaHeaders = (Map<String, String>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
             assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
@@ -273,7 +273,7 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("status"), equalTo(true));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
+            Map<String, String> kafkaHeaders = (Map<String, String>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
             assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
@@ -298,7 +298,7 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("status"), equalTo(true));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
+            Map<String, String> kafkaHeaders = (Map<String, String>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
             assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
@@ -336,7 +336,7 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("status"), equalTo(true));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
+            Map<String, String> kafkaHeaders = (Map<String, String>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
             assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
@@ -374,7 +374,7 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("kafka_key"), equalTo(testKey));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
+            Map<String, String> kafkaHeaders = (Map<String, String>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
             assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
@@ -412,7 +412,7 @@ public class KafkaSourceJsonTypeIT {
             assertThat(metadata.getAttributes().get("kafka_key"), equalTo(testKey));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
+            Map<String, String> kafkaHeaders = (Map<String, String>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
             assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
@@ -433,8 +433,8 @@ public class KafkaSourceJsonTypeIT {
         for (int i = 0; i < numRecords; i++) {
             String value = "{\"name\":\"testName" + i + "\", \"id\":" + (TEST_ID + i) + ", \"status\":true}";
             List<Header> headers = Arrays.asList(
-                new RecordHeader(headerKey1, headerValue1),
-                new RecordHeader(headerKey2, headerValue2)
+                new RecordHeader(headerKey1, headerValue1.getBytes(StandardCharsets.UTF_8)),
+                new RecordHeader(headerKey2, headerValue2.getBytes(StandardCharsets.UTF_8))
             );
             ProducerRecord<String, String> record =
                     new ProducerRecord<>(topicName, null, testKey, value, new RecordHeaders(headers));


### PR DESCRIPTION
### Description
- Update `KafkaSourceJsonTypeIT` to match the current `kafka_headers` type. The test cast headers to `Map<String, byte[]>`, but they are now `Map<String, String>`.
- Fix `kafka-plugin-integration-tests.yml` to checkout the PR head ref instead of the base branch. The workflow uses `pull_request_target` but was missing `ref: ${{
github.event.pull_request.head.sha }}`, so it was always testing the base branch code.

### Issues Resolved
Resolves #6865

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO