### PR TITLE
Adds Srikanth Padakanti (srikanthpadakanti) as a maintainer.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @divbok @sb2k16 @san81 @srikanthjg @graytaylor0 @dinujoh @kkondaka @KarstenSchnitter @dlvenable @oeyh @Zhangxunmt
+*   @divbok @sb2k16 @san81 @srikanthjg @graytaylor0 @dinujoh @kkondaka @srikanthpadakanti @KarstenSchnitter @dlvenable @oeyh @Zhangxunmt

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Taylor Gray            | [graytaylor0](https://github.com/graytaylor0)             | Amazon      |
 | Dinu John              | [dinujoh](https://github.com/dinujoh)                     | Amazon      |
 | Krishna Kondaka        | [kkondaka](https://github.com/kkondaka)                   | Amazon      |
+| Srikanth Padakanti     | [srikanthpadakanti](https://github.com/srikanthpadakanti) | Apple      |
 | Karsten Schnitter      | [KarstenSchnitter](https://github.com/KarstenSchnitter)   | SAP         |
 | David Venable          | [dlvenable](https://github.com/dlvenable)                 | Amazon      |
 | Hai Yan                | [oeyh](https://github.com/oeyh)                           | Amazon      |


### PR DESCRIPTION
### Description

This PR welcomes Srikanth Padakanti ( @srikanthpadakanti ) as a maintainer.

Srikanth has contributed [14 merged PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is%3Apr+author%3Asrikanthpadakanti+is%3Aclosed+) to the project and has two currently open. Some of his significant changes include:
* Adding the Prometheus source for both pull and push-based ingestion ([#](https://github.com/opensearch-project/data-prepper/pull/6627)[6627](https://github.com/opensearch-project/data-prepper/pull/6627), [#6743](https://github.com/opensearch-project/data-prepper/pull/6743)).
* Supporting the TSDB index type in the opensearch sink ([#](https://github.com/opensearch-project/data-prepper/pull/6691)[6691](https://github.com/opensearch-project/data-prepper/pull/6691)).
* Mutual TLS (mTLS) authentication with OpenSearch ([#](https://github.com/opensearch-project/data-prepper/pull/6755)[6755](https://github.com/opensearch-project/data-prepper/pull/6755)).
* Major improvements to the file source including the ability to tail ([#](https://github.com/opensearch-project/data-prepper/pull/6853)[6853](https://github.com/opensearch-project/data-prepper/pull/6853)).

Participating in PR reviews is an important part of maintaining the project and he has participated in [five PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is%3Apr+-author%3Asrikanthpadakanti+reviewed-by%3Asrikanthpadakanti+is%3Aclosed) as a reviewer.

Additionally, he has created a RFC for Splunk HEC as a source ([#6823](https://github.com/opensearch-project/data-prepper/issues/6823)).
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
