### PR TITLE
Use the setup-gradle action to improve build times through caching.

### DIFF
--- a/.github/workflows/compatibility-data-prepper-api.yml
+++ b/.github/workflows/compatibility-data-prepper-api.yml
@@ -27,13 +27,18 @@ jobs:
 
     steps:
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: 11
         distribution: temurin
 
     - name: Checkout Data Prepper
       uses: actions/checkout@v6
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        add-job-summary: on-failure
 
     - name: Validate API compatibility
       run: ./gradlew -p data-prepper-api validateCompatibility

--- a/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
+++ b/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
@@ -45,10 +45,15 @@ jobs:
           chmod 644 ~/.aws/credentials ~/.aws/config
           ls -la ~/.aws/
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 11
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run basic grok with AWS secrets end-to-end tests with Gradle
         run: AWS_PROFILE=default ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:${{ matrix.test }}

--- a/.github/workflows/data-prepper-kafka-backward-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-kafka-backward-compatibility-e2e-tests.yml
@@ -20,10 +20,15 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 11
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run Kafka backward compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:kafka-buffer-backward-compatibility:kafkaBufferBackwardCompatibilityTest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
@@ -20,10 +20,15 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 11
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanLatestReleaseCompatibilityEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -21,10 +21,15 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 11
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run raw-span end-to-end tests with Gradle
         run: ./gradlew -PopenTelemetryVersion=${{ matrix.otelVersion }} -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
@@ -20,10 +20,15 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 11
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanPeerForwarderEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
@@ -20,10 +20,15 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 11
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run service-map end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:serviceMapPeerForwarderEndToEndTest

--- a/.github/workflows/e2e-tests-log-analytics.yml
+++ b/.github/workflows/e2e-tests-log-analytics.yml
@@ -22,11 +22,15 @@ jobs:
 
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 11
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run log analytics end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:${{ matrix.test }}

--- a/.github/workflows/e2e-tests-peer-forwarder.yml
+++ b/.github/workflows/e2e-tests-peer-forwarder.yml
@@ -22,11 +22,15 @@ jobs:
 
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 11
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Run peer-forward end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:peerforwarder:${{ matrix.test }}

--- a/.github/workflows/examples-trace-analytics.yml
+++ b/.github/workflows/examples-trace-analytics.yml
@@ -35,12 +35,18 @@ jobs:
 
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
+          distribution: temurin
 
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Build Analytics Service
         working-directory: ./examples/trace-analytics-sample-app/sample-app/analytics-service

--- a/.github/workflows/gradle-build-src.yml
+++ b/.github/workflows/gradle-build-src.yml
@@ -32,13 +32,17 @@ jobs:
 
     steps:
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin
 
     - name: Checkout Data Prepper
       uses: actions/checkout@v6
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        add-job-summary: on-failure
     - name: Check Gradle buildSrc
       run: ./gradlew -p buildSrc check
     - name: Upload Unit Test Results

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,11 +19,16 @@ jobs:
 
     steps:
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ matrix.java }}
+        distribution: temurin
     - name: Checkout Data Prepper
       uses: actions/checkout@v2
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        add-job-summary: on-failure
     - name: Build with Gradle
       run: ./gradlew --parallel --max-workers 2 build
     - name: Upload Unit Test Results

--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -31,11 +31,16 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Run Kafka Docker
         run: |

--- a/.github/workflows/kinesis-source-integration-tests.yml
+++ b/.github/workflows/kinesis-source-integration-tests.yml
@@ -43,12 +43,18 @@ jobs:
           aws configure set default.aws_secret_access_key ${{ steps.creds.outputs.aws-secret-access-key }}
           aws configure set default.aws_session_token ${{ steps.creds.outputs.aws-session-token }}
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
 
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Run Kinesis Source integration tests
         run: |

--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -15,13 +15,18 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 11
 
       - name: Checkout Data Prepper
         uses: actions/checkout@v4
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Load secret
         uses: 1password/load-secrets-action@v2

--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -33,13 +33,18 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
-          java-version:  ${{ matrix.java }}
+          distribution: temurin
+          java-version: ${{ matrix.java }}
 
       - name: Checkout Data Prepper
         uses: actions/checkout@v6
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Run Open Distro docker
         run: |

--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -55,13 +55,18 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
-          java-version:  ${{ matrix.java }}
+          distribution: temurin
+          java-version: ${{ matrix.java }}
 
       - name: Checkout Data Prepper
         uses: actions/checkout@v6
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Set password for OpenSearch version
         run: |
@@ -102,13 +107,18 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: ${{ matrix.java }}
 
       - name: Checkout Data Prepper
         uses: actions/checkout@v6
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
 
       - name: Generate client certificates
         run: |

--- a/.github/workflows/performance-test-compile.yml
+++ b/.github/workflows/performance-test-compile.yml
@@ -25,10 +25,15 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
       - name: Checkout Data Prepper
         uses: actions/checkout@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          add-job-summary: on-failure
       - name: Build performance tests with Gradle
         run: ./gradlew :performance-test:compileGatlingJava

--- a/.github/workflows/release-prepare-branch.yml
+++ b/.github/workflows/release-prepare-branch.yml
@@ -51,10 +51,15 @@ jobs:
         echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: 21
         distribution: temurin
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        add-job-summary: on-failure
 
     - name: Update version to next release
       id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,16 @@ jobs:
 
     steps:
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: 11
         distribution: temurin
     - name: Checkout Data Prepper
       uses: actions/checkout@v6
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        add-job-summary: on-failure
     - name: Get Version
       run:  grep '^version=' gradle.properties >> $GITHUB_ENV
     - name: Build Jar Files

--- a/.github/workflows/third-party-generate.yml
+++ b/.github/workflows/third-party-generate.yml
@@ -12,11 +12,16 @@ jobs:
 
     steps:
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: 11
+        distribution: temurin
     - name: Checkout Data Prepper
       uses: actions/checkout@v2
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        add-job-summary: on-failure
 
     - name: Generate Third Party Report
       run: ./gradlew --no-daemon generateThirdPartyReport


### PR DESCRIPTION
### Description

Use the setup-gradle action (at 6.1.0) to add caching to our builds. Update all setup-java actions to 5.2.0. 

Use commit SHAs for actions rather than version numbers for additional security on version changes. This was suggested as an improvement from the [recent postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) on the recent supply chain attack.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
