### PR TITLE
Add Throwable safety net to CloudWatch Logs sink Uploader

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/README.md
+++ b/data-prepper-plugins/cloudwatch-logs/README.md
@@ -111,6 +111,7 @@ threshold parameters.
 * `cloudWatchLogsRequestsSucceeded` - The number of log requests successfully made to CloudWatch Logs.
 * `cloudWatchLogsRequestsFailed` - The number of log requests failed to reach CloudWatch Logs.
 * `cloudWatchLogsEntityRejected` - The number of `PutLogEvents` responses where CloudWatch rejected the configured entity. The request itself still succeeds and events are released; this counter is the primary signal for misconfigured `entity` attributes.
+* `cloudWatchLogsUnhandledError` - The number of times an unexpected `Throwable` escaped the Uploader's normal retry/DLQ path. Distinct from `cloudWatchLogsEventsFailed`; non-zero values indicate a logic bug, classpath linkage failure, or response-handling error rather than transient API failure.
 
 ## Developer Guide
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
@@ -31,7 +31,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 @Builder
@@ -117,9 +119,27 @@ public class CloudWatchLogsDispatcher {
         private final boolean createLogGroup;
         private final boolean createLogStream;
 
+        @Builder.Default
+        private final Set<EventHandle> releasedHandles = new HashSet<>();
+        private boolean countedAsSuccess;
+        private boolean countedAsFailure;
+
         @Override
         public void run() {
-            upload();
+            try {
+                upload();
+            } catch (Throwable t) {
+                // Last-resort safety net for Throwables that escape upload().
+                LOG.error("Uploader thread for {}/{} encountered unexpected error; releasing {} events without DLQ",
+                        putLogEventsRequest.logGroupName(), putLogEventsRequest.logStreamName(), totalEventCount, t);
+                cloudWatchLogsMetrics.increaseUnhandledErrorCounter(1);
+                if (!countedAsSuccess && !countedAsFailure) {
+                    cloudWatchLogsMetrics.increaseLogEventFailCounter(totalEventCount);
+                }
+                for (final EventHandle handle : eventHandles) {
+                    releaseOnce(handle, dropIfDlqNotConfigured);
+                }
+            }
         }
 
         public void upload() {
@@ -164,6 +184,7 @@ public class CloudWatchLogsDispatcher {
 
             if (failedToTransmit) {
                 cloudWatchLogsMetrics.increaseLogEventFailCounter(totalEventCount);
+                countedAsFailure = true;
                 List<InputLogEvent> logEvents = putLogEventsRequest.logEvents();
                 for (int i = 0; i < logEvents.size(); i++) {
                     DlqObject dlqObject = CloudWatchLogsSinkUtils.createDlqObject(0, eventHandles.get(i), logEvents.get(i).message(), failureMessage, dlqPushHandler, dropIfDlqNotConfigured);
@@ -181,6 +202,7 @@ public class CloudWatchLogsDispatcher {
                             putLogEventsResponse.rejectedEntityInfo().errorTypeAsString());
                 }
                 cloudWatchLogsMetrics.increaseLogEventSuccessCounter(totalEventCount - dlqObjects.size());
+                countedAsSuccess = true;
                 releaseEventHandles(putLogEventsResponse);
             }
             CloudWatchLogsSinkUtils.handleDlqObjects(dlqObjects, dlqPushHandler);
@@ -281,7 +303,7 @@ public class CloudWatchLogsDispatcher {
 
         private void releaseEventHandles(final PutLogEventsResponse putLogEventsResponse) {
             if (putLogEventsResponse == null || putLogEventsResponse.rejectedLogEventsInfo() == null) {
-                eventHandles.forEach(eventHandle -> eventHandle.release(true));
+                eventHandles.forEach(eventHandle -> releaseOnce(eventHandle, true));
                 return;
             }
 
@@ -293,7 +315,22 @@ public class CloudWatchLogsDispatcher {
                         (tooNewStartIndex != null && i >= tooNewStartIndex);
 
                 if (!isRejected) {
-                    eventHandles.get(i).release(true);
+                    releaseOnce(eventHandles.get(i), true);
+                }
+            }
+        }
+
+        /**
+         * Releases an event handle exactly once. Prevents a second release with a conflicting
+         * result on the catch-all path, and prevents a single bad handle from aborting the rest
+         * of the batch.
+         */
+        private void releaseOnce(final EventHandle handle, final boolean result) {
+            if (releasedHandles.add(handle)) {
+                try {
+                    handle.release(result);
+                } catch (Throwable t) {
+                    LOG.warn("EventHandle.release threw", t);
                 }
             }
         }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
@@ -24,6 +24,7 @@ public class CloudWatchLogsMetrics {
     public static final String CLOUDWATCH_LOGS_LOG_SIZE = "cloudWatchLogsLogSize";
     public static final String CLOUDWATCH_LOGS_REQUEST_SIZE = "cloudWatchLogsRequestSize";
     public static final String CLOUDWATCH_LOGS_ENTITY_REJECTED = "cloudWatchLogsEntityRejected";
+    public static final String CLOUDWATCH_LOGS_UNHANDLED_ERROR = "cloudWatchLogsUnhandledError";
     private final Counter logEventSuccessCounter;
     private final Counter logEventFailCounter;
     private final Counter requestSuccessCount;
@@ -31,6 +32,7 @@ public class CloudWatchLogsMetrics {
     private final Counter requestMultiFailCount;
     private final Counter logLargeEventsDroppedCounter;
     private final Counter entityRejectedCounter;
+    private final Counter unhandledErrorCounter;
     private final DistributionSummary logSizeMetric;
     private final DistributionSummary requestSizeMetric;
 
@@ -42,6 +44,7 @@ public class CloudWatchLogsMetrics {
         this.requestSuccessCount = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED);
         this.logLargeEventsDroppedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_LARGE_EVENTS_DROPPED);
         this.entityRejectedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_REJECTED);
+        this.unhandledErrorCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_UNHANDLED_ERROR);
         this.logSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_LOG_SIZE);
         this.requestSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_REQUEST_SIZE);
     }
