### PR TITLE
Add classified error counters to CloudWatch Logs sink

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/README.md
+++ b/data-prepper-plugins/cloudwatch-logs/README.md
@@ -112,6 +112,9 @@ threshold parameters.
 * `cloudWatchLogsRequestsFailed` - The number of log requests failed to reach CloudWatch Logs.
 * `cloudWatchLogsEntityRejected` - The number of `PutLogEvents` responses where CloudWatch rejected the configured entity. The request itself still succeeds and events are released; this counter is the primary signal for misconfigured `entity` attributes.
 * `cloudWatchLogsUnhandledError` - The number of times an unexpected `Throwable` escaped the Uploader's normal retry/DLQ path. Distinct from `cloudWatchLogsEventsFailed`; non-zero values indicate a logic bug, classpath linkage failure, or response-handling error rather than transient API failure.
+* `cloudWatchLogsThrottled` - The number of `PutLogEvents` attempts that failed due to throttling (HTTP 429). Each retry that receives a throttle response increments this counter independently.
+* `cloudWatchLogsAccessDenied` - The number of requests or resource-creation attempts that failed due to insufficient IAM permissions. Covers both `PutLogEvents` access-denied responses and `CreateLogGroup`/`CreateLogStream` permission failures when `create_log_group` or `create_log_stream` is enabled.
+* `cloudWatchLogsResourceNotFound` - The number of `PutLogEvents` attempts that failed because the target log group or log stream does not exist. Only incremented when `create_log_group` and `create_log_stream` are both disabled — if the sink is configured to create resources, a resource-not-found error is internal control flow rather than an actionable user signal.
 
 ## Developer Guide
 

--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -65,6 +65,7 @@ task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
 
     useJUnitPlatform()
+    forkEvery = 1
 
     classpath = sourceSets.integrationTest.runtimeClasspath
     systemProperty 'tests.cloudwatch.log_group', System.getProperty('tests.cloudwatch.log_group')

--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
     testImplementation project(path: ':data-prepper-test:test-common')
