### PR TITLE
Apply sts_header_overrides to MSK IAM SASL (data-plane) authentication

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/MskIamAuthCredentialsCallbackHandler.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/MskIamAuthCredentialsCallbackHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.msk.auth.iam.IAMClientCallbackHandler;
+import software.amazon.msk.auth.iam.internals.AWSCredentialsCallback;
+
+/**
+ * MSK IAM SASL callback handler that supplies credentials from an STS AssumeRole call that applies
+ * the configured {@code sts_header_overrides}. The stock {@link IAMClientCallbackHandler} performs
+ * the role assumption without applying any STS header overrides. This reuses everything from the
+ * stock handler except the source of credentials.
+ *
+ * <p>The header-aware provider is AWS SDK v2 while aws-msk-iam-auth 2.0.3 expects SDK v1
+ * {@link AWSCredentials}, so the resolved temporary credentials are translated v2 to v1.
+ */
+public class MskIamAuthCredentialsCallbackHandler extends IAMClientCallbackHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(MskIamAuthCredentialsCallbackHandler.class);
+
+    @Override
+    protected void handleCallback(final AWSCredentialsCallback callback) {
+        final AwsCredentialsProvider provider = KafkaSecurityConfigurer.getMskCredentialsProvider();
+        try {
+            LOG.debug("Resolving MSK IAM credentials from header-aware provider {}",
+                    provider == null ? "null" : provider.getClass().getSimpleName());
+            callback.setAwsCredentials(toV1Credentials(provider.resolveCredentials()));
+        } catch (final Exception e) {
+            LOG.debug("Failed to resolve MSK IAM credentials with STS header overrides", e);
+            callback.setLoadingException(e);
+        }
+    }
+
+    private static AWSCredentials toV1Credentials(final AwsCredentials credentials) {
+        if (credentials instanceof AwsSessionCredentials) {
+            final AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentials;
+            return new BasicSessionCredentials(
+                    sessionCredentials.accessKeyId(),
+                    sessionCredentials.secretAccessKey(),
+                    sessionCredentials.sessionToken());
+        }
+        return new BasicAWSCredentials(credentials.accessKeyId(), credentials.secretAccessKey());
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.kafka.util;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicSaslClientCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicBasicCredentialsProvider;
+import org.opensearch.dataprepper.plugins.kafka.authenticator.MskIamAuthCredentialsCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
@@ -100,6 +101,10 @@ public class KafkaSecurityConfigurer {
     private static AwsCredentialsProvider mskCredentialsProvider;
     private static AwsCredentialsProvider awsGlueCredentialsProvider;
     private static GlueSchemaRegistryKafkaDeserializer glueDeserializer;
+
+    public static AwsCredentialsProvider getMskCredentialsProvider() {
+        return mskCredentialsProvider;
+    }
 
 
     /*public static void setSaslPlainTextProperties(final KafkaSourceConfig kafkaSourConfig,
@@ -231,18 +236,24 @@ public class KafkaSecurityConfigurer {
             if (Objects.isNull(awsConfig)) {
                 throw new RuntimeException("AWS Config needs to be specified when sasl/aws_msk_iam is set to \"role\"");
             }
-            String baseIamAuthConfig = "software.amazon.msk.auth.iam.IAMLoginModule required " +
-                "awsRoleArn=\"%s\" " +
-                "awsStsRegion=\"%s\"";
+            final Map<String, String> stsHeaderOverrides = awsConfig.getAwsStsHeaderOverrides();
+            if (Objects.nonNull(stsHeaderOverrides) && !stsHeaderOverrides.isEmpty()) {
+                properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS, MskIamAuthCredentialsCallbackHandler.class.getName());
+                properties.put(SASL_JAAS_CONFIG, "software.amazon.msk.auth.iam.IAMLoginModule required;");
+            } else {
+                String baseIamAuthConfig = "software.amazon.msk.auth.iam.IAMLoginModule required " +
+                    "awsRoleArn=\"%s\" " +
+                    "awsStsRegion=\"%s\"";
 
-            baseIamAuthConfig = String.format(baseIamAuthConfig, awsConfig.getStsRoleArn(), awsConfig.getRegion());
+                baseIamAuthConfig = String.format(baseIamAuthConfig, awsConfig.getStsRoleArn(), awsConfig.getRegion());
 
-            if (Objects.nonNull(awsConfig.getStsRoleSessionName())) {
-                baseIamAuthConfig += String.format(" awsRoleSessionName=\"%s\"", awsConfig.getStsRoleSessionName());
+                if (Objects.nonNull(awsConfig.getStsRoleSessionName())) {
+                    baseIamAuthConfig += String.format(" awsRoleSessionName=\"%s\"", awsConfig.getStsRoleSessionName());
+                }
+
+                baseIamAuthConfig += ";";
+                properties.put(SASL_JAAS_CONFIG, baseIamAuthConfig);
             }
-
-            baseIamAuthConfig += ";";
-            properties.put(SASL_JAAS_CONFIG, baseIamAuthConfig);
         } else if (awsIamAuthConfig == AwsIamAuthConfig.DEFAULT) {
             properties.put(SASL_JAAS_CONFIG,
                     "software.amazon.msk.auth.iam.IAMLoginModule required;");

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/MskIamAuthCredentialsCallbackHandlerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/MskIamAuthCredentialsCallbackHandlerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.msk.auth.iam.internals.AWSCredentialsCallback;
+
+import javax.security.auth.callback.Callback;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MskIamAuthCredentialsCallbackHandlerTest {
+
+    @Mock
+    private AwsCredentialsProvider mskCredentialsProvider;
+
+    private final MskIamAuthCredentialsCallbackHandler objectUnderTest = new MskIamAuthCredentialsCallbackHandler();
+
+    @Test
+    void handleResolvesSessionCredentialsAndConvertsToV1() throws Exception {
+        final AwsSessionCredentials sessionCredentials = AwsSessionCredentials.create(
+                "accessKeyId", "secretAccessKey", "sessionToken");
+        when(mskCredentialsProvider.resolveCredentials()).thenReturn(sessionCredentials);
+        final AWSCredentialsCallback callback = new AWSCredentialsCallback();
+
+        try (final MockedStatic<KafkaSecurityConfigurer> mockedConfigurer = mockStatic(KafkaSecurityConfigurer.class)) {
+            mockedConfigurer.when(KafkaSecurityConfigurer::getMskCredentialsProvider).thenReturn(mskCredentialsProvider);
+            objectUnderTest.handle(new Callback[]{callback});
+        }
+
+        assertThat(callback.isSuccessful(), is(true));
+        final AWSCredentials credentials = callback.getAwsCredentials();
+        assertThat(credentials, instanceOf(BasicSessionCredentials.class));
+        assertThat(credentials.getAWSAccessKeyId(), is("accessKeyId"));
+        assertThat(credentials.getAWSSecretKey(), is("secretAccessKey"));
+        assertThat(((BasicSessionCredentials) credentials).getSessionToken(), is("sessionToken"));
+    }
+
+    @Test
+    void handleResolvesNonSessionCredentialsAndConvertsToV1() throws Exception {
+        final AwsBasicCredentials basicCredentials = AwsBasicCredentials.create("accessKeyId", "secretAccessKey");
+        when(mskCredentialsProvider.resolveCredentials()).thenReturn(basicCredentials);
+        final AWSCredentialsCallback callback = new AWSCredentialsCallback();
+
+        try (final MockedStatic<KafkaSecurityConfigurer> mockedConfigurer = mockStatic(KafkaSecurityConfigurer.class)) {
+            mockedConfigurer.when(KafkaSecurityConfigurer::getMskCredentialsProvider).thenReturn(mskCredentialsProvider);
+            objectUnderTest.handle(new Callback[]{callback});
+        }
+
+        assertThat(callback.isSuccessful(), is(true));
+        final AWSCredentials credentials = callback.getAwsCredentials();
+        assertThat(credentials, instanceOf(BasicAWSCredentials.class));
+        assertThat(credentials.getAWSAccessKeyId(), is("accessKeyId"));
+        assertThat(credentials.getAWSSecretKey(), is("secretAccessKey"));
+    }
+
+    @Test
+    void handleSetsLoadingExceptionWhenProviderThrows() throws Exception {
+        final RuntimeException resolveException = new RuntimeException("Access denied");
+        when(mskCredentialsProvider.resolveCredentials()).thenThrow(resolveException);
+        final AWSCredentialsCallback callback = new AWSCredentialsCallback();
+
+        try (final MockedStatic<KafkaSecurityConfigurer> mockedConfigurer = mockStatic(KafkaSecurityConfigurer.class)) {
+            mockedConfigurer.when(KafkaSecurityConfigurer::getMskCredentialsProvider).thenReturn(mskCredentialsProvider);
+            objectUnderTest.handle(new Callback[]{callback});
+        }
+
+        assertThat(callback.isSuccessful(), is(false));
+        assertThat(callback.getLoadingException(), is(sameInstance(resolveException)));
+    }
+
+    @Test
+    void handleSetsLoadingExceptionWhenProviderIsNull() throws Exception {
+        final AWSCredentialsCallback callback = new AWSCredentialsCallback();
+
+        try (final MockedStatic<KafkaSecurityConfigurer> mockedConfigurer = mockStatic(KafkaSecurityConfigurer.class)) {
+            mockedConfigurer.when(KafkaSecurityConfigurer::getMskCredentialsProvider).thenReturn(null);
+            objectUnderTest.handle(new Callback[]{callback});
+        }
+
+        assertThat(callback.isSuccessful(), is(false));
+        assertThat(callback.getLoadingException(), instanceOf(NullPointerException.class));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicBasicCredentialsProvider;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicSaslClientCallbackHandler;
+import org.opensearch.dataprepper.plugins.kafka.authenticator.MskIamAuthCredentialsCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsCredentialsConfig;
@@ -171,6 +172,21 @@ public class KafkaSecurityConfigurerTest {
         assertThat(props.get("ssl.engine.factory.class"), is(nullValue()));
         assertThat(props.get("sasl.client.callback.handler.class"),
                 is("software.amazon.msk.auth.iam.IAMClientCallbackHandler"));
+    }
+
+    @Test
+    public void testSetAuthPropertiesBootstrapServersWithSaslIAMRoleAndStsHeaderOverrides() throws IOException {
+        final Properties props = new Properties();
+        final KafkaSourceConfig kafkaSourceConfig =
+                createKafkaSinkConfig("kafka-pipeline-bootstrap-servers-sasl-iam-role-with-headers.yaml");
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        assertThat(props.getProperty("bootstrap.servers"), is("localhost:9092"));
+        assertThat(props.getProperty("sasl.mechanism"), is("AWS_MSK_IAM"));
+        assertThat(props.getProperty("security.protocol"), is("SASL_SSL"));
+        assertThat(props.getProperty("sasl.jaas.config"),
+                is("software.amazon.msk.auth.iam.IAMLoginModule required;"));
+        assertThat(props.get("sasl.client.callback.handler.class"),
+                is(MskIamAuthCredentialsCallbackHandler.class.getName()));
     }
 
     @Test


### PR DESCRIPTION
### Description
The Kafka plugin already applies the configured `sts_header_overrides` to the STS `AssumeRole` call used to fetch MSK bootstrap brokers, but **not** to the data-plane SASL (`AWS_MSK_IAM`) connection used for the actual consume/produce. That broker authentication delegates credential resolution to the `aws-msk-iam-auth` library's internal role assumption, which has no way to apply STS header overrides, so the configured headers are silently dropped for the broker connection.

This change makes `sts_header_overrides` apply consistently across all STS `AssumeRole` calls the plugin performs for MSK:
- When `aws_msk_iam: role` is configured **with** `sts_header_overrides`, the SASL client callback handler is switched to a custom handler that resolves credentials from the same header-aware `StsAssumeRoleCredentialsProvider` already used for bootstrap-broker discovery, and the JAAS config is set to default mode so the library does not perform its own (header-less) role assumption.
- The role is assumed once, with the overrides applied, and the resolved temporary credentials are converted to the SDK v1 credential type that `aws-msk-iam-auth` expects.

Behavior is unchanged when no `sts_header_overrides` are configured, and for `aws_msk_iam: default`.

### Issues Resolved
Resolves #6923

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
