### PR TITLE
Add metadata for document routing to OpenSearch source

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +60,7 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.INDEX_METADATA_ATTRIBUTE_NAME;
 
@@ -307,13 +309,19 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
 
     private List<Event> getDocumentsFromResponse(final SearchResponse<ObjectNode> searchResponse) {
         return searchResponse.hits().hits().stream()
-                .map(hit -> JacksonEvent.builder()
-                        .withData(hit.source())
-                        .withEventMetadataAttributes(
-                                Map.of(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME, hit.id(),
-                                        INDEX_METADATA_ATTRIBUTE_NAME, hit.index(),
-                                        DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME, hit.version()))
-                        .withEventType(EventType.DOCUMENT.toString()).build())
+                .map(hit -> {
+                    final Map<String, Object> eventMetadataAttributes = new HashMap<>();
+                    eventMetadataAttributes.put(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME, hit.id());
+                    eventMetadataAttributes.put(INDEX_METADATA_ATTRIBUTE_NAME, hit.index());
+                    eventMetadataAttributes.put(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME, hit.version());
+                    if (Objects.nonNull(hit.routing())) {
+                        eventMetadataAttributes.put(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME, hit.routing());
+                    }
+                    return JacksonEvent.builder()
+                            .withData(hit.source())
+                            .withEventMetadataAttributes(eventMetadataAttributes)
+                            .withEventType(EventType.DOCUMENT.toString()).build();
+                })
                 .collect(Collectors.toList());
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -53,12 +53,14 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.INDEX_METADATA_ATTRIBUTE_NAME;
 
@@ -306,13 +308,19 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory<
 
     private List<Event> getDocumentsFromResponse(final SearchResponse<ObjectNode> searchResponse) {
         return searchResponse.hits().hits().stream()
-                .map(hit -> JacksonEvent.builder()
-                        .withData(hit.source())
-                        .withEventMetadataAttributes(
-                                Map.of(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME, hit.id(),
-                                        INDEX_METADATA_ATTRIBUTE_NAME, hit.index(),
-                                        DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME, hit.version()))
-                        .withEventType(EventType.DOCUMENT.toString()).build())
+                .map(hit -> {
+                    final Map<String, Object> eventMetadataAttributes = new HashMap<>();
+                    eventMetadataAttributes.put(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME, hit.id());
+                    eventMetadataAttributes.put(INDEX_METADATA_ATTRIBUTE_NAME, hit.index());
+                    eventMetadataAttributes.put(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME, hit.version());
+                    if (Objects.nonNull(hit.routing())) {
+                        eventMetadataAttributes.put(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME, hit.routing());
+                    }
+                    return JacksonEvent.builder()
+                            .withData(hit.source())
+                            .withEventMetadataAttributes(eventMetadataAttributes)
+                            .withEventType(EventType.DOCUMENT.toString()).build();
+                })
                 .collect(Collectors.toList());
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/MetadataKeyAttributes.java
@@ -9,4 +9,5 @@ public class MetadataKeyAttributes {
     public static final String DOCUMENT_ID_METADATA_ATTRIBUTE_NAME = "opensearch-document_id";
     public static final String INDEX_METADATA_ATTRIBUTE_NAME = "opensearch-index";
     public static final String DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME = "opensearch_document_version";
+    public static final String DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME = "opensearch-document_routing";
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
@@ -68,6 +68,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.INDEX_NOT_FOUND_EXCEPTION;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.PIT_RESOURCE_LIMIT_ERROR_TYPE;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME;
 
 @ExtendWith(MockitoExtension.class)
@@ -130,12 +131,14 @@ public class ElasticsearchAccessorTest {
         when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
         when(firstHit.source()).thenReturn(mock(ObjectNode.class));
         when(firstHit.version()).thenReturn(1L);
+        when(firstHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         final Hit<ObjectNode> secondHit = mock(Hit.class);
         when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.source()).thenReturn(mock(ObjectNode.class));
         when(secondHit.version()).thenReturn(2L);
+        when(secondHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         hits.add(firstHit);
         hits.add(secondHit);
@@ -156,6 +159,8 @@ public class ElasticsearchAccessorTest {
         assertThat(createScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(createScrollResponse.getDocuments().get(1), notNullValue());
         assertThat(createScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+        assertThat(createScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(firstHit.routing()));
+        assertThat(createScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(secondHit.routing()));
 
         final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
         assertThat(searchRequest, notNullValue());
@@ -465,6 +470,7 @@ public class ElasticsearchAccessorTest {
         when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
         when(firstHit.source()).thenReturn(mock(ObjectNode.class));
         when(firstHit.version()).thenReturn(1L);
+        when(firstHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         final Hit<ObjectNode> secondHit = mock(Hit.class);
         when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
@@ -472,6 +478,7 @@ public class ElasticsearchAccessorTest {
         when(secondHit.source()).thenReturn(mock(ObjectNode.class));
         when(secondHit.sort()).thenReturn(searchAfter);
         when(secondHit.version()).thenReturn(2L);
+        when(secondHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         hits.add(firstHit);
         hits.add(secondHit);
@@ -494,6 +501,8 @@ public class ElasticsearchAccessorTest {
         assertThat(searchWithSearchAfterResults.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchWithSearchAfterResults.getDocuments().get(1), notNullValue());
         assertThat(searchWithSearchAfterResults.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+        assertThat(searchWithSearchAfterResults.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(firstHit.routing()));
+        assertThat(searchWithSearchAfterResults.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(secondHit.routing()));
 
         final SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
         assertThat(searchRequest, notNullValue());
@@ -525,6 +534,7 @@ public class ElasticsearchAccessorTest {
         when(firstHit.index()).thenReturn(index);
         when(firstHit.source()).thenReturn(mock(ObjectNode.class));
         when(firstHit.version()).thenReturn(1L);
+        when(firstHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         final Hit<ObjectNode> secondHit = mock(Hit.class);
         when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
@@ -532,6 +542,7 @@ public class ElasticsearchAccessorTest {
         when(secondHit.source()).thenReturn(mock(ObjectNode.class));
         when(secondHit.sort()).thenReturn(searchAfter);
         when(secondHit.version()).thenReturn(2L);
+        when(secondHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         hits.add(firstHit);
         hits.add(secondHit);
@@ -552,6 +563,8 @@ public class ElasticsearchAccessorTest {
         assertThat(searchWithSearchAfterResults.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchWithSearchAfterResults.getDocuments().get(1), notNullValue());
         assertThat(searchWithSearchAfterResults.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+        assertThat(searchWithSearchAfterResults.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(firstHit.routing()));
+        assertThat(searchWithSearchAfterResults.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(secondHit.routing()));
 
         assertThat(searchWithSearchAfterResults.getNextSearchAfter(), equalTo(secondHit.sort()));
 
@@ -577,12 +590,14 @@ public class ElasticsearchAccessorTest {
         when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
         when(firstHit.source()).thenReturn(mock(ObjectNode.class));
         when(firstHit.version()).thenReturn(1L);
+        when(firstHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         final Hit<ObjectNode> secondHit = mock(Hit.class);
         when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.source()).thenReturn(mock(ObjectNode.class));
         when(secondHit.version()).thenReturn(2L);
+        when(secondHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         hits.add(firstHit);
         hits.add(secondHit);
@@ -605,6 +620,8 @@ public class ElasticsearchAccessorTest {
         assertThat(searchScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchScrollResponse.getDocuments().get(1), notNullValue());
         assertThat(searchScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+        assertThat(searchScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(firstHit.routing()));
+        assertThat(searchScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(secondHit.routing()));
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -66,6 +66,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.INDEX_NOT_FOUND_EXCEPTION;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.PIT_RESOURCE_LIMIT_ERROR_TYPE;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME;
 
 @ExtendWith(MockitoExtension.class)
@@ -461,12 +462,14 @@ public class OpenSearchAccessorTest {
         when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
         when(firstHit.source()).thenReturn(mock(ObjectNode.class));
         when(firstHit.version()).thenReturn(1L);
+        when(firstHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         final Hit<ObjectNode> secondHit = mock(Hit.class);
         when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.source()).thenReturn(mock(ObjectNode.class));
         when(secondHit.version()).thenReturn(2L);
+        when(secondHit.routing()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.sort()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
 
         hits.add(firstHit);
@@ -488,6 +491,8 @@ public class OpenSearchAccessorTest {
         assertThat(searchWithSearchAfterResults.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchWithSearchAfterResults.getDocuments().get(1), notNullValue());
         assertThat(searchWithSearchAfterResults.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+        assertThat(searchWithSearchAfterResults.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(firstHit.routing()));
+        assertThat(searchWithSearchAfterResults.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(secondHit.routing()));
 
         assertThat(searchWithSearchAfterResults.getNextSearchAfter(), equalTo(secondHit.sort()));
 
@@ -513,12 +518,14 @@ public class OpenSearchAccessorTest {
         when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
         when(firstHit.source()).thenReturn(mock(ObjectNode.class));
         when(firstHit.version()).thenReturn(1L);
+        when(firstHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         final Hit<ObjectNode> secondHit = mock(Hit.class);
         when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
         when(secondHit.source()).thenReturn(mock(ObjectNode.class));
         when(secondHit.version()).thenReturn(2L);
+        when(secondHit.routing()).thenReturn(UUID.randomUUID().toString());
 
         hits.add(firstHit);
         hits.add(secondHit);
@@ -541,6 +548,8 @@ public class OpenSearchAccessorTest {
         assertThat(searchScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(1L));
         assertThat(searchScrollResponse.getDocuments().get(1), notNullValue());
         assertThat(searchScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_VERSION_METADATA_ATTRIBUTE_NAME), equalTo(2L));
+        assertThat(searchScrollResponse.getDocuments().get(0).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(firstHit.routing()));
+        assertThat(searchScrollResponse.getDocuments().get(1).getMetadata().getAttribute(DOCUMENT_ROUTING_METADATA_ATTRIBUTE_NAME), equalTo(secondHit.routing()));
     }
 
     @Test


### PR DESCRIPTION
### Description
This change makes the document routing (`_routing`) available within the pipeline configuration via the `opensearch-document_routing` event metadata attribute for the OpenSearch source, mirroring the existing `opensearch-document_id`, `opensearch-index`, and `opensearch_document_version` metadata.

The routing value is read from each search `hit.routing()` across all three read strategies (PIT, scroll, and no-search-context). Since most documents do not use custom routing, the attribute is only added when a routing value is present, so documents without routing are unaffected.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR:
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)