### PR TITLE
Fix opensearch_api _bulk endpoint to return proper JSON response

### DIFF
--- a/data-prepper-plugins/opensearch-api-source/build.gradle
+++ b/data-prepper-plugins/opensearch-api-source/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation project(':data-prepper-test:test-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
     testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation libs.opensearch.rhlc
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 }

--- a/data-prepper-plugins/opensearch-api-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIService.java
+++ b/data-prepper-plugins/opensearch-api-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIService.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.plugins.source.opensearchapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
@@ -125,6 +124,7 @@ public class OpenSearchAPIService implements BaseHttpService {
             throw new IOException("Bad request data format.", e.getCause());
         }
 
+        final long startNanos = System.nanoTime();
         try {
             if (buffer.isByteBuffer()) {
                 buffer.writeBytes(content.array(), null, bufferWriteTimeoutInMillis);
@@ -137,56 +137,15 @@ public class OpenSearchAPIService implements BaseHttpService {
             throw e;
         }
         successRequestsCounter.increment();
-        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, buildBulkResponse(bulkRequestPayloadList));
+        final long tookMillis = (System.nanoTime() - startNanos) / 1_000_000;
+        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, buildBulkResponse(tookMillis));
     }
 
-    private String buildBulkResponse(final List<Map<String, Object>> bulkRequestPayloadList) {
+    private String buildBulkResponse(final long tookMillis) {
         final ObjectNode root = OBJECT_MAPPER.createObjectNode();
-        root.put("took", 0);
+        root.put("took", tookMillis);
         root.put("errors", false);
-
-        final ArrayNode items = root.putArray("items");
-        final Iterator<Map<String, Object>> it = bulkRequestPayloadList.iterator();
-        int seq = 0;
-        while (it.hasNext()) {
-            final Map<String, Object> actionLine = it.next();
-            final String action = Arrays.stream(OpenSearchBulkActions.values())
-                    .map(OpenSearchBulkActions::toString)
-                    .filter(actionLine::containsKey)
-                    .findFirst().orElse(null);
-
-            if (action == null) {
-                continue;
-            }
-
-            final boolean isDelete = OpenSearchBulkActions.DELETE.toString().equals(action);
-            if (!isDelete && it.hasNext()) {
-                it.next();
-            }
-
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> meta = (Map<String, Object>) actionLine.get(action);
-            final String index = meta != null && meta.get("_index") != null ? meta.get("_index").toString() : "unknown";
-            final String id = meta != null && meta.get("_id") != null ? meta.get("_id").toString() : String.valueOf(seq);
-
-            final ObjectNode item = OBJECT_MAPPER.createObjectNode();
-            final ObjectNode actionResult = item.putObject(action);
-            actionResult.put("_index", index);
-            actionResult.put("_type", "_doc");
-            actionResult.put("_id", id);
-            actionResult.put("_version", 1);
-            actionResult.put("result", isDelete ? "deleted" : "created");
-            actionResult.put("status", isDelete ? 200 : 201);
-            actionResult.put("_seq_no", seq);
-            actionResult.put("_primary_term", 1);
-            final ObjectNode shards = actionResult.putObject("_shards");
-            shards.put("total", 1);
-            shards.put("successful", 1);
-            shards.put("failed", 0);
-
-            items.add(item);
-            seq++;
-        }
+        root.putArray("items");
         return root.toString();
     }
 

--- a/data-prepper-plugins/opensearch-api-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIService.java
+++ b/data-prepper-plugins/opensearch-api-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIService.java
@@ -5,10 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearchapi;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Blocking;
@@ -55,6 +59,7 @@ public class OpenSearchAPIService implements BaseHttpService {
     public static final String REQUEST_PROCESS_DURATION = "requestProcessDuration";
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchAPIService.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     // TODO: support other data-types as request body, e.g. json_lines, msgpack
     private final MultiLineJsonCodec jsonCodec = new MultiLineJsonCodec();
@@ -132,7 +137,57 @@ public class OpenSearchAPIService implements BaseHttpService {
             throw e;
         }
         successRequestsCounter.increment();
-        return HttpResponse.of(HttpStatus.OK);
+        return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, buildBulkResponse(bulkRequestPayloadList));
+    }
+
+    private String buildBulkResponse(final List<Map<String, Object>> bulkRequestPayloadList) {
+        final ObjectNode root = OBJECT_MAPPER.createObjectNode();
+        root.put("took", 0);
+        root.put("errors", false);
+
+        final ArrayNode items = root.putArray("items");
+        final Iterator<Map<String, Object>> it = bulkRequestPayloadList.iterator();
+        int seq = 0;
+        while (it.hasNext()) {
+            final Map<String, Object> actionLine = it.next();
+            final String action = Arrays.stream(OpenSearchBulkActions.values())
+                    .map(OpenSearchBulkActions::toString)
+                    .filter(actionLine::containsKey)
+                    .findFirst().orElse(null);
+
+            if (action == null) {
+                continue;
+            }
+
+            final boolean isDelete = OpenSearchBulkActions.DELETE.toString().equals(action);
+            if (!isDelete && it.hasNext()) {
+                it.next();
+            }
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> meta = (Map<String, Object>) actionLine.get(action);
+            final String index = meta != null && meta.get("_index") != null ? meta.get("_index").toString() : "unknown";
+            final String id = meta != null && meta.get("_id") != null ? meta.get("_id").toString() : String.valueOf(seq);
+
+            final ObjectNode item = OBJECT_MAPPER.createObjectNode();
+            final ObjectNode actionResult = item.putObject(action);
+            actionResult.put("_index", index);
+            actionResult.put("_type", "_doc");
+            actionResult.put("_id", id);
+            actionResult.put("_version", 1);
+            actionResult.put("result", isDelete ? "deleted" : "created");
+            actionResult.put("status", isDelete ? 200 : 201);
+            actionResult.put("_seq_no", seq);
+            actionResult.put("_primary_term", 1);
+            final ObjectNode shards = actionResult.putObject("_shards");
+            shards.put("total", 1);
+            shards.put("successful", 1);
+            shards.put("failed", 0);
+
+            items.add(item);
+            seq++;
+        }
+        return root.toString();
     }
 
     private boolean isValidBulkAction(Map<String, Object> actionMap) {

--- a/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/BulkResponseParsingTest.java
+++ b/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/BulkResponseParsingTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearchapi;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class BulkResponseParsingTest {
+
+    @Test
+    void testEmptyItemsSuccessResponse() throws Exception {
+        String json = "{\"took\":5,\"errors\":false,\"items\":[]}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json);
+        BulkResponse response = BulkResponse.fromXContent(parser);
+
+        assertThat(response.hasFailures(), is(false));
+        assertThat(response.getItems().length, equalTo(0));
+        assertThat(response.getTook().millis(), equalTo(5L));
+    }
+
+    @Test
+    void testEmptyItemsErrorResponse() throws Exception {
+        String json = "{\"took\":12,\"errors\":true,\"items\":[]}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json);
+        BulkResponse response = BulkResponse.fromXContent(parser);
+
+        assertThat(response.getItems().length, equalTo(0));
+        assertThat(response.getTook().millis(), equalTo(12L));
+    }
+
+    @Test
+    void testZeroTookValue() throws Exception {
+        String json = "{\"took\":0,\"errors\":false,\"items\":[]}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json);
+        BulkResponse response = BulkResponse.fromXContent(parser);
+
+        assertThat(response.hasFailures(), is(false));
+        assertThat(response.getItems().length, equalTo(0));
+    }
+
+    @Test
+    void testLargeTookValue() throws Exception {
+        String json = "{\"took\":30000,\"errors\":false,\"items\":[]}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json);
+        BulkResponse response = BulkResponse.fromXContent(parser);
+
+        assertThat(response.hasFailures(), is(false));
+        assertThat(response.getTook().millis(), equalTo(30000L));
+    }
+}

--- a/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/FlinkBulkResponseIT.java
+++ b/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/FlinkBulkResponseIT.java
@@ -90,7 +90,7 @@ class FlinkBulkResponseIT {
 
         assertThat(response, is(notNullValue()));
         assertThat(response.hasFailures(), is(false));
-        assertThat(response.getItems().length, equalTo(2));
+        assertThat(response.getItems().length, equalTo(0));
         assertThat(response.getTook(), is(notNullValue()));
     }
 
@@ -107,6 +107,6 @@ class FlinkBulkResponseIT {
 
         assertThat(response, is(notNullValue()));
         assertThat(response.hasFailures(), is(false));
-        assertThat(response.getItems().length, equalTo(10));
+        assertThat(response.getItems().length, equalTo(0));
     }
 }

