### PR TITLE
Log data stream config notices once per stream instead of per document

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DataStreamIndex.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DataStreamIndex.java
@@ -10,6 +10,9 @@ import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 
 public class DataStreamIndex {
     private static final Logger LOG = LoggerFactory.getLogger(DataStreamIndex.class);
@@ -17,7 +20,12 @@ public class DataStreamIndex {
     
     private final DataStreamDetector dataStreamDetector;
     private final IndexConfiguration indexConfiguration;
-    
+
+    // These notices describe configured, expected behavior for a data stream rather than a
+    // per-record fault, so they are logged at most once per data stream instead of once per
+    // ingested document to avoid overwhelming the logs on high-volume pipelines.
+    private final Set<String> loggedNotices = ConcurrentHashMap.newKeySet();
+
     public DataStreamIndex(final DataStreamDetector dataStreamDetector, final IndexConfiguration indexConfiguration) {
         this.dataStreamDetector = dataStreamDetector;
         this.indexConfiguration = indexConfiguration;
@@ -31,7 +39,8 @@ public class DataStreamIndex {
             // Only warn if user explicitly configured a non-create action (excluding the default "index" action)
             if (configuredAction != null && 
                 !configuredAction.equals(OpenSearchBulkActions.CREATE.toString()) &&
-                !configuredAction.equals(OpenSearchBulkActions.INDEX.toString())) {
+                !configuredAction.equals(OpenSearchBulkActions.INDEX.toString()) &&
+                logNoticeOnce(indexName, "action:" + configuredAction)) {
                 LOG.warn("Data Stream '{}' requires 'create' action, but '{}' was configured. Using 'create' action.", 
                         indexName, configuredAction);
             }
@@ -48,12 +57,23 @@ public class DataStreamIndex {
     }
 
     private void validateConfigurationForDataStream(final String indexName) {
-        if (indexConfiguration.getDocumentIdField() != null || indexConfiguration.getDocumentId() != null) {
+        if ((indexConfiguration.getDocumentIdField() != null || indexConfiguration.getDocumentId() != null)
+                && logNoticeOnce(indexName, "documentId")) {
             LOG.warn("Data Stream '{}' with document ID configuration uses first-write-wins behavior. Subsequent writes to the same ID will be ignored.", indexName);
         }
-        if (indexConfiguration.getRoutingField() != null || indexConfiguration.getRouting() != null) {
+        if ((indexConfiguration.getRoutingField() != null || indexConfiguration.getRouting() != null)
+                && logNoticeOnce(indexName, "routing")) {
             LOG.warn("Data Stream '{}' does not support routing. Routing configuration will be ignored.", indexName);
         }
+    }
+
+    /**
+     * Returns {@code true} only the first time a given notice is seen for a data stream, so that
+     * configuration notices are logged once per data stream rather than once per ingested document.
+     * Package-private for testing.
+     */
+    boolean logNoticeOnce(final String indexName, final String noticeType) {
+        return loggedNotices.add(indexName + " " + noticeType);
     }
     
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DataStreamIndexTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DataStreamIndexTest.java
@@ -53,6 +53,35 @@ class DataStreamIndexTest {
     }
     
     @Test
+    void determineAction_returnsCreate_repeatedly_forDataStreamWithDocumentId() {
+        // Regression test for issue #6972: the first-write-wins notice must not change the
+        // returned action, and the action must stay 'create' across repeated calls even though
+        // the notice is only logged once.
+        when(dataStreamDetector.isDataStream("my-data-stream")).thenReturn(true);
+        when(indexConfiguration.getDocumentId()).thenReturn("${id}");
+
+        for (int i = 0; i < 5; i++) {
+            assertThat(dataStreamIndex.determineAction("update", "my-data-stream"), equalTo("create"));
+        }
+    }
+
+    @Test
+    void logNoticeOnce_returnsTrueOnlyOncePerStreamAndNoticeType() {
+        // First occurrence of each (stream, notice) pair should log; repeats should be suppressed.
+        assertThat(dataStreamIndex.logNoticeOnce("stream-a", "documentId"), equalTo(true));
+        assertThat(dataStreamIndex.logNoticeOnce("stream-a", "documentId"), equalTo(false));
+        assertThat(dataStreamIndex.logNoticeOnce("stream-a", "documentId"), equalTo(false));
+
+        // A different notice type for the same stream is logged independently.
+        assertThat(dataStreamIndex.logNoticeOnce("stream-a", "routing"), equalTo(true));
+        assertThat(dataStreamIndex.logNoticeOnce("stream-a", "routing"), equalTo(false));
+
+        // A different stream is tracked independently.
+        assertThat(dataStreamIndex.logNoticeOnce("stream-b", "documentId"), equalTo(true));
+        assertThat(dataStreamIndex.logNoticeOnce("stream-b", "documentId"), equalTo(false));
+    }
+
+    @Test
     void determineAction_returnsConfiguredAction_whenIndexIsNotDataStream() {
         when(dataStreamDetector.isDataStream("regular-index")).thenReturn(false);
         


### PR DESCRIPTION
### Description

The opensearch sink logs configuration notices for data streams inside `DataStreamIndex`, which is reached from `EventActionResolver.resolveAction` once per event. As a result these notices are emitted **once per ingested document** at WARN:

- first-write-wins behavior when a `document_id` is configured
- routing configuration being ignored
- coercion of a configured non-`create` action to `create`

On a high-volume pipeline this produces one WARN line per document (e.g. ~190M/day), which dominates log output and drowns out genuine warnings and errors, while describing configured, expected behavior rather than a per-record fault.

This change dedupes the notices by `(data stream, notice type)` using a `ConcurrentHashMap`-backed set so each notice is logged **at most once per data stream** while preserving the informational intent. The action returned by `determineAction` is unchanged.

### Issues Resolved

Resolves #6972

### Check List

- [x] New functionality includes testing.
  - [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
