### PR TITLE
fix(sqs): Prevent sensitive data exposure in exception logging

### DIFF
--- a/data-prepper-plugins/sqs-common/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/common/SafeExceptionSummary.java
+++ b/data-prepper-plugins/sqs-common/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/common/SafeExceptionSummary.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.sqs.common;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkException;
+
+/**
+ * Extracts only safe, non-sensitive fields from exceptions for logging purposes.
+ * <p>
+ * This class uses an allowlist approach: only explicitly safe fields are included
+ * in the summary. This prevents accidental exposure of sensitive data such as
+ * SQS receipt handles, IAM credentials, AWS account IDs, or customer data that
+ * may appear in exception messages or stack traces.
+ * <p>
+ * Safe fields include: exception class name, AWS error code, HTTP status code,
+ * request ID, and whether the error is retryable.
+ */
+public final class SafeExceptionSummary {
+
+    private static final int MAX_CAUSE_DEPTH = 5;
+
+    private SafeExceptionSummary() {
+    }
+
+    /**
+     * Produces a safe, non-sensitive summary of the given exception.
+     *
+     * @param e the exception to summarize
+     * @return a string containing only safe metadata about the exception
+     */
+    public static String summarize(final Throwable e) {
+        if (e == null) {
+            return "null";
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append(e.getClass().getSimpleName());
+
+        if (e instanceof AwsServiceException) {
+            appendAwsServiceDetails(sb, (AwsServiceException) e);
+        } else if (e instanceof SdkException) {
+            appendSdkDetails(sb, (SdkException) e);
+        }
+
+        appendCauseChain(sb, e);
+        return sb.toString();
+    }
+
+    private static void appendAwsServiceDetails(final StringBuilder sb, final AwsServiceException e) {
+        sb.append(" [");
+        sb.append("statusCode=").append(e.statusCode());
+
+        if (e.awsErrorDetails() != null) {
+            if (e.awsErrorDetails().errorCode() != null) {
+                sb.append(", errorCode=").append(e.awsErrorDetails().errorCode());
+            }
+            if (e.awsErrorDetails().serviceName() != null) {
+                sb.append(", service=").append(e.awsErrorDetails().serviceName());
+            }
+        }
+
+        if (e.requestId() != null) {
+            sb.append(", requestId=").append(e.requestId());
+        }
+
+        sb.append(", retryable=").append(e.retryable());
+        sb.append("]");
+    }
+
+    private static void appendSdkDetails(final StringBuilder sb, final SdkException e) {
+        sb.append(" [retryable=").append(e.retryable()).append("]");
+    }
+
+    private static void appendCauseChain(final StringBuilder sb, final Throwable e) {
+        Throwable cause = e.getCause();
+        int depth = 0;
+        while (cause != null && depth < MAX_CAUSE_DEPTH) {
+            sb.append(" <- ").append(cause.getClass().getSimpleName());
+            if (cause instanceof AwsServiceException) {
+                final AwsServiceException awsCause = (AwsServiceException) cause;
+                if (awsCause.awsErrorDetails() != null && awsCause.awsErrorDetails().errorCode() != null) {
+                    sb.append("(").append(awsCause.awsErrorDetails().errorCode()).append(")");
+                }
+            }
+            cause = cause.getCause();
+            depth++;
+        }
+    }
+}

--- a/data-prepper-plugins/sqs-common/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/common/SqsWorkerCommon.java
+++ b/data-prepper-plugins/sqs-common/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/common/SqsWorkerCommon.java
@@ -104,7 +104,7 @@ public class SqsWorkerCommon {
             return messages;
         }
         catch (SqsException | StsException e) {
-            LOG.error("Error reading from SQS: {}. Retrying with exponential backoff.", e.getMessage());
+            LOG.error("Error reading from SQS: {}. Retrying with exponential backoff.", SafeExceptionSummary.summarize(e));
             recordSqsException(e);
             applyBackoff();
             return Collections.emptyList();
@@ -172,7 +172,7 @@ public class SqsWorkerCommon {
             }
         } catch (SdkException e) {
             sqsMessagesDeleteFailedCounter.increment(entries.size());
-            LOG.error("Failed to delete messages from SQS queue [{}]: {}", queueUrl, e.getMessage());
+            LOG.error("Failed to delete messages from SQS queue: {}", SafeExceptionSummary.summarize(e));
         }
     }
 
@@ -200,7 +200,7 @@ public class SqsWorkerCommon {
         catch (Exception e) {
             sqsVisibilityTimeoutChangeFailedCount.increment();
             LOG.error("Failed to set visibility timeout for message {} to {}. Reason: {}",
-                    messageIdForLogging, newVisibilityTimeoutSeconds, e.getMessage());
+                    messageIdForLogging, newVisibilityTimeoutSeconds, SafeExceptionSummary.summarize(e));
         }
     }
 