+    integrationTestImplementation 'org.wiremock:wiremock:3.13.2'
+    integrationTestImplementation project(':data-prepper-api').sourceSets.test.output
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsMetricsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsMetricsIT.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.metrics.MetricsTestUtil;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsMetrics;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.AwsConfig;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatchLogsSinkConfig;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.ThresholdConfig;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CloudWatchLogsMetricsIT {
+
+    private static final String PIPELINE_NAME = "pipeline";
+    private static final String PLUGIN_NAME = "name";
+    private static final String METRICS_PREFIX = PIPELINE_NAME + "." + PLUGIN_NAME + ".";
+
+    private WireMockServer wireMockServer;
+
+    @BeforeAll
+    void setUp() {
+        MetricsTestUtil.initMetrics();
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    void tearDown() {
+        if (wireMockServer != null && wireMockServer.isRunning()) {
+            wireMockServer.stop();
+        }
+        MetricsTestUtil.initMetrics();
+    }
+
+    @Test
+    void throttled_counter_increments_on_http_429_from_wiremock_IT() {
+        MetricsTestUtil.initMetrics();
+
+        wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                        com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(429)
+                        .withHeader("Content-Type", "application/x-amz-json-1.1")
+                        .withHeader("x-amzn-ErrorType", "Throttling")
+                        .withBody("{\"__type\":\"Throttling\",\"message\":\"Rate exceeded\"}")));
+
+        final CloudWatchLogsSink sink = buildSinkWithEndpoint(false, false);
+        sink.doInitialize();
+
+        final Collection<Record<Event>> records = createRecords(2);
+        sink.doOutput(records);
+
+        await().atMost(java.time.Duration.ofSeconds(60))
+                .pollInterval(java.time.Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    sink.doOutput(Collections.emptyList());
+                    final double throttledCount = getCounterValue(
+                            METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED);
+                    assertThat("cloudWatchLogsThrottled should have incremented",
+                            throttledCount, greaterThan(0.0));
+                });
+
+        final double requestsFailedCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED);
+        assertThat("cloudWatchLogsRequestsFailed must also increment on throttling",
+                requestsFailedCount, greaterThan(0.0));
+
+        final double throttledCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED);
+        assertThat("requestsFailed >= throttled",
+                requestsFailedCount, greaterThanOrEqualTo(throttledCount));
+    }
+
+    @Test
+    void resource_not_found_counter_increments_on_terminal_rnf_from_wiremock_IT() {
+        MetricsTestUtil.initMetrics();
+
+        wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                        com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(400)
+                        .withHeader("Content-Type", "application/x-amz-json-1.1")
+                        .withHeader("x-amzn-ErrorType", "ResourceNotFoundException")
+                        .withBody("{\"__type\":\"ResourceNotFoundException\",\"message\":\"The specified log group does not exist.\"}")));
+
+        final CloudWatchLogsSink sink = buildSinkWithEndpoint(false, false);
+        sink.doInitialize();
+
+        final Collection<Record<Event>> records = createRecords(2);
+        sink.doOutput(records);
+
+        await().atMost(java.time.Duration.ofSeconds(60))
+                .pollInterval(java.time.Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    sink.doOutput(Collections.emptyList());
+                    final double rnfCount = getCounterValue(
+                            METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND);
+                    assertThat("cloudWatchLogsResourceNotFound should have incremented",
+                            rnfCount, greaterThan(0.0));
+                });
+
+        final double requestsFailedCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED);
+        assertThat("cloudWatchLogsRequestsFailed must also increment on terminal RNF",
+                requestsFailedCount, greaterThan(0.0));
+
+        final double rnfCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND);
+        assertThat("requestsFailed >= resourceNotFound",
+                requestsFailedCount, greaterThanOrEqualTo(rnfCount));
+    }
+
+    @Test
+    void resource_not_found_counter_does_not_increment_when_autocreate_succeeds_IT() {
+        MetricsTestUtil.initMetrics();
+        wireMockServer.resetAll();
+
+        final String scenarioName = "autocreate-success";
+        final String stateAfterRnf = "resources-created";
+
+        wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                        com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs(com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED)
+                .withHeader("X-Amz-Target", com.github.tomakehurst.wiremock.client.WireMock.containing("PutLogEvents"))
+                .willReturn(aResponse()
+                        .withStatus(400)
+                        .withHeader("Content-Type", "application/x-amz-json-1.1")
+                        .withHeader("x-amzn-ErrorType", "ResourceNotFoundException")
+                        .withBody("{\"__type\":\"ResourceNotFoundException\",\"message\":\"The specified log group does not exist.\"}"))
+                .willSetStateTo(stateAfterRnf));
+
+        wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                        com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .withHeader("X-Amz-Target", com.github.tomakehurst.wiremock.client.WireMock.containing("CreateLogGroup"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/x-amz-json-1.1")
+                        .withBody("{}")));
+
+        wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                        com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .withHeader("X-Amz-Target", com.github.tomakehurst.wiremock.client.WireMock.containing("CreateLogStream"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/x-amz-json-1.1")
+                        .withBody("{}")));
+
+        wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                        com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs(stateAfterRnf)
+                .withHeader("X-Amz-Target", com.github.tomakehurst.wiremock.client.WireMock.containing("PutLogEvents"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/x-amz-json-1.1")
+                        .withBody("{\"nextSequenceToken\":\"token\",\"rejectedLogEventsInfo\":null}")));
+
+        final CloudWatchLogsSink sink = buildSinkWithEndpoint(true, true);
+        sink.doInitialize();
+
+        final Collection<Record<Event>> records = createRecords(2);
+        sink.doOutput(records);
+
+        await().atMost(java.time.Duration.ofSeconds(60))
+                .pollInterval(java.time.Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    sink.doOutput(Collections.emptyList());
+                    final double successCount = getCounterValue(
+                            METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED);
+                    assertThat("cloudWatchLogsRequestsSucceeded should have incremented after auto-create",
+                            successCount, greaterThan(0.0));
+                });
+
+        final double rnfCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND);
+        assertThat("cloudWatchLogsResourceNotFound must NOT increment when auto-create succeeds",
+                rnfCount, org.hamcrest.Matchers.equalTo(0.0));
+
+        final double requestsFailedCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED);
+        assertThat("cloudWatchLogsRequestsFailed must NOT increment when auto-create recovers",
+                requestsFailedCount, org.hamcrest.Matchers.equalTo(0.0));
+    }
+
+    @Test
+    void access_denied_counter_increments_with_real_aws_IT() {
+        final String logGroup = System.getProperty("tests.cloudwatch.log_group");
+        final String logStream = System.getProperty("tests.cloudwatch.log_stream");
+        final String region = System.getProperty("tests.aws.region");
+        final String role = System.getProperty("tests.aws.role");
+
+        Assumptions.assumeTrue(logGroup != null && !logGroup.isEmpty(),
+                "Skipping real-AWS AccessDenied test: tests.cloudwatch.log_group not set");
+        Assumptions.assumeTrue(logStream != null && !logStream.isEmpty(),
+                "Skipping real-AWS AccessDenied test: tests.cloudwatch.log_stream not set");
+        Assumptions.assumeTrue(region != null && !region.isEmpty(),
+                "Skipping real-AWS AccessDenied test: tests.aws.region not set");
+        Assumptions.assumeTrue(role != null && !role.isEmpty(),
+                "Skipping real-AWS AccessDenied test: tests.aws.role not set");
+
+        MetricsTestUtil.initMetrics();
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, Collections.emptyMap());
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+        final PluginMetrics pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
+
+        final AwsConfig awsConfig = mock(AwsConfig.class);
+        when(awsConfig.getAwsRegion()).thenReturn(Region.of(region));
+        when(awsConfig.getAwsStsRoleArn()).thenReturn(role);
+        when(awsConfig.getAwsStsExternalId()).thenReturn(null);
+        when(awsConfig.getAwsStsHeaderOverrides()).thenReturn(null);
+
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        when(awsCredentialsSupplier.getProvider(Mockito.any(AwsCredentialsOptions.class)))
+                .thenReturn(software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.create());
+
+        final CloudWatchLogsSinkConfig config = mock(CloudWatchLogsSinkConfig.class);
+        when(config.getAwsConfig()).thenReturn(awsConfig);
+        when(config.getLogGroup()).thenReturn(logGroup);
+        when(config.getLogStream()).thenReturn(logStream);
+        when(config.getEndpoint()).thenReturn(null);
+        when(config.getMaxRetries()).thenReturn(3);
+        when(config.getWorkers()).thenReturn(1);
+        when(config.getDlq()).thenReturn(null);
+        when(config.getHeaderOverrides()).thenReturn(new HashMap<>());
+        when(config.getCreateLogGroup()).thenReturn(false);
+        when(config.getCreateLogStream()).thenReturn(false);
+        when(config.getEntityConfig()).thenReturn(null);
+
+        final ThresholdConfig thresholdConfig = mock(ThresholdConfig.class);
+        when(thresholdConfig.getBatchSize()).thenReturn(1);
+        when(thresholdConfig.getFlushInterval()).thenReturn(5L);
+        when(thresholdConfig.getMaxEventSizeBytes()).thenReturn(10000L);
+        when(thresholdConfig.getMaxRequestSizeBytes()).thenReturn(10000L);
+        when(config.getThresholdConfig()).thenReturn(thresholdConfig);
+
+        final PluginFactory pluginFactory = mock(PluginFactory.class);
+
+        final CloudWatchLogsSink sink = new CloudWatchLogsSink(
+                pluginSetting, pluginMetrics, pluginFactory, config, awsCredentialsSupplier);
+        sink.doInitialize();
+
+        final Collection<Record<Event>> records = createRecords(1);
+        sink.doOutput(records);
+
+        await().atMost(java.time.Duration.ofSeconds(60))
+                .pollInterval(java.time.Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    sink.doOutput(Collections.emptyList());
+                    final double accessDeniedCount = getCounterValue(
+                            METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ACCESS_DENIED);
+                    assertThat("cloudWatchLogsAccessDenied should have incremented",
+                            accessDeniedCount, greaterThan(0.0));
+                });
+
+        final double requestsFailedCount = getCounterValue(
+                METRICS_PREFIX + CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED);
+        assertThat("cloudWatchLogsRequestsFailed must also increment on access denied",
+                requestsFailedCount, greaterThan(0.0));
+    }
+
+    private CloudWatchLogsSink buildSinkWithEndpoint(final boolean createLogGroup, final boolean createLogStream) {
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, Collections.emptyMap());
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+        final PluginMetrics pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
+
+        final AwsConfig awsConfig = mock(AwsConfig.class);
+        when(awsConfig.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        when(awsConfig.getAwsStsRoleArn()).thenReturn(null);
+        when(awsConfig.getAwsStsExternalId()).thenReturn(null);
+        when(awsConfig.getAwsStsHeaderOverrides()).thenReturn(null);
+
+        final StaticCredentialsProvider staticCreds = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("test", "test"));
+
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        when(awsCredentialsSupplier.getProvider(Mockito.any(AwsCredentialsOptions.class)))
+                .thenReturn(staticCreds);
+        lenient().when(awsCredentialsSupplier.getDefaultRegion()).thenReturn(Optional.of(Region.US_EAST_1));
+
+        final CloudWatchLogsSinkConfig config = mock(CloudWatchLogsSinkConfig.class);
+        when(config.getAwsConfig()).thenReturn(awsConfig);
+        when(config.getLogGroup()).thenReturn("test-log-group");
+        when(config.getLogStream()).thenReturn("test-log-stream");
+        when(config.getEndpoint()).thenReturn("http://localhost:" + wireMockServer.port());
+        when(config.getMaxRetries()).thenReturn(2);
+        when(config.getWorkers()).thenReturn(1);
+        when(config.getDlq()).thenReturn(null);
+        when(config.getHeaderOverrides()).thenReturn(new HashMap<>());
+        when(config.getCreateLogGroup()).thenReturn(createLogGroup);
+        when(config.getCreateLogStream()).thenReturn(createLogStream);
+        when(config.getEntityConfig()).thenReturn(null);
+
+        final ThresholdConfig thresholdConfig = mock(ThresholdConfig.class);
+        when(thresholdConfig.getBatchSize()).thenReturn(1);
+        when(thresholdConfig.getFlushInterval()).thenReturn(5L);
+        when(thresholdConfig.getMaxEventSizeBytes()).thenReturn(10000L);
+        when(thresholdConfig.getMaxRequestSizeBytes()).thenReturn(10000L);
+        when(config.getThresholdConfig()).thenReturn(thresholdConfig);
+
+        final PluginFactory pluginFactory = mock(PluginFactory.class);
+
+        return new CloudWatchLogsSink(pluginSetting, pluginMetrics, pluginFactory, config, awsCredentialsSupplier);
+    }
+
+    private Collection<Record<Event>> createRecords(final int count) {
+        final Collection<Record<Event>> records = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            final Map<String, String> data = new HashMap<>();
+            data.put("message", "test-event-" + i);
+            final EventHandle eventHandle = mock(EventHandle.class);
+            final Event event = JacksonLog.builder()
+                    .withData(data)
+                    .withEventHandle(eventHandle)
+                    .build();
+            records.add(new Record<>(event));
+        }
+        return records;
+    }
+
+    private double getCounterValue(final String meterName) {
+        try {
+            return Metrics.globalRegistry.get(meterName).counter().count();
+        } catch (final io.micrometer.core.instrument.search.MeterNotFoundException e) {
+            return 0.0;
+        }
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
@@ -169,7 +169,9 @@ public class CloudWatchLogsDispatcher {
                             // else branch and normal retry/DLQ logic takes over.
                         } else {
                             failureMessage = e.getMessage();
-                            cloudWatchLogsMetrics.increaseResourceNotFoundCounter(1);
+                            if (!createLogGroup && !createLogStream) {
+                                cloudWatchLogsMetrics.increaseResourceNotFoundCounter(1);
+                            }
                             failCount = handlePutLogEventsFailure(e, failCount, backoff);
                         }
                     } catch (CloudWatchLogsException | SdkClientException e) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import com.linecorp.armeria.client.retry.Backoff;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
