### PR TITLE
Add additional logging for number of records read from an S3 object, along with which object corresponds to a message for S3-SQS 

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
@@ -234,6 +234,8 @@ class S3ObjectWorker implements S3ObjectHandler {
         if (recordsWritten == 0) {
             LOG.warn("Failed to find any records in S3 object: s3ObjectReference={}.", s3ObjectReference);
             s3ObjectPluginMetrics.getS3ObjectNoRecordsFound().increment();
+        } else {
+            LOG.info("Completed reading S3 object: s3ObjectReference={}, records={}", s3ObjectReference, recordsWritten);
         }
         s3ObjectPluginMetrics.getS3ObjectSizeSummary().record(s3ObjectSize);
         s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(recordsWritten);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
@@ -291,8 +291,12 @@ public class SqsWorker implements Runnable {
                         }
                         if (result == true) {
                             final boolean successfullyDeletedAllMessages = deleteSqsMessages(waitingForAcknowledgements);
-                            if (successfullyDeletedAllMessages && s3SourceConfig.isDeleteS3ObjectsOnRead()) {
-                                deleteS3Objects(s3ObjectDeletionWaitingForAcknowledgments);
+                            if (successfullyDeletedAllMessages) {
+                                LOG.info("Deleted SQS message for S3 object s3://{}/{}, sqsMessageId={}",
+                                    parsedMessage.getBucketName(), parsedMessage.getObjectKey(), parsedMessage.getMessage().messageId());
+                                if (s3SourceConfig.isDeleteS3ObjectsOnRead()) {
+                                    deleteS3Objects(s3ObjectDeletionWaitingForAcknowledgments);
+                                }
                             }
                         }
                     },
@@ -392,10 +396,12 @@ public class SqsWorker implements Runnable {
             if (deleteMessageBatchResponse.hasSuccessful()) {
                 final int deletedMessagesCount = deleteMessageBatchResponse.successful().size();
                 if (deletedMessagesCount > 0) {
-                    final String successfullyDeletedMessages = deleteMessageBatchResponse.successful().stream()
-                            .map(DeleteMessageBatchResultEntry::id)
-                            .collect(Collectors.joining(", "));
-                    LOG.info("Deleted {} messages from SQS. [{}]", deletedMessagesCount, successfullyDeletedMessages);
+                    if (!endToEndAcknowledgementsEnabled) {
+                        final String successfullyDeletedMessages = deleteMessageBatchResponse.successful().stream()
+                                .map(DeleteMessageBatchResultEntry::id)
+                                .collect(Collectors.joining(", "));
+                        LOG.info("Deleted {} messages from SQS. [{}]", deletedMessagesCount, successfullyDeletedMessages);
+                    }
                     sqsMessagesDeletedCounter.increment(deletedMessagesCount);
                 }
             }


### PR DESCRIPTION
### Description
This change adds an additional log for S3-SQS as a source that clearly shows which object corresponds to each SQS message on delete, and an additional log for the S3 source that shows how many records were read/written to the buffer after the object is processed.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
