### PR TITLE
feat(opensearch): Add full bulk response body logging for debugging

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -358,6 +358,9 @@ public final class BulkRetryStrategy {
             incrementErrorCounters(e);
             return handleRetriesAndFailures(bulkRequestForRetry, attemptNumber, null, e);
         }
+        if (LOG.isDebugEnabled()) {
+            logBulkResponseDetails(bulkRequestForRetry, bulkResponse, attemptNumber);
+        }
         if (bulkResponse.errors()) {
             return handleRetriesAndFailures(bulkRequestForRetry, attemptNumber, bulkResponse, null);
         } else {
@@ -371,7 +374,7 @@ public final class BulkRetryStrategy {
                 for (int i = 0; i < bulkRequestForRetry.getOperationsCount(); i++) {
                     final BulkOperationWrapper op = (BulkOperationWrapper) bulkRequestForRetry.getOperationAt(i);
                     final BulkResponseItem item = bulkResponse.items().get(i);
-                    LOG.debug("Document indexed successfully: id={}, index={}, status={}", op.getId(), op.getIndex(), item.status());
+                    LOG.debug("Document indexed successfully: id={}, index={}, status={}, seqNo={}, primaryTerm={}", op.getId(), op.getIndex(), item.status(), item.seqNo(), item.primaryTerm());
                 }
             }
             List<BulkOperationWrapper> successfulOperations = new ArrayList<>(bulkRequestForRetry.getOperations());
@@ -380,6 +383,32 @@ public final class BulkRetryStrategy {
             documentsDuplicates.increment(totalDuplicateDocuments);
         }
         return null;
+    }
+
+    private void logBulkResponseDetails(final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest,
+                                          final BulkResponse bulkResponse,
+                                          final int attemptNumber) {
+        final int requestCount = bulkRequest.getOperationsCount();
+        final int responseCount = bulkResponse.items().size();
+        LOG.debug("Bulk response: attempt={}, errors={}, requestItems={}, responseItems={}, took={}ms",
+                attemptNumber, bulkResponse.errors(), requestCount, responseCount, bulkResponse.took());
+        if (requestCount != responseCount) {
+            LOG.warn("BULK RESPONSE MISMATCH: request had {} items but response has {} items. attempt={}",
+                    requestCount, responseCount, attemptNumber);
+        }
+        for (int i = 0; i < responseCount; i++) {
+            final BulkResponseItem item = bulkResponse.items().get(i);
+            final BulkOperationWrapper op = (i < requestCount) ? (BulkOperationWrapper) bulkRequest.getOperationAt(i) : null;
+            final String docId = op != null ? op.getId() : "UNKNOWN";
+            final ErrorCause error = item.error();
+            if (error != null) {
+                LOG.debug("Bulk response item: position={}, id={}, responseId={}, status={}, seqNo={}, primaryTerm={}, error.type={}, error.reason={}",
+                        i, docId, item.id(), item.status(), item.seqNo(), item.primaryTerm(), error.type(), error.reason());
+            } else {
+                LOG.debug("Bulk response item: position={}, id={}, responseId={}, status={}, seqNo={}, primaryTerm={}",
+                        i, docId, item.id(), item.status(), item.seqNo(), item.primaryTerm());
+            }
+        }
     }
 
     private AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> createBulkRequestForRetry(
@@ -430,7 +459,7 @@ public final class BulkRetryStrategy {
                     if(isDuplicateDocument(bulkItemResponse)) {
                         documentsDuplicates.increment();
                     }
-                    LOG.debug("Document indexed successfully (retry path): id={}, index={}, status={}", bulkOperation.getId(), bulkOperation.getIndex(), bulkItemResponse.status());
+                    LOG.debug("Document indexed successfully (retry path): id={}, index={}, status={}, seqNo={}, primaryTerm={}", bulkOperation.getId(), bulkOperation.getIndex(), bulkItemResponse.status(), bulkItemResponse.seqNo(), bulkItemResponse.primaryTerm());
                     successfulOperations.add(bulkOperation);
                 }
                 index++;
@@ -471,7 +500,7 @@ public final class BulkRetryStrategy {
                 if(isDuplicateDocument(bulkItemResponse)) {
                     documentsDuplicates.increment();
                 }
-                LOG.debug("Document indexed successfully (final attempt): id={}, index={}, status={}", bulkOperation.getId(), bulkOperation.getIndex(), bulkItemResponse.status());
+                LOG.debug("Document indexed successfully (final attempt): id={}, index={}, status={}, seqNo={}, primaryTerm={}", bulkOperation.getId(), bulkOperation.getIndex(), bulkItemResponse.status(), bulkItemResponse.seqNo(), bulkItemResponse.primaryTerm());
                 successfulOperations.add(bulkOperation);
             }
         }


### PR DESCRIPTION
Add detailed per-item response logging to BulkRetryStrategy to diagnose client issues

- Request vs response item count (catches mismatches)
- Per-item: position, request doc ID, response doc ID, status, seqNo, primaryTerm, and error details if present
- Comparison of request ID vs response ID to detect position misalignment

### Description
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
