### PR TITLE
Add /ready endpoint to DataPrepperServer for ALB health check readiness gating

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/Pipeline.java
@@ -80,6 +80,7 @@ public class Pipeline implements HeadlessPipeline {
     private final ExecutorService sinkExecutorService;
     private final EventFactory eventFactory;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private volatile boolean sourceStarted = false;
     private final List<PipelineObserver> observers = Collections.synchronizedList(new LinkedList<>());
 
     /**
@@ -242,6 +243,15 @@ public class Pipeline implements HeadlessPipeline {
         return true;
     }
 
+    /**
+     * Returns whether the pipeline source has been started and is ready to receive traffic.
+     *
+     * @return true if the source has been started, false otherwise
+     */
+    public boolean isSourceStarted() {
+        return sourceStarted;
+    }
+
     // This method needs to be synchronzied with shutdown
     private synchronized void startSourceAndProcessors() {
         if (isStopRequested()) {
@@ -249,8 +259,8 @@ public class Pipeline implements HeadlessPipeline {
         }
         LOG.info("Pipeline [{}] Sink is ready, starting source...", name);
         source.start(buffer);
-
-        LOG.info("Pipeline [{}] - Submitting request to initiate the pipeline processing", name);
+        sourceStarted = true;
+        LOG.info("Pipeline [{}] - Source started, pipeline ready for traffic", name);
         for (int i = 0; i < processorThreads; i++) {
             final int finalI = i;
             final List<Processor> processors = processorSets.stream().map(

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/server/DataPrepperServer.java
@@ -37,6 +37,7 @@ public class DataPrepperServer {
     private final ListPipelinesHandler listPipelinesHandler;
     private final GetPipelinesHandler getPipelinesHandler;
     private final ShutdownHandler shutdownHandler;
+    private final ReadinessHandler readinessHandler;
     private final EncryptionHttpHandler encryptionHttpHandler;
     private final PrometheusMeterRegistry prometheusMeterRegistry;
     private final Authenticator authenticator;
@@ -49,6 +50,7 @@ public class DataPrepperServer {
             final ListPipelinesHandler listPipelinesHandler,
             final ShutdownHandler shutdownHandler,
             final GetPipelinesHandler getPipelinesHandler,
+            final ReadinessHandler readinessHandler,
             @Autowired(required = false) @Nullable final EncryptionHttpHandler encryptionHttpHandler,
             @Autowired(required = false) @Nullable final PrometheusMeterRegistry prometheusMeterRegistry,
             @Autowired(required = false) @Nullable final Authenticator authenticator
@@ -57,6 +59,7 @@ public class DataPrepperServer {
         this.listPipelinesHandler = listPipelinesHandler;
         this.shutdownHandler = shutdownHandler;
         this.getPipelinesHandler = getPipelinesHandler;
+        this.readinessHandler = readinessHandler;
         this.encryptionHttpHandler = encryptionHttpHandler;
         this.prometheusMeterRegistry = prometheusMeterRegistry;
         this.authenticator = authenticator;
@@ -79,6 +82,7 @@ public class DataPrepperServer {
         createContext(server, listPipelinesHandler, authenticator, "/list");
         createContext(server, shutdownHandler, authenticator, "/shutdown");
         createContext(server, getPipelinesHandler, authenticator, "/pipelines");
+        createContext(server, readinessHandler, authenticator, "/ready");
 
         if (encryptionHttpHandler != null) {
             createContext(server, encryptionHttpHandler, authenticator, "/encryption/rotate");

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/server/ReadinessHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/server/ReadinessHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.core.pipeline.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.opensearch.dataprepper.core.pipeline.Pipeline;
+import org.opensearch.dataprepper.core.pipeline.PipelinesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * HttpHandler to handle readiness check requests.
+ * Returns 200 OK when all pipeline sources have started and are ready to receive traffic.
+ * Returns 503 Service Unavailable when any pipeline source has not yet started.
+ *
+ * This endpoint is designed to be used as an ALB health check target to prevent
+ * routing traffic to targets before their data ingestion ports are listening.
+ */
+public class ReadinessHandler implements HttpHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReadinessHandler.class);
+    private final PipelinesProvider pipelinesProvider;
+
+    public ReadinessHandler(final PipelinesProvider pipelinesProvider) {
+        this.pipelinesProvider = pipelinesProvider;
+    }
+
+    @Override
+    public void handle(final HttpExchange exchange) throws IOException {
+        final String requestMethod = exchange.getRequestMethod();
+        if (!requestMethod.equals(HttpMethod.GET)) {
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
+            exchange.getResponseBody().close();
+            return;
+        }
+
+        try {
+            final Map<String, Pipeline> pipelines = pipelinesProvider.getTransformationPipelines();
+
+            if (pipelines.isEmpty()) {
+                LOG.debug("Readiness check: no pipelines registered yet");
+                final byte[] response = "{\"ready\":false,\"reason\":\"no pipelines registered\"}".getBytes();
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_UNAVAILABLE, response.length);
+                exchange.getResponseBody().write(response);
+                return;
+            }
+
+            final boolean allReady = pipelines.values().stream()
+                    .allMatch(Pipeline::isSourceStarted);
+
+            if (allReady) {
+                LOG.debug("Readiness check: all {} pipelines ready", pipelines.size());
+                final byte[] response = "{\"ready\":true}".getBytes();
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+            } else {
+                final String notReady = pipelines.entrySet().stream()
+                        .filter(e -> !e.getValue().isSourceStarted())
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.joining(", "));
+                LOG.debug("Readiness check: pipelines not ready: [{}]", notReady);
+                final byte[] response = String.format(
+                        "{\"ready\":false,\"reason\":\"pipelines not started: [%s]\"}", notReady).getBytes();
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_UNAVAILABLE, response.length);
+                exchange.getResponseBody().write(response);
+            }
+        } catch (final Exception e) {
+            LOG.error("Caught exception during readiness check", e);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
+        } finally {
+            exchange.getResponseBody().close();
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/server/config/DataPrepperServerConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/pipeline/server/config/DataPrepperServerConfiguration.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.core.pipeline.PipelinesProvider;
 import org.opensearch.dataprepper.core.pipeline.server.DataPrepperCoreAuthenticationProvider;
 import org.opensearch.dataprepper.core.pipeline.server.GetPipelinesHandler;
 import org.opensearch.dataprepper.core.pipeline.server.ListPipelinesHandler;
+import org.opensearch.dataprepper.core.pipeline.server.ReadinessHandler;
 import org.opensearch.dataprepper.core.pipeline.server.ShutdownHandler;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -83,5 +84,10 @@ public class DataPrepperServerConfiguration {
     @Bean
     public GetPipelinesHandler GetPipelinesHandler(final PipelinesProvider pipelinesProvider) {
         return new GetPipelinesHandler(pipelinesProvider);
+    }
+
+    @Bean
+    public ReadinessHandler readinessHandler(final PipelinesProvider pipelinesProvider) {
+        return new ReadinessHandler(pipelinesProvider);
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/PipelineTests.java
@@ -212,6 +212,29 @@ class PipelineTests {
     }
 
     @Test
+    void testIsSourceStartedIsFalseBeforeExecuteAndTrueAfterSourceStarts() {
+        final Source<Record<String>> testSource = new TestSource();
+        final TestSink testSink = new TestSink();
+        final DataFlowComponent<Sink> sinkDataFlowComponent = mock(DataFlowComponent.class);
+        when(sinkDataFlowComponent.getComponent()).thenReturn(testSink);
+        testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
+                Collections.emptyList(), Collections.singletonList(sinkDataFlowComponent),
+                router, eventFactory, acknowledgementSetManager, sourceCoordinatorFactory, TEST_PROCESSOR_THREADS,
+                TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout, peerForwarderDrainTimeout);
+
+        assertFalse("isSourceStarted should be false before execute", testPipeline.isSourceStarted());
+
+        testPipeline.execute();
+
+        await().atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(100))
+                .until(testPipeline::isSourceStarted);
+        assertTrue("isSourceStarted should be true after source starts", testPipeline.isSourceStarted());
+
+        testPipeline.shutdown();
+    }
+
+    @Test
     void testPipelineDelayedReadyShutdownBeforeReady() throws InterruptedException {
         final Duration delayTime = Duration.ofSeconds(2);
         final Source<Record<String>> testSource = new TestSource();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/server/DataPrepperServerTest.java
@@ -57,6 +57,9 @@ public class DataPrepperServerTest {
     private GetPipelinesHandler getPipelinesHandler;
 
     @Mock
+    private ReadinessHandler readinessHandler;
+
+    @Mock
     private EncryptionHttpHandler encryptionHttpHandler;
 
     @Mock
@@ -74,7 +77,7 @@ public class DataPrepperServerTest {
     @AfterEach
     public void tearDown() {
         verifyNoMoreInteractions(server, httpServerProvider, listPipelinesHandler, shutdownHandler,
-                prometheusMeterRegistry, authenticator, context, socketAddress);
+                readinessHandler, prometheusMeterRegistry, authenticator, context, socketAddress);
     }
 
     @Test
@@ -93,7 +96,7 @@ public class DataPrepperServerTest {
         verifyServerStart();
         verify(server).createContext(eq("/metrics/prometheus"), any(PrometheusMetricsHandler.class));
         verify(server).createContext(eq("/metrics/sys"), any(PrometheusMetricsHandler.class));
-        verify(context, times(5)).setAuthenticator(eq(authenticator));
+        verify(context, times(6)).setAuthenticator(eq(authenticator));
     }
 
     @Test
@@ -107,7 +110,7 @@ public class DataPrepperServerTest {
         verify(server).createContext(eq("/metrics/prometheus"), any(PrometheusMetricsHandler.class));
         verify(server).createContext(eq("/metrics/sys"), any(PrometheusMetricsHandler.class));
         verify(server).createContext(eq("/encryption/rotate"), any(EncryptionHttpHandler.class));
-        verify(context, times(6)).setAuthenticator(eq(authenticator));
+        verify(context, times(7)).setAuthenticator(eq(authenticator));
     }
 
     @Test
@@ -118,7 +121,7 @@ public class DataPrepperServerTest {
         dataPrepperServer.start();
 
         verifyServerStart();
-        verify(context, times(3)).setAuthenticator(eq(authenticator));
+        verify(context, times(4)).setAuthenticator(eq(authenticator));
     }
 
     @Test
@@ -171,6 +174,7 @@ public class DataPrepperServerTest {
         verify(server).createContext("/list", listPipelinesHandler);
         verify(server).createContext(eq("/shutdown"), eq(shutdownHandler));
         verify(server).createContext(eq("/pipelines"), eq(getPipelinesHandler));
+        verify(server).createContext(eq("/ready"), eq(readinessHandler));
         final ArgumentCaptor<ExecutorService> executorServiceArgumentCaptor = ArgumentCaptor.forClass(ExecutorService.class);
         verify(server).setExecutor(executorServiceArgumentCaptor.capture());
         final ExecutorService actualExecutorService = executorServiceArgumentCaptor.getValue();
@@ -187,6 +191,6 @@ public class DataPrepperServerTest {
                                                     final Authenticator authenticator,
                                                     final EncryptionHttpHandler encryptionHttpHandler) {
         return new DataPrepperServer(
-                httpServerProvider, listPipelinesHandler, shutdownHandler, getPipelinesHandler, encryptionHttpHandler, prometheusMeterRegistry, authenticator);
+                httpServerProvider, listPipelinesHandler, shutdownHandler, getPipelinesHandler, readinessHandler, encryptionHttpHandler, prometheusMeterRegistry, authenticator);
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/server/ReadinessHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/pipeline/server/ReadinessHandlerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.core.pipeline.server;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.core.pipeline.Pipeline;
+import org.opensearch.dataprepper.core.pipeline.PipelinesProvider;
+
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReadinessHandlerTest {
+
+    @Mock
+    private PipelinesProvider pipelinesProvider;
+
+    @Mock
+    private HttpExchange httpExchange;
+
+    @Mock
+    private OutputStream outputStream;
+
+    @Mock
+    private Headers headers;
+
+    @BeforeEach
+    public void beforeEach() {
+        when(httpExchange.getResponseBody())
+                .thenReturn(outputStream);
+    }
+
+    private ReadinessHandler createObjectUnderTest() {
+        return new ReadinessHandler(pipelinesProvider);
+    }
+
+    @Test
+    public void testReturns200WhenAllPipelinesReady() throws IOException {
+        final Pipeline pipeline1 = mock(Pipeline.class);
+        final Pipeline pipeline2 = mock(Pipeline.class);
+        when(pipeline1.isSourceStarted()).thenReturn(true);
+        when(pipeline2.isSourceStarted()).thenReturn(true);
+
+        final Map<String, Pipeline> pipelines = new HashMap<>();
+        pipelines.put("pipeline-1", pipeline1);
+        pipelines.put("pipeline-2", pipeline2);
+
+        when(pipelinesProvider.getTransformationPipelines()).thenReturn(pipelines);
+        when(httpExchange.getResponseHeaders()).thenReturn(headers);
+        when(httpExchange.getRequestMethod()).thenReturn(HttpMethod.GET);
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        verify(headers).add(eq("Content-Type"), eq("application/json"));
+        verify(httpExchange).sendResponseHeaders(eq(HttpURLConnection.HTTP_OK), eq((long) "{\"ready\":true}".getBytes().length));
+
+        final ArgumentCaptor<byte[]> responseCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(outputStream).write(responseCaptor.capture());
+        final String responseBody = new String(responseCaptor.getValue());
+        assertThat(responseBody, containsString("\"ready\":true"));
+        verify(outputStream).close();
+    }
+
+    @Test
+    public void testReturns503WhenSomePipelinesNotReady() throws IOException {
+        final Pipeline readyPipeline = mock(Pipeline.class);
+        final Pipeline notReadyPipeline = mock(Pipeline.class);
+        when(readyPipeline.isSourceStarted()).thenReturn(true);
+        when(notReadyPipeline.isSourceStarted()).thenReturn(false);
+
+        final Map<String, Pipeline> pipelines = new HashMap<>();
+        pipelines.put("ready-pipeline", readyPipeline);
+        pipelines.put("not-ready-pipeline", notReadyPipeline);
+
+        when(pipelinesProvider.getTransformationPipelines()).thenReturn(pipelines);
+        when(httpExchange.getResponseHeaders()).thenReturn(headers);
+        when(httpExchange.getRequestMethod()).thenReturn(HttpMethod.GET);
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        verify(headers).add(eq("Content-Type"), eq("application/json"));
+
+        final ArgumentCaptor<Integer> statusCaptor = ArgumentCaptor.forClass(Integer.class);
+        final ArgumentCaptor<Long> lengthCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(httpExchange).sendResponseHeaders(statusCaptor.capture(), lengthCaptor.capture());
+        assertThat(statusCaptor.getValue(), org.hamcrest.Matchers.equalTo(HttpURLConnection.HTTP_UNAVAILABLE));
+
+        final ArgumentCaptor<byte[]> responseCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(outputStream).write(responseCaptor.capture());
+        final String responseBody = new String(responseCaptor.getValue());
+        assertThat(responseBody, containsString("\"ready\":false"));
+        assertThat(responseBody, containsString("not-ready-pipeline"));
+        verify(outputStream).close();
+    }
+
+    @Test
+    public void testReturns503WhenNoPipelinesNotReady() throws IOException {
+        final Pipeline notReadyPipeline1 = mock(Pipeline.class);
+        final Pipeline notReadyPipeline2 = mock(Pipeline.class);
+        when(notReadyPipeline1.isSourceStarted()).thenReturn(false);
+        when(notReadyPipeline2.isSourceStarted()).thenReturn(false);
+
+        final Map<String, Pipeline> pipelines = new HashMap<>();
+        pipelines.put("pipeline-a", notReadyPipeline1);
+        pipelines.put("pipeline-b", notReadyPipeline2);
+
+        when(pipelinesProvider.getTransformationPipelines()).thenReturn(pipelines);
+        when(httpExchange.getResponseHeaders()).thenReturn(headers);
+        when(httpExchange.getRequestMethod()).thenReturn(HttpMethod.GET);
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        final ArgumentCaptor<byte[]> responseCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(outputStream).write(responseCaptor.capture());
+        final String responseBody = new String(responseCaptor.getValue());
+        assertThat(responseBody, containsString("\"ready\":false"));
+        assertThat(responseBody, containsString("pipeline-a"));
+        assertThat(responseBody, containsString("pipeline-b"));
+        verify(httpExchange).sendResponseHeaders(eq(HttpURLConnection.HTTP_UNAVAILABLE), eq((long) responseCaptor.getValue().length));
+        verify(outputStream).close();
+    }
+
+    @Test
+    public void testReturns503WhenNoPipelinesRegistered() throws IOException {
+        final Map<String, Pipeline> pipelines = new HashMap<>();
+
+        when(pipelinesProvider.getTransformationPipelines()).thenReturn(pipelines);
+        when(httpExchange.getResponseHeaders()).thenReturn(headers);
+        when(httpExchange.getRequestMethod()).thenReturn(HttpMethod.GET);
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        verify(headers).add(eq("Content-Type"), eq("application/json"));
+
+        final ArgumentCaptor<byte[]> responseCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(outputStream).write(responseCaptor.capture());
+        final String responseBody = new String(responseCaptor.getValue());
+        assertThat(responseBody, containsString("\"ready\":false"));
+        assertThat(responseBody, containsString("no pipelines registered"));
+        verify(httpExchange).sendResponseHeaders(eq(HttpURLConnection.HTTP_UNAVAILABLE), eq((long) responseCaptor.getValue().length));
+        verify(outputStream).close();
+    }
+
+    @Test
+    public void testReturns200WithSinglePipelineReady() throws IOException {
+        final Pipeline pipeline = mock(Pipeline.class);
+        when(pipeline.isSourceStarted()).thenReturn(true);
+
+        final Map<String, Pipeline> pipelines = new HashMap<>();
+        pipelines.put("my-pipeline", pipeline);
+
+        when(pipelinesProvider.getTransformationPipelines()).thenReturn(pipelines);
+        when(httpExchange.getResponseHeaders()).thenReturn(headers);
+        when(httpExchange.getRequestMethod()).thenReturn(HttpMethod.GET);
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        verify(httpExchange).sendResponseHeaders(eq(HttpURLConnection.HTTP_OK), eq((long) "{\"ready\":true}".getBytes().length));
+        verify(outputStream).close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PATCH, HttpMethod.PUT })
+    public void testReturns405ForNonGetMethods(String httpMethod) throws IOException {
+        when(httpExchange.getRequestMethod()).thenReturn(httpMethod);
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        verify(httpExchange).sendResponseHeaders(eq(HttpURLConnection.HTTP_BAD_METHOD), eq(0L));
+        verify(outputStream).close();
+    }
+
+    @Test
+    public void testReturns500WhenExceptionThrown() throws IOException {
+        when(httpExchange.getRequestMethod()).thenReturn(HttpMethod.GET);
+        when(pipelinesProvider.getTransformationPipelines()).thenThrow(new RuntimeException("test exception"));
+
+        final ReadinessHandler handler = createObjectUnderTest();
+        handler.handle(httpExchange);
+
+        verify(httpExchange).sendResponseHeaders(eq(HttpURLConnection.HTTP_INTERNAL_ERROR), eq(0L));
+        verify(outputStream).close();
+    }
+}


### PR DESCRIPTION
### Description

Add a `/ready` readiness endpoint on the admin server (port 4900) that returns `200 OK` only after all pipeline sources have started listening, and `503 Service Unavailable` while any pipeline source is still initializing.

During auto-scaling events, the existing ALB health check on `/list` passes as soon as port 4900 starts, but the data ingestion port (e.g. 21890) hasn't started yet. The ALB routes traffic to the target, gets connection refused, and returns a 502 to the customer. This new endpoint enables the ALB health check to be pointed at `/ready` so targets are only marked healthy once they can actually serve traffic.

Changes:
- Add `volatile boolean sourceStarted` flag to `Pipeline.java` that flips after `source.start()`
- Add `ReadinessHandler` implementing `GET /ready` that checks `isSourceStarted()` on all pipelines
- Wire the handler into `DataPrepperServer` and Spring configuration

### Issues Resolved

NULL

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).