### PR TITLE
Set "drop" as an alias for noop sink

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/NoopSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/NoopSink.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
-@DataPrepperPlugin(name = "noop", pluginType = Sink.class)
+@DataPrepperPlugin(name = "noop",
+        alternateNames = { "drop" },
+        pluginType = Sink.class)
 public class NoopSink implements Sink<Record<Object>> {
     private static final Logger LOG = LoggerFactory.getLogger(NoopSink.class);
 


### PR DESCRIPTION
### Description
Set `drop` as an alias for noop sink
 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
