### PR TITLE
Update deprecated GitHub Actions to versions already used in the project

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -11,7 +11,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/create-documentation-issue.yml
+++ b/.github/workflows/create-documentation-issue.yml
@@ -21,7 +21,7 @@ jobs:
           installation_id: 22958780
 
       - name: Checkout code
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Edit the issue template
         run: |

--- a/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
+++ b/.github/workflows/data-prepper-aws-secrets-e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git clone the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: configure aws credentials
@@ -50,7 +50,7 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/data-prepper-kafka-backward-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-kafka-backward-compatibility-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/e2e-tests-log-analytics.yml
+++ b/.github/workflows/e2e-tests-log-analytics.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/e2e-tests-peer-forwarder.yml
+++ b/.github/workflows/e2e-tests-peer-forwarder.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/examples-trace-analytics.yml
+++ b/.github/workflows/examples-trace-analytics.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build Sample App
         working-directory: examples/trace-analytics-sample-app
@@ -41,7 +41,7 @@ jobs:
           distribution: temurin
 
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: temurin
     - name: Checkout Data Prepper
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:

--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/kinesis-source-integration-tests.yml
+++ b/.github/workflows/kinesis-source-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
 
       - name: Git clone the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -54,7 +54,7 @@ jobs:
           distribution: temurin
 
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 11
 
       - name: Checkout Data Prepper
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/performance-test-compile.yml
+++ b/.github/workflows/performance-test-compile.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - name: Checkout Data Prepper
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/release-prepare-branch.yml
+++ b/.github/workflows/release-prepare-branch.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout Data Prepper
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Validate release branch
       id: validate_branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
           echo 'release_latest_tag: ${{ github.event.inputs.release-latest-tag }}' >> release-description.yaml
 
       - name: Create tag
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ github.TOKEN }}
           script: |

--- a/.github/workflows/staging-resources-cdk-check.yml
+++ b/.github/workflows/staging-resources-cdk-check.yml
@@ -22,12 +22,12 @@ jobs:
         working-directory: ./release/staging-resources-cdk
     steps:
     - name: Set up Node.js
-      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '16'
 
     - name: Checkout Data Prepper
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install NPM Dependencies
       run: npm install

--- a/.github/workflows/testing-resources-cdk-check.yml
+++ b/.github/workflows/testing-resources-cdk-check.yml
@@ -19,12 +19,12 @@ jobs:
         working-directory: ./testing/aws-testing-cdk
     steps:
     - name: Set up Node.js
-      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '18'
 
     - name: Checkout Data Prepper
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install NPM Dependencies
       run: npm install

--- a/.github/workflows/third-party-generate.yml
+++ b/.github/workflows/third-party-generate.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: 11
         distribution: temurin
     - name: Checkout Data Prepper
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:
@@ -39,7 +39,7 @@ jobs:
         private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
       with:
         token: ${{ steps.github_app_token.outputs.token }}
         add-paths: THIRD-PARTY


### PR DESCRIPTION
## Summary

Bumps deprecated GitHub Actions in workflow files to the highest SHA already pinned elsewhere in this repository. No new versions are introduced — every target SHA is already trusted by another workflow.

| Action | From | To | Source |
|---|---|---|---|
| `actions/checkout` | v2 (`ee0669bd…`) and v4 (`34e11487…`) | v6 (`de0fac2e…`) | `release.yml` |
| `actions/setup-node` | v2 (`7c12f801…`) | v4 (`49933ea5…`) | `release.yml` |
| `actions/github-script` | v6 (`d7906e4a…`, `3a2844b7…`) | v8 (`ed597411…`) | `license-header-comment.yml` |
| `peter-evans/create-pull-request` | v4 (`38e0b6e6…`) | v6 (`c5a78066…`) | `release.yml` |

The deprecated v2/v4 versions of `actions/checkout`, `actions/setup-node@v2`, and `actions/github-script@v6` use Node 16 and are no longer maintained by GitHub.

### Not addressed (no newer version is referenced in this repository)

These actions remain on deprecated versions but are intentionally not changed here, since the task scope was to standardize on versions already trusted in the repo:

- `codecov/codecov-action@v1` (`29386c70…`) in `gradle.yml`
- `EnricoMi/publish-unit-test-result-action@v1` (`b9f6c61d…`) in `gradle.yml`, `gradle-build-src.yml`, `kafka-plugin-integration-tests.yml`, `kinesis-source-integration-tests.yml`, `opensearch-sink-opendistro-integration-tests.yml`, `opensearch-sink-opensearch-integration-tests.yml`

These can be addressed separately.

## Test plan

- [ ] CI workflows run successfully on this PR
- [ ] No behavior changes — only action SHA pins are updated