@@ -168,6 +169,7 @@ public class CloudWatchLogsDispatcher {
                             // else branch and normal retry/DLQ logic takes over.
                         } else {
                             failureMessage = e.getMessage();
+                            cloudWatchLogsMetrics.increaseResourceNotFoundCounter(1);
                             failCount = handlePutLogEventsFailure(e, failCount, backoff);
                         }
                     } catch (CloudWatchLogsException | SdkClientException e) {
@@ -216,7 +218,8 @@ public class CloudWatchLogsDispatcher {
          */
         private int handlePutLogEventsFailure(final Exception e, final int currentFailCount, final Backoff backoff)
                 throws InterruptedException {
-            LOG.error(NOISY, "Failed to push logs with error: {}", e.getMessage());
+            final String classification = classifyAndCountFailure(e);
+            LOG.error(NOISY, "Failed to push logs (classification={}): {}", classification, e.getMessage());
             cloudWatchLogsMetrics.increaseRequestFailCounter(1);
             final int newFailCount = currentFailCount + 1;
             if (newFailCount % MULTIPLE_FAILURES_METRIC_COUNT == 0) {
@@ -227,6 +230,28 @@ public class CloudWatchLogsDispatcher {
                 Thread.sleep(delayMillis);
             }
             return newFailCount;
+        }
+
+        /**
+         * Classifies an exception as access-denied, throttled, or unclassified and increments
+         * the corresponding classified counter. ResourceNotFound is NOT classified here — it is
+         * counted structurally at the terminal catch site. Returns the classification label for
+         * logging. Never throws.
+         */
+        private String classifyAndCountFailure(final Exception e) {
+            if (e instanceof AwsServiceException) {
+                final AwsServiceException ase = (AwsServiceException) e;
+                if (ase.isThrottlingException()) {
+                    cloudWatchLogsMetrics.increaseThrottledCounter(1);
+                    return "throttled";
+                }
+                if (ase.awsErrorDetails() != null
+                        && "AccessDeniedException".equals(ase.awsErrorDetails().errorCode())) {
+                    cloudWatchLogsMetrics.increaseAccessDeniedCounter(1);
+                    return "accessDenied";
+                }
+            }
+            return "unclassified";
         }
 
         /**

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
@@ -245,13 +245,19 @@ public class CloudWatchLogsDispatcher {
                     cloudWatchLogsMetrics.increaseThrottledCounter(1);
                     return "throttled";
                 }
-                if (ase.awsErrorDetails() != null
-                        && "AccessDeniedException".equals(ase.awsErrorDetails().errorCode())) {
+                if (isAccessDenied(ase)) {
                     cloudWatchLogsMetrics.increaseAccessDeniedCounter(1);
                     return "accessDenied";
                 }
             }
             return "unclassified";
+        }
+
+        private static boolean isAccessDenied(final AwsServiceException ase) {
+            if (ase.awsErrorDetails() == null || ase.awsErrorDetails().errorCode() == null) {
+                return false;
+            }
+            return ase.awsErrorDetails().errorCode().contains("AccessDenied");
         }
 
         /**
@@ -274,7 +280,7 @@ public class CloudWatchLogsDispatcher {
                 } catch (ResourceAlreadyExistsException e) {
                     LOG.debug("Log group already exists: {}", logGroupName);
                 } catch (CloudWatchLogsException | SdkClientException e) {
-                    LOG.warn("Unable to create log group '{}': {}", logGroupName, e.getMessage());
+                    classifyAndCountResourceCreationFailure(e, "log group", logGroupName);
                 }
             }
 
@@ -289,8 +295,17 @@ public class CloudWatchLogsDispatcher {
                 } catch (ResourceAlreadyExistsException e) {
                     LOG.debug("Log stream already exists: {}/{}", logGroupName, logStreamName);
                 } catch (CloudWatchLogsException | SdkClientException e) {
-                    LOG.warn("Unable to create log stream '{}/{}': {}", logGroupName, logStreamName, e.getMessage());
+                    classifyAndCountResourceCreationFailure(e, "log stream", logGroupName + "/" + logStreamName);
                 }
+            }
+        }
+
+        private void classifyAndCountResourceCreationFailure(final Exception e, final String resourceType, final String resourceName) {
+            if (e instanceof AwsServiceException && isAccessDenied((AwsServiceException) e)) {
+                cloudWatchLogsMetrics.increaseAccessDeniedCounter(1);
+                LOG.warn("Access denied creating {} '{}': {}", resourceType, resourceName, e.getMessage());
+            } else {
+                LOG.warn("Unable to create {} '{}': {}", resourceType, resourceName, e.getMessage());
             }
         }
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
@@ -25,6 +25,9 @@ public class CloudWatchLogsMetrics {
     public static final String CLOUDWATCH_LOGS_REQUEST_SIZE = "cloudWatchLogsRequestSize";
     public static final String CLOUDWATCH_LOGS_ENTITY_REJECTED = "cloudWatchLogsEntityRejected";
     public static final String CLOUDWATCH_LOGS_UNHANDLED_ERROR = "cloudWatchLogsUnhandledError";
+    public static final String CLOUDWATCH_LOGS_ACCESS_DENIED = "cloudWatchLogsAccessDenied";
+    public static final String CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND = "cloudWatchLogsResourceNotFound";
+    public static final String CLOUDWATCH_LOGS_THROTTLED = "cloudWatchLogsThrottled";
     private final Counter logEventSuccessCounter;
     private final Counter logEventFailCounter;
     private final Counter requestSuccessCount;
@@ -33,6 +36,9 @@ public class CloudWatchLogsMetrics {
     private final Counter logLargeEventsDroppedCounter;
     private final Counter entityRejectedCounter;
     private final Counter unhandledErrorCounter;
+    private final Counter accessDeniedCounter;
+    private final Counter resourceNotFoundCounter;
+    private final Counter throttledCounter;
     private final DistributionSummary logSizeMetric;
     private final DistributionSummary requestSizeMetric;
 
@@ -45,6 +51,9 @@ public class CloudWatchLogsMetrics {
         this.logLargeEventsDroppedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_LARGE_EVENTS_DROPPED);
         this.entityRejectedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_REJECTED);
         this.unhandledErrorCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_UNHANDLED_ERROR);
+        this.accessDeniedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ACCESS_DENIED);
+        this.resourceNotFoundCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND);
+        this.throttledCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED);
         this.logSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_LOG_SIZE);
         this.requestSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_REQUEST_SIZE);
     }
@@ -79,6 +88,18 @@ public class CloudWatchLogsMetrics {
 
     public void increaseUnhandledErrorCounter(int value) {
         unhandledErrorCounter.increment(value);
+    }
+
+    public void increaseAccessDeniedCounter(int value) {
+        accessDeniedCounter.increment(value);
+    }
+
+    public void increaseResourceNotFoundCounter(int value) {
+        resourceNotFoundCounter.increment(value);
+    }
+
+    public void increaseThrottledCounter(int value) {
+        throttledCounter.increment(value);
     }
 
     public void recordLogSize(int value) {

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -23,7 +23,9 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse
 import software.amazon.awssdk.services.cloudwatchlogs.model.RejectedLogEventsInfo;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
 
 import java.util.ArrayList;
@@ -771,5 +773,143 @@ class CloudWatchLogsDispatcherTest {
         verify(mockCloudWatchLogsMetrics, times(1)).increaseLogEventSuccessCounter(eventHandles.size());
         verify(mockCloudWatchLogsMetrics, never()).increaseUnhandledErrorCounter(anyInt());
         verify(mockCloudWatchLogsMetrics, never()).increaseLogEventFailCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_access_denied_exception_WHEN_put_log_events_SHOULD_increment_access_denied_counter_and_request_fail_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final CloudWatchLogsException accessDeniedException = (CloudWatchLogsException) CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDeniedException")
+                        .errorMessage("User is not authorized")
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(403).build())
+                        .build())
+                .message("User is not authorized")
+                .statusCode(403)
+                .build();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(accessDeniedException);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseAccessDeniedCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseThrottledCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_throttling_exception_WHEN_put_log_events_SHOULD_increment_throttled_counter_and_request_fail_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final CloudWatchLogsException throttledException = (CloudWatchLogsException) CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("Throttling")
+                        .errorMessage("Rate exceeded")
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(429).build())
+                        .build())
+                .message("Rate exceeded")
+                .statusCode(429)
+                .build();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(throttledException);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseThrottledCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseAccessDeniedCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_resource_not_found_and_create_flag_false_WHEN_terminal_rnf_SHOULD_increment_resource_not_found_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcherWithCreateFlag(RETRY_COUNT, false, false);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message("missing").build());
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseResourceNotFoundCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseAccessDeniedCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseThrottledCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_resource_not_found_and_create_flag_true_WHEN_creation_succeeds_SHOULD_not_increment_resource_not_found_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcherWithCreateFlag(RETRY_COUNT, true, true);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message("missing").build())
+                .thenReturn(mock(PutLogEventsResponse.class));
+        when(mockCloudWatchLogsClient.createLogGroup(any(CreateLogGroupRequest.class)))
+                .thenReturn(mock(CreateLogGroupResponse.class));
+        when(mockCloudWatchLogsClient.createLogStream(any(CreateLogStreamRequest.class)))
+                .thenReturn(mock(CreateLogStreamResponse.class));
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestSuccessCounter(1);
+    }
+
+    @Test
+    void GIVEN_sdk_client_exception_WHEN_put_log_events_SHOULD_only_increment_generic_fail_counter_and_no_classified_counters() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(SdkClientException.create("Connection timed out"));
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseAccessDeniedCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseThrottledCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_aws_service_exception_with_null_error_details_WHEN_put_log_events_SHOULD_only_increment_generic_fail_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final CloudWatchLogsException exceptionWithNullDetails = (CloudWatchLogsException) CloudWatchLogsException.builder()
+                .message("Unknown service error")
+                .build();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(exceptionWithNullDetails);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseAccessDeniedCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, never()).increaseThrottledCounter(anyInt());
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -520,6 +520,8 @@ class CloudWatchLogsDispatcherTest {
         verify(mockCloudWatchLogsClient, times(2)).putLogEvents(any(PutLogEventsRequest.class));
         verify(mockCloudWatchLogsMetrics, times(1)).increaseRequestSuccessCounter(1);
         verify(mockCloudWatchLogsMetrics, never()).increaseRequestFailCounter(1);
+        // Non-access-denied exception during creation must NOT be misclassified.
+        verify(mockCloudWatchLogsMetrics, never()).increaseAccessDeniedCounter(anyInt());
     }
 
     @Test
@@ -911,5 +913,93 @@ class CloudWatchLogsDispatcherTest {
         verify(mockCloudWatchLogsMetrics, never()).increaseAccessDeniedCounter(anyInt());
         verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
         verify(mockCloudWatchLogsMetrics, never()).increaseThrottledCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_access_denied_without_exception_suffix_WHEN_put_log_events_SHOULD_increment_access_denied_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcher(RETRY_COUNT);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final CloudWatchLogsException accessDeniedException = (CloudWatchLogsException) CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDenied")
+                        .errorMessage("User is not authorized")
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(403).build())
+                        .build())
+                .message("User is not authorized")
+                .statusCode(403)
+                .build();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(accessDeniedException);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseAccessDeniedCounter(1);
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+        verify(mockCloudWatchLogsMetrics, never()).increaseThrottledCounter(anyInt());
+    }
+
+    @Test
+    void GIVEN_create_log_stream_throws_access_denied_WHEN_create_resources_SHOULD_increment_access_denied_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcherWithCreateFlag(RETRY_COUNT, true, true);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final CloudWatchLogsException accessDeniedException = (CloudWatchLogsException) CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDeniedException")
+                        .errorMessage("Not authorized to create log stream")
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(403).build())
+                        .build())
+                .message("Not authorized to create log stream")
+                .statusCode(403)
+                .build();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message("missing").build())
+                .thenReturn(mock(PutLogEventsResponse.class));
+        when(mockCloudWatchLogsClient.createLogGroup(any(CreateLogGroupRequest.class)))
+                .thenReturn(mock(CreateLogGroupResponse.class));
+        when(mockCloudWatchLogsClient.createLogStream(any(CreateLogStreamRequest.class)))
+                .thenThrow(accessDeniedException);
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseAccessDeniedCounter(1);
+    }
+
+    @Test
+    void GIVEN_create_log_group_throws_access_denied_WHEN_create_resources_SHOULD_increment_access_denied_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcherWithCreateFlag(RETRY_COUNT, true, true);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        final CloudWatchLogsException accessDeniedException = (CloudWatchLogsException) CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDenied")
+                        .errorMessage("Not authorized to create log group")
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(403).build())
+                        .build())
+                .message("Not authorized to create log group")
+                .statusCode(403)
+                .build();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message("missing").build())
+                .thenReturn(mock(PutLogEventsResponse.class));
+        when(mockCloudWatchLogsClient.createLogGroup(any(CreateLogGroupRequest.class)))
+                .thenThrow(accessDeniedException);
+        when(mockCloudWatchLogsClient.createLogStream(any(CreateLogStreamRequest.class)))
+                .thenReturn(mock(CreateLogStreamResponse.class));
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        verify(mockCloudWatchLogsMetrics, times(1)).increaseAccessDeniedCounter(1);
+        verify(mockCloudWatchLogsClient, times(1)).createLogStream(any(CreateLogStreamRequest.class));
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcherTest.java
@@ -570,6 +570,8 @@ class CloudWatchLogsDispatcherTest {
         // Subsequent ResourceNotFoundExceptions flow to the normal retry/DLQ path: fail counter incremented for every retry.
         verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
         verify(mockCloudWatchLogsMetrics, never()).increaseRequestSuccessCounter(1);
+        // When create flags are on, RNF after failed creation is internal control flow — not actionable by the user.
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
     }
 
     @Test
@@ -1001,5 +1003,45 @@ class CloudWatchLogsDispatcherTest {
 
         verify(mockCloudWatchLogsMetrics, times(1)).increaseAccessDeniedCounter(1);
         verify(mockCloudWatchLogsClient, times(1)).createLogStream(any(CreateLogStreamRequest.class));
+    }
+
+    @Test
+    void GIVEN_only_create_log_stream_true_AND_rnf_after_creation_SHOULD_not_increment_resource_not_found_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcherWithCreateFlag(RETRY_COUNT, false, true);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message("missing").build());
+        when(mockCloudWatchLogsClient.createLogStream(any(CreateLogStreamRequest.class)))
+                .thenReturn(mock(CreateLogStreamResponse.class));
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // User delegated creation to the sink — RNF is internal, not actionable.
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
+    }
+
+    @Test
+    void GIVEN_only_create_log_group_true_AND_rnf_after_creation_SHOULD_not_increment_resource_not_found_counter() {
+        cloudWatchLogsDispatcher = getCloudWatchLogsDispatcherWithCreateFlag(RETRY_COUNT, true, false);
+
+        final List<EventHandle> eventHandles = getSampleEventHandles();
+        when(mockCloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message("missing").build());
+        when(mockCloudWatchLogsClient.createLogGroup(any(CreateLogGroupRequest.class)))
+                .thenReturn(mock(CreateLogGroupResponse.class));
+
+        final List<InputLogEvent> inputLogEventList = cloudWatchLogsDispatcher.prepareInputLogEvents(getSampleBufferedData());
+        cloudWatchLogsDispatcher.dispatchLogs(inputLogEventList, eventHandles);
+
+        executeDispatcherRunnable();
+
+        // User delegated creation to the sink — RNF is internal, not actionable.
+        verify(mockCloudWatchLogsMetrics, never()).increaseResourceNotFoundCounter(anyInt());
+        verify(mockCloudWatchLogsMetrics, times(RETRY_COUNT)).increaseRequestFailCounter(1);
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetricsTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetricsTest.java
@@ -20,6 +20,9 @@ class CloudWatchLogsMetricsTest {
     private Counter mockFailedRequestCounter;
     private Counter mockEntityRejectedCounter;
     private Counter mockUnhandledErrorCounter;
+    private Counter mockAccessDeniedCounter;
+    private Counter mockResourceNotFoundCounter;
+    private Counter mockThrottledCounter;
 
     @BeforeEach
     void setUp() {
@@ -30,6 +33,9 @@ class CloudWatchLogsMetricsTest {
         mockFailedRequestCounter = mock(Counter.class);
         mockEntityRejectedCounter = mock(Counter.class);
         mockUnhandledErrorCounter = mock(Counter.class);
+        mockAccessDeniedCounter = mock(Counter.class);
+        mockResourceNotFoundCounter = mock(Counter.class);
+        mockThrottledCounter = mock(Counter.class);
 
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_EVENTS_SUCCEEDED)).thenReturn(mockSuccessEventCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED)).thenReturn(mockSuccessRequestCounter);
@@ -37,6 +43,9 @@ class CloudWatchLogsMetricsTest {
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED)).thenReturn(mockFailedRequestCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_REJECTED)).thenReturn(mockEntityRejectedCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_UNHANDLED_ERROR)).thenReturn(mockUnhandledErrorCounter);
+        when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ACCESS_DENIED)).thenReturn(mockAccessDeniedCounter);
+        when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND)).thenReturn(mockResourceNotFoundCounter);
+        when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED)).thenReturn(mockThrottledCounter);
 
         testCloudWatchLogsMetrics = new CloudWatchLogsMetrics(mockPluginMetrics);
     }
@@ -80,5 +89,23 @@ class CloudWatchLogsMetricsTest {
     void WHEN_increase_unhandled_error_counter_called_THEN_unhandled_error_counter_increase_method_should_be_called() {
         testCloudWatchLogsMetrics.increaseUnhandledErrorCounter(1);
         verify(mockUnhandledErrorCounter, times(1)).increment(1);
+    }
+
+    @Test
+    void WHEN_increase_access_denied_counter_called_THEN_access_denied_counter_increase_method_should_be_called() {
+        testCloudWatchLogsMetrics.increaseAccessDeniedCounter(1);
+        verify(mockAccessDeniedCounter, times(1)).increment(1);
+    }
+
+    @Test
+    void WHEN_increase_resource_not_found_counter_called_THEN_resource_not_found_counter_increase_method_should_be_called() {
+        testCloudWatchLogsMetrics.increaseResourceNotFoundCounter(1);
+        verify(mockResourceNotFoundCounter, times(1)).increment(1);
+    }
+
+    @Test
+    void WHEN_increase_throttled_counter_called_THEN_throttled_counter_increase_method_should_be_called() {
+        testCloudWatchLogsMetrics.increaseThrottledCounter(1);
+        verify(mockThrottledCounter, times(1)).increment(1);
     }
 }


### PR DESCRIPTION
## Summary

- Add 3 classified error counters (`cloudWatchLogsAccessDenied`, `cloudWatchLogsResourceNotFound`, `cloudWatchLogsThrottled`) to the CloudWatch Logs sink, letting operators alarm on specific failure modes instead of relying on the single opaque `cloudWatchLogsRequestsFailed` total
- Place classification logic in a new `classifyAndCountFailure()` method in the `Uploader` inner class, with a defensive null-check on `awsErrorDetails` before reading `errorCode`
- Count `ResourceNotFoundException` at the terminal catch site rather than in `classifyAndCountFailure()` because the error is only terminal when auto-create is disabled or has already been attempted
- Keep all 3 counters additive to the existing `cloudWatchLogsRequestsFailed` counter so existing alarms remain unaffected

## Test plan

- [ ] Verify 3 new unit tests in `CloudWatchLogsMetricsTest` pass (counter initialization and increment)
- [ ] Verify 6 new unit tests in `CloudWatchLogsDispatcherTest` pass (access denied, throttling, terminal ResourceNotFound, successful auto-create does not increment ResourceNotFound, SdkClientException does not increment classified counters, null error details does not throw)
- [ ] Verify 4 new WireMock-based integration tests in `CloudWatchLogsMetricsIT` pass (counters materialize in a Micrometer registry without real AWS credentials)
- [ ] Run full `./gradlew :data-prepper-plugins:cloudwatch-logs:test` and confirm no regressions
- [ ] Confirm the optional real-AWS gated IT is skipped in CI and passes when credentials are available locally