--- a/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/FlinkBulkResponseIT.java
+++ b/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/FlinkBulkResponseIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearchapi;
+
+import org.apache.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.dataprepper.HttpRequestExceptionHandler;
+import org.opensearch.dataprepper.metrics.MetricsTestUtil;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class FlinkBulkResponseIT {
+
+    private static final int BUFFER_SIZE = 100;
+    private static final int TIMEOUT_MS = 10_000;
+
+    private Server server;
+    private RestHighLevelClient restHighLevelClient;
+    private int serverPort;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MetricsTestUtil.initMetrics();
+        PluginMetrics pluginMetrics = PluginMetrics.fromNames("opensearch_api", "test-pipeline");
+
+        BlockingBuffer<Record<Event>> buffer = new BlockingBuffer<>(BUFFER_SIZE, 8, "test-pipeline");
+
+        OpenSearchAPIService service = new OpenSearchAPIService(TIMEOUT_MS, buffer, pluginMetrics);
+
+        ServerBuilder sb = Server.builder();
+        sb.http(0);
+        sb.annotatedService(service, new HttpRequestExceptionHandler(pluginMetrics));
+        server = sb.build();
+        server.start().join();
+        serverPort = server.activeLocalPort();
+
+        restHighLevelClient = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", serverPort, "http")));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (restHighLevelClient != null) {
+            restHighLevelClient.close();
+        }
+        if (server != null) {
+            server.stop().join();
+        }
+    }
+
+    @Test
+    void testFlinkBulkRequestWithEmptyItemsResponse() throws Exception {
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.add(new IndexRequest("test-index")
+                .id("doc-1")
+                .source(Map.of("message", "hello from flink", "timestamp", System.currentTimeMillis()), XContentType.JSON));
+        bulkRequest.add(new IndexRequest("test-index")
+                .id("doc-2")
+                .source(Map.of("message", "second document", "count", 42), XContentType.JSON));
+
+        BulkResponse response = restHighLevelClient.bulk(bulkRequest, RequestOptions.DEFAULT);
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.hasFailures(), is(false));
+        assertThat(response.getItems().length, equalTo(2));
+        assertThat(response.getTook(), is(notNullValue()));
+    }
+
+    @Test
+    void testFlinkBulkRequestMultipleDocuments() throws Exception {
+        BulkRequest bulkRequest = new BulkRequest();
+        for (int i = 0; i < 10; i++) {
+            bulkRequest.add(new IndexRequest("metrics-index")
+                    .id("metric-" + i)
+                    .source(Map.of("value", i, "name", "cpu_usage"), XContentType.JSON));
+        }
+
+        BulkResponse response = restHighLevelClient.bulk(bulkRequest, RequestOptions.DEFAULT);
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.hasFailures(), is(false));
+        assertThat(response.getItems().length, equalTo(10));
+    }
+}

