### PR TITLE
Update the Claude command to generate release notes with some allowed tools

### DIFF
--- a/.claude/commands/generate-release-notes.md
+++ b/.claude/commands/generate-release-notes.md
@@ -1,3 +1,13 @@
+---
+description: Generate release notes for Data Prepper version $ARGUMENTS.
+allowed-tools:
+  - Bash(gh issue list *)
+  - Bash(gh pr list *)
+  - Read(release/script/release-notes/**)
+  - Read(release/release-notes/**)
+  - Write(release/release-notes/**)
+---
+
 Generate release notes for Data Prepper version $ARGUMENTS.
 
 ## Overview


### PR DESCRIPTION
### Description

The generate release notes Claude command needs access to some tools. This PR adds these permissions so that the user doesn't have to grant them. They are rather safe - mostly read access. There is write access to the release-notes directory, but that is the whole purpose of the tool.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
