### PR TITLE
Add support for named configurations in aws config block

### DIFF
--- a/data-prepper-plugins/aws-lambda/src/integrationTest/java/org/opensearch/dataprepper/plugins/lambda/LambdaProcessorSinkIT.java
+++ b/data-prepper-plugins/aws-lambda/src/integrationTest/java/org/opensearch/dataprepper/plugins/lambda/LambdaProcessorSinkIT.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.types.ByteCount;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.plugins.lambda.common.config.InvocationType;
@@ -188,7 +189,7 @@ public class LambdaProcessorSinkIT {
         lambdaProcessorConfig = mock(LambdaProcessorConfig.class);
         expressionEvaluator = mock(ExpressionEvaluator.class);
         awsCredentialsProvider = DefaultCredentialsProvider.create();
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         pluginFactory = mock(PluginFactory.class);
         JsonInputCodecConfig jsonInputCodecConfig = mock(JsonInputCodecConfig.class);
         when(jsonInputCodecConfig.getKeyName()).thenReturn(null);

--- a/data-prepper-plugins/aws-lambda/src/integrationTest/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorIT.java
+++ b/data-prepper-plugins/aws-lambda/src/integrationTest/java/org/opensearch/dataprepper/plugins/lambda/processor/LambdaProcessorIT.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
@@ -145,7 +146,7 @@ public class LambdaProcessorIT {
         lambdaProcessorConfig = mock(LambdaProcessorConfig.class);
         expressionEvaluator = mock(ExpressionEvaluator.class);
         awsCredentialsProvider = DefaultCredentialsProvider.create();
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         pluginFactory = mock(PluginFactory.class);
         JsonInputCodecConfig jsonInputCodecConfig = mock(JsonInputCodecConfig.class);
         when(jsonInputCodecConfig.getKeyName()).thenReturn(null);
@@ -476,7 +477,7 @@ public class LambdaProcessorIT {
         when(lambdaProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
 
         // Setup the mock for getProvider
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         // Mock the factory to inject our CountingRetryCondition into the LambdaAsyncClient
         try (MockedStatic<LambdaClientFactory> mockedFactory = mockStatic(LambdaClientFactory.class)) {

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsConfig.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsConfig.java
@@ -11,6 +11,7 @@ package org.opensearch.dataprepper.aws.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.AssertTrue;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.Map;
@@ -33,6 +34,10 @@ public class AwsConfig {
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
 
+    @JsonProperty("configuration")
+    private String configuration;
+
+
     @JsonProperty("sts_external_id")
     @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
     private String awsStsExternalId;
@@ -52,4 +57,18 @@ public class AwsConfig {
     public Map<String, String> getAwsStsHeaderOverrides() {
         return awsStsHeaderOverrides;
     }
+
+    @AssertTrue(message = "'configuration' cannot be used together with 'region', 'sts_role_arn', 'sts_header_overrides', or 'sts_external_id'. " +
+            "Use either a named configuration reference or inline credentials, not both.")
+    public boolean isValidConfiguration() {
+        if (configuration != null) {
+            return awsRegion == null && awsStsRoleArn == null && awsStsHeaderOverrides == null && awsStsExternalId == null;
+        }
+        return true;
+    }
+
+    public String getConfiguration() {
+        return configuration;
+    }
+
 }

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
@@ -28,6 +28,14 @@ public interface AwsCredentialsSupplier {
     AwsCredentialsProvider getProvider(AwsCredentialsOptions options);
 
     /**
+     * Gets an AWS SDK {@link AwsCredentialsProvider} resolved from a named configuration
+     * defined in the extensions.aws.configurations block.
+     * @param configurationName The name of the configuration (e.g. "ecs_task_role")
+     * @return An {@link AwsCredentialsProvider} to use.
+     */
+    AwsCredentialsProvider getProvider(String configurationName);
+
+    /**
      * Gets the default region if it is configured. Otherwise returns null
      * @return Default {@link Region}
      */

--- a/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsConfigTest.java
+++ b/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsConfigTest.java
@@ -49,6 +49,64 @@ public class AwsConfigTest {
         assertThat(awsConfig.getAwsRegion(), equalTo(Region.of(testRegion)));
     }
 
+    @Test
+    void TestConfigOptions_configuration_returns_value() throws NoSuchFieldException, IllegalAccessException {
+        final String configName = "ecs_task_role";
+        reflectivelySetField(awsConfig, "configuration", configName);
+        assertThat(awsConfig.getConfiguration(), equalTo(configName));
+    }
+
+    @Test
+    void TestConfigOptions_configuration_returns_null_by_default() {
+        assertThat(awsConfig.getConfiguration(), equalTo(null));
+    }
+
+    @Test
+    void isValidConfiguration_returns_true_when_configuration_is_null() {
+        assertThat(awsConfig.isValidConfiguration(), equalTo(true));
+    }
+
+    @Test
+    void isValidConfiguration_returns_true_when_only_configuration_is_set() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsConfig, "configuration", "my_config");
+        assertThat(awsConfig.isValidConfiguration(), equalTo(true));
+    }
+
+    @Test
+    void isValidConfiguration_returns_false_when_configuration_and_region_are_set() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsConfig, "configuration", "my_config");
+        reflectivelySetField(awsConfig, "awsRegion", "us-east-1");
+        assertThat(awsConfig.isValidConfiguration(), equalTo(false));
+    }
+
+    @Test
+    void isValidConfiguration_returns_false_when_configuration_and_sts_role_arn_are_set() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsConfig, "configuration", "my_config");
+        reflectivelySetField(awsConfig, "awsStsRoleArn", "arn:aws:iam::123456789012:role/TestRole");
+        assertThat(awsConfig.isValidConfiguration(), equalTo(false));
+    }
+
+    @Test
+    void isValidConfiguration_returns_false_when_configuration_and_sts_header_overrides_are_set() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsConfig, "configuration", "my_config");
+        reflectivelySetField(awsConfig, "awsStsHeaderOverrides", Map.of("key", "value"));
+        assertThat(awsConfig.isValidConfiguration(), equalTo(false));
+    }
+
+    @Test
+    void isValidConfiguration_returns_false_when_configuration_and_sts_external_id_are_set() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsConfig, "configuration", "my_config");
+        reflectivelySetField(awsConfig, "awsStsExternalId", "ext-id-123");
+        assertThat(awsConfig.isValidConfiguration(), equalTo(false));
+    }
+
+    @Test
+    void isValidConfiguration_returns_true_when_inline_credentials_used_without_configuration() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsConfig, "awsRegion", "us-east-1");
+        reflectivelySetField(awsConfig, "awsStsRoleArn", "arn:aws:iam::123456789012:role/TestRole");
+        assertThat(awsConfig.isValidConfiguration(), equalTo(true));
+    }
+
     private void reflectivelySetField(final AwsConfig awsConfig, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
         final Field field = AwsConfig.class.getDeclaredField(fieldName);
         try {

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPlugin.java
@@ -32,7 +32,9 @@ public class AwsPlugin implements ExtensionPlugin {
 
         this.awsPluginConfig = awsPluginConfig;
 
-        final CredentialsProviderFactory credentialsProviderFactory = new CredentialsProviderFactory(awsPluginConfig != null ? awsPluginConfig.getDefaultStsConfiguration() : new AwsStsConfiguration());
+        final CredentialsProviderFactory credentialsProviderFactory = new CredentialsProviderFactory(
+                awsPluginConfig != null ? awsPluginConfig.getDefaultStsConfiguration() : new AwsStsConfiguration(),
+                awsPluginConfig);
         final CredentialsCache credentialsCache = new CredentialsCache();
         defaultAwsCredentialsSupplier = new DefaultAwsCredentialsSupplier(credentialsProviderFactory, credentialsCache);
     }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfig.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfig.java
@@ -9,7 +9,13 @@
 
 package org.opensearch.dataprepper.plugins.aws;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AwsPluginConfig {
 
@@ -18,5 +24,25 @@ public class AwsPluginConfig {
 
     public AwsStsConfiguration getDefaultStsConfiguration() {
         return defaultStsConfiguration;
+    }
+
+    private Map<String, AwsStsConfiguration> allOtherConfigurations = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, AwsStsConfiguration> getAllOtherConfigurations() {
+        return allOtherConfigurations;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalConfiguration(String name, AwsStsConfiguration configuration) {
+        allOtherConfigurations.put(name, configuration);
+    }
+
+    public Collection<String> listNonDefaultConfigurations() {
+        return allOtherConfigurations.keySet();
+    }
+
+    public AwsStsConfiguration getConfiguration(String name) {
+        return allOtherConfigurations.get(name);
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
@@ -28,6 +28,10 @@ public class AwsStsConfiguration {
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
 
+    @JsonProperty("use_aws_sdk_default")
+    private boolean useAwsSdkDefault = false;
+
+
     public Region getAwsRegion() {
         return awsRegion != null ? Region.of(awsRegion) : null;
     }
@@ -38,5 +42,9 @@ public class AwsStsConfiguration {
 
     public Map<String, String> getStsHeaderOverrides() {
         return awsStsHeaderOverrides;
+    }
+
+    public boolean isUseAwsSdkDefault() {
+        return useAwsSdkDefault;
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -41,10 +41,42 @@ class CredentialsProviderFactory {
     static final long STS_CLIENT_MAX_BACKOFF_MILLIS = 60000L;
 
     private final AwsStsConfiguration defaultStsConfiguration;
+    private final AwsPluginConfig awsPluginConfig;
 
     public CredentialsProviderFactory(final AwsStsConfiguration defaultStsConfiguration) {
+        this(defaultStsConfiguration, null);
+    }
+
+    public CredentialsProviderFactory(final AwsStsConfiguration defaultStsConfiguration, final AwsPluginConfig awsPluginConfig) {
         Objects.requireNonNull(defaultStsConfiguration);
         this.defaultStsConfiguration = defaultStsConfiguration;
+        this.awsPluginConfig = awsPluginConfig;
+    }
+
+    AwsCredentialsOptions resolveNamedConfiguration(final String configurationName) {
+        if (awsPluginConfig == null) {
+            throw new IllegalArgumentException("Named configuration '" + configurationName +
+                    "' referenced but no aws extensions configured");
+        }
+        final AwsStsConfiguration namedConfig = awsPluginConfig.getConfiguration(configurationName);
+        if (namedConfig == null) {
+            throw new IllegalArgumentException("Named configuration '" + configurationName +
+                    "' not found in extensions.aws.configurations");
+        }
+        if (namedConfig.isUseAwsSdkDefault()) {
+            return AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider();
+        }
+        final AwsCredentialsOptions.Builder builder = AwsCredentialsOptions.builder();
+        if (namedConfig.getAwsRegion() != null) {
+            builder.withRegion(namedConfig.getAwsRegion());
+        }
+        if (namedConfig.getAwsStsRoleArn() != null) {
+            builder.withStsRoleArn(namedConfig.getAwsStsRoleArn());
+        }
+        if (namedConfig.getStsHeaderOverrides() != null) {
+            builder.withStsHeaderOverrides(namedConfig.getStsHeaderOverrides());
+        }
+        return builder.build();
     }
 
     Region getDefaultRegion() {

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
@@ -32,6 +32,12 @@ class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     }
 
     @Override
+    public AwsCredentialsProvider getProvider(final String configurationName) {
+        final AwsCredentialsOptions options = credentialsProviderFactory.resolveNamedConfiguration(configurationName);
+        return getProvider(options);
+    }
+
+    @Override
     public Optional<Region> getDefaultRegion() {
         return Optional.ofNullable(credentialsProviderFactory.getDefaultRegion());
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigTest.java
@@ -9,11 +9,15 @@
 
 package org.opensearch.dataprepper.plugins.aws;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AwsPluginConfigTest {
 
@@ -26,4 +30,56 @@ public class AwsPluginConfigTest {
         assertThat(objectUnderTest.getDefaultStsConfiguration().getAwsRegion(), nullValue());
         assertThat(objectUnderTest.getDefaultStsConfiguration().getAwsStsRoleArn(), nullValue());
     }
+
+    @Test
+    void testNamedConfiguration_via_json() throws JsonProcessingException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final String json = "{\"default\": {\"region\": \"us-east-1\", \"sts_role_arn\": \"arn:aws:iam::123456789012:role/DefaultRole\"}, " +
+                "\"ecs_task_role\": {\"use_aws_sdk_default\": true}}";
+
+        final AwsPluginConfig objectUnderTest = objectMapper.readValue(json, AwsPluginConfig.class);
+
+        assertThat(objectUnderTest.getDefaultStsConfiguration(), notNullValue());
+        assertThat(objectUnderTest.getDefaultStsConfiguration().getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/DefaultRole"));
+
+        assertThat(objectUnderTest.getConfiguration("ecs_task_role"), notNullValue());
+        assertTrue(objectUnderTest.getConfiguration("ecs_task_role").isUseAwsSdkDefault());
+    }
+
+    @Test
+    void testNamedConfiguration_not_found_returns_null() {
+        final AwsPluginConfig objectUnderTest = new AwsPluginConfig();
+        assertThat(objectUnderTest.getConfiguration("nonexistent"), nullValue());
+    }
+
+    @Test
+    void testListNonDefaultConfigurations_empty_by_default() {
+        final AwsPluginConfig objectUnderTest = new AwsPluginConfig();
+        assertTrue(objectUnderTest.listNonDefaultConfigurations().isEmpty());
+    }
+
+    @Test
+    void testListNonDefaultConfigurations_returns_named_configs() throws JsonProcessingException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final String json = "{\"default\": {}, \"config_a\": {\"use_aws_sdk_default\": true}, \"config_b\": {\"region\": \"eu-west-1\"}}";
+
+        final AwsPluginConfig objectUnderTest = objectMapper.readValue(json, AwsPluginConfig.class);
+
+        assertThat(objectUnderTest.listNonDefaultConfigurations().size(), equalTo(2));
+        assertTrue(objectUnderTest.listNonDefaultConfigurations().contains("config_a"));
+        assertTrue(objectUnderTest.listNonDefaultConfigurations().contains("config_b"));
+    }
+
+    @Test
+    void testGetAllOtherConfigurations_returns_map() throws JsonProcessingException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final String json = "{\"default\": {}, \"config_a\": {\"use_aws_sdk_default\": true}}";
+
+        final AwsPluginConfig objectUnderTest = objectMapper.readValue(json, AwsPluginConfig.class);
+
+        assertThat(objectUnderTest.getAllOtherConfigurations(), notNullValue());
+        assertThat(objectUnderTest.getAllOtherConfigurations().size(), equalTo(1));
+        assertTrue(objectUnderTest.getAllOtherConfigurations().containsKey("config_a"));
+    }
+
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
@@ -49,6 +49,20 @@ public class AwsStsConfigurationTest {
         assertThat(objectUnderTest.getStsHeaderOverrides(), equalTo(Map.of("abc", "123", "def", "456")));
     }
 
+    @Test
+    void testUseAwsSdkDefault_defaults_to_false() throws JsonProcessingException {
+        final String jsonConfiguration = "{\"sts_role_arn\": \"arn:aws:iam::123456789012:role/test-role\"}";
+        final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(jsonConfiguration, AwsStsConfiguration.class);
+        assertThat(objectUnderTest.isUseAwsSdkDefault(), equalTo(false));
+    }
+
+    @Test
+    void testUseAwsSdkDefault_true() throws JsonProcessingException {
+        final String jsonConfiguration = "{\"use_aws_sdk_default\": true}";
+        final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(jsonConfiguration, AwsStsConfiguration.class);
+        assertThat(objectUnderTest.isUseAwsSdkDefault(), equalTo(true));
+    }
+
     private static List<Region> getRegions() {
         return Region.regions();
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -52,6 +52,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -530,4 +532,67 @@ class CredentialsProviderFactoryTest {
     private String createStsRole() {
         return String.format("arn:aws:iam::123456789012:role/%s", UUID.randomUUID());
     }
+
+    @Nested
+    class ResolveNamedConfiguration {
+        @Test
+        void throws_when_awsPluginConfig_is_null() {
+            final CredentialsProviderFactory factory = new CredentialsProviderFactory(defaultStsConfiguration);
+            assertThrows(IllegalArgumentException.class, () -> factory.resolveNamedConfiguration("some_config"));
+        }
+
+        @Test
+        void throws_when_named_config_not_found() {
+            final AwsPluginConfig pluginConfig = mock(AwsPluginConfig.class);
+            when(pluginConfig.getConfiguration("missing")).thenReturn(null);
+            final CredentialsProviderFactory factory = new CredentialsProviderFactory(defaultStsConfiguration, pluginConfig);
+            assertThrows(IllegalArgumentException.class, () -> factory.resolveNamedConfiguration("missing"));
+        }
+
+        @Test
+        void returns_default_credentials_when_useAwsSdkDefault_is_true() {
+            final AwsPluginConfig pluginConfig = mock(AwsPluginConfig.class);
+            final AwsStsConfiguration namedConfig = mock(AwsStsConfiguration.class);
+            when(namedConfig.isUseAwsSdkDefault()).thenReturn(true);
+            when(pluginConfig.getConfiguration("ecs_task_role")).thenReturn(namedConfig);
+            final CredentialsProviderFactory factory = new CredentialsProviderFactory(defaultStsConfiguration, pluginConfig);
+
+            final AwsCredentialsOptions result = factory.resolveNamedConfiguration("ecs_task_role");
+            assertThat(result, equalTo(AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider()));
+        }
+
+        @Test
+        void returns_options_with_region_and_role() {
+            final AwsPluginConfig pluginConfig = mock(AwsPluginConfig.class);
+            final AwsStsConfiguration namedConfig = mock(AwsStsConfiguration.class);
+            when(namedConfig.isUseAwsSdkDefault()).thenReturn(false);
+            when(namedConfig.getAwsRegion()).thenReturn(Region.EU_WEST_1);
+            when(namedConfig.getAwsStsRoleArn()).thenReturn("arn:aws:iam::123456789012:role/TestRole");
+            when(namedConfig.getStsHeaderOverrides()).thenReturn(Map.of("key", "value"));
+            when(pluginConfig.getConfiguration("custom_config")).thenReturn(namedConfig);
+            final CredentialsProviderFactory factory = new CredentialsProviderFactory(defaultStsConfiguration, pluginConfig);
+
+            final AwsCredentialsOptions result = factory.resolveNamedConfiguration("custom_config");
+            assertThat(result.getRegion(), equalTo(Region.EU_WEST_1));
+            assertThat(result.getStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/TestRole"));
+            assertThat(result.getStsHeaderOverrides(), equalTo(Map.of("key", "value")));
+        }
+
+        @Test
+        void returns_options_with_nulls_when_fields_not_set() {
+            final AwsPluginConfig pluginConfig = mock(AwsPluginConfig.class);
+            final AwsStsConfiguration namedConfig = mock(AwsStsConfiguration.class);
+            when(namedConfig.isUseAwsSdkDefault()).thenReturn(false);
+            when(namedConfig.getAwsRegion()).thenReturn(null);
+            when(namedConfig.getAwsStsRoleArn()).thenReturn(null);
+            when(namedConfig.getStsHeaderOverrides()).thenReturn(null);
+            when(pluginConfig.getConfiguration("minimal")).thenReturn(namedConfig);
+            final CredentialsProviderFactory factory = new CredentialsProviderFactory(defaultStsConfiguration, pluginConfig);
+
+            final AwsCredentialsOptions result = factory.resolveNamedConfiguration("minimal");
+            assertThat(result.getRegion(), nullValue());
+            assertThat(result.getStsRoleArn(), nullValue());
+        }
+    }
+
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
@@ -110,4 +110,20 @@ class DefaultAwsCredentialsSupplierTest {
     private static List<Region> getRegions() {
         return Region.regions();
     }
+
+    @Test
+    void getProvider_with_configurationName_resolves_and_delegates() {
+        final String configName = "ecs_task_role";
+        final AwsCredentialsOptions resolvedOptions = mock(AwsCredentialsOptions.class);
+        final AwsCredentialsProvider expectedProvider = mock(AwsCredentialsProvider.class);
+
+        when(credentialsProviderFactory.resolveNamedConfiguration(configName)).thenReturn(resolvedOptions);
+        when(credentialsCache.getOrCreate(any(), any())).thenReturn(expectedProvider);
+
+        final AwsCredentialsProvider result = createObjectUnderTest().getProvider(configName);
+
+        assertThat(result, equalTo(expectedProvider));
+        verify(credentialsProviderFactory).resolveNamedConfiguration(configName);
+    }
+
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.AwsConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatchLogsSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsMetrics;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsClientFactory;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsRequest;
@@ -157,7 +158,7 @@ public class CloudWatchLogsIT {
         when(awsConfig.getAwsStsRoleArn()).thenReturn(awsRole);
         when(awsConfig.getAwsStsExternalId()).thenReturn(null);
         when(awsConfig.getAwsStsHeaderOverrides()).thenReturn(null);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         cloudWatchLogsClient = CloudWatchLogsClientFactory.createCwlClient(awsConfig, awsCredentialsSupplier, new HashMap<>(), null);
         logGroupName = System.getProperty("tests.cloudwatch.log_group");
         logStreamName = createLogStream(logGroupName);
@@ -557,7 +558,7 @@ public class CloudWatchLogsIT {
         when(thresholdConfig.getMaxRequestSizeBytes()).thenReturn(1000L);
         lenient().when(thresholdConfig.getFlushInterval()).thenReturn(1L);
         AwsCredentialsProvider provider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(provider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(provider);
 
         sink = createObjectUnderTest();
         Collection<Record<Event>> records = getRecordList(NUM_RECORDS);

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactoryTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsClientFactoryTest.java
@@ -63,7 +63,7 @@ class CloudWatchLogsClientFactoryTest {
 
     @Test
     void GIVEN_default_credentials_SHOULD_return_non_null_client() {
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
         final CloudWatchLogsClient cloudWatchLogsClientToTest = CloudWatchLogsClientFactory.createCwlClient(mockAwsConfig, mockAwsCredentialsSupplier, new HashMap<>(), null);
 
         assertNotNull(cloudWatchLogsClientToTest);
@@ -94,7 +94,7 @@ class CloudWatchLogsClientFactoryTest {
         when(mockAwsConfig.getAwsStsHeaderOverrides()).thenReturn(stsHeaderOverrides);
 
         final AwsCredentialsProvider expectedCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(mockAwsCredentialsSupplier.getProvider(ArgumentMatchers.any())).thenReturn(expectedCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(ArgumentMatchers.any(AwsCredentialsOptions.class))).thenReturn(expectedCredentialsProvider);
 
         final CloudWatchLogsClientBuilder cloudWatchLogsClientBuilder = mock(CloudWatchLogsClientBuilder.class);
         when(cloudWatchLogsClientBuilder.region(mockAwsConfig.getAwsRegion())).thenReturn(cloudWatchLogsClientBuilder);
@@ -130,7 +130,7 @@ class CloudWatchLogsClientFactoryTest {
             "X-Custom-Header", "custom-value",
             "X-Request-ID", "request-123"
         );
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
 
         final CloudWatchLogsClientBuilder cloudWatchLogsClientBuilder = mock(CloudWatchLogsClientBuilder.class);
         when(cloudWatchLogsClientBuilder.region(any())).thenReturn(cloudWatchLogsClientBuilder);
@@ -161,7 +161,7 @@ class CloudWatchLogsClientFactoryTest {
     void GIVEN_empty_custom_headers_SHOULD_create_client_without_custom_headers() {
         // Arrange
         final Map<String, String> emptyHeaders = new HashMap<>();
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
 
         final CloudWatchLogsClientBuilder cloudWatchLogsClientBuilder = mock(CloudWatchLogsClientBuilder.class);
         when(cloudWatchLogsClientBuilder.region(any())).thenReturn(cloudWatchLogsClientBuilder);
@@ -191,7 +191,7 @@ class CloudWatchLogsClientFactoryTest {
     void GIVEN_endpoint_SHOULD_create_client_with_endpoint_override() {
         // Arrange
         final String customEndpoint = "https://logs.us-west-2.amazonaws.com";
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
 
         final CloudWatchLogsClientBuilder cloudWatchLogsClientBuilder = mock(CloudWatchLogsClientBuilder.class);
         when(cloudWatchLogsClientBuilder.region(any())).thenReturn(cloudWatchLogsClientBuilder);
@@ -218,7 +218,7 @@ class CloudWatchLogsClientFactoryTest {
     @Test
     void GIVEN_null_endpoint_SHOULD_create_client_without_endpoint_override() {
         // Arrange
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
 
         final CloudWatchLogsClientBuilder cloudWatchLogsClientBuilder = mock(CloudWatchLogsClientBuilder.class);
         when(cloudWatchLogsClientBuilder.region(any())).thenReturn(cloudWatchLogsClientBuilder);
@@ -240,7 +240,7 @@ class CloudWatchLogsClientFactoryTest {
     @Test
     void GIVEN_empty_endpoint_SHOULD_create_client_without_endpoint_override() {
         // Arrange
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
 
         final CloudWatchLogsClientBuilder cloudWatchLogsClientBuilder = mock(CloudWatchLogsClientBuilder.class);
         when(cloudWatchLogsClientBuilder.region(any())).thenReturn(cloudWatchLogsClientBuilder);

--- a/data-prepper-plugins/http-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/http/HttpSinkIT.java
+++ b/data-prepper-plugins/http-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/http/HttpSinkIT.java
@@ -25,6 +25,7 @@ import static org.awaitility.Awaitility.await;
 import org.mockito.quality.Strictness;
 import org.opensearch.dataprepper.aws.api.AwsConfig;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.core.pipeline.Pipeline;
 import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -165,7 +166,7 @@ class HttpSinkIT {
         when(pluginSetting.getName()).thenReturn("name");
         pipelineDescription = mock(PipelineDescription.class);
         awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenAnswer(options -> DefaultCredentialsProvider.create());
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenAnswer(options -> DefaultCredentialsProvider.create());
         
         when(pipelineDescription.getPipelineName()).thenReturn("test-pipeline");
     }
@@ -550,7 +551,7 @@ class HttpSinkIT {
     @Test
     public void testToVerifyLackOfCredentialsResultInFailure() throws Exception {
         AwsCredentialsProvider provider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(provider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(provider);
         sigv4Server.createContext("/success", exchange -> {
             String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
             if (authHeader == null || !authHeader.contains("AWS4-HMAC-SHA256")) {

--- a/data-prepper-plugins/http-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/http/AwsAuthenticationDecorator.java
+++ b/data-prepper-plugins/http-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/http/AwsAuthenticationDecorator.java
@@ -41,11 +41,20 @@ public class AwsAuthenticationDecorator implements AuthenticationDecorator {
     private final String serviceName;
 
     public AwsAuthenticationDecorator(@Nonnull final AwsCredentialsSupplier awsCredentialsSupplier,
-                                      @Nonnull final AwsConfig awsConfig,
+                                      final AwsConfig awsConfig,
                                       @Nonnull final String serviceName) {
-        this.region = awsConfig.getAwsRegion();
         this.serviceName = serviceName;
-        this.credentialsProvider = awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig));
+        if (awsConfig != null && awsConfig.getConfiguration() != null) {
+            this.region = awsCredentialsSupplier.getDefaultRegion().orElse(null);
+            this.credentialsProvider = awsCredentialsSupplier.getProvider(awsConfig.getConfiguration());
+        } else if (awsConfig != null) {
+            this.region = awsConfig.getAwsRegion();
+            this.credentialsProvider = awsCredentialsSupplier.getProvider(convertToCredentialOptions(awsConfig));
+        } else {
+            this.region = awsCredentialsSupplier.getDefaultRegion().orElse(null);
+            this.credentialsProvider = awsCredentialsSupplier.getProvider(
+                    AwsCredentialsOptions.defaultOptionsWithDefaultCredentialsProvider());
+        }
     }
 
     private static AwsCredentialsOptions convertToCredentialOptions(final AwsConfig awsConfig) {

--- a/data-prepper-plugins/http-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/http/AwsAuthenticationDecoratorTest.java
+++ b/data-prepper-plugins/http-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/http/AwsAuthenticationDecoratorTest.java
@@ -206,7 +206,18 @@ public class AwsAuthenticationDecoratorTest {
     }
 
     @Test
-    void test_constructor_with_null_config_throws_exception() {
-        assertThrows(NullPointerException.class, () -> new AwsAuthenticationDecorator(awsCredentialsSupplier, null, TEST_SERVICE_NAME));
+    void test_constructor_with_null_config_uses_default_credentials() {
+        final AwsAuthenticationDecorator decorator = new AwsAuthenticationDecorator(awsCredentialsSupplier, null, TEST_SERVICE_NAME);
+        assertThat(decorator, notNullValue());
+    }
+
+    @Test
+    void test_constructor_with_named_configuration() {
+        when(awsConfig.getConfiguration()).thenReturn("ecs_task_role");
+        when(awsCredentialsSupplier.getDefaultRegion()).thenReturn(java.util.Optional.of(TEST_REGION));
+        when(awsCredentialsSupplier.getProvider("ecs_task_role")).thenReturn(awsCredentialsProvider);
+
+        final AwsAuthenticationDecorator decorator = new AwsAuthenticationDecorator(awsCredentialsSupplier, awsConfig, TEST_SERVICE_NAME);
+        assertThat(decorator, notNullValue());
     }
 }

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/MLProcessorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -90,7 +91,7 @@ public class MLProcessorTest {
         lenient().when(expressionEvaluator.evaluateConditional(eq("condition"), any())).thenReturn(true);
         lenient().when(mlProcessorConfig.getServiceName()).thenReturn(ServiceName.SAGEMAKER);
         lenient().when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_WEST_2);
-        lenient().when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        lenient().when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         lenient().when(mlProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         lenient().when(mlProcessorConfig.getDlqPluginSetting()).thenReturn(null);
         lenient().when(pluginMetrics.counter(NUMBER_OF_ML_PROCESSOR_SUCCESS)).thenReturn(successCounter);

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/client/S3ClientFactoryTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/client/S3ClientFactoryTest.java
@@ -45,7 +45,7 @@ public class S3ClientFactoryTest {
     void setUp() {
         when(mlProcessorConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_WEST_2);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
     }
 
     @Test

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/common/SageMakerBatchJobCreatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
@@ -123,7 +124,7 @@ public class SageMakerBatchJobCreatorTest {
         when(mlProcessorConfig.getInputKey()).thenReturn(sourceKey);
         when(mlProcessorConfig.getRetryTimeWindow()).thenReturn(DEFAULT_RETRY_WINDOW);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         counter = mock(Counter.class);
         when(pluginMetrics.counter(NUMBER_OF_SUCCESSFUL_BATCH_JOBS_CREATION)).thenReturn(counter);
         when(pluginMetrics.counter(NUMBER_OF_FAILED_BATCH_JOBS_CREATION)).thenReturn(counter);

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/connector/AwsConnectorExecutorTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/connector/AwsConnectorExecutorTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.MLProcessorConfig;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.exception.MLBatchJobException;
@@ -77,7 +78,7 @@ class AwsConnectorExecutorTest {
         when(config.getAwsAuthenticationOptions()).thenReturn(awsAuthOptions);
         when(awsAuthOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
         when(awsAuthOptions.getAwsStsRoleArn()).thenReturn(null);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         when(awsCredentialsProvider.resolveCredentials()).thenReturn(AwsBasicCredentials.create("accessKey", "secretKey"));
 
         executor = new AwsConnectorExecutor(connector, config, awsCredentialsSupplier, httpClientExecutor);

--- a/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/util/MlCommonRequesterTest.java
+++ b/data-prepper-plugins/ml-inference-processor/src/test/java/org/opensearch/dataprepper/plugins/ml_inference/processor/util/MlCommonRequesterTest.java
@@ -11,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.MLProcessorConfig;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.ActionType;
 import org.opensearch.dataprepper.plugins.ml_inference.processor.configuration.AwsAuthenticationOptions;
@@ -66,7 +67,7 @@ public class MlCommonRequesterTest {
         when(mockMLProcessorConfig.getActionType()).thenReturn(ActionType.BATCH_PREDICT);
         when(mockMLProcessorConfig.getAwsAuthenticationOptions()).thenReturn(mockAwsAuthenticationOptions);
         when(mockAwsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_WEST_2);
-        when(mockAwsCredentialsSupplier.getProvider(any())).thenReturn(mockAwsCredentialsProvider);
+        when(mockAwsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockAwsCredentialsProvider);
         when(mockAwsCredentialsProvider.resolveCredentials()).thenReturn(mockAwsCredentials);
 
         mlCommonRequester = new MlCommonRequester(Aws4Signer.create(), mockMLProcessorConfig, mockAwsCredentialsSupplier, mockHttpClientExecutor);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
@@ -168,7 +168,7 @@ class ConnectionConfigurationTests {
                 ConnectionConfiguration.readConnectionConfiguration(openSearchSinkConfig);
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         final RestHighLevelClient client = connectionConfiguration.createClient(awsCredentialsSupplier);
         when(apacheHttpClientBuilder.build()).thenReturn(apacheHttpClient);
@@ -410,7 +410,7 @@ class ConnectionConfigurationTests {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         connectionConfiguration.createClient(awsCredentialsSupplier);
 
@@ -435,7 +435,7 @@ class ConnectionConfigurationTests {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         final OpenSearchClient openSearchClient;
         final RestHighLevelClient client = connectionConfiguration.createClient(awsCredentialsSupplier);
@@ -473,7 +473,7 @@ class ConnectionConfigurationTests {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         connectionConfiguration.createClient(awsCredentialsSupplier);
 
@@ -509,7 +509,7 @@ class ConnectionConfigurationTests {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         final RestHighLevelClient client = connectionConfiguration.createClient(awsCredentialsSupplier);
         final OpenSearchClient openSearchClient = connectionConfiguration.createOpenSearchClient(client, awsCredentialsSupplier);
@@ -549,7 +549,7 @@ class ConnectionConfigurationTests {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         connectionConfiguration.createClient(awsCredentialsSupplier);
 
@@ -584,7 +584,7 @@ class ConnectionConfigurationTests {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
 
         final RestHighLevelClient client = connectionConfiguration.createClient(awsCredentialsSupplier);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration_ServerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration_ServerTest.java
@@ -22,6 +22,7 @@ import org.opensearch.client.core.MainResponse;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.InfoResponse;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 
 import javax.net.ssl.SSLException;
@@ -128,7 +129,7 @@ class ConnectionConfiguration_ServerTest {
     class DefaultSigV4Configuration {
         @BeforeEach
         void setUp() {
-            when(awsCredentialsSupplier.getProvider(any())).thenReturn(AnonymousCredentialsProvider.create());
+            when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(AnonymousCredentialsProvider.create());
         }
 
         private ConnectionConfiguration createObjectUnderTest() {

--- a/data-prepper-plugins/otel-trace-group-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OpenSearchClientFactoryTest.java
+++ b/data-prepper-plugins/otel-trace-group-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OpenSearchClientFactoryTest.java
@@ -122,7 +122,7 @@ class OpenSearchClientFactoryTest {
         assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo(TEST_ROLE));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         objectUnderTest = OpenSearchClientFactory.fromConnectionConfiguration(connectionConfiguration);
         objectUnderTest.createRestHighLevelClient(awsCredentialsSupplier);
@@ -152,7 +152,7 @@ class OpenSearchClientFactoryTest {
         assertThat(connectionConfiguration.isAwsSigv4(), equalTo(true));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         objectUnderTest = OpenSearchClientFactory.fromConnectionConfiguration(connectionConfiguration);
         objectUnderTest.createRestHighLevelClient(awsCredentialsSupplier);
@@ -186,7 +186,7 @@ class OpenSearchClientFactoryTest {
         assertThat(connectionConfiguration.isAwsSigv4(), equalTo(true));
 
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         objectUnderTest = OpenSearchClientFactory.fromConnectionConfiguration(connectionConfiguration);
         objectUnderTest.createRestHighLevelClient(awsCredentialsSupplier);

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4SignerTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/SigV4SignerTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.otlp.http;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -41,7 +42,7 @@ class SigV4SignerTest {
 
         final AwsBasicCredentials mockCredentials = AwsBasicCredentials.create("mockAccessKey", "mockSecretKey");
         final StaticCredentialsProvider mockCredentialsProvider = StaticCredentialsProvider.create(mockCredentials);
-        when(mockSupplier.getProvider(any())).thenReturn(mockCredentialsProvider);
+        when(mockSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mockCredentialsProvider);
     }
 
     @Test

--- a/data-prepper-plugins/personalize-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/personalize/ClientFactoryTest.java
+++ b/data-prepper-plugins/personalize-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/personalize/ClientFactoryTest.java
@@ -61,7 +61,7 @@ class ClientFactoryTest {
     void createPersonalizeEventsClient_provides_correct_inputs_for_null_awsAuthenticationOptions() {
         when(personalizeSinkConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         final AwsCredentialsProvider expectedCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(expectedCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(expectedCredentialsProvider);
 
         final PersonalizeEventsClientBuilder personalizeEventsClientBuilder = mock(PersonalizeEventsClientBuilder.class);
         when(personalizeEventsClientBuilder.region(any())).thenReturn(personalizeEventsClientBuilder);
@@ -104,7 +104,7 @@ class ClientFactoryTest {
         when(awsAuthenticationOptions.getAwsStsHeaderOverrides()).thenReturn(stsHeaderOverrides);
 
         final AwsCredentialsProvider expectedCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(expectedCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(expectedCredentialsProvider);
 
         final PersonalizeEventsClientBuilder personalizeEventsClientBuilder = mock(PersonalizeEventsClientBuilder.class);
         when(personalizeEventsClientBuilder.region(region)).thenReturn(personalizeEventsClientBuilder);

--- a/data-prepper-plugins/prometheus-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSinkAMPIT.java
+++ b/data-prepper-plugins/prometheus-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSinkAMPIT.java
@@ -54,6 +54,7 @@ import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 
 import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.PrometheusSinkConfiguration;
 import org.opensearch.dataprepper.plugins.sink.prometheus.configuration.AuthTypeOptions;
@@ -215,8 +216,8 @@ public class PrometheusSinkAMPIT {
         queryRangeUrl = "api/v1/query_range";
         String remoteWriteUrl = url + "api/v1/remote_write";
         queryUrl = url + "api/v1/query";
-        when(awsCredentialsSupplier.getProvider(any())).thenAnswer(options -> DefaultCredentialsProvider.create());
-        lenient().when(awsQueryCredentialsSupplier.getProvider(any())).thenAnswer(options -> DefaultCredentialsProvider.create());
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenAnswer(options -> DefaultCredentialsProvider.create());
+        lenient().when(awsQueryCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenAnswer(options -> DefaultCredentialsProvider.create());
         thresholdConfig = mock(PrometheusSinkThresholdConfig.class);
         when(thresholdConfig.getMaxEvents()).thenReturn(NUM_RECORDS);
         when(thresholdConfig.getMaxRequestSizeBytes()).thenReturn(100000L);
@@ -984,7 +985,7 @@ public class PrometheusSinkAMPIT {
     void testToVerifyLackOfCredentialsResultInFailure() throws Exception {
 
         AwsCredentialsProvider provider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(provider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(provider);
         lenient().when(thresholdConfig.getFlushInterval()).thenReturn(1L);
         when(thresholdConfig.getMaxEvents()).thenReturn(1);
         PrometheusSink sink = createObjectUnderTest();

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSinkTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/PrometheusSinkTest.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.plugins.sink.prometheus.service.PrometheusSink
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -85,7 +86,7 @@ public class PrometheusSinkTest extends BaseDataPrepperPluginStandardTestSuite {
         PluginModel codecConfiguration = new PluginModel("http", new HashMap<>());
         awsCredentialsProvider = mock(AwsCredentialsProvider.class);
         awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         when(awsCredentialsSupplier.getDefaultRegion()).thenReturn(Optional.of(Region.of("us-west-2")));
         counter = mock(Counter.class);
         summary = mock(DistributionSummary.class);

--- a/data-prepper-plugins/s3-enrich-processor/src/test/java/org/opensearch/dataprepper/plugins/s3_enrich/processor/S3EnrichProcessorTest.java
+++ b/data-prepper-plugins/s3-enrich-processor/src/test/java/org/opensearch/dataprepper/plugins/s3_enrich/processor/S3EnrichProcessorTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.expression.ExpressionParsingException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -140,7 +141,7 @@ class S3EnrichProcessorTest {
 
         // --- AWS credential stubs ---
         final AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(credentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(credentialsProvider);
 
         // --- Plugin factory stub ---
         when(pluginFactory.loadPlugin(any(), any())).thenReturn(mock(org.opensearch.dataprepper.model.codec.InputCodec.class));

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -168,7 +169,7 @@ public class S3SinkIT {
         when(s3SinkConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(region);
 
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
 
         s3Client = S3Client.builder()
                 .credentialsProvider(awsCredentialsProvider)

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ClientFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ClientFactoryTest.java
@@ -82,7 +82,7 @@ class ClientFactoryTest {
         when(awsAuthenticationOptions.getAwsStsHeaderOverrides()).thenReturn(stsHeaderOverrides);
 
         final AwsCredentialsProvider expectedCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(expectedCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(expectedCredentialsProvider);
 
         final S3AsyncClientBuilder s3AsyncClientBuilder = mock(S3AsyncClientBuilder.class);
         when(s3AsyncClientBuilder.region(region)).thenReturn(s3AsyncClientBuilder);

--- a/data-prepper-plugins/sns-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sns/SnsClientFactoryTest.java
+++ b/data-prepper-plugins/sns-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sns/SnsClientFactoryTest.java
@@ -68,7 +68,7 @@ class SnsClientFactoryTest {
         when(awsAuthenticationOptions.getAwsStsHeaderOverrides()).thenReturn(stsHeaderOverrides);
 
         final AwsCredentialsProvider expectedCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(expectedCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(expectedCredentialsProvider);
 
         final SnsClientBuilder snsClientBuilder = mock(SnsClientBuilder.class);
         when(snsClientBuilder.region(region)).thenReturn(snsClientBuilder);

--- a/data-prepper-plugins/sqs-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkIT.java
+++ b/data-prepper-plugins/sqs-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkIT.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.aws.api.AwsConfig;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import io.micrometer.core.instrument.Counter;
@@ -251,7 +252,7 @@ public class SqsSinkIT {
         when(awsConfig.getAwsStsRoleArn()).thenReturn(awsRole);
         when(awsConfig.getAwsStsExternalId()).thenReturn(null);
         when(awsConfig.getAwsStsHeaderOverrides()).thenReturn(null);
-        when(awsCredentialsSupplier.getProvider(any())).thenAnswer(options -> DefaultCredentialsProvider.create());
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenAnswer(options -> DefaultCredentialsProvider.create());
         sqsClient = SqsClientFactory.createSqsClient(Region.of(awsRegion), DefaultCredentialsProvider.create());
         queueUrl = System.getProperty("tests.sqs.queue_url");
         sqsSinkConfig = mock(SqsSinkConfig.class);
@@ -679,7 +680,7 @@ public class SqsSinkIT {
     @Test
     public void testToVerifyLackOfCredentialsResultInFailure() throws Exception {
         AwsCredentialsProvider provider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(provider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(provider);
         when(thresholdConfig.getMaxEventsPerMessage()).thenReturn(1);
         lenient().when(thresholdConfig.getFlushInterval()).thenReturn(1L);
         sink = createObjectUnderTest();

--- a/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkTest.java
+++ b/data-prepper-plugins/sqs-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/sqs/SqsSinkTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.sqs;
 
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -98,7 +99,7 @@ public class SqsSinkTest {
         expressionEvaluator = mock(ExpressionEvaluator.class);
         awsCredentialsProvider = mock(AwsCredentialsProvider.class);
         awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(awsCredentialsProvider);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(awsCredentialsProvider);
         when(awsCredentialsSupplier.getDefaultRegion()).thenReturn(Optional.of(Region.of("us-west-2")));
         when(sqsSinkConfig.getDlq()).thenReturn(null);
         codecConfig = mock(PluginModel.class);

--- a/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSourceTest.java
+++ b/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSourceTest.java
@@ -13,6 +13,7 @@ package org.opensearch.dataprepper.plugins.source.sqs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -61,7 +62,7 @@ class SqsSourceTest {
         AwsAuthenticationOptions awsAuthenticationOptions = mock(AwsAuthenticationOptions.class);
         when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn("arn:aws:iam::123456789012:role/example-role");
         when(sqsSourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
-        when(awsCredentialsSupplier.getProvider(any())).thenReturn(mock(AwsCredentialsProvider.class));
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenReturn(mock(AwsCredentialsProvider.class));
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.of("us-east-2"));
         assertDoesNotThrow(() -> sqsSource.start(buffer));
     }


### PR DESCRIPTION
### Description
Add support for named configurations in aws config block

The aws block now supports- 
```
aws:
   configuration:
```
which is mutually exclusive from `region`, `sts_role_arn` and `sts_header_overrides`

For now, only http sink is enabling this. 
 
### Issues Resolved
Resolves #2570 , #4637
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
