### PR TITLE
Publish a pre-release GitHub Release and use that for the Jenkins job.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,14 +259,14 @@ jobs:
           echo 'release_latest_tag: ${{ github.event.inputs.release-latest-tag }}' >> release-description.yaml
 
       - name: Publish pre-release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          draft: false
-          prerelease: true
+          immutableCreate: false
+          generateReleaseNotes: false
           name: '${{ env.version }}'
-          tag_name: '${{ env.version }}'
-          files: |
-            release-description.yaml
+          tag: '${{ env.version }}'
+          artifacts: 'release-description.yaml'
+          prerelease: true
 
   generate-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,10 +258,11 @@ jobs:
           echo 'release_major_tag: ${{ github.event.inputs.release-major-tag }}' >> release-description.yaml
           echo 'release_latest_tag: ${{ github.event.inputs.release-latest-tag }}' >> release-description.yaml
 
-      - name: Draft release
+      - name: Publish pre-release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
-          draft: true
+          draft: false
+          prerelease: true
           name: '${{ env.version }}'
           tag_name: '${{ env.version }}'
           files: |

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -19,16 +19,16 @@ pipeline {
                 [key: 'ref', value: ('$.release.tag_name')],
                 [key: 'tag', value: '$.release.name'],
                 [key: 'action', value: '$.action'],
-                [key: 'isDraft', value: '$.release.draft'],
+                [key: 'isPreRelease', value: '$.release.prerelease'],
                 [key: 'release_url', value: '$.release.url'],
                 [key: 'assets_url', value: '$.release.assets_url']
             ],
             tokenCredentialId: 'jenkins-data-prepper-generic-webhook-token',
-            causeString: 'Triggered by draft release on data-prepper repository',
+            causeString: 'Triggered by pre-release on data-prepper repository',
             printContributedVariables: false,
             printPostContent: false,
-            regexpFilterText: ('$isDraft $action'),
-            regexpFilterExpression: ('^true created$')
+            regexpFilterText: ('$isPreRelease $action'),
+            regexpFilterExpression: ('^true published$')
         )
     }
     environment {
@@ -51,7 +51,7 @@ pipeline {
                     if ("$assets_url" != '') {
                         withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
                             String assets = sh(
-                                script: "curl -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assets_url}",
+                                script: "curl -s --fail -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assets_url}",
                                 returnStdout: true
                             )
                             String assetUrl = null
@@ -62,8 +62,12 @@ pipeline {
                                     assetUrl = item.url
                                 }
                             }
+                            if (assetUrl == null) {
+                                def availableAssets = parsedJson.collect { it.name }.join(', ')
+                                error("Asset '${assetName}' not found in release assets. Available assets: [${availableAssets}]. Assets URL: ${assets_url}")
+                            }
                             echo "Downloading release-description.yaml from $assetUrl"
-                            sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} -o ${WORKSPACE}/release-description.yaml"
+                            sh "curl -s --fail -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} -o ${WORKSPACE}/release-description.yaml"
                         }
                         def yamlFile = readYaml(file: "${WORKSPACE}/release-description.yaml")
                         VERSION = yamlFile.version
@@ -275,10 +279,13 @@ pipeline {
         success {
             node('Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host') {
                 script {
-                    if (release_url != null) {
-                        withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
-                            sh "curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${release_url} -d '{\"tag_name\":\"${TAG}\",\"draft\":false,\"prerelease\":false}'"
-                        }
+                    // The OpenSearch project no longer supports bot tokens with write access
+                    // to publish releases automatically. Instead, open an issue asking
+                    // maintainers to convert the pre-release into a full release.
+                    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                        def repository = 'opensearch-project/data-prepper'
+                        def issueBody = "The release workflow for tag `${TAG}` completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/${repository}/releases/tag/${TAG}"
+                        sh "GH_TOKEN=${GITHUB_TOKEN} gh issue create --title \"[Release - Action Required] Publish release for tag ${TAG}\" --body \"${issueBody}\" --repo ${repository}"
                     }
                 }
             }

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -284,8 +284,28 @@ pipeline {
                     // maintainers to convert the pre-release into a full release.
                     withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
                         def repository = 'opensearch-project/data-prepper'
-                        def issueBody = "The release workflow for tag `${TAG}` completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/${repository}/releases/tag/${TAG}"
+                        def codeOwners = sh(
+                            script: "GH_TOKEN=${GITHUB_TOKEN} gh api repos/${repository}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
+                            returnStdout: true
+                        ).trim()
+                        def issueBody = "The release workflow for tag `${TAG}` completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/${repository}/releases/tag/${TAG}\n\ncc: ${codeOwners}"
                         sh "GH_TOKEN=${GITHUB_TOKEN} gh issue create --title \"[Release - Action Required] Publish release for tag ${TAG}\" --body \"${issueBody}\" --repo ${repository}"
+                    }
+                }
+            }
+        }
+        failure {
+            node('Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host') {
+                script {
+                    // Notify maintainers so a broken release pipeline is not missed.
+                    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                        def repository = 'opensearch-project/data-prepper'
+                        def codeOwners = sh(
+                            script: "GH_TOKEN=${GITHUB_TOKEN} gh api repos/${repository}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
+                            returnStdout: true
+                        ).trim()
+                        def issueBody = "The release workflow for tag `${TAG}` failed.\n\nBuild: ${env.BUILD_URL}\n\nPlease investigate the failure and retry the release.\n\nRelease: https://github.com/${repository}/releases/tag/${TAG}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
+                        sh "GH_TOKEN=${GITHUB_TOKEN} gh issue create --title \"[RELEASE] Failed: release for tag ${TAG}\" --body \"${issueBody}\" --repo ${repository}"
                     }
                 }
             }


### PR DESCRIPTION
### Description

Per changes in the OpenSearch project, we can no longer modify repos using bots. So the new process is to publish a pre-release Release. Then the Jenkins job will use this pre-release. It's final step is to create a GitHub issue instead of publishing the Release.

This should fix: https://build.ci.opensearch.org/job/release-data-prepper/30/
 
Inspired by the equivalent pre-release migrations in other OpenSearch repositories:

  - [opensearch-jvector#535 — Fix release workflows to use pre-releases and update releasing.md with new process](https://github.com/opensearch-project/opensearch-jvector/pull/535)
  - [spring-data-opensearch#705 — Fix release workflows to use pre-releases and update releasing.md with new process](https://github.com/opensearch-project/spring-data-opensearch/pull/705)
  - [spring-data-opensearch#709 — Fix jenkins workflow post actions](https://github.com/opensearch-project/spring-data-opensearch/pull/709)
  - [opensearch-build-libraries#22 — Add standard release pipeline library with generic trigger](https://github.com/opensearch-project/opensearch-build-libraries/pull/22)

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