--- a/data-prepper-plugins/sqs-common/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/common/SafeExceptionSummaryTest.java
+++ b/data-prepper-plugins/sqs-common/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/common/SafeExceptionSummaryTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.sqs.common;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sqs.model.SqsException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+class SafeExceptionSummaryTest {
+
+    private static final String FAKE_RECEIPT_HANDLE = "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a+Tt7eyMpGd3QR1SSgp9myQ";
+    private static final String FAKE_ACCOUNT_ID = "123456789012";
+    private static final String FAKE_QUEUE_URL = "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue";
+    private static final String FAKE_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+    private static final String FAKE_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    private static final String FAKE_SESSION_TOKEN = "FwoGZXIvYXdzEBYaDHqa0AP6QEcco3u0iiLEAiEPgk7mO3Y7lg==";
+
+    @Test
+    void summarize_withNull_returnsNull() {
+        assertThat(SafeExceptionSummary.summarize(null), equalTo("null"));
+    }
+
+    @Test
+    void summarize_withPlainException_returnsClassName() {
+        final RuntimeException e = new RuntimeException("secret data: " + FAKE_RECEIPT_HANDLE);
+        final String summary = SafeExceptionSummary.summarize(e);
+
+        assertThat(summary, containsString("RuntimeException"));
+        assertThat("Receipt handle must not appear in summary", summary, not(containsString(FAKE_RECEIPT_HANDLE)));
+        assertThat("Exception message must not appear in summary", summary, not(containsString("secret data")));
+    }
+
+    @Test
+    void summarize_withAwsServiceException_includesSafeFieldsOnly() {
+        final SqsException e = (SqsException) SqsException.builder()
+                .message("User: arn:aws:iam::" + FAKE_ACCOUNT_ID + ":role/MyRole is not authorized, receiptHandle=" + FAKE_RECEIPT_HANDLE)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDenied")
+                        .serviceName("SQS")
+                        .build())
+                .statusCode(403)
+                .requestId("req-12345-abcde")
+                .build();
+
+        final String summary = SafeExceptionSummary.summarize(e);
+
+        // Safe fields are present
+        assertThat(summary, containsString("SqsException"));
+        assertThat(summary, containsString("statusCode=403"));
+        assertThat(summary, containsString("errorCode=AccessDenied"));
+        assertThat(summary, containsString("service=SQS"));
+        assertThat(summary, containsString("requestId=req-12345-abcde"));
+
+        // Sensitive data is NOT present
+        assertThat("Account ID must not appear", summary, not(containsString(FAKE_ACCOUNT_ID)));
+        assertThat("Receipt handle must not appear", summary, not(containsString(FAKE_RECEIPT_HANDLE)));
+        assertThat("ARN must not appear", summary, not(containsString("arn:aws:iam")));
+        assertThat("Raw message must not appear", summary, not(containsString("is not authorized")));
+    }
+
+    @Test
+    void summarize_withCredentialsInMessage_doesNotLeakCredentials() {
+        final RuntimeException e = new RuntimeException(
+                "Failed to sign request: accessKeyId=" + FAKE_ACCESS_KEY
+                        + ", secretAccessKey=" + FAKE_SECRET_KEY
+                        + ", sessionToken=" + FAKE_SESSION_TOKEN);
+
+        final String summary = SafeExceptionSummary.summarize(e);
+
+        assertThat("Access key must not appear", summary, not(containsString(FAKE_ACCESS_KEY)));
+        assertThat("Secret key must not appear", summary, not(containsString(FAKE_SECRET_KEY)));
+        assertThat("Session token must not appear", summary, not(containsString(FAKE_SESSION_TOKEN)));
+        assertThat("Only class name should appear", summary, containsString("RuntimeException"));
+    }
+
+    @Test
+    void summarize_withQueueUrlInMessage_doesNotLeakQueueUrl() {
+        final RuntimeException e = new RuntimeException(
+                "Failed to delete message from " + FAKE_QUEUE_URL + " with receiptHandle=" + FAKE_RECEIPT_HANDLE);
+
+        final String summary = SafeExceptionSummary.summarize(e);
+
+        assertThat("Queue URL must not appear", summary, not(containsString(FAKE_QUEUE_URL)));
+        assertThat("Account ID must not appear", summary, not(containsString(FAKE_ACCOUNT_ID)));
+        assertThat("Receipt handle must not appear", summary, not(containsString(FAKE_RECEIPT_HANDLE)));
+    }
+
+    @Test
+    void summarize_withNestedCause_includesCauseClassNameOnly() {
+        final RuntimeException innerCause = new RuntimeException(
+                "Credential expired: accessKeyId=" + FAKE_ACCESS_KEY);
+        final SdkClientException outerException = SdkClientException.builder()
+                .message("Unable to execute request: " + FAKE_QUEUE_URL)
+                .cause(innerCause)
+                .build();
+
+        final String summary = SafeExceptionSummary.summarize(outerException);
+
+        assertThat(summary, containsString("SdkClientException"));
+        assertThat(summary, containsString("RuntimeException"));
+        assertThat("Queue URL must not appear", summary, not(containsString(FAKE_QUEUE_URL)));
+        assertThat("Access key must not appear", summary, not(containsString(FAKE_ACCESS_KEY)));
+        assertThat("Cause message must not appear", summary, not(containsString("Credential expired")));
+    }
+
+    @Test
+    void summarize_withSdkClientException_includesRetryableFlag() {
+        final SdkClientException e = SdkClientException.builder()
+                .message("Connection timed out to " + FAKE_QUEUE_URL)
+                .build();
+
+        final String summary = SafeExceptionSummary.summarize(e);
+
+        assertThat(summary, containsString("SdkClientException"));
+        assertThat(summary, containsString("retryable="));
+        assertThat("Queue URL must not appear", summary, not(containsString(FAKE_QUEUE_URL)));
+    }
+
+    @Test
+    void summarize_withDeeplyCausedChain_limitsDepth() {
+        Throwable current = new RuntimeException("leaf: " + FAKE_SECRET_KEY);
+        for (int i = 0; i < 10; i++) {
+            current = new RuntimeException("level " + i + ": " + FAKE_ACCESS_KEY, current);
+        }
+
+        final String summary = SafeExceptionSummary.summarize(current);
+
+        assertThat("Secret key must not appear", summary, not(containsString(FAKE_SECRET_KEY)));
+        assertThat("Access key must not appear", summary, not(containsString(FAKE_ACCESS_KEY)));
+        // Should not overflow — limited to MAX_CAUSE_DEPTH
+        assertThat(summary, containsString("RuntimeException"));
+    }
+}