@@ -72,6 +75,10 @@ public class CloudWatchLogsMetrics {
 
     public void increaseEntityRejectedCounter(int value) {
         entityRejectedCounter.increment(value);
+    }
+
+    public void increaseUnhandledErrorCounter(int value) {
+        unhandledErrorCounter.increment(value);
     }
 
     public void recordLogSize(int value) {

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -38,6 +38,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -292,6 +294,13 @@ class CloudWatchLogsDispatcherTest {
 
         verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
         verify(mockCloudWatchLogsMetrics, never()).increaseRequestSuccessCounter(1);
+
+        // Pin the contract that the catch-all in run() does NOT fire on the normal
+        // CloudWatchLogsException retry-exhaustion path. Without this, a future refactor that
+        // accidentally routes a normal exception through the catch-all (e.g. by removing the
+        // inner catch (Exception e)) would silently double-fire metrics — every retry-exhaustion
+        // would increment both eventsFailed AND unhandledError, and this test would still pass.
+        verify(mockCloudWatchLogsMetrics, never()).increaseUnhandledErrorCounter(anyInt());
 
         // No events should be released after max retries
         eventHandles.forEach(eventHandle -> verify(eventHandle).release(true));
@@ -665,5 +674,102 @@ class CloudWatchLogsDispatcherTest {
         verify(mockCloudWatchLogsMetrics, times(1)).increaseEntityRejectedCounter(1);
         verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestSuccessCounter(1);
         eventHandles.forEach(eventHandle -> verify(eventHandle).release(true));
+    }
+
+    @Test
+    void GIVEN_error_thrown_from_put_log_events_WHEN_run_SHOULD_route_to_unhandled_error_path() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(new NoSuchMethodError("simulated linkage failure"));
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // Dedicated unhandled-error metric incremented once — distinct from normal retry exhaustion.
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseUnhandledErrorCounter(1);
+        // Neither count flag was set before the Error escaped, so events must be accounted as failed.
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseLogEventFailCounter(eventHandles.size());
+        // No phantom successes.
+        verify(mockCloudWatchLogsMetrics, never()).increaseLogEventSuccessCounter(anyInt());
+        // Every handle released exactly once with dropIfDlqNotConfigured=true so the source can make forward progress.
+        eventHandles.forEach(handle -> verify(handle, times(1)).release(true));
+    }
+
+    @Test
+    void GIVEN_runtime_exception_from_response_handling_WHEN_run_SHOULD_route_to_unhandled_error_path() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        when(response.rejectedLogEventsInfo()).thenThrow(new RuntimeException("simulated response failure"));
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseUnhandledErrorCounter(1);
+        // PutLogEvents itself succeeded (request-level success), but the events couldn't be
+        // accounted because of the response-handling failure → fail counter increments.
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseLogEventFailCounter(eventHandles.size());
+        verify(mockCloudWatchLogsMetrics, never()).increaseLogEventSuccessCounter(anyInt());
+        eventHandles.forEach(handle -> verify(handle, times(1)).release(true));
+    }
+
+    @Test
+    void GIVEN_throwable_after_success_counted_WHEN_run_SHOULD_not_double_count_failures() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        when(response.rejectedLogEventsInfo())
+                .thenReturn(null)
+                .thenThrow(new RuntimeException("simulated post-success failure"));
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // Catch-all fired.
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseUnhandledErrorCounter(1);
+        // Critical: success was already counted; the catch-all must NOT also count failures.
+        verify(mockCloudWatchLogsMetrics, never()).increaseLogEventFailCounter(anyInt());
+        // Success counter was incremented before the Throwable escaped.
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseLogEventSuccessCounter(eventHandles.size());
+    }
+
+    @Test
+    void GIVEN_event_handle_release_throws_WHEN_run_SHOULD_swallow_and_continue_releasing_other_handles() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        // Handle at index 5 throws on release() — releaseOnce must swallow and the loop must continue.
+        doThrow(new RuntimeException("simulated bad handle"))
+                .when(eventHandles.get(5)).release(true);
+
+        final PutLogEventsResponse response = mock(PutLogEventsResponse.class);
+        when(response.rejectedLogEventsInfo()).thenReturn(null);
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(response);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // Every handle had release(true) attempted exactly once — the bad handle did not abort the loop.
+        eventHandles.forEach(handle -> verify(handle, times(1)).release(true));
+        // No handle was released with the catch-all's negative result — the success path completed.
+        eventHandles.forEach(handle -> verify(handle, never()).release(false));
+        // Success path completed normally — catch-all NOT triggered.
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseLogEventSuccessCounter(eventHandles.size());
+        verify(mockCloudWatchLogsMetrics, never()).increaseUnhandledErrorCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseLogEventFailCounter(anyInt());
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetricsTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetricsTest.java
@@ -19,6 +19,7 @@ class CloudWatchLogsMetricsTest {
     private Counter mockFailedEventCounter;
     private Counter mockFailedRequestCounter;
     private Counter mockEntityRejectedCounter;
+    private Counter mockUnhandledErrorCounter;
 
     @BeforeEach
     void setUp() {
@@ -28,12 +29,14 @@ class CloudWatchLogsMetricsTest {
         mockFailedEventCounter = mock(Counter.class);
         mockFailedRequestCounter = mock(Counter.class);
         mockEntityRejectedCounter = mock(Counter.class);
+        mockUnhandledErrorCounter = mock(Counter.class);
 
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_EVENTS_SUCCEEDED)).thenReturn(mockSuccessEventCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED)).thenReturn(mockSuccessRequestCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_EVENTS_FAILED)).thenReturn(mockFailedEventCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED)).thenReturn(mockFailedRequestCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_REJECTED)).thenReturn(mockEntityRejectedCounter);
+        when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_UNHANDLED_ERROR)).thenReturn(mockUnhandledErrorCounter);
 
         testCloudWatchLogsMetrics = new CloudWatchLogsMetrics(mockPluginMetrics);
     }
