### PR TITLE
Fix bug that would cause ddb stream processing to start before export completed

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
@@ -197,7 +197,7 @@ public class ExportScheduler implements Runnable {
 
         // Currently, we need to maintain a global state to track the overall progress.
         // So that we can easily tell if all the export files are loaded
-        LoadStatus loadStatus = new LoadStatus(totalFiles.get(), 0, totalRecords.get(), 0);
+        LoadStatus loadStatus = new LoadStatus(dataFileInfo.size(), 0, totalRecords.get(), 0);
         enhancedSourceCoordinator.createPartition(new GlobalState(exportArn, Optional.of(loadStatus.toMap())));
 
         dataFileInfo.forEach((key, size) -> {

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.ExportProgressState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.ExportSummary;
+import org.opensearch.dataprepper.plugins.source.dynamodb.model.LoadStatus;
 import org.opensearch.dataprepper.plugins.source.dynamodb.utils.DynamoDBSourceAggregateMetrics;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeExportRequest;
@@ -184,6 +185,12 @@ class ExportSchedulerTest {
         assertThat(createdPartitions.get(0), instanceOf(GlobalState.class));
         assertThat(createdPartitions.get(1), instanceOf(DataFilePartition.class));
         assertThat(createdPartitions.get(2), instanceOf(DataFilePartition.class));
+
+        // Verify the GlobalState LoadStatus has accurate totalFiles count
+        GlobalState globalState = (GlobalState) createdPartitions.get(0);
+        LoadStatus loadStatus = LoadStatus.fromMap(globalState.getProgressState().get());
+        assertThat(loadStatus.getTotalFiles(), equalTo(2));
+        assertThat(loadStatus.getLoadedFiles(), equalTo(0));
 
         // Complete the export partition
         verify(coordinator).completePartition(any(EnhancedSourcePartition.class));


### PR DESCRIPTION

### Description
The totalFiles was being set to 0 for the export item tracker, which would lead to stream data being processed at the same time as export. This could lead to extra documents due to delete stream events being overridden by export data, even with versioning enabled.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
