### PR TITLE
Add retry configuration options to opensearch sink

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/AdaptiveBackoffState.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/AdaptiveBackoffState.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Thread-safe shared state for adaptive backoff across worker threads.
+ * Tracks the last delay that resulted in a successful request and
+ * decays back toward the initial delay after sustained first-attempt successes.
+ */
+public class AdaptiveBackoffState {
+
+    private final AtomicLong lastSuccessfulDelay;
+    private final AtomicInteger consecutiveFirstAttemptSuccesses;
+    private final long initialDelayMs;
+    private final int decayThreshold;
+
+    public AdaptiveBackoffState(final long initialDelayMs, final int decayThreshold) {
+        this.initialDelayMs = initialDelayMs;
+        this.decayThreshold = decayThreshold;
+        this.lastSuccessfulDelay = new AtomicLong(initialDelayMs);
+        this.consecutiveFirstAttemptSuccesses = new AtomicInteger(0);
+    }
+
+    /**
+     * Returns the delay to start retries at, based on previous batch outcomes.
+     */
+    public long getStartingDelay() {
+        return lastSuccessfulDelay.get();
+    }
+
+    /**
+     * Called when a batch required retries and eventually succeeded at the given delay.
+     */
+    public void recordRetrySuccess(final long delayMs) {
+        lastSuccessfulDelay.set(delayMs);
+        consecutiveFirstAttemptSuccesses.set(0);
+    }
+
+    /**
+     * Called when a batch succeeds on the first attempt (no retries needed).
+     * After decay_threshold consecutive first-attempt successes, halves the starting delay.
+     */
+    public void recordFirstAttemptSuccess() {
+        int count = consecutiveFirstAttemptSuccesses.incrementAndGet();
+        if (count >= decayThreshold) {
+            long current = lastSuccessfulDelay.get();
+            long decayed = Math.max(initialDelayMs, current / 2);
+            lastSuccessfulDelay.compareAndSet(current, decayed);
+            consecutiveFirstAttemptSuccesses.set(0);
+        }
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngester.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngester.java
@@ -41,6 +41,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkR
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkApiWrapper;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkApiWrapperFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkOperationWriter;
+import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.RetryConfig;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingCompressedBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingUncompressedBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
@@ -218,6 +219,13 @@ public class BulkIngester implements Ingester {
         setupBulkRequestSupplier(requireAlias);
 
         final int maxRetries = openSearchSinkConfig.getRetryConfiguration().getMaxRetries();
+        final RetryConfig retryConfig = openSearchSinkConfig.getRetryConfiguration().getRetryConfig();
+        final long initialDelayMs = retryConfig.getInitialDelay().toMillis();
+        final long maxDelayMs = retryConfig.getMaxDelay().toMillis();
+        final double jitter = retryConfig.getJitter();
+        final AdaptiveBackoffState adaptiveBackoffState = retryConfig.isAdaptive()
+                ? new AdaptiveBackoffState(initialDelayMs, retryConfig.getDecayThreshold())
+                : null;
         bulkApiWrapper = BulkApiWrapperFactory.getWrapper(openSearchSinkConfig.getIndexConfiguration(),
                 openSearchClientSupplier);
 
@@ -237,7 +245,11 @@ public class BulkIngester implements Ingester {
                 pipeline,
                 PLUGIN_NAME,
                 openSearchSinkConfig.getIndexConfiguration().getQueryOnBulkFailures() ? existingDocumentQueryManager : null,
-                isExternalVersionType(versionType));
+                isExternalVersionType(versionType),
+                initialDelayMs,
+                maxDelayMs,
+                jitter,
+                adaptiveBackoffState);
 
         final IndexCache indexCache = new IndexCache();
         final DataStreamDetector dataStreamDetector = new DataStreamDetector(openSearchClient, indexCache);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -120,6 +120,10 @@ public final class BulkRetryStrategy {
     private final PluginMetrics pluginMetrics;
     private final Supplier<AccumulatingBulkRequest> bulkRequestSupplier;
     private final int maxRetries;
+    private final long initialDelayMs;
+    private final long maxDelayMs;
+    private final double jitter;
+    private final AdaptiveBackoffState adaptiveBackoffState;
     private final ObjectMapper objectMapper;
 
     private final Counter sentDocumentsCounter;
@@ -170,6 +174,25 @@ public final class BulkRetryStrategy {
                              final String pluginName,
                              final ExistingDocumentQueryManager existingDocumentQueryManager,
                              final boolean isExternalVersioning) {
+        this(requestFunction, logFailure, successfulOperationsHandler, pluginMetrics, maxRetries,
+             bulkRequestSupplier, pipelineName, pluginName, existingDocumentQueryManager,
+             isExternalVersioning, INITIAL_DELAY_MS, MAXIMUM_DELAY_MS, 0.0, null);
+    }
+
+    public BulkRetryStrategy(final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction,
+                             final BiConsumer<List<FailedBulkOperation>, Throwable> logFailure,
+                             final Consumer<List<BulkOperationWrapper>> successfulOperationsHandler,
+                             final PluginMetrics pluginMetrics,
+                             final int maxRetries,
+                             final Supplier<AccumulatingBulkRequest> bulkRequestSupplier,
+                             final String pipelineName,
+                             final String pluginName,
+                             final ExistingDocumentQueryManager existingDocumentQueryManager,
+                             final boolean isExternalVersioning,
+                             final long initialDelayMs,
+                             final long maxDelayMs,
+                             final double jitter,
+                             final AdaptiveBackoffState adaptiveBackoffState) {
         this.existingDocumentQueryManager = existingDocumentQueryManager;
         this.isExternalVersioning = isExternalVersioning;
         this.requestFunction = requestFunction;
@@ -178,6 +201,10 @@ public final class BulkRetryStrategy {
         this.pluginMetrics = pluginMetrics;
         this.bulkRequestSupplier = bulkRequestSupplier;
         this.maxRetries = maxRetries;
+        this.initialDelayMs = initialDelayMs;
+        this.maxDelayMs = maxDelayMs;
+        this.jitter = jitter;
+        this.adaptiveBackoffState = adaptiveBackoffState;
         this.objectMapper = new ObjectMapper();
 
         sentDocumentsCounter = pluginMetrics.counter(DOCUMENTS_SUCCESS);
@@ -215,12 +242,17 @@ public final class BulkRetryStrategy {
     }
 
     public void execute(final AccumulatingBulkRequest bulkRequest) throws InterruptedException {
-        final Backoff backoff = Backoff.exponential(INITIAL_DELAY_MS, MAXIMUM_DELAY_MS).withMaxAttempts(maxRetries);
+        final long startDelay = (adaptiveBackoffState != null) ? adaptiveBackoffState.getStartingDelay() : initialDelayMs;
+        Backoff backoff = Backoff.exponential(startDelay, maxDelayMs).withMaxAttempts(maxRetries);
+        if (jitter > 0) {
+            backoff = backoff.withJitter(jitter);
+        }
         BulkOperationRequestResponse operationResponse;
         BulkResponse response = null;
         Exception exception = null;
         AccumulatingBulkRequest request = bulkRequest;
         int attempt = 1;
+        long lastDelayMs = 0;
         do {
             operationResponse = handleRetry(request, response, attempt, exception);
             if (operationResponse != null) {
@@ -235,6 +267,7 @@ public final class BulkRetryStrategy {
                     handleFailures(request, null, e);
                     break;
                 }
+                lastDelayMs = delayMillis;
                 // Wait for backOff duration
                 try {
                     Thread.sleep(delayMillis);
@@ -243,6 +276,17 @@ public final class BulkRetryStrategy {
                 }
             }
         } while (operationResponse != null);
+
+        // Update adaptive state
+        if (adaptiveBackoffState != null) {
+            if (attempt == 1) {
+                // Succeeded on first attempt — no retries needed
+                adaptiveBackoffState.recordFirstAttemptSuccess();
+            } else if (lastDelayMs > 0) {
+                // Required retries — record the delay that worked
+                adaptiveBackoffState.recordRetrySuccess(lastDelayMs);
+            }
+        }
     }
 
     public boolean canRetry(final BulkResponse response) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/RetryConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/RetryConfiguration.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 
 import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.DlqConfiguration;
 import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.OpenSearchSinkConfig;
+import org.opensearch.dataprepper.plugins.sink.opensearch.configuration.RetryConfig;
 
 import java.util.Optional;
 
@@ -20,6 +21,7 @@ public class RetryConfiguration {
   private final String dlqFile;
   private final int maxRetries;
   private final DlqConfiguration dlq;
+  private final RetryConfig retryConfig;
 
   public String getDlqFile() {
     return dlqFile;
@@ -27,6 +29,10 @@ public class RetryConfiguration {
 
   public Optional<DlqConfiguration> getDlq() {
     return Optional.ofNullable(dlq);
+  }
+
+  public RetryConfig getRetryConfig() {
+    return retryConfig;
   }
 
   public int getMaxRetries() {
@@ -39,8 +45,8 @@ public class RetryConfiguration {
   public static class Builder {
     private String dlqFile;
     private int maxRetries = Integer.MAX_VALUE;
-
     private DlqConfiguration dlq;
+    private RetryConfig retryConfig = new RetryConfig();
 
     public Builder withDlqFile(final String dlqFile) {
       checkNotNull(dlqFile, "dlqFile cannot be null.");
@@ -59,6 +65,13 @@ public class RetryConfiguration {
       this.dlq = dlq;
       return this;
     }
+
+    public Builder withRetryConfig(final RetryConfig retryConfig) {
+      checkNotNull(retryConfig, "retryConfig cannot be null");
+      this.retryConfig = retryConfig;
+      return this;
+    }
+
     public RetryConfiguration build() {
       return new RetryConfiguration(this);
     }
@@ -68,6 +81,7 @@ public class RetryConfiguration {
     this.dlqFile = builder.dlqFile;
     this.maxRetries = builder.maxRetries;
     this.dlq = builder.dlq;
+    this.retryConfig = builder.retryConfig;
   }
 
  public static RetryConfiguration readRetryConfig(final OpenSearchSinkConfig openSearchSinkConfig) {
@@ -83,6 +97,10 @@ public class RetryConfiguration {
    final DlqConfiguration dlqConfiguration = openSearchSinkConfig.getDlq();
    if (dlqConfiguration != null) {
      builder = builder.withDlq(dlqConfiguration);
+   }
+   final RetryConfig retryConfig = openSearchSinkConfig.getRetryConfig();
+   if (retryConfig != null) {
+     builder = builder.withRetryConfig(retryConfig);
    }
    return builder.build();
   }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -203,6 +203,11 @@ public class OpenSearchSinkConfig {
     private Integer maxRetries = null;
 
     @Getter
+    @Valid
+    @JsonProperty("retry")
+    private RetryConfig retryConfig = new RetryConfig();
+
+    @Getter
     @JsonProperty("dlq")
     private DlqConfiguration dlq;
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/RetryConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/RetryConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.time.Duration;
+
+public class RetryConfig {
+
+    private static final Duration DEFAULT_INITIAL_DELAY = Duration.ofMillis(50);
+    private static final Duration DEFAULT_MAX_DELAY = Duration.ofMinutes(10);
+    private static final double DEFAULT_JITTER = 0.0;
+    private static final boolean DEFAULT_ADAPTIVE = false;
+    private static final int DEFAULT_DECAY_THRESHOLD = 3;
+
+    @Getter
+    @JsonProperty("initial_delay")
+    private Duration initialDelay = DEFAULT_INITIAL_DELAY;
+
+    @Getter
+    @JsonProperty("max_delay")
+    private Duration maxDelay = DEFAULT_MAX_DELAY;
+
+    @Getter
+    @JsonProperty("jitter")
+    private double jitter = DEFAULT_JITTER;
+
+    @Getter
+    @JsonProperty("adaptive")
+    private boolean adaptive = DEFAULT_ADAPTIVE;
+
+    @Getter
+    @JsonProperty("decay_threshold")
+    private int decayThreshold = DEFAULT_DECAY_THRESHOLD;
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/AdaptiveBackoffStateTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/AdaptiveBackoffStateTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AdaptiveBackoffStateTest {
+
+    private static final long INITIAL_DELAY_MS = 50;
+    private static final int DECAY_THRESHOLD = 3;
+
+    private AdaptiveBackoffState state;
+
+    @BeforeEach
+    void setUp() {
+        state = new AdaptiveBackoffState(INITIAL_DELAY_MS, DECAY_THRESHOLD);
+    }
+
+    @Test
+    void getStartingDelay_returns_initial_delay_when_no_retries_recorded() {
+        assertThat(state.getStartingDelay(), equalTo(INITIAL_DELAY_MS));
+    }
+
+    @Test
+    void recordRetrySuccess_updates_starting_delay() {
+        state.recordRetrySuccess(6400);
+        assertThat(state.getStartingDelay(), equalTo(6400L));
+    }
+
+    @Test
+    void recordRetrySuccess_resets_consecutive_success_counter() {
+        state.recordFirstAttemptSuccess();
+        state.recordFirstAttemptSuccess();
+        state.recordRetrySuccess(3200);
+        // Next 3 successes should decay from 3200, not trigger earlier
+        state.recordFirstAttemptSuccess();
+        state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(3200L));
+        state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(1600L));
+    }
+
+    @Test
+    void recordFirstAttemptSuccess_decays_after_threshold_consecutive_successes() {
+        state.recordRetrySuccess(6400);
+
+        state.recordFirstAttemptSuccess();
+        state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(6400L));
+
+        state.recordFirstAttemptSuccess(); // 3rd = threshold
+        assertThat(state.getStartingDelay(), equalTo(3200L));
+    }
+
+    @Test
+    void decay_continues_halving_on_each_threshold() {
+        state.recordRetrySuccess(6400);
+
+        // First decay: 6400 -> 3200
+        for (int i = 0; i < DECAY_THRESHOLD; i++) state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(3200L));
+
+        // Second decay: 3200 -> 1600
+        for (int i = 0; i < DECAY_THRESHOLD; i++) state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(1600L));
+
+        // Third decay: 1600 -> 800
+        for (int i = 0; i < DECAY_THRESHOLD; i++) state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(800L));
+    }
+
+    @Test
+    void decay_floors_at_initial_delay() {
+        state.recordRetrySuccess(100);
+
+        for (int i = 0; i < DECAY_THRESHOLD; i++) state.recordFirstAttemptSuccess();
+        // 100 / 2 = 50 = INITIAL_DELAY_MS (floor)
+        assertThat(state.getStartingDelay(), equalTo(INITIAL_DELAY_MS));
+
+        // Should not go below floor
+        for (int i = 0; i < DECAY_THRESHOLD; i++) state.recordFirstAttemptSuccess();
+        assertThat(state.getStartingDelay(), equalTo(INITIAL_DELAY_MS));
+    }
+
+    @Test
+    void concurrent_access_does_not_throw() throws InterruptedException {
+        Thread t1 = new Thread(() -> {
+            for (int i = 0; i < 1000; i++) {
+                state.recordRetrySuccess(i * 100L);
+                state.getStartingDelay();
+            }
+        });
+        Thread t2 = new Thread(() -> {
+            for (int i = 0; i < 1000; i++) {
+                state.recordFirstAttemptSuccess();
+                state.getStartingDelay();
+            }
+        });
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        // No exception = pass. Value is non-deterministic due to concurrency.
+        assertThat(state.getStartingDelay() >= INITIAL_DELAY_MS, equalTo(true));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -1653,4 +1653,95 @@ public class BulkRetryStrategyTests {
             return new BulkResponse.Builder().items(Arrays.asList()).errors(false).took(10).build();
         }
     }
+
+    @Test
+    public void testExecute_withAdaptiveBackoff_startsAtLastSuccessfulDelay() throws Exception {
+        final AdaptiveBackoffState adaptiveState = new AdaptiveBackoffState(50, 3);
+        adaptiveState.recordRetrySuccess(1600);
+
+        final BulkResponseItem successItem = successItemResponse("test-index");
+        final BulkResponseItem throttledItem = tooManyRequestItemResponse("test-index");
+        final int[] callCount = {0};
+
+        final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
+                bulkRequest -> {
+                    callCount[0]++;
+                    if (callCount[0] == 1) {
+                        // First attempt: partial failure (throttled)
+                        BulkResponse resp = mock(BulkResponse.class);
+                        when(resp.errors()).thenReturn(true);
+                        when(resp.items()).thenReturn(List.of(throttledItem));
+                        return resp;
+                    }
+                    // Second attempt: success
+                    return new BulkResponse.Builder().items(List.of()).errors(false).took(10).build();
+                },
+                logFailureConsumer,
+                (operations) -> {},
+                pluginMetrics,
+                10,
+                () -> mock(AccumulatingBulkRequest.class),
+                PIPELINE_NAME, PLUGIN_NAME, null, false,
+                50, 30000, 0.0, adaptiveState);
+
+        final BulkOperationWrapper mockOp = mock(BulkOperationWrapper.class);
+        final AccumulatingBulkRequest request = mock(AccumulatingBulkRequest.class);
+        lenient().when(request.getOperationsCount()).thenReturn(1);
+        lenient().when(request.getOperations()).thenReturn(List.of(mockOp));
+        lenient().when(request.getOperationAt(0)).thenReturn(mockOp);
+
+        bulkRetryStrategy.execute(request);
+
+        // After retry, the adaptive state should have recorded the delay
+        assertTrue("Adaptive state should record retry delay > initial",
+                adaptiveState.getStartingDelay() >= 1600);
+    }
+
+    @Test
+    public void testExecute_withAdaptiveBackoff_recordsFirstAttemptSuccess() throws Exception {
+        final AdaptiveBackoffState adaptiveState = new AdaptiveBackoffState(50, 3);
+        adaptiveState.recordRetrySuccess(6400);
+
+        final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
+                bulkRequest -> new BulkResponse.Builder().items(List.of()).errors(false).took(10).build(),
+                logFailureConsumer,
+                (operations) -> {},
+                pluginMetrics,
+                10,
+                () -> mock(AccumulatingBulkRequest.class),
+                PIPELINE_NAME, PLUGIN_NAME, null, false,
+                50, 30000, 0.0, adaptiveState);
+
+        final AccumulatingBulkRequest request = mock(AccumulatingBulkRequest.class);
+        lenient().when(request.getOperationsCount()).thenReturn(0);
+        lenient().when(request.getOperations()).thenReturn(List.of());
+
+        // 3 first-attempt successes should trigger decay: 6400 -> 3200
+        bulkRetryStrategy.execute(request);
+        bulkRetryStrategy.execute(request);
+        bulkRetryStrategy.execute(request);
+
+        assertEquals(3200, adaptiveState.getStartingDelay());
+    }
+
+    @Test
+    public void testExecute_withoutAdaptiveBackoff_usesConfiguredDelays() throws Exception {
+        final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
+                bulkRequest -> new BulkResponse.Builder().items(List.of()).errors(false).took(10).build(),
+                logFailureConsumer,
+                (operations) -> {},
+                pluginMetrics,
+                10,
+                () -> mock(AccumulatingBulkRequest.class),
+                PIPELINE_NAME, PLUGIN_NAME, null, false,
+                100, 5000, 0.0, null);
+
+        final AccumulatingBulkRequest request = mock(AccumulatingBulkRequest.class);
+        lenient().when(request.getOperationsCount()).thenReturn(0);
+        lenient().when(request.getOperations()).thenReturn(List.of());
+
+        // Should succeed without error when no adaptive state
+        bulkRetryStrategy.execute(request);
+        // No exception = pass. Non-adaptive mode works without AdaptiveBackoffState.
+    }
 }


### PR DESCRIPTION
### Description

This is a starting draft for more configuration options for the backoff and retry behavior of Data Prepper's opensearch sink when dealing with throttling and backpressure.

Summary

Adds configurable retry/backoff settings and an adaptive retry mode to the OpenSearch sink's BulkRetryStrategy. This addresses a feedback loop with OpenSearch where exponential backoff causes long silence periods, then the retry burst re-triggers throttling.

Changes

New configurations:

```
opensearch:
  retry:
    initial_delay: "50ms"     # Starting backoff delay (default: 50ms)
    max_delay: "10m"          # Maximum backoff cap (default: 10min)
    jitter: 0.0               # Jitter factor 0-1 (default: 0, no jitter)
    adaptive: false           # Enable cross-batch backoff memory (default: false)
    decay_threshold: 3        # Consecutive first-attempt successes before decaying (default: 3)
```

Adaptive mode behavior:

    When a batch requires retries, the delay that eventually succeeded is saved to shared state
    The next batch starts retries at that saved delay instead of ramping up from initial_delay
    After decay_threshold consecutive first-attempt successes, the saved delay halves back toward initial_delay
    State is shared across worker threads so one thread's throttling signal benefits the other

Jitter:

    Adds ±N% randomization to backoff delays to prevent synchronized retry bursts from multiple worker threads

Backward compatibility

    All new settings have defaults matching current behavior (no jitter, no adaptive, same 50ms/10min delays)
    Existing max_retries config is unchanged
    Old constructor is preserved as a delegate to the new one

Motivation

When OpenSearch throttles (429), the current behavior ramps exponentially from 50ms to 10min with no memory between batches. Each new batch starts at 50ms and wastes ~8 attempts before reaching the delay that actually works. With adaptive mode, the second batch skips directly to the last known good delay, reducing wasted retries from ~8 to ~1 per batch during sustained throttling.
 
### Issues Resolved
Related issues:

https://github.com/opensearch-project/data-prepper/issues/6901
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
