### PR TITLE
Update fast-uri and brace-expansion to fix CVEs CVE-2026-6322,CVE-2026-6321

### DIFF
--- a/release/staging-resources-cdk/package-lock.json
+++ b/release/staging-resources-cdk/package-lock.json
@@ -1777,7 +1777,7 @@
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
+        "fast-uri": "^3.1.2",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2"
       },
@@ -1825,7 +1825,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1870,7 +1870,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -1971,7 +1971,7 @@
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.6"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/testing/aws-testing-cdk/package-lock.json
+++ b/testing/aws-testing-cdk/package-lock.json
@@ -1841,7 +1841,7 @@
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
+        "fast-uri": "^3.1.2",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2"
       },
@@ -1889,7 +1889,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2035,7 +2035,7 @@
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.6"
       },
       "engines": {
         "node": "18 || 20 || >=22"


### PR DESCRIPTION
### Description
Update fast-uri and brace-expansion to fix CVEs CVE-2026-6322,CVE-2026-6321
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
