### PR TITLE
Handle read / socket timeouts in opensearch source point in time

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -22,6 +22,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSo
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchTimeoutException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
@@ -189,13 +190,8 @@ public class PitWorker implements SearchWorker, Runnable {
         final List<SortingOptions> sortingOptions = SortingOptions.fromSortConfigs(searchConfiguration.getSort());
 
         do {
-            searchWithSearchAfterResults = searchAccessor.searchWithPit(SearchPointInTimeRequest.builder()
-                    .withPitId(openSearchIndexProgressState.getPitId())
-                    .withKeepAlive(EXTEND_KEEP_ALIVE_TIME)
-                    .withPaginationSize(searchConfiguration.getBatchSize())
-                    .withSearchAfter(getSearchAfter(openSearchIndexProgressState, searchWithSearchAfterResults))
-                    .withSortOptions(sortingOptions)
-                    .build());
+            searchWithSearchAfterResults = searchWithRetry(openSearchIndexProgressState, searchConfiguration,
+                    searchWithSearchAfterResults, sortingOptions);
 
             searchWithSearchAfterResults.getDocuments().stream().map(Record::new).forEach(record -> {
                 try {
@@ -245,6 +241,41 @@ public class PitWorker implements SearchWorker, Runnable {
 
     private OpenSearchIndexProgressState initializeProgressState() {
         return new OpenSearchIndexProgressState();
+    }
+
+    private static final int MAX_SEARCH_RETRIES = 50;
+    private static final Duration SEARCH_RETRY_BACKOFF = Duration.ofSeconds(5);
+
+    private SearchWithSearchAfterResults searchWithRetry(final OpenSearchIndexProgressState openSearchIndexProgressState,
+                                                         final SearchConfiguration searchConfiguration,
+                                                         final SearchWithSearchAfterResults previousResults,
+                                                         final List<SortingOptions> sortingOptions) {
+        for (int attempt = 1; attempt <= MAX_SEARCH_RETRIES; attempt++) {
+            try {
+                return searchAccessor.searchWithPit(SearchPointInTimeRequest.builder()
+                        .withPitId(openSearchIndexProgressState.getPitId())
+                        .withKeepAlive(EXTEND_KEEP_ALIVE_TIME)
+                        .withPaginationSize(searchConfiguration.getBatchSize())
+                        .withSearchAfter(getSearchAfter(openSearchIndexProgressState, previousResults))
+                        .withSortOptions(sortingOptions)
+                        .build());
+            } catch (final SearchTimeoutException e) {
+                LOG.warn("Search request failed (attempt {}/{}): {}. Retrying after {} seconds.",
+                        attempt, MAX_SEARCH_RETRIES, e.getMessage(), SEARCH_RETRY_BACKOFF.getSeconds());
+                openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
+                if (attempt == MAX_SEARCH_RETRIES) {
+                    throw new RuntimeException(String.format("Search request failed after %d retries", MAX_SEARCH_RETRIES), e);
+                }
+                try {
+                    Thread.sleep(SEARCH_RETRY_BACKOFF.toMillis());
+                } catch (final InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted during search retry backoff", ex);
+                }
+            }
+        }
+        // Should never reach here
+        throw new RuntimeException("Unexpected state: search retry loop exited without returning or throwing");
     }
 
     private List<String> getSearchAfter(final OpenSearchIndexProgressState openSearchIndexProgressState, final SearchWithSearchAfterResults searchWithSearchAfterResults) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -33,6 +33,7 @@ import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchTimeoutException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollRequest;
@@ -300,7 +301,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
             }
             throw e;
         } catch (final IOException e) {
-            throw new RuntimeException(e);
+            throw new SearchTimeoutException(String.format("Search request failed due to I/O error: %s", e.getMessage()), e);
         }
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactory.java
@@ -114,6 +114,10 @@ public class OpenSearchClientFactory {
             builder.connectionTimeout(openSearchSourceConfiguration.getConnectionConfiguration().getConnectTimeout());
         }
 
+        if (Objects.nonNull(openSearchSourceConfiguration.getConnectionConfiguration().getSocketTimeout())) {
+            builder.readTimeout(openSearchSourceConfiguration.getConnectionConfiguration().getSocketTimeout());
+        }
+
         attachSSLContext(builder, openSearchSourceConfiguration);
 
         return builder.build();

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/exceptions/SearchTimeoutException.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/exceptions/SearchTimeoutException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions;
+
+public class SearchTimeoutException extends RuntimeException {
+    public SearchTimeoutException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SearchTimeoutException(final String message) {
+        super(message);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -31,6 +31,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSo
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchTimeoutException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
@@ -631,5 +632,110 @@ public class PitWorkerTest {
             a.<Runnable>getArgument(0).run();
             return null;
         }).when(indexProcessingTimeTimer).record(any(Runnable.class));
+    }
+
+    @Test
+    void run_with_SearchTimeoutException_retries_and_succeeds() throws Exception {
+        mockTimerCallable();
+
+        final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
+        when(sourcePartition.getPartitionState()).thenReturn(Optional.empty());
+
+        final String pitId = UUID.randomUUID().toString();
+        final CreatePointInTimeResponse createPointInTimeResponse = mock(CreatePointInTimeResponse.class);
+        when(createPointInTimeResponse.getPitId()).thenReturn(pitId);
+        when(searchAccessor.createPit(any(CreatePointInTimeRequest.class))).thenReturn(createPointInTimeResponse);
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getBatchSize()).thenReturn(2);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        final Event testEvent = mock(Event.class);
+        final JsonNode testData = mock(JsonNode.class);
+        when(testEvent.getJsonNode()).thenReturn(testData);
+        when(objectMapper.writeValueAsBytes(testData)).thenReturn(new byte[10]);
+
+        // First call throws SearchTimeoutException, second call succeeds
+        final SearchWithSearchAfterResults successResults = mock(SearchWithSearchAfterResults.class);
+        when(successResults.getNextSearchAfter()).thenReturn(null);
+        when(successResults.getDocuments()).thenReturn(List.of(testEvent));
+
+        when(searchAccessor.searchWithPit(any(SearchPointInTimeRequest.class)))
+                .thenThrow(new SearchTimeoutException("Read timed out"))
+                .thenReturn(successResults);
+
+        doNothing().when(bufferAccumulator).add(any(Record.class));
+        doNothing().when(bufferAccumulator).flush();
+        doNothing().when(searchAccessor).deletePit(any(DeletePointInTimeRequest.class));
+
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier))
+                .thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        doNothing().when(sourceCoordinator).closePartition(partitionKey, Duration.ZERO, 1, false);
+
+        createObjectUnderTest().run();
+
+        // Verify the partition was completed (not given up) since retry succeeded
+        verify(sourceCoordinator).closePartition(partitionKey, Duration.ZERO, 1, false);
+        verify(sourceCoordinator, never()).giveUpPartition(partitionKey);
+    }
+
+    @Test
+    void run_with_SocketTimeoutException_retries_and_succeeds() throws Exception {
+        mockTimerCallable();
+
+        final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
+        when(sourcePartition.getPartitionState()).thenReturn(Optional.empty());
+
+        final String pitId = UUID.randomUUID().toString();
+        final CreatePointInTimeResponse createPointInTimeResponse = mock(CreatePointInTimeResponse.class);
+        when(createPointInTimeResponse.getPitId()).thenReturn(pitId);
+        when(searchAccessor.createPit(any(CreatePointInTimeRequest.class))).thenReturn(createPointInTimeResponse);
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getBatchSize()).thenReturn(2);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        final Event testEvent = mock(Event.class);
+        final JsonNode testData = mock(JsonNode.class);
+        when(testEvent.getJsonNode()).thenReturn(testData);
+        when(objectMapper.writeValueAsBytes(testData)).thenReturn(new byte[10]);
+
+        final SearchWithSearchAfterResults successResults = mock(SearchWithSearchAfterResults.class);
+        when(successResults.getNextSearchAfter()).thenReturn(null);
+        when(successResults.getDocuments()).thenReturn(List.of(testEvent));
+
+        // First call throws SearchTimeoutException (wrapping SocketTimeoutException), second succeeds
+        when(searchAccessor.searchWithPit(any(SearchPointInTimeRequest.class)))
+                .thenThrow(new SearchTimeoutException("Read timed out", new java.net.SocketTimeoutException("Read timed out")))
+                .thenReturn(successResults);
+
+        doNothing().when(bufferAccumulator).add(any(Record.class));
+        doNothing().when(bufferAccumulator).flush();
+        doNothing().when(searchAccessor).deletePit(any(DeletePointInTimeRequest.class));
+
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier))
+                .thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        doNothing().when(sourceCoordinator).closePartition(partitionKey, Duration.ZERO, 1, false);
+
+        createObjectUnderTest().run();
+
+        verify(sourceCoordinator).closePartition(partitionKey, Duration.ZERO, 1, false);
+        verify(sourceCoordinator, never()).giveUpPartition(partitionKey);
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -34,6 +34,7 @@ import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.opensearch.dataprepper.plugins.source.opensearch.ClientRefresher;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchTimeoutException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollRequest;
@@ -618,5 +619,33 @@ public class OpenSearchAccessorTest {
         final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
         assertThat(searchRequest.sort().size(), equalTo(1));
         assertThat(searchRequest.sort().get(0).field().field(), equalTo("@timestamp"));
+    }
+
+    @Test
+    void search_with_pit_throws_SearchTimeoutException_on_IOException() throws IOException {
+        final SearchPointInTimeRequest searchPointInTimeRequest = mock(SearchPointInTimeRequest.class);
+        when(searchPointInTimeRequest.getPitId()).thenReturn(UUID.randomUUID().toString());
+        when(searchPointInTimeRequest.getPaginationSize()).thenReturn(100);
+        when(searchPointInTimeRequest.getSearchAfter()).thenReturn(null);
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class)))
+                .thenThrow(new IOException("Read timed out"));
+
+        final SearchAccessor accessor = createObjectUnderTest();
+        assertThrows(SearchTimeoutException.class, () -> accessor.searchWithPit(searchPointInTimeRequest));
+    }
+
+    @Test
+    void search_with_pit_throws_SearchTimeoutException_on_SocketTimeoutException() throws IOException {
+        final SearchPointInTimeRequest searchPointInTimeRequest = mock(SearchPointInTimeRequest.class);
+        when(searchPointInTimeRequest.getPitId()).thenReturn(UUID.randomUUID().toString());
+        when(searchPointInTimeRequest.getPaginationSize()).thenReturn(100);
+        when(searchPointInTimeRequest.getSearchAfter()).thenReturn(null);
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class)))
+                .thenThrow(new java.net.SocketTimeoutException("connect timed out"));
+
+        final SearchAccessor accessor = createObjectUnderTest();
+        assertThrows(SearchTimeoutException.class, () -> accessor.searchWithPit(searchPointInTimeRequest));
     }
 }


### PR DESCRIPTION
### Description
Catch IOExceptions from transient slow response for opensearch during pagination in opensearch source
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