--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/RawSqsMessageHandler.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/RawSqsMessageHandler.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.source.sqs.common.SafeExceptionSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -51,7 +52,8 @@ public class RawSqsMessageHandler implements SqsMessageHandler {
             buffer.writeAll(records, bufferTimeoutMillis);
 
         } catch (Exception e) {
-            LOG.error("Error processing SQS message: {}", e.getMessage(), e);
+            LOG.error("Error processing SQS message: {}", SafeExceptionSummary.summarize(e));
+            LOG.debug("Full exception trace for SQS message processing failure:", e);
             throw new RuntimeException(e);
         }
     }

--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsWorker.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsWorker.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.plugins.source.sqs.common.OnErrorOption;
+import org.opensearch.dataprepper.plugins.source.sqs.common.SafeExceptionSummary;
 import org.opensearch.dataprepper.plugins.source.sqs.common.SqsWorkerCommon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +86,7 @@ public class SqsWorker implements Runnable {
             try {
                 messagesProcessed = processSqsMessages();
             } catch (final Exception e) {
-                LOG.error("Unable to process SQS messages. Processing error due to: {}", e.getMessage());
+                LOG.error("Unable to process SQS messages. Processing error due to: {}", SafeExceptionSummary.summarize(e));
                 sqsWorkerCommon.applyBackoff();
             }
 
@@ -201,7 +202,7 @@ public class SqsWorker implements Runnable {
             return Optional.of(sqsWorkerCommon.buildDeleteMessageBatchRequestEntry(message.messageId(), message.receiptHandle()));
         } catch (final Exception e) {
             sqsWorkerCommon.getSqsMessagesFailedCounter().increment();
-            LOG.error("Error processing from SQS: {}. Retrying with exponential backoff.", e.getMessage());
+            LOG.error("Error processing from SQS: {}. Retrying with exponential backoff.", SafeExceptionSummary.summarize(e));
             sqsWorkerCommon.applyBackoff();
             if (queueConfig.getOnErrorOption().equals(OnErrorOption.DELETE_MESSAGES)) {
                 return Optional.of(sqsWorkerCommon.buildDeleteMessageBatchRequestEntry(message.messageId(), message.receiptHandle()));


### PR DESCRIPTION
Replace e.getMessage() with SafeExceptionSummary that extracts only safe metadata (exception class, AWS error code, HTTP status, request ID, retryable flag). This prevents SQS receipt handles, IAM credentials, AWS account IDs, and customer data from being logged at ERROR level.

Changes:
- Add SafeExceptionSummary utility using allowlist approach
- Update all LOG.error calls in SqsWorkerCommon, SqsWorker, and RawSqsMessageHandler to use safe summaries
- Move full stack traces to DEBUG level only
- Add 8 unit tests verifying sensitive data is never in output

Fixes #6996

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
