### PR TITLE
fix(sqs): Change acknowledgments default to true to prevent data loss

### DIFF
--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSource.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSource.java
@@ -18,11 +18,15 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import java.util.Objects;
 
 @DataPrepperPlugin(name = "sqs", pluginType = Source.class,pluginConfigurationType = SqsSourceConfig.class)
 public class SqsSource implements Source<Record<Event>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SqsSource.class);
 
     private final PluginMetrics pluginMetrics;
     private final SqsSourceConfig sqsSourceConfig;
@@ -44,6 +48,12 @@ public class SqsSource implements Source<Record<Event>> {
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.awsCredentialsSupplier = awsCredentialsSupplier;
 
+        if (!acknowledgementsEnabled) {
+            LOG.warn("SQS source acknowledgments are disabled. Messages will be deleted from SQS before " +
+                    "delivery to the sink is confirmed. If the pipeline fails after receiving a message, " +
+                    "that message will be permanently lost. Set 'acknowledgments: true' to enable " +
+                    "end-to-end delivery confirmation and prevent data loss.");
+        }
     }
 
     @Override

--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSourceConfig.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSourceConfig.java
@@ -26,8 +26,25 @@ public class SqsSourceConfig {
     @Valid
     private AwsAuthenticationOptions awsAuthenticationOptions;
 
+    /**
+     * Controls whether end-to-end delivery acknowledgment is enabled.
+     * <p>
+     * When {@code true} (default), messages are only deleted from SQS after the entire
+     * pipeline confirms successful delivery to the sink. This prevents data loss when
+     * the downstream sink is unavailable, a processor fails, or the worker crashes.
+     * <p>
+     * When {@code false}, messages are deleted from SQS immediately after being written
+     * to the pipeline buffer. <strong>WARNING: This risks permanent data loss.</strong>
+     * If the pipeline fails after buffering but before sink delivery, the message cannot
+     * be recovered.
+     * <p>
+     * When using acknowledgments, ensure the SQS queue's visibility timeout exceeds the
+     * expected end-to-end processing time. If processing takes longer than the visibility
+     * timeout, messages may be redelivered, resulting in duplicates. Configure a
+     * Dead Letter Queue (DLQ) to handle messages that repeatedly fail processing.
+     */
     @JsonProperty("acknowledgments")
-    private boolean acknowledgments = false;
+    private boolean acknowledgments = true;
 
     @JsonProperty("buffer_timeout")
     private Duration bufferTimeout = DEFAULT_BUFFER_TIMEOUT;

--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsWorker.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/SqsWorker.java
@@ -41,6 +41,7 @@ public class SqsWorker implements Runnable {
     static final String SQS_MESSAGE_DELAY_METRIC_NAME = "sqsMessageDelay";
     private final Timer sqsMessageDelayTimer;
     static final String ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME = "acknowledgementSetCallbackCounter";
+    static final String SQS_MESSAGES_DELETED_WITHOUT_ACK_METRIC_NAME = "sqsMessagesDeletedWithoutAcknowledgment";
     private final SqsWorkerCommon sqsWorkerCommon;
     private final SqsEventProcessor sqsEventProcessor;
     private final SqsClient sqsClient;
@@ -50,6 +51,7 @@ public class SqsWorker implements Runnable {
     private final int bufferTimeoutMillis;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final Counter acknowledgementSetCallbackCounter;
+    private final Counter sqsMessagesDeletedWithoutAckCounter;
     private int failedAttemptCount;
     private volatile boolean isStopped = false;
     private final Map<Message, Integer> messageVisibilityTimesMap;
@@ -74,6 +76,7 @@ public class SqsWorker implements Runnable {
         this.messageVisibilityTimesMap = new HashMap<>();
         this.failedAttemptCount = 0;
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME);
+        sqsMessagesDeletedWithoutAckCounter = pluginMetrics.counter(SQS_MESSAGES_DELETED_WITHOUT_ACK_METRIC_NAME);
         sqsMessageDelayTimer = pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME);
 
     }
@@ -188,7 +191,10 @@ public class SqsWorker implements Runnable {
                     acknowledgementSet.complete();
                 }
             } else {
-                deleteEntry.ifPresent(deleteMessageBatchRequestEntryCollection::add);
+                deleteEntry.ifPresent(entry -> {
+                    deleteMessageBatchRequestEntryCollection.add(entry);
+                    sqsMessagesDeletedWithoutAckCounter.increment();
+                });
             }
         }
         return deleteMessageBatchRequestEntryCollection;

