### PR TITLE
Adds project rules and steering for Claude Code and Kiro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ data-prepper-main/src/test/resources/logstash-conf/logstash-filter.yaml
 .DS_Store
 .idea
 *.iml
-.kiro
+.kiro/*
+!.kiro/steering/
 .vscode
 .project
 .classpath
@@ -40,4 +41,3 @@ trace-tester.py
 
 # Claude Code
 .claude/settings.local.json
-CLAUDE.md

--- a/.kiro/steering/CONTRIBUTING.md
+++ b/.kiro/steering/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../CONTRIBUTING.md

--- a/.kiro/steering/developer_guide.md
+++ b/.kiro/steering/developer_guide.md
@@ -1,0 +1,1 @@
+../../docs/developer_guide.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+OpenSearch Data Prepper welcomes AI-assisted development and does not require
+any particular AI tool. Guidance for contributors — human or AI — lives in the
+existing developer and contributing docs. This file imports those so Claude
+Code picks them up automatically; other AI tools should be pointed at the same
+files.
+
+@docs/developer_guide.md
+@CONTRIBUTING.md

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -251,6 +251,12 @@ fails, please check the *Summary* section of that Action. There may be artifacts
 can download these and view the result information. Additionally, many builds have *Unit Test Results* job
 which includes a summary of the results.
 
+## AI and agentic development
+
+We welcome and encourage the use of AI tools and agentic development.
+This project does not enforce or require any particular AI tool and the tool choice is similar to choosing an IDE.
+If you want to add AI tooling to the project, please commit it in such a way that it can be used by other AI tools.
+
 ## More Information
 
 We have the following pages for specific development guidance on the topics:


### PR DESCRIPTION
### Description

We already have some developer documentation that is relevant for AI tools as well as people. This adds instructions for Claude Code and Kiro to use them. For Claude Code it uses includes and for Kiro it is a symlink in the steering directory.

Also added some additional clarity in the developer guide about using AI.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
