### PR TITLE
Optimize MongoDBExportPartitionSupplier for uniform _id type collections

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -186,7 +186,7 @@ public class BsonHelper {
         }
     }
 
-    private static boolean isClassNumber(final String className) {
+    public static boolean isClassNumber(final String className) {
         return className.equals("java.lang.Integer") || className.equals("java.lang.Long") || className.equals("java.lang.Double")
                 || className.equals("org.bson.types.Decimal128");
     }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplier.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplier.java
@@ -6,13 +6,14 @@
 package org.opensearch.dataprepper.plugins.mongo.export;
 
 import com.mongodb.MongoClientException;
-import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.mongo.client.BsonHelper;
@@ -37,6 +38,9 @@ public class MongoDBExportPartitionSupplier implements Function<ExportPartition,
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBExportPartitionSupplier.class);
     private static final String MONGODB_PARTITION_KEY_FORMAT = "%s|%s|%s|%s|%s"; // partition format: <db.collection>|<gte>|<lt>|<gteClassName>|<lteClassName>
     private static final String COLLECTION_SPLITTER = "\\.";
+    private static final Bson ID_PROJECTION = Projections.include("_id");
+    private static final Bson ID_ASC = Sorts.ascending("_id");
+    private static final Bson ID_DESC = Sorts.descending("_id");
 
     private final MongoDBSourceConfig sourceConfig;
     private final EnhancedSourceCoordinator enhancedSourceCoordinator;
@@ -50,95 +54,143 @@ public class MongoDBExportPartitionSupplier implements Function<ExportPartition,
         this.documentDBAggregateMetrics = documentDBAggregateMetrics;
     }
 