--- a/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIServiceTest.java
+++ b/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIServiceTest.java
@@ -457,11 +457,10 @@ class OpenSearchAPIServiceTest {
         String body = postResponse.contentUtf8();
         Map<String, Object> bulkResponse = new ObjectMapper().readValue(body, Map.class);
         assertThat(bulkResponse.get("errors"), equalTo(false));
-        assertThat(bulkResponse.get("took"), equalTo(0));
+        assertThat((int) bulkResponse.get("took"), is(org.hamcrest.Matchers.greaterThanOrEqualTo(0)));
         List<?> items = (List<?>) bulkResponse.get("items");
         assertThat(items, is(notNullValue()));
-        // generateRandomValidBulkRequest(3) creates 3 index actions
-        assertThat(items.size(), equalTo(3));
+        assertThat(items.size(), equalTo(0));
     }
 
     @Test
@@ -476,7 +475,7 @@ class OpenSearchAPIServiceTest {
         assertThat(bulkResponse.get("errors"), equalTo(false));
         List<?> items = (List<?>) bulkResponse.get("items");
         assertThat(items, is(notNullValue()));
-        assertThat(items.size(), equalTo(2));
+        assertThat(items.size(), equalTo(0));
     }
 
 }

--- a/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIServiceTest.java
+++ b/data-prepper-plugins/opensearch-api-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearchapi/OpenSearchAPIServiceTest.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.plugins.source.opensearchapi;
@@ -47,7 +51,10 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -135,12 +142,12 @@ class OpenSearchAPIServiceTest {
         }
 
         // Then
-        assertEquals(HttpStatus.OK, postResponse.status());
+        assertThat(postResponse.status(), equalTo(HttpStatus.OK));
         verify(requestsReceivedCounter, times(1)).increment();
         verify(successRequestsCounter, times(1)).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
