### PR TITLE
Honor fractional Retry-After header values

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/retry/RetryAfterHeaderStrategy.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/main/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/retry/RetryAfterHeaderStrategy.java
@@ -31,6 +31,7 @@ public class RetryAfterHeaderStrategy implements RetryStrategy {
     private static final String RATE_LIMIT_REMAINING = "X-RateLimit-Remaining";
     private static final String RATE_LIMIT_RESET = "X-RateLimit-Reset";
     private static final String RETRY_AFTER = "Retry-After";
+    private static final int MAX_RETRY_AFTER_SECONDS = 86400; // ceiling guards against int overflow in the sleep calculation
     private static final List<HttpStatus> DEFAULT_RATE_LIMIT_STATUS_CODES = Arrays.asList(HttpStatus.TOO_MANY_REQUESTS);
 
     private final List<Integer> retryAttemptSleepTime;
@@ -127,8 +128,12 @@ public class RetryAfterHeaderStrategy implements RetryStrategy {
             if (headers != null && headers.containsKey(RETRY_AFTER)) {
                 String retryAfter = headers.getFirst(RETRY_AFTER);
                 if (retryAfter != null) {
-                    int seconds = Integer.parseInt(retryAfter);
-                    return Optional.of(Math.max(seconds, 1));
+                    // Some services send a fractional Retry-After (e.g. 299.997); round up so we never wait less than requested.
+                    final double parsedSeconds = Double.parseDouble(retryAfter);
+                    if (Double.isFinite(parsedSeconds)) {
+                        final int seconds = (int) Math.min(Math.ceil(parsedSeconds), MAX_RETRY_AFTER_SECONDS);
+                        return Optional.of(Math.max(seconds, 1));
+                    }
                 }
             }
             if (headers != null && headers.containsKey(RATE_LIMIT_REMAINING) && headers.containsKey(RATE_LIMIT_RESET)) {

--- a/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/retry/RetryAfterHeaderStrategyTest.java
+++ b/data-prepper-plugins/saas-source-plugins/source-crawler/src/test/java/org/opensearch/dataprepper/plugins/source/source_crawler/utils/retry/RetryAfterHeaderStrategyTest.java
@@ -243,6 +243,71 @@ class RetryAfterHeaderStrategyTest {
     }
 
     @Test
+    void calculateSleepTime_WithFractionalRetryAfterHeader_RoundsUpToNextSecond() {
+        final RetryAfterHeaderStrategy retryAfterHeaderStrategy = new RetryAfterHeaderStrategy(1);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("retry-after", "299.997");
+        final HttpClientErrorException exception = new HttpClientErrorException(
+                HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", headers, null, null);
+
+        final long sleepTime = retryAfterHeaderStrategy.calculateSleepTime(exception, 0);
+
+        assertThat(sleepTime, equalTo(300000L));
+    }
+
+    @Test
+    void calculateSleepTime_WithSmallFractionalRetryAfterHeader_RoundsUpToNextSecond() {
+        final RetryAfterHeaderStrategy retryAfterHeaderStrategy = new RetryAfterHeaderStrategy(1);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("retry-after", "123.39");
+        final HttpClientErrorException exception = new HttpClientErrorException(
+                HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", headers, null, null);
+
+        final long sleepTime = retryAfterHeaderStrategy.calculateSleepTime(exception, 0);
+
+        assertThat(sleepTime, equalTo(124000L));
+    }
+
+    @Test
+    void calculateSleepTime_WithSubSecondRetryAfterHeader_UsesMinimumOneSecond() {
+        final RetryAfterHeaderStrategy retryAfterHeaderStrategy = new RetryAfterHeaderStrategy(1);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("retry-after", "0.5");
+        final HttpClientErrorException exception = new HttpClientErrorException(
+                HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", headers, null, null);
+
+        final long sleepTime = retryAfterHeaderStrategy.calculateSleepTime(exception, 0);
+
+        assertThat(sleepTime, equalTo(1000L));
+    }
+
+    @Test
+    void calculateSleepTime_WithNonFiniteRetryAfterHeader_FallsBackToDefault() {
+        final RetryAfterHeaderStrategy retryAfterHeaderStrategy = new RetryAfterHeaderStrategy(1);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("retry-after", "Infinity");
+        final HttpClientErrorException exception = new HttpClientErrorException(
+                HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", headers, null, null);
+
+        final long sleepTime = retryAfterHeaderStrategy.calculateSleepTime(exception, 0);
+
+        assertThat(sleepTime, equalTo(5000L));
+    }
+
+    @Test
+    void calculateSleepTime_WithExcessiveRetryAfterHeader_IsClampedToMaximum() {
+        final RetryAfterHeaderStrategy retryAfterHeaderStrategy = new RetryAfterHeaderStrategy(1);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("retry-after", "999999999999");
+        final HttpClientErrorException exception = new HttpClientErrorException(
+                HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", headers, null, null);
+
+        final long sleepTime = retryAfterHeaderStrategy.calculateSleepTime(exception, 0);
+
+        assertThat(sleepTime, equalTo(86400000L));
+    }
+
+    @Test
     void calculateSleepTime_WithEmptyRetryAfterHeader_FallsBackToDefault() {
         final RetryAfterHeaderStrategy retryAfterHeaderStrategy = new RetryAfterHeaderStrategy(1);
         final HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION




### Description
RetryAfterHeaderStrategy parsed the Retry-After header with Integer.parseInt, which throws on fractional second values that some HTTP services return (e.g. 299.997). The exception was swallowed and the header ignored, so the client fell back to a short fixed backoff and retried far sooner than the server requested. Under HTTP 429 this collapses one backoff window into a burst of premature retries.

Parse the value as a decimal and round up so the client never waits less than requested. Guard against non-finite and excessively large values, which the decimal parser would otherwise accept where the integer parser previously rejected them, to avoid integer overflow in the sleep calculation.
 
### Issues Resolved
Resolves #[6927]
 
### Check List
- [Y ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [Y ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
