### PR TITLE
Add mutual_tls authentication plugin for HTTP-based sources

### DIFF
--- a/data-prepper-plugins/armeria-common/build.gradle
+++ b/data-prepper-plugins/armeria-common/build.gradle
@@ -13,4 +13,6 @@ dependencies {
     implementation libs.armeria.core
     implementation libs.armeria.grpc
     testImplementation libs.armeria.junit
+    testImplementation libs.bouncycastle.bcprov
+    testImplementation libs.bouncycastle.bcpkix
 }

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ArmeriaHttpAuthenticationProvider.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ArmeriaHttpAuthenticationProvider.java
@@ -39,4 +39,14 @@ public interface ArmeriaHttpAuthenticationProvider {
     default Optional<Function<? super HttpService, ? extends HttpService>> getAuthenticationDecorator() {
         return Optional.empty();
     }
+
+    /**
+     * Gets client authentication (mTLS) configuration.
+     * Called during server setup when SSL is enabled to configure client certificate verification.
+     *
+     * @return an optional client auth configuration for mTLS
+     */
+    default Optional<ClientAuthConfiguration> getClientAuthConfiguration() {
+        return Optional.empty();
+    }
 }

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ClientAuthConfiguration.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ClientAuthConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.armeria.authentication;
+
+import io.netty.handler.ssl.ClientAuth;
+
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * Configuration for client certificate authentication (mTLS).
+ * This interface restricts what authentication plugins can configure
+ * on the TLS context, preventing plugins from modifying server keys,
+ * protocols, or ciphers.
+ */
+public interface ClientAuthConfiguration {
+
+    /**
+     * @return the client authentication mode (REQUIRE, OPTIONAL, or NONE)
+     */
+    ClientAuth getClientAuth();
+
+    /**
+     * @return the TrustManagerFactory used to verify client certificates
+     */
+    TrustManagerFactory getTrustManagerFactory();
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/MutualTlsAuthenticationConfig.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/MutualTlsAuthenticationConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.armeria.authentication;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MutualTlsAuthenticationConfig {
+
+    @JsonProperty("ssl_trust_certificate_file")
+    @NotBlank(message = "ssl_trust_certificate_file is required for mutual_tls authentication")
+    private String sslTrustCertificateFile;
+
+    public String getSslTrustCertificateFile() {
+        return sslTrustCertificateFile;
+    }
+
+    @AssertTrue(message = "ssl_trust_certificate_file must exist and be readable")
+    boolean isTrustCertificateFileValid() {
+        if (sslTrustCertificateFile == null || sslTrustCertificateFile.isBlank()) {
+            return true;
+        }
+        Path path = Path.of(sslTrustCertificateFile);
+        return Files.exists(path) && Files.isReadable(path);
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/plugins/MutualTlsArmeriaHttpAuthenticationProvider.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/plugins/MutualTlsArmeriaHttpAuthenticationProvider.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import io.netty.handler.ssl.ClientAuth;
+import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider;
+import org.opensearch.dataprepper.armeria.authentication.ClientAuthConfiguration;
+import org.opensearch.dataprepper.armeria.authentication.MutualTlsAuthenticationConfig;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.annotations.Experimental;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.util.Objects;
+import java.util.Optional;
+
+@Experimental
+@DataPrepperPlugin(name = "mutual_tls",
+        pluginType = ArmeriaHttpAuthenticationProvider.class,
+        pluginConfigurationType = MutualTlsAuthenticationConfig.class)
+public class MutualTlsArmeriaHttpAuthenticationProvider implements ArmeriaHttpAuthenticationProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MutualTlsArmeriaHttpAuthenticationProvider.class);
+
+    private final TrustManagerFactory trustManagerFactory;
+
+    @DataPrepperPluginConstructor
+    public MutualTlsArmeriaHttpAuthenticationProvider(final MutualTlsAuthenticationConfig config) {
+        Objects.requireNonNull(config, "mutual_tls authentication config must not be null");
+        Objects.requireNonNull(config.getSslTrustCertificateFile(),
+                "ssl_trust_certificate_file is required for mutual_tls authentication");
+
+        final Path trustCertPath = Path.of(config.getSslTrustCertificateFile());
+        if (!Files.exists(trustCertPath)) {
+            throw new IllegalArgumentException(
+                    "ssl_trust_certificate_file does not exist: " + trustCertPath);
+        }
+        if (!Files.isReadable(trustCertPath)) {
+            throw new IllegalArgumentException(
+                    "ssl_trust_certificate_file is not readable: " + trustCertPath);
+        }
+
+        this.trustManagerFactory = buildTrustManagerFactory(config.getSslTrustCertificateFile());
+        LOG.info("mutual_tls authentication configured with trust CA: {}", config.getSslTrustCertificateFile());
+    }
+
+    @Override
+    public Optional<ClientAuthConfiguration> getClientAuthConfiguration() {
+        return Optional.of(new ClientAuthConfiguration() {
+            @Override
+            public ClientAuth getClientAuth() {
+                return ClientAuth.REQUIRE;
+            }
+
+            @Override
+            public TrustManagerFactory getTrustManagerFactory() {
+                return trustManagerFactory;
+            }
+        });
+    }
+
+    private TrustManagerFactory buildTrustManagerFactory(final String trustCertFile) {
+        try {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+
+            try (FileInputStream fis = new FileInputStream(trustCertFile)) {
+                int certIndex = 0;
+                for (java.security.cert.Certificate cert : cf.generateCertificates(fis)) {
+                    trustStore.setCertificateEntry("ca-" + certIndex++, cert);
+                }
+            }
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(trustStore);
+            return tmf;
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Failed to load trust certificate from " + trustCertFile + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/MutualTlsArmeriaHttpAuthenticationProviderTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/MutualTlsArmeriaHttpAuthenticationProviderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import io.netty.handler.ssl.ClientAuth;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opensearch.dataprepper.armeria.authentication.ClientAuthConfiguration;
+import org.opensearch.dataprepper.armeria.authentication.MutualTlsAuthenticationConfig;
+
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MutualTlsArmeriaHttpAuthenticationProviderTest {
+
+    @TempDir
+    static Path tempDir;
+
+    private static Path caCertFile;
+
+    @BeforeAll
+    static void generateCerts() throws Exception {
+        KeyPair caKeyPair = TestCertificateGenerator.generateKeyPair();
+        X509Certificate caCert = TestCertificateGenerator.generateCaCertificate(caKeyPair);
+        caCertFile = TestCertificateGenerator.writeCertificateToPem(caCert, tempDir.resolve("ca.crt"));
+    }
+
+    @Test
+    void constructor_throws_when_config_is_null() {
+        assertThrows(NullPointerException.class, () -> new MutualTlsArmeriaHttpAuthenticationProvider(null));
+    }
+
+    @Test
+    void constructor_throws_when_trust_cert_file_is_null() {
+        MutualTlsAuthenticationConfig config = mock(MutualTlsAuthenticationConfig.class);
+        when(config.getSslTrustCertificateFile()).thenReturn(null);
+        assertThrows(NullPointerException.class, () -> new MutualTlsArmeriaHttpAuthenticationProvider(config));
+    }
+
+    @Test
+    void constructor_throws_when_trust_cert_file_does_not_exist() {
+        MutualTlsAuthenticationConfig config = mock(MutualTlsAuthenticationConfig.class);
+        when(config.getSslTrustCertificateFile()).thenReturn("/nonexistent/path/ca.crt");
+        assertThrows(IllegalArgumentException.class, () -> new MutualTlsArmeriaHttpAuthenticationProvider(config));
+    }
+
+    @Test
+    void getClientAuthConfiguration_returns_non_empty() {
+        MutualTlsAuthenticationConfig config = mock(MutualTlsAuthenticationConfig.class);
+        when(config.getSslTrustCertificateFile()).thenReturn(caCertFile.toString());
+
+        MutualTlsArmeriaHttpAuthenticationProvider provider = new MutualTlsArmeriaHttpAuthenticationProvider(config);
+
+        assertThat(provider.getClientAuthConfiguration().isPresent(), is(true));
+    }
+
+    @Test
+    void getClientAuthConfiguration_returns_client_auth_require() {
+        MutualTlsAuthenticationConfig config = mock(MutualTlsAuthenticationConfig.class);
+        when(config.getSslTrustCertificateFile()).thenReturn(caCertFile.toString());
+
+        MutualTlsArmeriaHttpAuthenticationProvider provider = new MutualTlsArmeriaHttpAuthenticationProvider(config);
+        Optional<ClientAuthConfiguration> clientAuthConfig = provider.getClientAuthConfiguration();
+
+        assertThat(clientAuthConfig.get().getClientAuth(), equalTo(ClientAuth.REQUIRE));
+        assertThat(clientAuthConfig.get().getTrustManagerFactory(), is(notNullValue()));
+    }
+
+    @Test
+    void getAuthenticationDecorator_returns_empty() {
+        MutualTlsAuthenticationConfig config = mock(MutualTlsAuthenticationConfig.class);
+        when(config.getSslTrustCertificateFile()).thenReturn(caCertFile.toString());
+
+        MutualTlsArmeriaHttpAuthenticationProvider provider = new MutualTlsArmeriaHttpAuthenticationProvider(config);
+
+        assertThat(provider.getAuthenticationDecorator().isEmpty(), is(true));
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/TestCertificateGenerator.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/TestCertificateGenerator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+/**
+ * Generates test certificates at runtime using BouncyCastle.
+ * Avoids committing private keys to the repository.
+ */
+public final class TestCertificateGenerator {
+
+    static {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private TestCertificateGenerator() {
+    }
+
+    public static KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048, new SecureRandom());
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    public static X509Certificate generateCaCertificate(KeyPair keyPair) throws Exception {
+        X500Name subject = new X500Name("CN=Test CA");
+        BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
+        Date notBefore = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        Date notAfter = Date.from(Instant.now().plus(365, ChronoUnit.DAYS));
+
+        JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                subject, serial, notBefore, notAfter, subject, keyPair.getPublic());
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
+        X509CertificateHolder holder = certBuilder.build(signer);
+        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(holder);
+    }
+
+    public static X509Certificate generateSignedCertificate(KeyPair subjectKeyPair, KeyPair caKeyPair,
+                                                            X509Certificate caCert, String cn) throws Exception {
+        X500Name issuer = new X500Name(caCert.getSubjectX500Principal().getName());
+        X500Name subject = new X500Name("CN=" + cn);
+        BigInteger serial = BigInteger.valueOf(System.currentTimeMillis() + cn.hashCode());
+        Date notBefore = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        Date notAfter = Date.from(Instant.now().plus(365, ChronoUnit.DAYS));
+
+        JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuer, serial, notBefore, notAfter, subject, subjectKeyPair.getPublic());
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(caKeyPair.getPrivate());
+        X509CertificateHolder holder = certBuilder.build(signer);
+        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(holder);
+    }
+
+    public static Path writeCertificateToPem(X509Certificate cert, Path file) throws Exception {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter writer = new JcaPEMWriter(sw)) {
+            writer.writeObject(cert);
+        }
+        Files.writeString(file, sw.toString());
+        return file;
+    }
+
+    public static Path writePrivateKeyToPem(KeyPair keyPair, Path file) throws Exception {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter writer = new JcaPEMWriter(sw)) {
+            writer.writeObject(keyPair.getPrivate());
+        }
+        Files.writeString(file, sw.toString());
+        return file;
+    }
+}

--- a/data-prepper-plugins/http-source-common/build.gradle
+++ b/data-prepper-plugins/http-source-common/build.gradle
@@ -18,6 +18,9 @@ dependencies {
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation project(':data-prepper-test:test-common')
+    testImplementation project(':data-prepper-plugins:armeria-common').sourceSets.test.output
+    testImplementation libs.bouncycastle.bcprov
+    testImplementation libs.bouncycastle.bcpkix
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/BaseHttpSource.java
+++ b/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/BaseHttpSource.java
@@ -102,7 +102,18 @@ public abstract class BaseHttpSource<T extends Record<?>> implements Source<T> {
                         new ByteArrayInputStream(certificate.getPrivateKey().getBytes(StandardCharsets.UTF_8)
                         )
                 );
+                authenticationProvider.getClientAuthConfiguration().ifPresent(clientAuthConfig -> {
+                    sb.tlsCustomizer(sslContextBuilder -> {
+                        sslContextBuilder.clientAuth(clientAuthConfig.getClientAuth());
+                        sslContextBuilder.trustManager(clientAuthConfig.getTrustManagerFactory());
+                    });
+                });
             } else {
+                if (authenticationProvider.getClientAuthConfiguration().isPresent()) {
+                    throw new IllegalStateException(
+                            "mutual_tls authentication requires ssl: true. " +
+                            "Configure ssl: true with ssl_certificate_file and ssl_key_file.");
+                }
                 logger.warn("Creating {} source without SSL/TLS. This is not secure.", sourceName);
                 logger.warn("In order to set up TLS for the {} source, go here: https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/http-source#ssl", sourceName);
                 sb.http(sourceConfig.getPort());

--- a/data-prepper-plugins/http-source-common/src/test/java/org/opensearch/dataprepper/http/MutualTlsIntegrationTest.java
+++ b/data-prepper-plugins/http-source-common/src/test/java/org/opensearch/dataprepper/http/MutualTlsIntegrationTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.http;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.Server;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider;
+import org.opensearch.dataprepper.armeria.authentication.MutualTlsAuthenticationConfig;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.MutualTlsArmeriaHttpAuthenticationProvider;
+import org.opensearch.dataprepper.plugins.TestCertificateGenerator;
+import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
+import org.opensearch.dataprepper.plugins.codec.CompressionOption;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MutualTlsIntegrationTest {
+
+    @TempDir
+    static Path tempDir;
+
+    private static Path caCertFile;
+    private static Path serverCertFile;
+    private static Path serverKeyFile;
+    private static Path clientCertFile;
+    private static Path clientKeyFile;
+
+    @Mock
+    private HttpServerConfig sourceConfig;
+
+    @Mock
+    private PipelineDescription pipelineDescription;
+
+    @Mock
+    private PluginFactory pluginFactory;
+
+    private BaseHttpSource<Record<Event>> source;
+    private Buffer<Record<Event>> buffer;
+    private int actualPort;
+
+    @BeforeAll
+    static void generateCerts() throws Exception {
+        KeyPair caKeyPair = TestCertificateGenerator.generateKeyPair();
+        X509Certificate caCert = TestCertificateGenerator.generateCaCertificate(caKeyPair);
+        caCertFile = TestCertificateGenerator.writeCertificateToPem(caCert, tempDir.resolve("ca.crt"));
+
+        KeyPair serverKeyPair = TestCertificateGenerator.generateKeyPair();
+        X509Certificate serverCert = TestCertificateGenerator.generateSignedCertificate(
+                serverKeyPair, caKeyPair, caCert, "localhost");
+        serverCertFile = TestCertificateGenerator.writeCertificateToPem(serverCert, tempDir.resolve("server.crt"));
+        serverKeyFile = TestCertificateGenerator.writePrivateKeyToPem(serverKeyPair, tempDir.resolve("server.key"));
+
+        KeyPair clientKeyPair = TestCertificateGenerator.generateKeyPair();
+        X509Certificate clientCert = TestCertificateGenerator.generateSignedCertificate(
+                clientKeyPair, caKeyPair, caCert, "test-client");
+        clientCertFile = TestCertificateGenerator.writeCertificateToPem(clientCert, tempDir.resolve("client.crt"));
+        clientKeyFile = TestCertificateGenerator.writePrivateKeyToPem(clientKeyPair, tempDir.resolve("client.key"));
+    }
+
+    @BeforeEach
+    void setUp() {
+        String pipelineName = UUID.randomUUID().toString();
+        lenient().when(pipelineDescription.getPipelineName()).thenReturn(pipelineName);
+
+        lenient().when(sourceConfig.getPort()).thenReturn(0);
+        lenient().when(sourceConfig.getPath()).thenReturn("/");
+        lenient().when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(10000);
+        lenient().when(sourceConfig.getBufferTimeoutInMillis()).thenReturn(8000);
+        lenient().when(sourceConfig.getThreadCount()).thenReturn(2);
+        lenient().when(sourceConfig.getMaxConnectionCount()).thenReturn(100);
+        lenient().when(sourceConfig.getMaxPendingRequests()).thenReturn(100);
+        lenient().when(sourceConfig.getCompression()).thenReturn(CompressionOption.NONE);
+        lenient().when(sourceConfig.hasHealthCheckService()).thenReturn(true);
+        lenient().when(sourceConfig.isSsl()).thenReturn(true);
+        lenient().when(sourceConfig.getSslCertificateFile()).thenReturn(serverCertFile.toString());
+        lenient().when(sourceConfig.getSslKeyFile()).thenReturn(serverKeyFile.toString());
+
+        MutualTlsAuthenticationConfig mtlsConfig = mock(MutualTlsAuthenticationConfig.class);
+        when(mtlsConfig.getSslTrustCertificateFile()).thenReturn(caCertFile.toString());
+        MutualTlsArmeriaHttpAuthenticationProvider mtlsProvider =
+                new MutualTlsArmeriaHttpAuthenticationProvider(mtlsConfig);
+
+        when(pluginFactory.loadPlugin(eq(ArmeriaHttpAuthenticationProvider.class), any(PluginSetting.class)))
+                .thenReturn(mtlsProvider);
+
+        PluginMetrics pluginMetrics = PluginMetrics.fromNames("test_source", pipelineName);
+
+        source = new TestHttpSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+        buffer = new BlockingBuffer<>(10, 8, "test-pipeline");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (source != null) {
+            source.stop();
+        }
+    }
+
+    @Test
+    void client_with_valid_cert_connects_successfully() throws Exception {
+        source.start(buffer);
+        actualPort = getActivePort(source);
+
+        ClientFactory factory = ClientFactory.builder()
+                .tlsNoVerify()
+                .tls(new File(clientCertFile.toString()), new File(clientKeyFile.toString()))
+                .build();
+
+        AggregatedHttpResponse response = WebClient.builder()
+                .factory(factory)
+                .build()
+                .execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTPS)
+                        .authority("127.0.0.1:" + actualPort)
+                        .method(HttpMethod.GET)
+                        .path("/health")
+                        .build())
+                .aggregate()
+                .join();
+
+        assertThat(response.status(), equalTo(HttpStatus.OK));
+        factory.close();
+    }
+
+    @Test
+    void client_without_cert_fails_tls_handshake() throws Exception {
+        source.start(buffer);
+        actualPort = getActivePort(source);
+
+        ClientFactory factory = ClientFactory.builder()
+                .tlsNoVerify()
+                .build();
+
+        Exception exception = assertThrows(Exception.class, () -> {
+            WebClient.builder()
+                    .factory(factory)
+                    .build()
+                    .execute(RequestHeaders.builder()
+                            .scheme(SessionProtocol.HTTPS)
+                            .authority("127.0.0.1:" + actualPort)
+                            .method(HttpMethod.GET)
+                            .path("/health")
+                            .build())
+                    .aggregate()
+                    .join();
+        });
+
+        assertThat("Expected TLS/handshake failure in cause chain",
+                hasTlsException(exception), equalTo(true));
+        factory.close();
+    }
+
+    @Test
+    void mutual_tls_without_ssl_throws_on_start() {
+        when(sourceConfig.isSsl()).thenReturn(false);
+
+        assertThrows(IllegalStateException.class, () -> source.start(buffer));
+    }
+
+    private static int getActivePort(BaseHttpSource<?> source) throws Exception {
+        Field serverField = BaseHttpSource.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        Server server = (Server) serverField.get(source);
+        return server.activeLocalPort();
+    }
+
+    private static boolean hasTlsException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof javax.net.ssl.SSLHandshakeException ||
+                    current instanceof javax.net.ssl.SSLException ||
+                    current instanceof com.linecorp.armeria.common.ClosedSessionException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static class TestHttpSource extends BaseHttpSource<Record<Event>> {
+        TestHttpSource(HttpServerConfig config, PluginMetrics metrics, PluginFactory factory, PipelineDescription desc) {
+            super(config, metrics, factory, desc, "test-source",
+                    org.slf4j.LoggerFactory.getLogger(TestHttpSource.class));
+        }
+
+        @Override
+        public BaseHttpService getHttpService(int bufferTimeoutInMillis, Buffer<Record<Event>> buffer, PluginMetrics pluginMetrics) {
+            return new TestService();
+        }
+    }
+
+    @com.linecorp.armeria.server.annotation.Blocking
+    private static class TestService implements BaseHttpService {
+        @com.linecorp.armeria.server.annotation.Post("/test")
+        public com.linecorp.armeria.common.HttpResponse doPost() {
+            return com.linecorp.armeria.common.HttpResponse.of(HttpStatus.OK);
+        }
+    }
+}

--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -61,6 +61,35 @@ source:
 This plugin uses pluggable authentication for HTTP servers. To provide custom authentication,
 create a plugin which implements [`ArmeriaHttpAuthenticationProvider`](../armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ArmeriaHttpAuthenticationProvider.java)
 
+#### Mutual TLS (mTLS) Authentication
+
+**Status: Experimental**
+
+The `mutual_tls` authentication plugin requires connecting clients to present a valid TLS certificate signed by a trusted Certificate Authority (CA). The server verifies the client certificate during the TLS handshake and rejects connections that do not present a valid certificate.
+
+This requires `ssl: true` to be configured on the source. If `mutual_tls` is configured without SSL enabled, the source will fail to start with an `IllegalStateException`.
+
+```yaml
+source:
+  http:
+    ssl: true
+    ssl_certificate_file: "/path/to/server.crt"
+    ssl_key_file: "/path/to/server.key"
+    authentication:
+      mutual_tls:
+        ssl_trust_certificate_file: "/path/to/ca.crt"
+```
+
+Configuration options:
+
+* `ssl_trust_certificate_file` (Required): Path to the PEM file containing one or more trusted CA certificates used to verify client certificates. Multiple CA certificates can be concatenated in a single PEM file.
+
+Limitations:
+
+* Only file paths are supported (inline PEM content is not supported in this version).
+* CRL/OCSP revocation checking is not yet supported. See [#6940](https://github.com/opensearch-project/data-prepper/issues/6940).
+* Handshake rejection logging/metrics are not yet available. See [#6942](https://github.com/opensearch-project/data-prepper/issues/6942).
+
 
 ### SSL
 

--- a/data-prepper-plugins/opensearch-api-source/README.md
+++ b/data-prepper-plugins/opensearch-api-source/README.md
@@ -59,6 +59,35 @@ source:
 This plugin uses pluggable authentication for HTTP servers. To provide custom authentication,
 create a plugin which implements [`ArmeriaHttpAuthenticationProvider`](../armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ArmeriaHttpAuthenticationProvider.java)
 
+#### Mutual TLS (mTLS) Authentication
+
+**Status: Experimental**
+
+The `mutual_tls` authentication plugin requires connecting clients to present a valid TLS certificate signed by a trusted Certificate Authority (CA). The server verifies the client certificate during the TLS handshake and rejects connections that do not present a valid certificate.
+
+This requires `ssl: true` to be configured on the source. If `mutual_tls` is configured without SSL enabled, the source will fail to start with an `IllegalStateException`.
+
+```yaml
+source:
+  opensearch_api:
+    ssl: true
+    ssl_certificate_file: "/path/to/server.crt"
+    ssl_key_file: "/path/to/server.key"
+    authentication:
+      mutual_tls:
+        ssl_trust_certificate_file: "/path/to/ca.crt"
+```
+
+Configuration options:
+
+* `ssl_trust_certificate_file` (Required): Path to the PEM file containing one or more trusted CA certificates used to verify client certificates. Multiple CA certificates can be concatenated in a single PEM file.
+
+Limitations:
+
+* Only file paths are supported (inline PEM content is not supported in this version).
+* CRL/OCSP revocation checking is not yet supported. See [#6940](https://github.com/opensearch-project/data-prepper/issues/6940).
+* Handshake rejection logging/metrics are not yet available. See [#6942](https://github.com/opensearch-project/data-prepper/issues/6942).
+
 
 ### SSL
 


### PR DESCRIPTION
**Description**

Adds a `mutual_tls` authentication plugin that enables mTLS client certificate
authentication on all HTTP-based sources. Clients must present a valid certificate
signed by the configured trust CA to connect.

This is implemented as an `ArmeriaHttpAuthenticationProvider` plugin (consistent with
`http_basic` and `unauthenticated`), with a new `getTlsCustomizer()` method on the
interface for TLS-layer configuration.

Configuration example:
```
source:
  opensearch_api:
    ssl: true
    ssl_certificate_file: "/certs/server.crt"
    ssl_key_file: "/certs/server.key"
    authentication:
      mutual_tls:
        ssl_trust_certificate_file: "/certs/ca.crt"
```
Works on all HTTP-based sources: `http`, `opensearch_api`, `otel_trace_source`,
`otel_metrics_source`, `otel_logs_source`.

**Issues Resolved**

Resolves #6889

**Check List**
- [x] New functionality includes testing (unit + integration)
- [x] Commits are signed with DCO (Signed-off-by)