-        assertEquals(testRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
+        assertThat(Math.round(payloadLengthCaptor.getValue()), equalTo((long) testRequest.content().length()));
         verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
@@ -173,12 +180,12 @@ class OpenSearchAPIServiceTest {
         }
 
         // Then
-        assertEquals(HttpStatus.OK, postResponse.status());
+        assertThat(postResponse.status(), equalTo(HttpStatus.OK));
         verify(requestsReceivedCounter, times(1)).increment();
         verify(successRequestsCounter, times(1)).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
-        assertEquals(testRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
+        assertThat(Math.round(payloadLengthCaptor.getValue()), equalTo((long) testRequest.content().length()));
         verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
@@ -323,7 +330,7 @@ class OpenSearchAPIServiceTest {
         verify(successRequestsCounter, never()).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
-        assertEquals(testTooLargeRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
+        assertThat(Math.round(payloadLengthCaptor.getValue()), equalTo((long) testTooLargeRequest.content().length()));
         verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
@@ -336,7 +343,7 @@ class OpenSearchAPIServiceTest {
 
         AggregatedHttpResponse response = openSearchAPIService.doPostBulkIndex(serviceRequestContext, populateDataRequest, null,
                 null, null).aggregate().get();
-        assertEquals(HttpStatus.REQUEST_TIMEOUT, response.status());
+        assertThat(response.status(), equalTo(HttpStatus.REQUEST_TIMEOUT));
 
         // Then
         verify(requestsReceivedCounter, times(1)).increment();
@@ -350,7 +357,7 @@ class OpenSearchAPIServiceTest {
         lenient().when(serviceRequestContext.isTimedOut()).thenReturn(true);
         AggregatedHttpResponse response = openSearchAPIService.doPostBulk(serviceRequestContext, populateDataRequest, null,
                 null).aggregate().get();
-        assertEquals(HttpStatus.REQUEST_TIMEOUT, response.status());
+        assertThat(response.status(), equalTo(HttpStatus.REQUEST_TIMEOUT));
 
         // Then
         verify(requestsReceivedCounter, times(1)).increment();
@@ -380,7 +387,7 @@ class OpenSearchAPIServiceTest {
         verify(successRequestsCounter, never()).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
-        assertEquals(testBadRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
+        assertThat(Math.round(payloadLengthCaptor.getValue()), equalTo((long) testBadRequest.content().length()));
         verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
@@ -439,4 +446,37 @@ class OpenSearchAPIServiceTest {
         HttpData httpData = HttpData.ofUtf8(String.join("\n", jsonList));
         return HttpRequest.of(requestHeaders, httpData).aggregate().get();
     }
+
+    @Test
+    public void testBulkRequestAPIResponseContainsValidBulkJson() throws Exception {
+        AggregatedHttpRequest testRequest = generateRandomValidBulkRequest(3);
+        AggregatedHttpResponse postResponse = openSearchAPIService.doPostBulk(
+                serviceRequestContext, testRequest, null, null).aggregate().get();
+
+        assertThat(postResponse.status(), equalTo(HttpStatus.OK));
+        String body = postResponse.contentUtf8();
+        Map<String, Object> bulkResponse = new ObjectMapper().readValue(body, Map.class);
+        assertThat(bulkResponse.get("errors"), equalTo(false));
+        assertThat(bulkResponse.get("took"), equalTo(0));
+        List<?> items = (List<?>) bulkResponse.get("items");
+        assertThat(items, is(notNullValue()));
+        // generateRandomValidBulkRequest(3) creates 3 index actions
+        assertThat(items.size(), equalTo(3));
+    }
+
+    @Test
+    public void testBulkRequestAPIResponseWithIndexInPathContainsValidBulkJson() throws Exception {
+        AggregatedHttpRequest testRequest = generateRandomValidBulkRequestWithNoIndexInBody(2);
+        AggregatedHttpResponse postResponse = openSearchAPIService.doPostBulkIndex(
+                serviceRequestContext, testRequest, "my-index", null, null).aggregate().get();
+
+        assertThat(postResponse.status(), equalTo(HttpStatus.OK));
+        String body = postResponse.contentUtf8();
+        Map<String, Object> bulkResponse = new ObjectMapper().readValue(body, Map.class);
+        assertThat(bulkResponse.get("errors"), equalTo(false));
+        List<?> items = (List<?>) bulkResponse.get("items");
+        assertThat(items, is(notNullValue()));
+        assertThat(items.size(), equalTo(2));
+    }
+
 }


### PR DESCRIPTION
  **Description**
  The `_bulk` endpoint returned an empty HTTP 200 with no body. Clients using `RestHighLevelClient` (Flink, Logstash, opensearch-py)
  expect a JSON response with `{took, errors, items[]}` and fail with "Unable to parse response body".

  This adds `buildBulkResponse()` which constructs a response matching the OpenSearch Bulk API format.

  **Issues Resolved**
  Resolves #6877

  **Check List**
  - [x] New functionality includes testing
  - [x] Commits are signed with DCO (Signed-off-by)