### PR TITLE
Adding support for rate_limiter processor

### DIFF
--- a/data-prepper-plugins/rate-limiter-processor/build.gradle
+++ b/data-prepper-plugins/rate-limiter-processor/build.gradle
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation project(':data-prepper-api')
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    testImplementation project(':data-prepper-test:plugin-test-framework')
+}

--- a/data-prepper-plugins/rate-limiter-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterMode.java
+++ b/data-prepper-plugins/rate-limiter-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.processor.ratelimiter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum RateLimiterMode {
+    DROP("drop"),
+    HOLD("hold");
+
+    private static final Map<String, RateLimiterMode> MODES_MAP = Arrays.stream(RateLimiterMode.values())
+            .collect(Collectors.toMap(
+                    value -> value.name,
+                    value -> value
+            ));
+
+    private final String name;
+
+    RateLimiterMode(String name) {
+        this.name = name.toLowerCase();
+    }
+
+    @JsonCreator
+    static RateLimiterMode fromOptionValue(final String option) {
+        return MODES_MAP.get(option.toLowerCase());
+    }
+
+    @JsonValue
+    public String getOptionValue() {
+        return name;
+    }
+}

--- a/data-prepper-plugins/rate-limiter-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessor.java
+++ b/data-prepper-plugins/rate-limiter-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.processor.ratelimiter;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.model.processor.AbstractProcessor;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DataPrepperPlugin(name = "rate_limiter", pluginType = Processor.class, pluginConfigurationType = RateLimiterProcessorConfig.class)
+public class RateLimiterProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
+    private final int eventsPerSecond;
+    private final long counterRetentionSeconds;
+    private final RateLimiterMode whenExceeds;
+    private final String limitWhen;
+    private final ExpressionEvaluator expressionEvaluator;
+    private final ConcurrentHashMap<Long, AtomicInteger> emittedPerSecond = new ConcurrentHashMap<>();
+
+    @DataPrepperPluginConstructor
+    public RateLimiterProcessor(final PluginMetrics pluginMetrics,
+                                final RateLimiterProcessorConfig config,
+                                final ExpressionEvaluator expressionEvaluator) {
+        super(pluginMetrics);
+        this.eventsPerSecond = config.getEventsPerSecond();
+        this.counterRetentionSeconds = config.getCounterRetention().getSeconds();
+        this.whenExceeds = config.getWhenExceeds();
+        this.limitWhen = config.getLimitWhen();
+        this.expressionEvaluator = expressionEvaluator;
+
+        if (limitWhen != null && !expressionEvaluator.isValidExpressionStatement(limitWhen)) {
+            throw new InvalidPluginConfigurationException(
+                    String.format("limit_when \"%s\" is not a valid expression statement.", limitWhen));
+        }
+    }
+
+    @Override
+    public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
+        final Collection<Record<Event>> output = new ArrayList<>();
+
+        for (final Record<Event> record : records) {
+            if (limitWhen != null && !expressionEvaluator.evaluateConditional(limitWhen, record.getData())) {
+                output.add(record);
+                continue;
+            }
+
+            if (whenExceeds == RateLimiterMode.DROP) {
+                final long now = System.currentTimeMillis() / 1000;
+                final AtomicInteger count = emittedPerSecond.computeIfAbsent(now, k -> new AtomicInteger(0));
+                if (count.incrementAndGet() <= eventsPerSecond) {
+                    output.add(record);
+                }
+            } else {
+                waitForCapacity();
+                output.add(record);
+            }
+        }
+
+        evictOldCounters();
+        return output;
+    }
+
+    private void waitForCapacity() {
+        while (true) {
+            final long now = System.currentTimeMillis() / 1000;
+            final AtomicInteger count = emittedPerSecond.computeIfAbsent(now, k -> new AtomicInteger(0));
+            if (count.incrementAndGet() <= eventsPerSecond) {
+                return;
+            }
+            count.decrementAndGet();
+            try {
+                long sleepMs = 1000 - (System.currentTimeMillis() % 1000);
+                Thread.sleep(sleepMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private void evictOldCounters() {
+        final long now = System.currentTimeMillis() / 1000;
+        emittedPerSecond.keySet().removeIf(second -> now - second > counterRetentionSeconds);
+    }
+
+
+    @Override
+    public void prepareForShutdown() {
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/data-prepper-plugins/rate-limiter-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessorConfig.java
+++ b/data-prepper-plugins/rate-limiter-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessorConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.processor.ratelimiter;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Duration;
+
+@JsonPropertyOrder
+@JsonClassDescription("The <code>rate_limiter</code> processor controls the number of events processed per second. " +
+        "By default, <code>rate_limiter</code> drops events that exceed the configured number allowed per second.")
+public class RateLimiterProcessorConfig {
+
+    @JsonPropertyDescription("The number of events allowed per second.")
+    @JsonProperty("events_per_second")
+    @NotNull
+    private int eventsPerSecond;
+
+    @JsonPropertyDescription("Indicates what action the <code>rate_limiter</code> takes when the number of events received is greater than the number of events allowed per second. " +
+            "Default value is drop, which drops the excess events received in that second.")
+    @JsonProperty(value = "when_exceeds", defaultValue = "drop")
+    private RateLimiterMode whenExceeds = RateLimiterMode.DROP;
+
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a> such as <code>/log_type == \"INFO\"</code>. " +
+            "When specified, only events where the condition evaluates to true are subject to rate limiting. " +
+            "Events that do not match pass through unaffected.")
+    @JsonProperty("limit_when")
+    private String limitWhen;
+
+    @JsonPropertyDescription("The duration to track per-second event counts. " +
+            "Counters older than this are discarded to free resources. Default is 60 seconds.")
+    @JsonProperty(value = "counter_retention", defaultValue = "PT60S")
+    private Duration counterRetention = Duration.ofSeconds(60);
+
+    public int getEventsPerSecond() {
+        return eventsPerSecond;
+    }
+
+    public RateLimiterMode getWhenExceeds() {
+        return whenExceeds;
+    }
+
+    public String getLimitWhen() {
+        return limitWhen;
+    }
+
+    public Duration getCounterRetention() {
+        return counterRetention;
+    }
+}

--- a/data-prepper-plugins/rate-limiter-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessorConfigTest.java
+++ b/data-prepper-plugins/rate-limiter-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessorConfigTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.processor.ratelimiter;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RateLimiterProcessorConfigTest {
+
+    @Test
+    void test_default_config() {
+        final RateLimiterProcessorConfig config = new RateLimiterProcessorConfig();
+        assertThat(config.getWhenExceeds(), equalTo(RateLimiterMode.DROP));
+        assertThat(config.getLimitWhen(), nullValue());
+        assertThat(config.getCounterRetention(),equalTo(Duration.ofSeconds(60)));
+    }
+}

--- a/data-prepper-plugins/rate-limiter-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessorTest.java
+++ b/data-prepper-plugins/rate-limiter-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/ratelimiter/RateLimiterProcessorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.processor.ratelimiter;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.test.plugins.DataPrepperPluginTest;
+import org.opensearch.dataprepper.test.plugins.PluginConfigurationFile;
+import org.opensearch.dataprepper.test.plugins.junit.BaseDataPrepperPluginStandardTestSuite;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+@DataPrepperPluginTest(pluginName = "rate_limiter", pluginType = Processor.class)
+class RateLimiterProcessorTest extends BaseDataPrepperPluginStandardTestSuite {
+
+    @Test
+    void test_events_under_limit_all_pass_through(
+            @PluginConfigurationFile("rate_limiter_default.yaml") final Processor<Record<Event>, Record<Event>> processor,
+            final EventFactory eventFactory) {
+        final List<Record<Event>> records = createEvents(eventFactory, 200);
+
+        final Collection<Record<Event>> result = processor.execute(records);
+
+        assertThat(result, notNullValue());
+        assertThat(result.size(), equalTo(200));
+    }
+
+    @Test
+    void test_events_over_limit_are_dropped(
+            @PluginConfigurationFile("rate_limiter_default.yaml") final Processor<Record<Event>, Record<Event>> processor,
+            final EventFactory eventFactory) {
+        final List<Record<Event>> records = createEvents(eventFactory, 500);
+
+        final Collection<Record<Event>> result = processor.execute(records);
+
+        assertThat(result, notNullValue());
+        assertThat(result.size(), lessThanOrEqualTo(400));
+    }
+
+    @Test
+    void test_counts_accumulate_across_multiple_execute_calls(
+            @PluginConfigurationFile("rate_limiter_default.yaml") final Processor<Record<Event>, Record<Event>> processor,
+            final EventFactory eventFactory) {
+        final Collection<Record<Event>> result1 = processor.execute(createEvents(eventFactory, 300));
+        final Collection<Record<Event>> result2 = processor.execute(createEvents(eventFactory, 200));
+
+        assertThat(result1.size() + result2.size(), lessThanOrEqualTo(400));
+    }
+
+    @Test
+    void test_limit_when_only_rate_limits_matching_events(
+            @PluginConfigurationFile("rate_limiter_with_limit_when.yaml") final Processor<Record<Event>, Record<Event>> processor,
+            final EventFactory eventFactory) {
+        final List<Record<Event>> records = new ArrayList<>();
+        records.addAll(createEvents(eventFactory, 5, Map.of("message", "test", "level", "DEBUG")));
+        records.addAll(createEvents(eventFactory, 5, Map.of("message", "test", "level", "INFO")));
+
+        final Collection<Record<Event>> result = processor.execute(records);
+
+        assertThat(result, notNullValue());
+        assertThat(result.size(), equalTo(7));
+    }
+
+    @Test
+    void test_hold_mode(
+            @PluginConfigurationFile("rate_limiter_hold_mode.yaml") final Processor<Record<Event>, Record<Event>> processor,
+            final EventFactory eventFactory) {
+        final List<Record<Event>> records = createEvents(eventFactory, 3);
+        final Collection<Record<Event>> result = processor.execute(records);
+        assertThat(result, notNullValue());
+        assertThat(result.size(), equalTo(3));
+    }
+
+    private List<Record<Event>> createEvents(final EventFactory eventFactory, final int count) {
+        return createEvents(eventFactory, count, Map.of("message", "test"));
+    }
+
+    private List<Record<Event>> createEvents(final EventFactory eventFactory, final int count, final Map<String, Object> data) {
+        final List<Record<Event>> records = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            final Event event = eventFactory.eventBuilder(LogEventBuilder.class)
+                    .withData(data)
+                    .build();
+            records.add(new Record<>(event));
+        }
+        return records;
+    }
+}

--- a/data-prepper-plugins/rate-limiter-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/ratelimiter/rate_limiter_default.yaml
+++ b/data-prepper-plugins/rate-limiter-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/ratelimiter/rate_limiter_default.yaml
@@ -1,0 +1,14 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - rate_limiter:
+        events_per_second: 400
+  sink:
+    - unused:

--- a/data-prepper-plugins/rate-limiter-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/ratelimiter/rate_limiter_hold_mode.yaml
+++ b/data-prepper-plugins/rate-limiter-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/ratelimiter/rate_limiter_hold_mode.yaml
@@ -1,0 +1,15 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - rate_limiter:
+        events_per_second: 2
+        when_exceeds: hold
+  sink:
+    - unused:

--- a/data-prepper-plugins/rate-limiter-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/ratelimiter/rate_limiter_with_limit_when.yaml
+++ b/data-prepper-plugins/rate-limiter-processor/src/test/resources/org/opensearch/dataprepper/plugins/processor/ratelimiter/rate_limiter_with_limit_when.yaml
@@ -1,0 +1,15 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+test-pipeline:
+  source:
+    unused:
+  processor:
+    - rate_limiter:
+        events_per_second: 2
+        limit_when: /level == "DEBUG"
+  sink:
+    - unused:

--- a/settings.gradle
+++ b/settings.gradle
@@ -216,6 +216,7 @@ include 'data-prepper-plugins:saas-source-plugins:crowdstrike-source'
 include 'data-prepper-plugins:saas-source-plugins:microsoft-office365-source'
 include 'data-prepper-plugins:otlp-sink'
 include 'data-prepper-plugins:otel-apm-service-map-processor'
+include 'data-prepper-plugins:rate-limiter-processor'
 
 
 include 'e2e-test:kafka-buffer-backward-compatibility'


### PR DESCRIPTION
# Add standalone `rate_limiter` processor for wall-clock based event throttling

## Description

Adds a new `rate_limiter` processor that controls the number of events emitted to the sink per second. Unlike the existing `rate_limiter` aggregate action which uses Guava's `RateLimiter.tryAcquire()`, This processor uses a per-second counter shared across all worker threads.


**Example usage:**

```yaml
throttling-pipeline:
  source:
    http:
      port: 2021
      path: "/log/ingest"
  processor:
    - rate_limiter:
        events_per_second: 400
  sink:
    - file:
        path: /tmp/test-drop.txt

```

**Configuration options:**

| Option | Required | Default | Description |
|--------|----------|---------|-------------|
| `events_per_second` | Yes | - | The number of events allowed per second |
| `when_exceeds` | No | `drop` | Action when rate is exceeded. `drop` discards excess events. `hold` blocks the worker until capacity is available in the next second|
| `limit_when` | No | - | A conditional expression. Only events matching this condition are subject to rate limiting. Non-matching events pass through unaffected. |
| `counter_retention` | No | `PT60S` | Duration to retain per-second counters before eviction. |


## Check List

- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
