### PR TITLE
Add test result artifact upload to raw span peer forwarder e2e workflow

### DIFF
--- a/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
@@ -27,3 +27,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanPeerForwarderEndToEndTest
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: raw-span-peer-forwarder-e2e-results-java-${{ matrix.java }}
+          path: '**/test-results/**/*.xml'


### PR DESCRIPTION
### Description
Add test result artifact upload to the raw span peer forwarder e2e workflow, matching the pattern used in `gradle.yml` and `kafka-plugin-integration-tests.yml`.
This makes it possible to diagnose intermittent test failures by examining the uploaded XML results.

### Issues Resolved
Ref #6721

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO