### PR TITLE
Detect zstd compressed objects in automatic compression mode

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/CompressionOption.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/CompressionOption.java
@@ -51,7 +51,9 @@ public enum CompressionOption {
             return CompressionOption.GZIP;
         } else if(fileName.endsWith(".snappy")){
             return CompressionOption.SNAPPY;
-        }else {
+        } else if (fileName.endsWith(".zst") || fileName.endsWith(".zstd")) {
+            return CompressionOption.ZSTD;
+        } else {
             return CompressionOption.NONE;
         }
     }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/CompressionOptionTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/CompressionOptionTest.java
@@ -34,6 +34,16 @@ class CompressionOptionTest {
     }
 
     @Test
+    void testFromFileName_zstd() {
+        assertThat(CompressionOption.fromFileName("temp.zst"), is(CompressionOption.ZSTD));
+    }
+
+    @Test
+    void testFromFileName_zstd_longExtension() {
+        assertThat(CompressionOption.fromFileName("temp.zstd"), is(CompressionOption.ZSTD));
+    }
+
+    @Test
     void testFromFileName_default() {
         assertThat(CompressionOption.fromFileName("temp.txt"), is(CompressionOption.NONE));
     }


### PR DESCRIPTION
  ### Description

  `CompressionOption.fromFileName()` backs the `automatic` compression option for the S3 source (both the SQS-notification and scan paths) and the S3 enrich processor. It only recognized `.gz` (GZIP) and `.snappy` (SNAPPY) and silently fell back to `NONE`
  for everything else, so zstd-compressed objects were passed to the codec without decompression and failed to parse — even though `ZSTD` is a valid `CompressionOption` with a working `ZstdDecompressionEngine` already wired in.

  This change maps the `.zst` (canonical, per the zstd CLI and RFC 8478) and `.zstd` (informal alternate spelling) extensions to `CompressionOption.ZSTD`, so automatic detection decompresses these objects correctly.

  **Behavior is unchanged** unless a user explicitly configures `compression: automatic`; the shipped default is `NONE`. No new compression engine or dependency is introduced — the fix reuses the existing `ZstdDecompressionEngine`. Because the fix lives
  in the shared `common` enum, all three consumers (s3-source SQS path, s3-source scan path, and s3-enrich-processor) are corrected at once.

  Unit tests were added covering both the `.zst` and `.zstd` extensions.

  ### Issues Resolved
  Resolves #[Issue number to be closed when this PR is merged]

  ### Check List
  - [x] New functionality includes testing.
  - [ ] New functionality has a documentation issue. Please link to it in this PR.
    - [ ] New functionality has javadoc added
  - [x] Commits are signed with a real name per the DCO

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).