### PR TITLE
Replace unsafe String casts with instanceof check in AtlassianOauthConfig                                    

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianOauthConfig.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/main/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianOauthConfig.java
@@ -66,10 +66,10 @@ public class AtlassianOauthConfig implements AtlassianAuthConfig {
 
     public AtlassianOauthConfig(AtlassianSourceConfig atlassianSourceConfig) {
         this.atlassianSourceConfig = atlassianSourceConfig;
-        this.accessToken = (String) atlassianSourceConfig.getAuthenticationConfig().getOauth2Config()
-                .getAccessToken().getValue();
-        this.refreshToken = (String) atlassianSourceConfig.getAuthenticationConfig()
-                .getOauth2Config().getRefreshToken().getValue();
+        this.accessToken = resolveStringValue(atlassianSourceConfig.getAuthenticationConfig().getOauth2Config()
+                .getAccessToken().getValue());
+        this.refreshToken = resolveStringValue(atlassianSourceConfig.getAuthenticationConfig()
+                .getOauth2Config().getRefreshToken().getValue());
         this.clientId = atlassianSourceConfig.getAuthenticationConfig().getOauth2Config().getClientId();
         this.clientSecret = atlassianSourceConfig.getAuthenticationConfig().getOauth2Config().getClientSecret();
     }
@@ -150,8 +150,8 @@ public class AtlassianOauthConfig implements AtlassianAuthConfig {
                     // Refreshing the secrets. It should help if someone already renewed the tokens.
                     // Refreshing one of the secret refreshes the entire store so triggering refresh on just one
                     oauth2Config.getAccessToken().refresh();
-                    this.accessToken = (String) oauth2Config.getAccessToken().getValue();
-                    this.refreshToken = (String) oauth2Config.getRefreshToken().getValue();
+                    this.accessToken = resolveStringValue(oauth2Config.getAccessToken().getValue());
+                    this.refreshToken = resolveStringValue(oauth2Config.getRefreshToken().getValue());
                     this.expireTime = Instant.now().plusSeconds(10);
                 }
                 throw new RuntimeException("Failed to renew access token message:" + ex.getMessage(), ex);
@@ -179,5 +179,12 @@ public class AtlassianOauthConfig implements AtlassianAuthConfig {
         //For OAuth based flow, we use a different source url
         this.cloudId = getAtlassianAccountCloudId();
         this.url = OAuth2_URL + atlassianSourceConfig.getOauth2UrlContext() + SLASH + this.cloudId + SLASH;
+    }
+
+    private String resolveStringValue(final Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        }
+        return value != null ? value.toString() : null;
     }
 }

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianAuthFactoryTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianAuthFactoryTest.java
@@ -22,6 +22,7 @@ import org.opensearch.dataprepper.plugins.source.atlassian.configuration.Oauth2C
 
 import java.util.UUID;
 
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.when;

--- a/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianOauthConfigTest.java
+++ b/data-prepper-plugins/saas-source-plugins/atlassian-commons/src/test/java/org/opensearch/dataprepper/plugins/source/atlassian/rest/auth/AtlassianOauthConfigTest.java
@@ -188,4 +188,65 @@ public class AtlassianOauthConfigTest {
         }
     }
 
+    @Test
+    void testConstructor_handles_non_string_getValue() throws NoSuchFieldException, IllegalAccessException {
+        Oauth2Config oauth2Config = confluenceSourceConfig.getAuthenticationConfig().getOauth2Config();
+        PluginConfigVariable nonStringAccessToken = new PluginConfigVariable() {
+            @Override
+            public Object getValue() { return 12345; }
+            @Override
+            public void setValue(Object updatedValue) {}
+            @Override
+            public void refresh() {}
+            @Override
+            public boolean isUpdatable() { return false; }
+        };
+        PluginConfigVariable nonStringRefreshToken = new PluginConfigVariable() {
+            @Override
+            public Object getValue() { return 67890; }
+            @Override
+            public void setValue(Object updatedValue) {}
+            @Override
+            public void refresh() {}
+            @Override
+            public boolean isUpdatable() { return false; }
+        };
+        ReflectivelySetField.setField(Oauth2Config.class, oauth2Config, "accessToken", nonStringAccessToken);
+        ReflectivelySetField.setField(Oauth2Config.class, oauth2Config, "refreshToken", nonStringRefreshToken);
+
+        AtlassianOauthConfig jiraOauthConfig = new AtlassianOauthConfig(confluenceSourceConfig);
+
+        assertEquals("12345", jiraOauthConfig.getAccessToken());
+        assertEquals("67890", jiraOauthConfig.getRefreshToken());
+    }
+
+    @Test
+    void testRenewCredentials_handles_non_string_getValue_after_refresh()
+            throws NoSuchFieldException, IllegalAccessException {
+        AtlassianOauthConfig jiraOauthConfig = new AtlassianOauthConfig(confluenceSourceConfig);
+        Oauth2Config oauth2Config = confluenceSourceConfig.getAuthenticationConfig().getOauth2Config();
+
+        PluginConfigVariable nonStringAccessToken = new PluginConfigVariable() {
+            @Override
+            public Object getValue() { return 99999; }
+            @Override
+            public void setValue(Object updatedValue) {}
+            @Override
+            public void refresh() {}
+            @Override
+            public boolean isUpdatable() { return true; }
+        };
+        ReflectivelySetField.setField(Oauth2Config.class, oauth2Config, "accessToken", nonStringAccessToken);
+        ReflectivelySetField.setField(Oauth2Config.class, oauth2Config, "refreshToken", accessTokenVariable);
+        when(accessTokenVariable.getValue()).thenReturn("refreshed_token");
+
+        HttpClientErrorException unauthorizedException = new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+        when(restTemplateMock.postForEntity(any(String.class), any(HttpEntity.class), any(Class.class)))
+                .thenThrow(unauthorizedException);
+        jiraOauthConfig.restTemplate = restTemplateMock;
+
+        assertThrows(RuntimeException.class, jiraOauthConfig::renewCredentials);
+        assertEquals("99999", jiraOauthConfig.getAccessToken());
+    }
+
 }


### PR DESCRIPTION
### Description
Replace unsafe `(String)` casts on `PluginConfigVariable.getValue()` in `AtlassianOauthConfig` with a `resolveStringValue()` helper that uses `instanceof` check and `toString()` fallback.          
 
### Issues Resolved
Resolves #6874 
https://github.com/opensearch-project/data-prepper/issues/6874 
 
### Check List
- [ X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ X ] New functionality has javadoc added
- [ X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