+    /**
+     * Detects whether the collection has a uniform _id type by checking the first and last documents.
+     * If uniform, we can use a simple Filters.gt() instead of the complex $or query across all BSON types.
+     */
+    boolean isUniformIdType(final MongoCollection<Document> col) {
+        final Document first = col.find().projection(ID_PROJECTION).sort(ID_ASC).limit(1).first();
+        final Document last = col.find().projection(ID_PROJECTION).sort(ID_DESC).limit(1).first();
+        if (first == null || last == null) {
+            return true;
+        }
+        final String firstType = first.get("_id").getClass().getName();
+        final String lastType = last.get("_id").getClass().getName();
+        if (BsonHelper.isClassNumber(firstType) && BsonHelper.isClassNumber(lastType)) {
+            return true;
+        }
+        return firstType.equals(lastType);
+    }
+
+    private Bson buildNextStartFilter(final Object lastLteValue, final String lteClassName, final boolean uniformType) {
+        if (uniformType) {
+            return Filters.gt("_id", lastLteValue);
+        }
+        final String lteValueString = BsonHelper.getPartitionStringFromMongoDBId(lastLteValue, lteClassName);
+        return buildGtQuery(lteValueString, lteClassName, MAX_KEY);
+    }
+
+    private void addPartition(final List<PartitionIdentifier> partitions, final String collectionDbName,
+                              final Object gteValue, final String gteClassName,
+                              final Object lteValue, final String lteClassName) {
+        final String gteValueString = BsonHelper.getPartitionStringFromMongoDBId(gteValue, gteClassName);
+        final String lteValueString = BsonHelper.getPartitionStringFromMongoDBId(lteValue, lteClassName);
+        LOG.debug("Partition of {} : { gte: {} class: {}, lte: {} class {} }",
+                collectionDbName, gteValueString, gteClassName, lteValueString, lteClassName);
+        partitions.add(PartitionIdentifier.builder()
+                .withPartitionKey(String.format(MONGODB_PARTITION_KEY_FORMAT,
+                        collectionDbName, gteValueString, lteValueString, gteClassName, lteClassName))
+                .build());
+    }
+
     private PartitionIdentifierBatch buildPartitions(final ExportPartition exportPartition) {
         documentDBAggregateMetrics.getExportApiInvocations().increment();
         final List<PartitionIdentifier> collectionPartitions = new ArrayList<>();
         final String collectionDbName = exportPartition.getCollection();
-        List<String> collection = List.of(collectionDbName.split(COLLECTION_SPLITTER));
+        final List<String> collection = List.of(collectionDbName.split(COLLECTION_SPLITTER));
         if (collection.size() < 2) {
             documentDBAggregateMetrics.getExport4xxErrors().increment();
             throw new IllegalArgumentException("Invalid Collection Name. Must be in db.collection format");
         }
-        final Optional<ExportProgressState> exportProgressStateOptional = exportPartition
-                .getProgressState();
-        final Object lastEndDocId = exportProgressStateOptional.map(
-                ExportProgressState::getLastEndDocId).orElse(null);
+
+        final Optional<ExportProgressState> exportProgressStateOptional = exportPartition.getProgressState();
+        final Object lastEndDocId = exportProgressStateOptional.map(ExportProgressState::getLastEndDocId).orElse(null);
         boolean isLastBatch = false;
         Object endDocId = lastEndDocId;
+
         try (MongoClient mongoClient = MongoDBConnection.getMongoClient(sourceConfig)) {
             final MongoDatabase db = mongoClient.getDatabase(collection.get(0));
-            final MongoCollection<Document> col = db.getCollection(collectionDbName.substring(collection.get(0).length()+1));
+            final MongoCollection<Document> col = db.getCollection(
+                    collectionDbName.substring(collection.get(0).length() + 1));
             final int partitionSize = exportPartition.getPartitionSize();
-            FindIterable<Document> startIterable;
+
+            final boolean uniformType = isUniformIdType(col);
+            LOG.info("Collection {} has {} _id type. Using {} partition query strategy.",
+                    collectionDbName, uniformType ? "uniform" : "mixed", uniformType ? "simple $gt" : "$or-based");
+
+            Bson startFilter;
             if (lastEndDocId != null) {
-                startIterable = col.find(Filters.gt("_id", lastEndDocId))
-                        .projection(new Document("_id", 1))
-                        .sort(new Document("_id", 1))
-                        .limit(1);
+                startFilter = Filters.gt("_id", lastEndDocId);
             } else {
-                startIterable = col.find()
-                        .projection(new Document("_id", 1))
-                        .sort(new Document("_id", 1))
-                        .limit(1);
+                startFilter = new Document();
             }
+
             while (!Thread.currentThread().isInterrupted()) {
-                try (final MongoCursor<Document> startCursor = startIterable.iterator()) {
-                    if (!startCursor.hasNext()) {
-                        LOG.info("No records to process or has reached end of the export partition.");
-                        isLastBatch = true;
-                        break;
-                    }
-                    final Document startDoc = startCursor.next();
-                    final Object gteValue = startDoc.get("_id");
-                    final String gteClassName = gteValue.getClass().getName();
+                final Document startDoc = col.find(startFilter)
+                        .projection(ID_PROJECTION)
+                        .sort(ID_ASC)
+                        .limit(1)
+                        .first();
 
-                    // Get end doc
-                    Document endDoc = startIterable.skip(partitionSize - 1).limit(1).first();
-                    if (endDoc == null) {
-                        // this means we have reached the end of the doc
-                        endDoc = col.find()
-                                .projection(new Document("_id", 1))
-                                .sort(new Document("_id", -1))
-                                .limit(1)
-                                .first();
-                        isLastBatch = true;
-                    }
-
-                    final Object lteValue = endDoc.get("_id");
-                    final String lteClassName = lteValue.getClass().getName();
-                    endDocId = lteValue;
-                    final String gteValueString = BsonHelper.getPartitionStringFromMongoDBId(gteValue, gteClassName);
-                    final String lteValueString = BsonHelper.getPartitionStringFromMongoDBId(lteValue, lteClassName);
-                    LOG.debug("Partition of {} : { gte: {} class: {}, lte: {} class {} }", collectionDbName, gteValueString, gteClassName, lteValueString, lteClassName);
-                    collectionPartitions.add(
-                        PartitionIdentifier
-                            .builder()
-                            .withPartitionKey(String.format(MONGODB_PARTITION_KEY_FORMAT, collectionDbName, gteValueString, lteValueString, gteClassName, lteClassName))
-                            .build());
-                    documentDBAggregateMetrics.getExportPartitionQueryCount().increment();
-
-                    if (isLastBatch) {
-                        break;
-                    }
-
-                    // extend the ownership of the partition
-                    enhancedSourceCoordinator.saveProgressStateForPartition(exportPartition, null);
-
-                    startIterable = col.find(buildGtQuery(lteValueString, lteClassName, MAX_KEY))
-                            .projection(new Document("_id", 1))
-                            .sort(new Document("_id", 1))
-                            .limit(1);
+                if (startDoc == null) {
+                    LOG.info("No records to process or has reached end of the export partition.");
+                    isLastBatch = true;
+                    break;
                 }
+
+                final Object gteValue = startDoc.get("_id");
+                final String gteClassName = gteValue.getClass().getName();
+
+                final Document endOfPageDoc = col.find(Filters.gte("_id", gteValue))
+                        .projection(ID_PROJECTION)
+                        .sort(ID_ASC)
+                        .skip(partitionSize - 1)
+                        .limit(1)
+                        .first();
+
+                final Object lteValue;
+                final String lteClassName;
+
+                if (endOfPageDoc == null) {
+                    final Document lastDoc = col.find()
+                            .projection(ID_PROJECTION)
+                            .sort(ID_DESC)
+                            .limit(1)
+                            .first();
+                    if (lastDoc == null) {
+                        isLastBatch = true;
+                        break;
+                    }
+                    lteValue = lastDoc.get("_id");
+                    lteClassName = lteValue.getClass().getName();
+                    isLastBatch = true;
+                } else {
+                    lteValue = endOfPageDoc.get("_id");
+                    lteClassName = lteValue.getClass().getName();
+                }
+
+                endDocId = lteValue;
+                addPartition(collectionPartitions, collectionDbName, gteValue, gteClassName, lteValue, lteClassName);
+                documentDBAggregateMetrics.getExportPartitionQueryCount().increment();
+
+                if (isLastBatch) {
+                    break;
+                }
+
+                // extend the ownership of the partition
+                enhancedSourceCoordinator.saveProgressStateForPartition(exportPartition, null);
+
+                startFilter = buildNextStartFilter(lteValue, lteClassName, uniformType);
             }
         } catch (final IllegalArgumentException | MongoClientException e) {
             // IllegalArgumentException is thrown when database or collection name is not valid
             // MongoClientException is thrown for exceptions indicating a failure condition with the MongoClient
             documentDBAggregateMetrics.getExport4xxErrors().increment();
-            LOG.error("Client side exception while build partitions.", e);
+            LOG.error("Client side exception while building partitions.", e);
             throw new RuntimeException(e);
         } catch (final Exception e) {
             documentDBAggregateMetrics.getExport5xxErrors().increment();
-            LOG.error("Server side exception while build partitions.", e);
+            LOG.error("Server side exception while building partitions.", e);
             throw new RuntimeException(e);
         }
 

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplierTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplierTest.java
@@ -9,7 +9,6 @@ import com.mongodb.MongoClientException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import io.micrometer.core.instrument.Counter;
 import org.bson.Document;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.mongo.client.MongoDBConnection;
@@ -31,6 +31,7 @@ import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateM
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -92,38 +93,45 @@ public class MongoDBExportPartitionSupplierTest {
     @Test
     public void test_buildPartitionsCollection() {
         try (MockedStatic<MongoDBConnection> mongoDBConnectionMockedStatic = mockStatic(MongoDBConnection.class)) {
-            // Given a collection with 5000 items which should be split to two partitions: 0-3999 and 4000-4999
             MongoClient mongoClient = mock(MongoClient.class);
             MongoDatabase mongoDatabase = mock(MongoDatabase.class);
             MongoCollection col = mock(MongoCollection.class);
-            FindIterable findIterable = mock(FindIterable.class);
-            MongoCursor cursor = mock(MongoCursor.class);
+
             mongoDBConnectionMockedStatic.when(() -> MongoDBConnection.getMongoClient(any(MongoDBSourceConfig.class)))
                     .thenReturn(mongoClient);
             when(mongoClient.getDatabase(anyString())).thenReturn(mongoDatabase);
             when(mongoDatabase.getCollection(anyString())).thenReturn(col);
-            when(col.find()).thenReturn(findIterable);
-            when(col.find(any(Bson.class))).thenReturn(findIterable);
-            when(findIterable.projection(any())).thenReturn(findIterable);
-            when(findIterable.sort(any())).thenReturn(findIterable);
-            when(findIterable.skip(anyInt())).thenReturn(findIterable);
-            when(findIterable.limit(anyInt())).thenReturn(findIterable);
-            when(findIterable.iterator()).thenReturn(cursor);
-            when(cursor.hasNext()).thenReturn(true, true, false);
-            // mock startDoc and endDoc returns, 0-3999, and 4000-4999
-            when(cursor.next())
-                    .thenReturn(new Document("_id", "0"))
-                    .thenReturn(new Document("_id", "4000"));
-            when(findIterable.first())
-                    .thenReturn(new Document("_id", "3999"))
-                    .thenReturn(null)
-                    .thenReturn(new Document("_id", "4999"));
-            // When Apply Partition create logics
+
+            // Track col.find() calls (no-arg) to distinguish isUniformIdType and lastDoc queries
+            final AtomicInteger noArgFindCount = new AtomicInteger(0);
+            when(col.find()).thenAnswer((Answer<FindIterable>) invocation -> {
+                int callNum = noArgFindCount.incrementAndGet();
+                switch (callNum) {
+                    case 1: return createFindIterable(new Document("_id", "0"));    // isUniformIdType first
+                    case 2: return createFindIterable(new Document("_id", "4999")); // isUniformIdType last
+                    case 3: return createFindIterable(new Document("_id", "4999")); // lastDoc when endOfPage is null
+                    default: return createFindIterable(null);
+                }
+            });
+
+            // Track col.find(Bson) calls for partition boundary queries
+            final AtomicInteger bsonFindCount = new AtomicInteger(0);
+            when(col.find(any(Bson.class))).thenAnswer((Answer<FindIterable>) invocation -> {
+                int callNum = bsonFindCount.incrementAndGet();
+                switch (callNum) {
+                    case 1: return createFindIterable(new Document("_id", "0"));    // 1st start doc
+                    case 2: return createFindIterableWithSkip(new Document("_id", "3999")); // 1st end
+                    case 3: return createFindIterable(new Document("_id", "4000")); // 2nd start doc
+                    case 4: return createFindIterableWithSkip(null);                 // 2nd end -> null
+                    default: return createFindIterable(null);
+                }
+            });
+
             final PartitionIdentifierBatch partitionIdentifierBatch = testSupplier.apply(exportPartition);
             assertThat(partitionIdentifierBatch.isLastBatch(), is(true));
             assertThat(partitionIdentifierBatch.getEndDocId(), equalTo("4999"));
             List<PartitionIdentifier> partitions = partitionIdentifierBatch.getPartitionIdentifiers();
-            // Then dependencies are called
+
             verify(mongoClient).getDatabase(eq("test"));
             verify(mongoClient, times(1)).close();
             verify(mongoDatabase).getCollection(eq("collection"));
@@ -131,7 +139,7 @@ public class MongoDBExportPartitionSupplierTest {
             verify(exportPartitionQueryCount, times(2)).increment();
             verify(export4xxErrors, never()).increment();
             verify(export5xxErrors, never()).increment();
-            // And partitions are created
+
             assertThat(partitions.size(), is(2));
             assertThat(partitions.get(0).getPartitionKey(), is("test.collection|0|3999|java.lang.String|java.lang.String"));
             assertThat(partitions.get(1).getPartitionKey(), is("test.collection|4000|4999|java.lang.String|java.lang.String"));
@@ -159,5 +167,24 @@ public class MongoDBExportPartitionSupplierTest {
             verify(export4xxErrors).increment();
             verify(export5xxErrors, never()).increment();
         }
+    }
+
+    private FindIterable createFindIterable(Document result) {
+        FindIterable iterable = mock(FindIterable.class);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(result);
+        return iterable;
+    }
+
+    private FindIterable createFindIterableWithSkip(Document result) {
+        FindIterable iterable = mock(FindIterable.class);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(result);
+        return iterable;
     }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplier_IsUniformIdTypeTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplier_IsUniformIdTypeTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.mongo.export;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfig;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MongoDBExportPartitionSupplier_IsUniformIdTypeTest {
+
+    @Mock
+    private MongoDBSourceConfig sourceConfig;
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+    @Mock
+    private DocumentDBSourceAggregateMetrics aggregateMetrics;
+    @Mock
+    private MongoCollection<Document> collection;
+    @Mock
+    private FindIterable<Document> findIterable;
+
+    private MongoDBExportPartitionSupplier supplier;
+
+    @BeforeEach
+    void setUp() {
+        supplier = new MongoDBExportPartitionSupplier(sourceConfig, sourceCoordinator, aggregateMetrics);
+        when(collection.find()).thenReturn(findIterable);
+        when(findIterable.projection(any())).thenReturn(findIterable);
+        when(findIterable.sort(any())).thenReturn(findIterable);
+        when(findIterable.limit(1)).thenReturn(findIterable);
+    }
+
+    @Test
+    void isUniformIdType_emptyCollection_returnsTrue() {
+        when(findIterable.first()).thenReturn(null);
+        assertThat(supplier.isUniformIdType(collection), is(true));
+    }
+
+    @Test
+    void isUniformIdType_uniformObjectId_returnsTrue() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", new ObjectId()))
+                .thenReturn(new Document("_id", new ObjectId()));
+        assertThat(supplier.isUniformIdType(collection), is(true));
+    }
+
+    @Test
+    void isUniformIdType_uniformString_returnsTrue() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", "abc"))
+                .thenReturn(new Document("_id", "xyz"));
+        assertThat(supplier.isUniformIdType(collection), is(true));
+    }
+
+    @Test
+    void isUniformIdType_mixedTypes_returnsFalse() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", 1))
+                .thenReturn(new Document("_id", new ObjectId()));
+        assertThat(supplier.isUniformIdType(collection), is(false));
+    }
+
+    @Test
+    void isUniformIdType_integerAndLong_returnsTrue() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", 42))
+                .thenReturn(new Document("_id", 999999999999L));
+        assertThat(supplier.isUniformIdType(collection), is(true));
+    }
+
+    @Test
+    void isUniformIdType_doubleAndDecimal128_returnsTrue() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", 3.14))
+                .thenReturn(new Document("_id", Decimal128.parse("99.99")));
+        assertThat(supplier.isUniformIdType(collection), is(true));
+    }
+
+    @Test
+    void isUniformIdType_doubleAndInteger_returnsTrue() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", 3.14))
+                .thenReturn(new Document("_id", 42));
+        assertThat(supplier.isUniformIdType(collection), is(true));
+    }
+
+    @Test
+    void isUniformIdType_stringAndObjectId_returnsFalse() {
+        when(findIterable.first())
+                .thenReturn(new Document("_id", "abc"))
+                .thenReturn(new Document("_id", new ObjectId()));
+        assertThat(supplier.isUniformIdType(collection), is(false));
+    }
+}


### PR DESCRIPTION
### Description

For collections with uniform _id types, replace the $or query with a simple `Filters.gt("_id", value)` for finding partition boundaries. This allows DocumentDB to use a single B-tree index seek instead of multi-index scan.

Changes:
- Add isUniformIdType() that checks first/last doc _id types
- Add buildNextStartFilter() with simple $gt for uniform types, falling back to $or-based query for mixed types
- Use fresh Filters.gte() + skip() per iteration for partition end
- Extract addPartition() helper to reduce duplication
- Make BsonHelper.isClassNumber() public for numeric type grouping

Performance: 14M docs (10GB) partitioned in ~30 seconds.


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
