### PR TITLE
Make ImmutablePluginConfigVariable.refresh() a no-op instead of throwing

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigVariable.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigVariable.java
@@ -31,12 +31,17 @@ public interface PluginConfigVariable {
     void setValue(Object updatedValue);
 
     /**
-     * Refresh the secret value on demand
+     * Refresh the secret value on demand.
+     * <p>
+     * This call semantically means to refresh the value from the underlying data store. If that
+     * is not supported an implementation should perform a no-op.
      */
     void refresh();
 
     /**
-     * Returns if the variable is updatable.
+     * Returns if the variable is updatable from Data Prepper itself. This indicates
+     * that Data Prepper itself can update the actual value, not that the value itself can be
+     * updated from another system.
      *
      * @return true if this variable is updatable, false otherwise
      */

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
@@ -90,8 +90,6 @@ public class VariableExpander {
 
         @Override
         public void refresh() {
-            // No-op as this is immutable
-            throw new UnsupportedOperationException("ImmutablePluginConfigVariable doesn't support this operation");
         }
 
         @Override

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -196,6 +196,29 @@ class VariableExpanderTest {
     }
 
     @Test
+    void testImmutablePluginConfigVariable_refresh_does_not_throw() throws IOException {
+        final String testSecretReference = UUID.randomUUID().toString();
+        final JsonParser jsonParser = JSON_FACTORY.createParser(String.format("\"%s\"", testSecretReference));
+        jsonParser.nextToken();
+        objectUnderTest = new VariableExpander(OBJECT_MAPPER, Set.of(pluginConfigValueTranslator));
+        final Object actualResult = objectUnderTest.translate(jsonParser, PluginConfigVariable.class);
+        PluginConfigVariable pluginConfigVariableInstance = (PluginConfigVariable) actualResult;
+        pluginConfigVariableInstance.refresh();
+        assertThat(pluginConfigVariableInstance.getValue().toString(), equalTo(testSecretReference));
+    }
+
+    @Test
+    void testImmutablePluginConfigVariable_setValue_throws() throws IOException {
+        final String testSecretReference = UUID.randomUUID().toString();
+        final JsonParser jsonParser = JSON_FACTORY.createParser(String.format("\"%s\"", testSecretReference));
+        jsonParser.nextToken();
+        objectUnderTest = new VariableExpander(OBJECT_MAPPER, Set.of(pluginConfigValueTranslator));
+        final Object actualResult = objectUnderTest.translate(jsonParser, PluginConfigVariable.class);
+        PluginConfigVariable pluginConfigVariableInstance = (PluginConfigVariable) actualResult;
+        assertThrows(UnsupportedOperationException.class, () -> pluginConfigVariableInstance.setValue("new-value"));
+    }
+
+    @Test
     void testTranslateJsonParserWithSPluginConfigVariableValue_translate_failure() throws IOException {
         final String testSecretKey = "testSecretKey";
         final String testTranslatorKey = "test_prefix";


### PR DESCRIPTION
### Description

The `refresh()` method semantically means "re-read from your backing store." For an immutable variable with no backing store, this is naturally a no-op. Only `setValue()` should throw since it attempts to mutate the value. This allows callers to safely call `refresh()` without needing to guard with `isUpdatable()` checks.

I also updated the Javadocs on these to make this clearer.

I took note of this issue while reviewing PR #6856. We should be able to call `refresh()` safely.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
