### PR TITLE
Fix bug in s3 eventbridge notification where a new field was introduced

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3EventBridgeNotification.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3EventBridgeNotification.java
@@ -1,6 +1,7 @@
 package org.opensearch.dataprepper.plugins.source.s3;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
@@ -86,6 +87,7 @@ public class S3EventBridgeNotification {
         return detail;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Detail {
         private final String version;
         private final Bucket bucket;
@@ -94,6 +96,7 @@ public class S3EventBridgeNotification {
         private final String requester;
         private final String sourceIpAddress;
         private final String reason;
+        private final String eventVersion;
 
         @JsonCreator
         public Detail(@JsonProperty(value = "version") final String version,
@@ -102,7 +105,8 @@ public class S3EventBridgeNotification {
                       @JsonProperty("request-id") final String requestId,
                       @JsonProperty("requester") final String requester,
                       @JsonProperty("source-ip-address") final String sourceIpAddress,
-                      @JsonProperty("reason") final String reason) {
+                      @JsonProperty("reason") final String reason,
+                      @JsonProperty("event-version") final String eventVersion) {
             this.version = version;
             this.bucket = bucket;
             this.object = object;
@@ -110,6 +114,7 @@ public class S3EventBridgeNotification {
             this.requester = requester;
             this.sourceIpAddress = sourceIpAddress;
             this.reason = reason;
+            this.eventVersion = eventVersion;
         }
 
         public String getVersion() {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventBridgeNotificationParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventBridgeNotificationParserTest.java
@@ -26,7 +26,7 @@ class S3EventBridgeNotificationParserTest {
             "\"object\":{\"key\":\"example-key\",\"size\":5,\"etag\":\"b1946ac92492d2347c6235b4d2611184\"," +
             "\"version-id\":\"IYV3p45BT0ac8hjHg1houSdS1a.Mro8e\",\"sequencer\":\"617f08299329d189\"}," +
             "\"request-id\":\"N4N7GDK58NMKJ12R\",\"requester\":\"123456789012\",\"source-ip-address\":\"1.2.3.4\"," +
-            "\"reason\":\"PutObject\"}}";
+            "\"reason\":\"PutObject\",\"event-version\":\"1.0\"}}";
 
     private final String SECURITY_LAKE_MESSAGE = "{\"source\":\"aws.s3\",\"time\":\"2021-11-12T00:00:00Z\",\"account\":\"123456789012\",\"region\":\"ca-central-1\"," +
             "\"resources\":[\"arn:aws:s3:::example-bucket\"],\"detail\":{\"bucket\":{\"name\":\"example-bucket\"}," +


### PR DESCRIPTION
### Description
AWS S3 recently added a new `event-version` field to the EventBridge notification detail schema. This causes Jackson deserialization failures in `S3EventBridgeNotificationDetail`
 
 Added `@JsonIgnoreProperties(ignoreUnknown = true)` to the Detail class so that new or unexpected fields in the EventBridge notification are safely ignored. Added `event-version` to the schema 
 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