@@ -71,5 +74,11 @@ class CloudWatchLogsMetricsTest {
     void WHEN_increase_entity_rejected_counter_called_THEN_entity_rejected_counter_increase_method_should_be_called() {
         testCloudWatchLogsMetrics.increaseEntityRejectedCounter(1);
         verify(mockEntityRejectedCounter, times(1)).increment(1);
+    }
+
+    @Test
+    void WHEN_increase_unhandled_error_counter_called_THEN_unhandled_error_counter_increase_method_should_be_called() {
+        testCloudWatchLogsMetrics.increaseUnhandledErrorCounter(1);
+        verify(mockUnhandledErrorCounter, times(1)).increment(1);
     }
 }


### PR DESCRIPTION
When an unchecked Throwable escaped Uploader.upload(), the executor worker thread terminated silently. The batch's events were never acknowledged, never DLQ'd, and never reflected in any metric — a fatal classpath or runtime issue produced no operator-visible signal beyond a single stderr line from ThreadPoolExecutor. This change makes such failures observable and recoverable: the unhandled-error path now emits a dedicated metric and structured log, accounts the lost events in the existing failure counter, and releases event handles so the source can make forward progress instead of waiting indefinitely for an ack.

Closing the safety gap also required fixing a latent correctness bug that a naive catch-all would have compounded. Success and failure metrics were incremented before the post-loop cleanup ran, so a Throwable escaping after that point would have produced succeeded + failed > total — breaking any percentage-based dashboard or "no events failed" alarm. Without addressing this, the safety net would have traded silent loss for inconsistent metrics.

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #6887
 
### Check List
- [Y ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [ Y] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