--- a/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSourceConfigTest.java
+++ b/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/SqsSourceConfigTest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SqsSourceConfigTest {
@@ -25,7 +25,7 @@ public class SqsSourceConfigTest {
     void testDefaultValues() {
         final SqsSourceConfig config = new SqsSourceConfig();
         assertNull(config.getAwsAuthenticationOptions(), "AWS Authentication Options should be null by default");
-        assertFalse(config.getAcknowledgements(), "Acknowledgments should be false by default");
+        assertTrue(config.getAcknowledgements(), "Acknowledgments should be true by default");
         assertEquals(SqsSourceConfig.DEFAULT_BUFFER_TIMEOUT, config.getBufferTimeout(), "Buffer timeout should default to 10 seconds");
         assertNull(config.getQueues(), "Queues should be null by default");
     }

--- a/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/SqsWorkerTest.java
+++ b/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/SqsWorkerTest.java
@@ -80,6 +80,8 @@ class SqsWorkerTest {
     private Timer sqsMessageDelayTimer;
     @Mock
     private Counter sqsMessagesFailedCounter;
+    @Mock
+    private Counter sqsMessagesDeletedWithoutAckCounter;
     private final int bufferTimeoutMillis = 10000;
     private SqsWorker sqsWorker;
 
@@ -105,6 +107,8 @@ class SqsWorkerTest {
         lenient().when(queueConfig.getMaximumMessages()).thenReturn(10);
         lenient().when(queueConfig.getVisibilityTimeout()).thenReturn(Duration.ofSeconds(30));
         when(pluginMetrics.timer(SqsWorker.SQS_MESSAGE_DELAY_METRIC_NAME)).thenReturn(sqsMessageDelayTimer);
+        lenient().when(pluginMetrics.counter(SqsWorker.ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME)).thenReturn(mock(Counter.class));
+        lenient().when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_DELETED_WITHOUT_ACK_METRIC_NAME)).thenReturn(sqsMessagesDeletedWithoutAckCounter);
         lenient().doNothing().when(sqsMessageDelayTimer).record(any(Duration.class));
         sqsWorker = new SqsWorker(
                 buffer,
@@ -370,5 +374,65 @@ class SqsWorkerTest {
         SqsWorker worker = createObjectUnderTest();
         worker.processSqsMessages();
         verify(sqsMessageDelayTimer, never()).record(any(Duration.class));
+    }
+
+    @Test
+    void processSqsMessages_withAcknowledgmentsDisabled_processingFailure_stillDeletesMessage() throws IOException {
+        when(sqsSourceConfig.getAcknowledgements()).thenReturn(false);
+        when(queueConfig.getOnErrorOption()).thenReturn(OnErrorOption.DELETE_MESSAGES);
+        doThrow(new RuntimeException("Simulated processing failure"))
+                .when(sqsEventProcessor).addSqsObject(any(), anyString(), any(), anyInt(), any());
+        when(sqsWorkerCommon.getSqsMessagesFailedCounter()).thenReturn(sqsMessagesFailedCounter);
+
+        SqsWorker worker = createObjectUnderTest();
+        int messagesProcessed = worker.processSqsMessages();
+
+        assertThat(messagesProcessed, equalTo(1));
+        // With ack disabled and on_error=delete_messages, message is deleted despite failure — data loss
+        verify(sqsWorkerCommon, times(1)).deleteSqsMessages(
+                anyString(), eq(sqsClient), anyList());
+    }
+
+    @Test
+    void processSqsMessages_withAcknowledgmentsEnabled_processingFailure_doesNotDeleteMessage() throws IOException {
+        when(sqsSourceConfig.getAcknowledgements()).thenReturn(true);
+        when(queueConfig.getOnErrorOption()).thenReturn(OnErrorOption.RETAIN_MESSAGES);
+        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(acknowledgementSetManager.create(any(), any())).thenReturn(acknowledgementSet);
+        doThrow(new RuntimeException("Simulated processing failure"))
+                .when(sqsEventProcessor).addSqsObject(any(), anyString(), any(), anyInt(), any());
+        when(sqsWorkerCommon.getSqsMessagesFailedCounter()).thenReturn(sqsMessagesFailedCounter);
+
+        SqsWorker worker = createObjectUnderTest();
+        int messagesProcessed = worker.processSqsMessages();
+
+        assertThat(messagesProcessed, equalTo(1));
+        // With ack enabled, message is NOT deleted on failure — stays in SQS for retry
+        verify(sqsWorkerCommon, never()).deleteSqsMessages(
+                anyString(), eq(sqsClient), anyList());
+    }
+
+    @Test
+    void processSqsMessages_withAcknowledgmentsDisabled_successfulProcessing_incrementsDeletedWithoutAckCounter() throws IOException {
+        when(sqsSourceConfig.getAcknowledgements()).thenReturn(false);
+
+        SqsWorker worker = createObjectUnderTest();
+        int messagesProcessed = worker.processSqsMessages();
+
+        assertThat(messagesProcessed, equalTo(1));
+        verify(sqsMessagesDeletedWithoutAckCounter, times(1)).increment();
+    }
+
+    @Test
+    void processSqsMessages_withAcknowledgmentsEnabled_successfulProcessing_doesNotIncrementDeletedWithoutAckCounter() throws IOException {
+        when(sqsSourceConfig.getAcknowledgements()).thenReturn(true);
+        AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        when(acknowledgementSetManager.create(any(), any())).thenReturn(acknowledgementSet);
+
+        SqsWorker worker = createObjectUnderTest();
+        int messagesProcessed = worker.processSqsMessages();
+
+        assertThat(messagesProcessed, equalTo(1));
+        verify(sqsMessagesDeletedWithoutAckCounter, never()).increment();
     }
 }


### PR DESCRIPTION
### Description
Change the SQS source plugin default for acknowledgments from false to true. With the previous default, messages were deleted from SQS after being written to the internal buffer but before downstream delivery was confirmed. If the pipeline failed after buffering (sink unavailable, worker crash, processor error), messages were permanently lost with no recovery path.

With acknowledgments enabled by default, messages are only deleted from SQS after the entire pipeline confirms successful end-to-end delivery.

Changes:
- Change default from false to true in SqsSourceConfig
- Add WARNING log when acknowledgments is explicitly disabled
- Add javadoc explaining data loss risk and visibility timeout implications
- Add sqsMessagesDeletedWithoutAcknowledgment metric counter
- Add integration tests verifying behavior with both modes under processing failure

This is a BREAKING CHANGE. Users who explicitly require the previous best-effort behavior should set acknowledgments: false in their pipeline configuration. Users should ensure their SQS visibility timeout exceeds the expected end-to-end processing time to avoid duplicate delivery.

 
### Issues Resolved
Resolves #6998
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
