### PR TITLE
Updates the Claude command to use the release blog in generating release notes

### DIFF
--- a/.claude/commands/generate-release-notes.md
+++ b/.claude/commands/generate-release-notes.md
@@ -3,9 +3,14 @@ description: Generate release notes for Data Prepper version $ARGUMENTS.
 allowed-tools:
   - Bash(gh issue list *)
   - Bash(gh pr list *)
+  - Bash(gh pr view *)
+  - Bash(gh api repos/opensearch-project/project-website/pulls/*)
+  - Bash(curl -sL https://raw.githubusercontent.com/opensearch-project/*)
   - Read(release/script/release-notes/**)
   - Read(release/release-notes/**)
   - Write(release/release-notes/**)
+  - AskUserQuestion
+  - WebFetch
 ---
 
 Generate release notes for Data Prepper version $ARGUMENTS.
@@ -59,7 +64,50 @@ Key style observations:
 - The date format is YYYY-MM-DD
 - Empty categories are kept in the output (the heading with no items below it)
 
-## Step 4: Categorize Each Item
+## Step 4: Find the Release Blog
+
+The OpenSearch project publishes a release blog post for each Data Prepper minor release
+in the `opensearch-project/project-website` repository. The blog is written by maintainers
+and reflects an editorial judgment of which changes matter most. It is an authoritative
+cross-check: every feature called out in the blog must appear in the release notes, and the
+blog's ordering tells us which items the maintainers consider most significant.
+
+**Skip this entire step for patch releases.** Blogs are only created for minor releases
+(those ending in `.0`, such as `2.16.0`). Patch releases (such as `2.15.1`) do not get a
+blog, so there is nothing to find or cross-check. When the version is a patch release, skip
+Step 4 outright and ignore the blog-related guidance in Step 7 (prominence ordering) and
+Step 8 (blog cross-check).
+
+1. **Try to find the blog PR automatically.** The blog post lives at
+   `_posts/YYYY-MM-DD-Data-Prepper-VERSION.md` (for example
+   `_posts/2026-06-16-Data-Prepper-2.16.md`). Search open and recently merged PRs:
+
+   ```
+   gh pr list --repo opensearch-project/project-website --search 'Data Prepper VERSION in:title' --state all --json number,title,url --limit 20
+   ```
+
+   You can also look directly for the post file in a candidate PR:
+
+   ```
+   gh api repos/opensearch-project/project-website/pulls/<PR_NUMBER>/files --jq '.[] | select(.filename | test("Data-Prepper")) | .raw_url'
+   ```
+
+   Then fetch the raw content of that file with `curl -sL <raw_url>` (or WebFetch).
+
+2. **If you cannot confidently identify the blog PR, ask the user.** Use AskUserQuestion to
+   request the release blog PR URL (or confirm that no blog exists yet). Do not guess at a
+   blog that may belong to a different version.
+
+3. **If no blog exists yet**, note this to the user and continue — the blog cross-check in
+   Step 7 and the prominence ordering in Step 6 are simply skipped.
+
+4. **Once you have the blog, extract two things:**
+   - The list of every feature, enhancement, and notable change it describes, with the
+     issue/PR number where given. This becomes the completeness checklist for Step 7.
+   - The order in which the blog presents items. Items with their own blog section, listed
+     earlier, are the most significant. This drives the ordering in Step 6.
+
+## Step 5: Categorize Each Item
 
 For each issue/PR:
 
@@ -78,7 +126,7 @@ For each issue/PR:
    milestone, produce one line. Prefer linking to the issue. If a PR has no corresponding
    issue, link to the PR.
 
-## Step 5: Reword Each Item
+## Step 6: Reword Each Item
 
 Rewrite each item to be:
 
@@ -92,7 +140,7 @@ Rewrite each item to be:
 
 Do NOT use the prefix tags like "feat:", "fix:", "refactor:" from commit messages.
 
-## Step 6: Produce the Output
+## Step 7: Produce the Output
 
 Write the release notes file to:
 `release/release-notes/data-prepper.release-notes-VERSION.md`
@@ -101,6 +149,12 @@ where VERSION is derived from the milestone (e.g. milestone `v2.15` produces ver
 if it's a minor release).
 
 Use today's date in the header.
+
+**Ordering within each category.** Within a category, list the items the release blog (Step 4)
+considers most significant first. Anything that has its own section in the blog, or appears
+earlier in it, goes higher in the matching release notes category. Items not mentioned in the
+blog follow, in a sensible order. When there is no blog — including every patch release — order
+by significance to the user.
 
 Format:
 
@@ -137,7 +191,7 @@ Format:
 
 Keep all six category headings even if a category has no items.
 
-## Step 7: Review
+## Step 8: Review
 
 After writing the file, read it back and check:
 - No duplicate items
@@ -146,5 +200,19 @@ After writing the file, read it back and check:
 - Wording is consistent in style
 - All links are correct
 
-Present the final file to the user and note any items where categorization was uncertain
-so they can review those specifically.
+**Cross-check against the release blog (from Step 4).** Skip this cross-check for patch
+releases, which have no blog. If a blog exists:
+- **Completeness:** every feature or notable change the blog describes must appear somewhere
+  in the release notes. If the blog highlights something the notes omit, add it. Treat the
+  blog as the source of truth for what shipped.
+- **Naming accuracy:** verify plugin, processor, and config option names against the blog and,
+  when in doubt, against the code in the repository. The blog is written and reviewed by
+  maintainers, so a mismatch usually means the release notes are wrong.
+- **Prominence:** confirm the most significant blog items are ordered near the top of their
+  category, per Step 6.
+- **Discrepancies:** call out to the user anything that appears in the blog but not in the
+  milestone (or vice versa) so they can reconcile it.
+
+Present the final file to the user. Note any items where categorization was uncertain, and
+report the result of the blog cross-check — including anything you added, renamed, or could
+not reconcile — so they can review those specifically.


### PR DESCRIPTION
### Description

Updates the Claude command to read the release blog and use that information to inform the generation of release notes.

Using the release blog is a good way to be sure that the release notes have all the features we expect. It also is a good indication of what we want to highlight so we can have these promoted better in the release notes.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
