### PR TITLE
Fix flaky EndToEndRawSpanTest in peer forwarder e2e tests

### DIFF
--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -52,6 +52,7 @@ class TraceTestConfiguration {
 }
 
 def RAW_SPAN_PIPELINE_YAML = 'raw-span-e2e-pipeline.yml'
+def RAW_SPAN_PEER_FORWARDER_PIPELINE_YAML = 'raw-span-peer-forwarder-e2e-pipeline.yml'
 def DATA_PREPPER_CONFIG_YAML = 'data_prepper.yml'
 def RAW_SPAN_TESTS_PATTERN = 'org.opensearch.dataprepper.integration.trace.EndToEndRawSpanTest.testPipelineEndToEnd*'
 def DATA_PREPPER_CONFIG_STATIC_YAML = 'data_prepper_static.yml'
@@ -89,11 +90,11 @@ List<TraceTestConfiguration> traceTestConfigurations = [
                 RAW_SPAN_TESTS_PATTERN,
                 [new TraceTestContainerConfiguration(
                         tasks.named('dataPrepperDockerImage'),
-                        RAW_SPAN_PIPELINE_YAML,
+                        RAW_SPAN_PEER_FORWARDER_PIPELINE_YAML,
                         DATA_PREPPER_CONFIG_STATIC_YAML),
                  new TraceTestContainerConfiguration(
                          tasks.named('dataPrepperDockerImage'),
-                         RAW_SPAN_PIPELINE_YAML,
+                         RAW_SPAN_PEER_FORWARDER_PIPELINE_YAML,
                          DATA_PREPPER_CONFIG_STATIC_YAML)],
                 'data-prepper'
         ),

--- a/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndRawSpanTest.java
+++ b/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndRawSpanTest.java
@@ -47,6 +47,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import org.assertj.core.api.SoftAssertions;
+
 import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,15 +115,18 @@ public class EndToEndRawSpanTest {
          *
          * TODO: Can we do better?
          */
+        final SoftAssertions softly = new SoftAssertions();
         expectedDocuments.forEach(expectedDoc -> {
             Set<Map.Entry<String, Object>> foundEntrySet = foundDocuments.stream()
                     .filter(i -> i.get("spanId").equals(expectedDoc.get("spanId")))
                     .findFirst().get()
                     .entrySet();
 
-            assertThat(foundEntrySet).containsAll(expectedDoc.entrySet());
+            softly.assertThat(foundEntrySet)
+                    .as("Document for spanId %s", expectedDoc.get("spanId"))
+                    .containsAll(expectedDoc.entrySet());
         });
-
+        softly.assertAll();
     }
 
     private SearchSourceBuilder createSearchSourceBuilder() {

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-from-build.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-from-build.yml
@@ -12,7 +12,7 @@ raw-pipeline:
       name: "entry-pipeline"
   processor:
     - otel_traces:
-        trace_flush_interval: 5
+        trace_flush_interval: 30
   sink:
     - opensearch:
         hosts: [ "https://node-0.example.com:9200" ]

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
@@ -12,7 +12,7 @@ raw-pipeline:
       name: "entry-pipeline"
   processor:
     - otel_traces:
-        trace_flush_interval: 5
+        trace_flush_interval: 30
   sink:
     - opensearch:
         hosts: [ "https://node-0.example.com:9200" ]

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline.yml
@@ -11,7 +11,7 @@ raw-pipeline:
       name: "entry-pipeline"
   processor:
     - otel_traces:
-        trace_flush_interval: 5
+        trace_flush_interval: 30
     - otel_trace_group:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-peer-forwarder-e2e-pipeline.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-peer-forwarder-e2e-pipeline.yml
@@ -11,7 +11,10 @@ raw-pipeline:
       name: "entry-pipeline"
   processor:
     - otel_traces:
-        trace_flush_interval: 5
+        # Long enough that a peer-forwarded root span arrives before its
+        # buffered child spans are garbage-collected with a null trace group.
+        # See https://github.com/opensearch-project/data-prepper/issues/6721
+        trace_flush_interval: 30
     - otel_trace_group:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-peer-forwarder-e2e-pipeline.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-peer-forwarder-e2e-pipeline.yml
@@ -1,3 +1,10 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 entry-pipeline:
   source:
     otel_trace_source:


### PR DESCRIPTION
### Description
Fixes the flaky `EndToEndRawSpanTest.testPipelineEndToEnd` failure in the raw span peer forwarder e2e workflow. Root cause analysis based on the test result artifacts from #6867 is in https://github.com/opensearch-project/data-prepper/issues/6721#issuecomment-4884659736.

Summary of the race: the test sends TRACE_2's child spans before its root span, and to a different node. The children are buffered by `OTelTraceRawProcessor` on the owner node while the root is peer-forwarded from the other node. With `trace_flush_interval: 5` in the e2e pipeline configs, a forwarded root that arrives later than 5 seconds causes the children to be flushed with a null trace group, and the `otel_trace_group` backfill also misses because the root is not indexed yet. The documents then stay null forever, so the test's 30 second polling can never recover. This happened in about 5% of CI runs, always on the same span.

Two changes:
1. Give the peer-forwarding e2e tests a `trace_flush_interval` of 30 instead of 5.
   - `rawSpanPeerForwarderEndToEndTest` gets its own pipeline config, `raw-span-peer-forwarder-e2e-pipeline.yml`. Root arrival flushes buffered children immediately; the interval only bounds how long they wait, so a longer window is strictly safer here. The production default is 180.
   - The compatibility configs (`-from-build` / `-latest-release`) are raised in place, since `rawSpanLatestReleaseCompatibilityEndToEndTest` also peer-forwards between its two nodes.
   - The shared `raw-span-e2e-pipeline.yml` stays at 5. `rawSpanEndToEndTest` runs its two nodes without peer forwarding, so its child spans can never meet their root; that test depends on the 5 second flush plus `otel_trace_group` backfill completing within its 30 second await.
2. Convert the field assertion to AssertJ soft assertions so a failure reports every span with missing fields instead of throwing on the first one. During the investigation, all 12 failures pointed at span 401 only because it is checked first; this change makes future reports show the full picture.

### Issues Resolved
Addresses #6721. I suggest keeping the issue open until a few weeks of CI runs confirm the failure rate has actually dropped (it was ~5% of runs), rather than auto-closing on merge.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
