### PR TITLE
Fixed flaky file-source unit tests #6984

### DIFF
--- a/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileReader.java
+++ b/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileReader.java
@@ -36,6 +36,7 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -82,6 +83,7 @@ public final class FileReader implements Runnable {
     private final InputCodec codec;
     private final boolean tailMode;
     private final DecompressionEngine decompressionEngine;
+    private final Clock clock;
 
     private final AtomicLong readOffset;
     private final StringBuilder partialLine;
@@ -102,11 +104,21 @@ public final class FileReader implements Runnable {
                           final CheckpointEntry checkpointEntry,
                           final FileReaderContext context,
                           final Runnable onComplete) {
+        this(path, fileIdentity, checkpointEntry, context, onComplete, Clock.systemDefaultZone());
+    }
+
+    FileReader(final Path path,
+                   final FileIdentity fileIdentity,
+                   final CheckpointEntry checkpointEntry,
+                   final FileReaderContext context,
+                   final Runnable onComplete,
+                   final Clock clock) {
         this.path = Objects.requireNonNull(path, "path must not be null");
         this.fileIdentity = Objects.requireNonNull(fileIdentity, "fileIdentity must not be null");
         this.checkpointEntry = Objects.requireNonNull(checkpointEntry, "checkpointEntry must not be null");
         Objects.requireNonNull(context, "context must not be null");
         this.onComplete = Objects.requireNonNull(onComplete, "onComplete must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
 
         this.buffer = context.getBuffer();
         this.eventFactory = context.getEventFactory();
@@ -145,9 +157,9 @@ public final class FileReader implements Runnable {
         this.cachedAbsolutePath = path.toAbsolutePath().toString();
         this.currentBatchCount = 0;
         this.batchStartOffset = readOffset.get();
-        this.batchOpenedAtMillis = System.currentTimeMillis();
+        this.batchOpenedAtMillis = clock.millis();
         this.lastRotationType = RotationType.NO_ROTATION;
-        this.lastActivityMillis = System.currentTimeMillis();
+        this.lastActivityMillis = clock.millis();
     }
 
     @Override
@@ -244,7 +256,7 @@ public final class FileReader implements Runnable {
 
     private void readLoop(final FileChannel channel, final long timeoutMillis, final boolean isDraining) throws IOException {
         final ByteBuffer byteBuffer = ByteBuffer.allocate(readBufferSize);
-        final long loopStart = System.currentTimeMillis();
+        final long loopStart = clock.millis();
         final ByteArrayOutputStream codecAccumulator = codec != null ? new ByteArrayOutputStream() : null;
         long codecBytesAccumulated = 0;
         final CharsetDecoder decoder = codec == null ? encoding.newDecoder()
@@ -254,7 +266,7 @@ public final class FileReader implements Runnable {
         final ByteBuffer decoderCarryover = codec == null ? ByteBuffer.allocate(8) : null;
 
         while (!Thread.currentThread().isInterrupted()) {
-            final long elapsed = System.currentTimeMillis() - loopStart;
+            final long elapsed = clock.millis() - loopStart;
             if (elapsed >= timeoutMillis) {
                 if (isDraining) {
                     long currentFileSize = 0;
@@ -305,10 +317,10 @@ public final class FileReader implements Runnable {
             }
 
             readOffset.addAndGet(Math.max(0, bytesRead));
-            lastActivityMillis = System.currentTimeMillis();
+            lastActivityMillis = clock.millis();
 
             if (acknowledgementsEnabled && currentAckSet != null && currentBatchCount > 0) {
-                final long batchAge = System.currentTimeMillis() - batchOpenedAtMillis;
+                final long batchAge = clock.millis() - batchOpenedAtMillis;
                 if (batchAge >= batchTimeout.toMillis()) {
                     completePendingAckSet();
                 }
@@ -421,9 +433,9 @@ public final class FileReader implements Runnable {
         long backpressureStartNanos = 0;
         boolean backpressureActive = false;
         final long maxRetryMillis = maxReadTimePerFile.toMillis();
-        final long retryStart = System.currentTimeMillis();
+        final long retryStart = clock.millis();
         while (!written && !Thread.currentThread().isInterrupted()) {
-            if (System.currentTimeMillis() - retryStart > maxRetryMillis) {
+            if (clock.millis() - retryStart > maxRetryMillis) {
                 LOG.warn("Backpressure retry timeout exceeded for file {}. Event may be lost.", path);
                 metrics.getDataLossEvents().increment();
                 break;
@@ -468,7 +480,7 @@ public final class FileReader implements Runnable {
         if (currentAckSet == null) {
             final long capturedBatchStart = readOffset.get();
             batchStartOffset = capturedBatchStart;
-            batchOpenedAtMillis = System.currentTimeMillis();
+            batchOpenedAtMillis = clock.millis();
             currentAckSet = acknowledgementSetManager.create(
                     result -> handleAcknowledgement(result, capturedBatchStart, currentBatchEndOffset),
                     acknowledgmentTimeout);

--- a/data-prepper-plugins/file-source/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileReaderPoolTest.java
+++ b/data-prepper-plugins/file-source/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileReaderPoolTest.java
@@ -103,9 +103,18 @@ class FileReaderPoolTest {
                 Duration.ofMinutes(30), createReaderContext());
     }
 
+    private FileReaderPool createPoolWithNonRunningExecutor(final int maxActiveFiles) {
+        when(metrics.getActiveFileCount()).thenReturn(new AtomicLong(0));
+        final ExecutorService nonRunningExecutor = mock(ExecutorService.class);
+        return new FileReaderPool(
+                checkpointRegistry, metrics, maxActiveFiles,
+                Duration.ofMinutes(30), createReaderContext(),
+                () -> nonRunningExecutor);
+    }
+
     @Test
     void addFile_submits_reader_when_under_max_active_files() {
-        FileReaderPool pool = createPool(10, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(10);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity = mock(FileIdentity.class);
@@ -120,7 +129,7 @@ class FileReaderPoolTest {
 
     @Test
     void addFile_is_idempotent_for_same_identity() {
-        FileReaderPool pool = createPool(10, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(10);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity = mock(FileIdentity.class);
@@ -135,7 +144,7 @@ class FileReaderPoolTest {
 
     @Test
     void addFile_queues_pending_when_at_max_active_files() {
-        FileReaderPool pool = createPool(1, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(1);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity1 = mock(FileIdentity.class);
@@ -151,7 +160,7 @@ class FileReaderPoolTest {
 
     @Test
     void addFile_does_not_add_pending_duplicate_to_queue() {
-        FileReaderPool pool = createPool(1, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(1);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity1 = mock(FileIdentity.class);
@@ -167,7 +176,7 @@ class FileReaderPoolTest {
 
     @Test
     void addFile_queues_multiple_pending_files() {
-        FileReaderPool pool = createPool(1, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(1);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity1 = mock(FileIdentity.class);
@@ -220,7 +229,7 @@ class FileReaderPoolTest {
     void closeReaderForPath_removes_matching_reader() {
         Counter filesClosed = mock(Counter.class);
         lenient().when(metrics.getFilesClosed()).thenReturn(filesClosed);
-        FileReaderPool pool = createPool(10, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(10);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity = mock(FileIdentity.class);
@@ -236,7 +245,7 @@ class FileReaderPoolTest {
 
     @Test
     void closeReaderForPath_does_nothing_when_no_match() {
-        FileReaderPool pool = createPool(10, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(10);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity = mock(FileIdentity.class);
@@ -251,7 +260,7 @@ class FileReaderPoolTest {
     void closeReaderForPath_promotes_pending_files() {
         Counter filesClosed = mock(Counter.class);
         lenient().when(metrics.getFilesClosed()).thenReturn(filesClosed);
-        FileReaderPool pool = createPool(1, 2);
+        FileReaderPool pool = createPoolWithNonRunningExecutor(1);
         when(checkpointRegistry.getOrCreate(anyString())).thenReturn(new CheckpointEntry());
 
         FileIdentity identity1 = mock(FileIdentity.class);

--- a/data-prepper-plugins/file-source/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileReaderTest.java
+++ b/data-prepper-plugins/file-source/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileReaderTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +51,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -630,14 +632,18 @@ class FileReaderTest {
         when(rotationDetector.checkRotation(any(), any(), any(long.class)))
                 .thenReturn(new RotationResult(RotationType.CREATE_RENAME, newIdentity));
 
+        final AtomicLong fakeNowMillis = new AtomicLong(0);
+        final Clock clock = mock(Clock.class);
+        when(clock.millis()).thenAnswer(inv -> fakeNowMillis.get());
+
         FileChannel mockChannel = mock(FileChannel.class);
         when(fileOps.openReadChannel(testFile)).thenReturn(mockChannel);
         when(mockChannel.position(anyLong())).thenReturn(mockChannel);
-        lenient().when(mockChannel.read(any(ByteBuffer.class))).thenAnswer(inv -> {
-            Thread.sleep(5);
+        when(mockChannel.read(any(ByteBuffer.class))).thenAnswer(inv -> {
             ByteBuffer buf = inv.getArgument(0);
             byte[] data = "A".repeat(buf.remaining()).getBytes();
             buf.put(data, 0, Math.min(data.length, buf.remaining()));
+            fakeNowMillis.set(1000);
             return buf.position();
         });
         when(mockChannel.size()).thenReturn(100000L);
@@ -649,14 +655,14 @@ class FileReaderTest {
         when(metrics.getFilesRotated()).thenReturn(filesRotated);
         when(metrics.getFilesClosed()).thenReturn(filesClosed);
         when(metrics.getFilesOpened()).thenReturn(mock(Counter.class));
-        lenient().when(metrics.getBytesRead()).thenReturn(bytesRead);
+        when(metrics.getBytesRead()).thenReturn(bytesRead);
         when(metrics.getDataLossEvents()).thenReturn(dataLossEvents);
 
         FileReaderContext context = new FileReaderContext(
                 buffer, eventFactory, fileOps, metrics, rotationDetector,
                 acknowledgementSetManager, false, StandardCharsets.UTF_8,
                 4096, 1048576, 5000, Duration.ofSeconds(30),
-                Duration.ofMillis(1), StartPosition.BEGINNING, false,
+                Duration.ofMillis(100), StartPosition.BEGINNING, false,
                 Duration.ofSeconds(30), 1000,
                 Duration.ofSeconds(5), 3, null, true, null);
 
@@ -668,7 +674,7 @@ class FileReaderTest {
 
         fileIdentity = mock(FileIdentity.class);
         final FileReader reader = new FileReader(testFile, fileIdentity, checkpointEntry, context,
-                () -> onCompleteCalled.set(true));
+                () -> onCompleteCalled.set(true), clock);
         reader.run();
 
         verify(dataLossEvents).increment();
@@ -682,14 +688,18 @@ class FileReaderTest {
         when(rotationDetector.checkRotation(any(), any(), any(long.class)))
                 .thenReturn(RotationResult.NO_ROTATION);
 
+        final AtomicLong fakeNowMillis = new AtomicLong(0);
+        final Clock clock = mock(Clock.class);
+        when(clock.millis()).thenAnswer(inv -> fakeNowMillis.get());
+
         FileChannel mockChannel = mock(FileChannel.class);
         when(fileOps.openReadChannel(testFile)).thenReturn(mockChannel);
         when(mockChannel.position(anyLong())).thenReturn(mockChannel);
         when(mockChannel.read(any(ByteBuffer.class))).thenAnswer(inv -> {
-            Thread.sleep(5);
             ByteBuffer buf = inv.getArgument(0);
             byte[] data = "A".repeat(buf.remaining()).getBytes();
             buf.put(data, 0, Math.min(data.length, buf.remaining()));
+            fakeNowMillis.set(1000);
             return buf.position();
         });
 
@@ -709,16 +719,18 @@ class FileReaderTest {
         FileReaderContext context = new FileReaderContext(
                 buffer, eventFactory, fileOps, metrics, rotationDetector,
                 acknowledgementSetManager, false, StandardCharsets.UTF_8,
-                4096, 1048576, 5000, Duration.ofMillis(1),
+                4096, 1048576, 5000, Duration.ofMillis(100),
                 Duration.ofSeconds(30), StartPosition.BEGINNING, false,
                 Duration.ofSeconds(30), 1000,
                 Duration.ofSeconds(5), 3, null, true, null);
 
         fileIdentity = mock(FileIdentity.class);
         final FileReader reader = new FileReader(testFile, fileIdentity, checkpointEntry, context,
-                () -> onCompleteCalled.set(true));
+                () -> onCompleteCalled.set(true), clock);
         reader.run();
 
+        verify(mockChannel, times(1)).read(any(ByteBuffer.class));
+        verify(bytesRead).increment(anyDouble());
         assertThat(onCompleteCalled.get(), equalTo(true));
     }
 
@@ -1251,14 +1263,18 @@ class FileReaderTest {
         when(rotationDetector.checkRotation(any(), any(), any(long.class)))
                 .thenReturn(new RotationResult(RotationType.CREATE_RENAME, newIdentity));
 
+        final AtomicLong fakeNowMillis = new AtomicLong(0);
+        final Clock clock = mock(Clock.class);
+        when(clock.millis()).thenAnswer(inv -> fakeNowMillis.get());
+
         FileChannel mockChannel = mock(FileChannel.class);
         when(fileOps.openReadChannel(testFile)).thenReturn(mockChannel);
         when(mockChannel.position(anyLong())).thenReturn(mockChannel);
         when(mockChannel.read(any(ByteBuffer.class))).thenAnswer(inv -> {
-            Thread.sleep(5);
             ByteBuffer buf = inv.getArgument(0);
             byte[] data = "A".repeat(buf.remaining()).getBytes();
             buf.put(data, 0, Math.min(data.length, buf.remaining()));
+            fakeNowMillis.set(1000);
             return buf.position();
         });
         when(mockChannel.size()).thenThrow(new IOException("channel closed"));
@@ -1277,7 +1293,7 @@ class FileReaderTest {
                 buffer, eventFactory, fileOps, metrics, rotationDetector,
                 acknowledgementSetManager, false, StandardCharsets.UTF_8,
                 4096, 1048576, 5000, Duration.ofSeconds(30),
-                Duration.ofMillis(1), StartPosition.BEGINNING, false,
+                Duration.ofMillis(100), StartPosition.BEGINNING, false,
                 Duration.ofSeconds(30), 1000,
                 Duration.ofSeconds(5), 3, null, true, null);
 
@@ -1289,8 +1305,11 @@ class FileReaderTest {
 
         fileIdentity = mock(FileIdentity.class);
         final FileReader reader = new FileReader(testFile, fileIdentity, checkpointEntry, context,
-                () -> onCompleteCalled.set(true));
+                () -> onCompleteCalled.set(true), clock);
         reader.run();
+
+        verify(mockChannel, times(1)).read(any(ByteBuffer.class));
+        verify(mockChannel).size();
     }
 
     @Test


### PR DESCRIPTION
### Description
The tests relied on wall-clock timing and background threads, so they passed locally but failed randomly on CI. I made them deterministic:
- Injected a java.time.Clock into FileReader so the read/drain timeout logic can be driven by a fake clock in tests instead of real time. Removed all Thread.sleep and tiny deadlines.
- Made the pool tests use a non-running executor so queueing and promotion counts are checked synchronously, not against a reader completing on a background thread.

No product behavior change; the default clock is still the system clock.
 
### Issues Resolved
Resolves #6984 
 
### Check List
- [ X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [ X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
