### PR TITLE
Disable FAIL_ON_UNKNOWN_PROPERTIES in SqsMessageParser ObjectMapper

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParser.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParser.java
@@ -22,17 +22,15 @@ public class S3EventNotificationParser implements S3NotificationParser {
             final S3EventNotification s3EventNotification = objectMapper.treeToValue(eventNode, S3EventNotification.class);
             if (s3EventNotification != null && s3EventNotification.getRecords() != null) {
                 return new ParsedMessage(message, s3EventNotification.getRecords());
+            } else if (message.body().contains("s3:TestEvent") && message.body().contains("Amazon S3")) {
+                LOG.info("Received s3:TestEvent message. Deleting from SQS queue.");
+                return new ParsedMessage(message, false);
             } else {
                 LOG.debug("SQS message with ID:{} does not have any S3 event notification records.", message.messageId());
                 return new ParsedMessage(message, true);
             }
         } catch (final JsonProcessingException e) {
-            if (message.body().contains("s3:TestEvent") && message.body().contains("Amazon S3")) {
-                LOG.info("Received s3:TestEvent message. Deleting from SQS queue.");
-                return new ParsedMessage(message, false);
-            } else {
-                LOG.error("SQS message with message ID:{} has invalid body which cannot be parsed into S3EventNotification. {}.", message.messageId(), e.getMessage());
-            }
+            LOG.error("SQS message with message ID:{} has invalid body which cannot be parsed into S3EventNotification. {}.", message.messageId(), e.getMessage());
         }
         return new ParsedMessage(message, true);
     }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/SqsMessageParser.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/SqsMessageParser.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.s3.parser;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.plugins.source.s3.S3SourceConfig;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -13,7 +14,8 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 public class SqsMessageParser {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .disable(FAIL_ON_UNKNOWN_PROPERTIES);
     private final S3SourceConfig s3SourceConfig;
     private final S3NotificationParser s3NotificationParser;
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventBridgeNotificationParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventBridgeNotificationParserTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.s3.parser;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class S3EventBridgeNotificationParserTest {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
     static final String EVENTBRIDGE_MESSAGE = "{\"version\":\"0\",\"id\":\"17793124-05d4-b198-2fde-7ededc63b103\",\"detail-type\":\"Object Created\"," +
             "\"source\":\"aws.s3\",\"account\":\"111122223333\",\"time\":\"2021-11-12T00:00:00Z\"," +
             "\"region\":\"ca-central-1\",\"resources\":[\"arn:aws:s3:::DOC-EXAMPLE-BUCKET1\"]," +

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.model.Message;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -22,7 +23,7 @@ public class S3EventNotificationParserTest {
                     "\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:xyz\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
                     "\"responseElements\":{\"x-amz-request-id\":\"xyz\",\"x-amz-id-2\":\"xyz\"},\"s3\":{\"s3SchemaVersion\":\"1.0\"," +
                     "\"configurationId\":\"xyz\",\"bucket\":{\"name\":\"my-bucket\",\"ownerIdentity\":{\"principalId\":\"ABC\"}," +
-                    "\"arn\":\"arn:aws:s3:::my-bucket\"},\"object\":{\"key\":\"path/to/myfile.log.gz\",\"size\":3159112,\"eTag\":\"abcd123\"," +
+                    "\"arn\":\"arn:aws:s3:::my-bucket\", \"unknownField\":\"test\"},\"object\":{\"key\":\"path/to/myfile.log.gz\",\"size\":3159112,\"eTag\":\"abcd123\"," +
                     "\"sequencer\":\"000\",\"hasObjectAnnotation\":false}}}]}";
 
     public static final String SNS_BASED_MESSAGE = "{\n" +
@@ -38,7 +39,7 @@ public class S3EventNotificationParserTest {
             "  \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:notifications:abc\"\n" +
             "}";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
     private Message message;
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
### Description
Disable FAIL_ON_UNKNOWN_PROPERTIES in SqsMessageParser ObjectMapper
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
