### PR TITLE
Add configurable shard_discovery_interval to DynamoDB stream source

### DIFF
--- a/data-prepper-plugins/dynamodb-source/build.gradle
+++ b/data-prepper-plugins/dynamodb-source/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-ion
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-ion'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 
     implementation project(path: ':data-prepper-plugins:aws-plugin-api')
     implementation project(path: ':data-prepper-plugins:buffer-common')
@@ -27,6 +28,6 @@ dependencies {
 
 
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation project(':data-prepper-test:test-common')
-    testImplementation project(':data-prepper-pipeline-parser')
 }

--- a/data-prepper-plugins/dynamodb-source/build.gradle
+++ b/data-prepper-plugins/dynamodb-source/build.gradle
@@ -28,4 +28,5 @@ dependencies {
 
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-test:test-common')
+    testImplementation project(':data-prepper-pipeline-parser')
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -102,11 +103,10 @@ public class DynamoDBService {
         final StreamConfig streamConfig = dynamoDBSourceConfig.getTableConfigs().get(0).getStreamConfig();
         ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
         Runnable streamScheduler = new StreamScheduler(coordinator, consumerFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig, new BackoffCalculator(dynamoDBSourceConfig.getTableConfigs().get(0).getExportConfig() != null));
-        // leader scheduler will handle the initialization. The shard discovery interval is only relevant when
-        // streaming; export-only tables (no stream config) fall back to the default interval.
-        Runnable leaderScheduler = streamConfig == null
-                ? new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs)
-                : new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs, streamConfig.getShardDiscoveryInterval());
+        final Duration leaseInterval = streamConfig == null
+                ? StreamConfig.DEFAULT_SHARD_DISCOVERY_INTERVAL
+                : streamConfig.getShardDiscoveryInterval();
+        Runnable leaderScheduler = new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs, leaseInterval);
 
         // May consider start or shutdown the scheduler on demand
         // Currently, event after the exports are done, the related scheduler will not be shutdown

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileLoaderFactory;
 import org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileScheduler;
@@ -98,10 +99,14 @@ public class DynamoDBService {
         DataFileLoaderFactory loaderFactory = new DataFileLoaderFactory(coordinator, s3Client, pluginMetrics, buffer);
         Runnable fileLoaderScheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
 
-        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, dynamoDBSourceConfig.getTableConfigs().get(0).getStreamConfig());
+        final StreamConfig streamConfig = dynamoDBSourceConfig.getTableConfigs().get(0).getStreamConfig();
+        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
         Runnable streamScheduler = new StreamScheduler(coordinator, consumerFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig, new BackoffCalculator(dynamoDBSourceConfig.getTableConfigs().get(0).getExportConfig() != null));
-        // leader scheduler will handle the initialization
-        Runnable leaderScheduler = new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs);
+        // leader scheduler will handle the initialization. The shard discovery interval is only relevant when
+        // streaming; export-only tables (no stream config) fall back to the default interval.
+        Runnable leaderScheduler = streamConfig == null
+                ? new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs)
+                : new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs, streamConfig.getShardDiscoveryInterval());
 
         // May consider start or shutdown the scheduler on demand
         // Currently, event after the exports are done, the related scheduler will not be shutdown

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -20,7 +20,7 @@ public class StreamConfig {
      * discovered and leased. Lowering it reduces shard-rotation read latency at the cost of more
      * frequent DescribeStream/ListShards calls against DynamoDB Streams.
      */
-    static final Duration DEFAULT_SHARD_DISCOVERY_INTERVAL = Duration.ofMinutes(1);
+    public static final Duration DEFAULT_SHARD_DISCOVERY_INTERVAL = Duration.ofMinutes(1);
 
     @JsonProperty(value = "start_position")
     private StreamStartPosition startPosition = StreamStartPosition.LATEST;

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -6,7 +6,8 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.time.DurationMin;
 import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
 import java.time.Duration;
@@ -21,12 +22,6 @@ public class StreamConfig {
      */
     static final Duration DEFAULT_SHARD_DISCOVERY_INTERVAL = Duration.ofMinutes(1);
 
-    /**
-     * Lower bound on the configurable shard discovery interval. Prevents pathologically small
-     * values that would busy-loop the leader and hammer DynamoDB Streams with DescribeStream/ListShards.
-     */
-    private static final Duration MINIMUM_SHARD_DISCOVERY_INTERVAL = Duration.ofSeconds(1);
-
     @JsonProperty(value = "start_position")
     private StreamStartPosition startPosition = StreamStartPosition.LATEST;
 
@@ -37,6 +32,8 @@ public class StreamConfig {
     private boolean disableCheckpointing = false;
 
     @JsonProperty("shard_discovery_interval")
+    @NotNull
+    @DurationMin(seconds = 1, message = "shard_discovery_interval must be at least 1 second.")
     private Duration shardDiscoveryInterval = DEFAULT_SHARD_DISCOVERY_INTERVAL;
 
     public StreamStartPosition getStartPosition() {
@@ -51,11 +48,6 @@ public class StreamConfig {
 
     public Duration getShardDiscoveryInterval() {
         return shardDiscoveryInterval;
-    }
-
-    @AssertTrue(message = "shard_discovery_interval must be at least 1 second.")
-    boolean isShardDiscoveryIntervalValid() {
-        return shardDiscoveryInterval != null && shardDiscoveryInterval.compareTo(MINIMUM_SHARD_DISCOVERY_INTERVAL) >= 0;
     }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -6,10 +6,27 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
+import java.time.Duration;
+
 public class StreamConfig {
-    
+
+    /**
+     * Default interval at which the leader node runs shard discovery. DynamoDB Streams shards
+     * roll over continuously, so this interval bounds how quickly newly opened child shards are
+     * discovered and leased. Lowering it reduces shard-rotation read latency at the cost of more
+     * frequent DescribeStream/ListShards calls against DynamoDB Streams.
+     */
+    static final Duration DEFAULT_SHARD_DISCOVERY_INTERVAL = Duration.ofMinutes(1);
+
+    /**
+     * Lower bound on the configurable shard discovery interval. Prevents pathologically small
+     * values that would busy-loop the leader and hammer DynamoDB Streams with DescribeStream/ListShards.
+     */
+    private static final Duration MINIMUM_SHARD_DISCOVERY_INTERVAL = Duration.ofSeconds(1);
+
     @JsonProperty(value = "start_position")
     private StreamStartPosition startPosition = StreamStartPosition.LATEST;
 
@@ -18,6 +35,9 @@ public class StreamConfig {
 
     @JsonProperty("disable_checkpointing")
     private boolean disableCheckpointing = false;
+
+    @JsonProperty("shard_discovery_interval")
+    private Duration shardDiscoveryInterval = DEFAULT_SHARD_DISCOVERY_INTERVAL;
 
     public StreamStartPosition getStartPosition() {
         return startPosition;
@@ -28,5 +48,14 @@ public class StreamConfig {
     }
 
     public boolean isDisableCheckpointing() { return disableCheckpointing; }
+
+    public Duration getShardDiscoveryInterval() {
+        return shardDiscoveryInterval;
+    }
+
+    @AssertTrue(message = "shard_discovery_interval must be at least 1 second.")
+    boolean isShardDiscoveryIntervalValid() {
+        return shardDiscoveryInterval != null && shardDiscoveryInterval.compareTo(MINIMUM_SHARD_DISCOVERY_INTERVAL) >= 0;
+    }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
@@ -62,7 +62,7 @@ public class LeaderScheduler implements Runnable {
         this(coordinator, dynamoDbClient, shardManager, tableConfigs, DEFAULT_LEASE_INTERVAL);
     }
 
-    LeaderScheduler(EnhancedSourceCoordinator coordinator,
+    public LeaderScheduler(EnhancedSourceCoordinator coordinator,
                     DynamoDbClient dynamoDbClient,
                     ShardManager shardManager,
                     List<TableConfig> tableConfigs,

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
@@ -20,10 +20,13 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
+import org.opensearch.dataprepper.plugins.source.dynamodb.leader.LeaderScheduler;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -113,6 +116,28 @@ class DynamoDBServiceTest {
 
         assertThat(runnableArgumentCaptor.getAllValues(), notNullValue());
         assertThat(runnableArgumentCaptor.getAllValues().size(), equalTo(4));
+    }
+
+    @Test
+    void test_leader_scheduler_receives_configured_shard_discovery_interval() throws NoSuchFieldException, IllegalAccessException {
+        final Duration configuredInterval = Duration.ofSeconds(20);
+        when(tableConfig.getStreamConfig()).thenReturn(streamConfig);
+        when(streamConfig.getShardDiscoveryInterval()).thenReturn(configuredInterval);
+        dynamoDBService = createObjectUnderTest();
+
+        final ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        dynamoDBService.start(buffer);
+        verify(executorService, times(4)).submit(runnableArgumentCaptor.capture());
+
+        final LeaderScheduler leaderScheduler = runnableArgumentCaptor.getAllValues().stream()
+                .filter(runnable -> runnable instanceof LeaderScheduler)
+                .map(runnable -> (LeaderScheduler) runnable)
+                .findFirst()
+                .orElseThrow();
+
+        final Field leaseIntervalField = LeaderScheduler.class.getDeclaredField("leaseInterval");
+        leaseIntervalField.setAccessible(true);
+        assertThat(leaseIntervalField.get(leaderScheduler), equalTo(configuredInterval));
     }
 
     @Test

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfigTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.pipeline.parser.DataPrepperDurationDeserializer;
+import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
+import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
+
+import java.time.Duration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class StreamConfigTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory())
+            .registerModule(new SimpleModule().addDeserializer(Duration.class, new DataPrepperDurationDeserializer()));
+
+    @Test
+    void test_defaults() throws JsonProcessingException {
+        final StreamConfig streamConfig = objectMapper.readValue("{}", StreamConfig.class);
+
+        assertThat(streamConfig.getStartPosition(), equalTo(StreamStartPosition.LATEST));
+        assertThat(streamConfig.getStreamViewForRemoves(), equalTo(StreamViewType.NEW_IMAGE));
+        assertThat(streamConfig.isDisableCheckpointing(), equalTo(false));
+        assertThat(streamConfig.getShardDiscoveryInterval(), equalTo(Duration.ofMinutes(1)));
+        assertThat(streamConfig.getShardDiscoveryInterval(), equalTo(StreamConfig.DEFAULT_SHARD_DISCOVERY_INTERVAL));
+    }
+
+    @Test
+    void test_shard_discovery_interval_is_configurable() throws JsonProcessingException {
+        final String yaml = "shard_discovery_interval: 15s";
+        final StreamConfig streamConfig = objectMapper.readValue(yaml, StreamConfig.class);
+
+        assertThat(streamConfig.getShardDiscoveryInterval(), equalTo(Duration.ofSeconds(15)));
+    }
+
+    @Test
+    void test_shard_discovery_interval_accepts_iso8601() throws JsonProcessingException {
+        final String yaml = "shard_discovery_interval: PT5M";
+        final StreamConfig streamConfig = objectMapper.readValue(yaml, StreamConfig.class);
+
+        assertThat(streamConfig.getShardDiscoveryInterval(), equalTo(Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void test_shard_discovery_interval_validation_accepts_default() {
+        final StreamConfig streamConfig = new StreamConfig();
+        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(true));
+    }
+
+    @Test
+    void test_shard_discovery_interval_validation_accepts_minimum() throws NoSuchFieldException, IllegalAccessException {
+        final StreamConfig streamConfig = new StreamConfig();
+        ReflectivelySetField.setField(StreamConfig.class, streamConfig, "shardDiscoveryInterval", Duration.ofSeconds(1));
+        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(true));
+    }
+
+    @Test
+    void test_shard_discovery_interval_validation_rejects_below_minimum() throws NoSuchFieldException, IllegalAccessException {
+        final StreamConfig streamConfig = new StreamConfig();
+        ReflectivelySetField.setField(StreamConfig.class, streamConfig, "shardDiscoveryInterval", Duration.ofMillis(500));
+        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(false));
+    }
+
+    @Test
+    void test_shard_discovery_interval_validation_rejects_null() throws NoSuchFieldException, IllegalAccessException {
+        final StreamConfig streamConfig = new StreamConfig();
+        ReflectivelySetField.setField(StreamConfig.class, streamConfig, "shardDiscoveryInterval", null);
+        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfigTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfigTest.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfigTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfigTest.java
@@ -7,22 +7,39 @@ package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opensearch.dataprepper.pipeline.parser.DataPrepperDurationDeserializer;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
 import java.time.Duration;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 class StreamConfigTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory())
-            .registerModule(new SimpleModule().addDeserializer(Duration.class, new DataPrepperDurationDeserializer()));
+    private ObjectMapper objectMapper;
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule());
+        validator = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory()
+                .getValidator();
+    }
 
     @Test
     void test_defaults() throws JsonProcessingException {
@@ -37,14 +54,14 @@ class StreamConfigTest {
 
     @Test
     void test_shard_discovery_interval_is_configurable() throws JsonProcessingException {
-        final String yaml = "shard_discovery_interval: 15s";
+        final String yaml = "shard_discovery_interval: PT15S";
         final StreamConfig streamConfig = objectMapper.readValue(yaml, StreamConfig.class);
 
         assertThat(streamConfig.getShardDiscoveryInterval(), equalTo(Duration.ofSeconds(15)));
     }
 
     @Test
-    void test_shard_discovery_interval_accepts_iso8601() throws JsonProcessingException {
+    void test_shard_discovery_interval_accepts_iso8601_minutes() throws JsonProcessingException {
         final String yaml = "shard_discovery_interval: PT5M";
         final StreamConfig streamConfig = objectMapper.readValue(yaml, StreamConfig.class);
 
@@ -52,29 +69,37 @@ class StreamConfigTest {
     }
 
     @Test
-    void test_shard_discovery_interval_validation_accepts_default() {
+    void test_validation_passes_with_default_value() {
         final StreamConfig streamConfig = new StreamConfig();
-        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(true));
+        final Set<ConstraintViolation<StreamConfig>> violations = validator.validate(streamConfig);
+
+        assertThat(violations, hasSize(0));
     }
 
     @Test
-    void test_shard_discovery_interval_validation_accepts_minimum() throws NoSuchFieldException, IllegalAccessException {
+    void test_validation_passes_at_minimum_boundary() throws NoSuchFieldException, IllegalAccessException {
         final StreamConfig streamConfig = new StreamConfig();
         ReflectivelySetField.setField(StreamConfig.class, streamConfig, "shardDiscoveryInterval", Duration.ofSeconds(1));
-        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(true));
+        final Set<ConstraintViolation<StreamConfig>> violations = validator.validate(streamConfig);
+
+        assertThat(violations, hasSize(0));
     }
 
     @Test
-    void test_shard_discovery_interval_validation_rejects_below_minimum() throws NoSuchFieldException, IllegalAccessException {
+    void test_validation_fails_below_minimum() throws NoSuchFieldException, IllegalAccessException {
         final StreamConfig streamConfig = new StreamConfig();
         ReflectivelySetField.setField(StreamConfig.class, streamConfig, "shardDiscoveryInterval", Duration.ofMillis(500));
-        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(false));
+        final Set<ConstraintViolation<StreamConfig>> violations = validator.validate(streamConfig);
+
+        assertThat(violations, hasSize(1));
     }
 
     @Test
-    void test_shard_discovery_interval_validation_rejects_null() throws NoSuchFieldException, IllegalAccessException {
+    void test_validation_fails_when_null() throws NoSuchFieldException, IllegalAccessException {
         final StreamConfig streamConfig = new StreamConfig();
         ReflectivelySetField.setField(StreamConfig.class, streamConfig, "shardDiscoveryInterval", null);
-        assertThat(streamConfig.isShardDiscoveryIntervalValid(), equalTo(false));
+        final Set<ConstraintViolation<StreamConfig>> violations = validator.validate(streamConfig);
+
+        assertThat(violations, hasSize(1));
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderSchedulerTest.java
@@ -334,6 +334,26 @@ class LeaderSchedulerTest {
     }
 
     @Test
+    void test_custom_lease_interval_controls_discovery_cadence() {
+        // A short interval should drive multiple shard-discovery passes in a small window,
+        // demonstrating that the configurable interval controls the leader loop cadence.
+        final Duration leaseInterval = Duration.ofMillis(100);
+        leaderScheduler = new LeaderScheduler(coordinator, dynamoDbClient, shardManager, List.of(tableConfig), leaseInterval);
+        leaderPartition = new LeaderPartition();
+        leaderPartition.getProgressState().get().setInitialized(true);
+        leaderPartition.getProgressState().get().setStreamArns(List.of(streamArn));
+        given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> leaderScheduler.run());
+
+        await().atMost(leaseInterval.multipliedBy(20))
+                .untilAsserted(() -> verify(coordinator, atLeast(3))
+                        .queryCompletedPartitions(eq(StreamPartition.PARTITION_TYPE), any(Instant.class)));
+        executorService.shutdownNow();
+    }
+
+    @Test
     void test_shardDiscovery_with_failure_to_save_partition_state_reacquires_partition() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
         leaderScheduler = new LeaderScheduler(coordinator, dynamoDbClient, shardManager, List.of(tableConfig));
         leaderPartition = new LeaderPartition();


### PR DESCRIPTION
### Description
The DynamoDB stream source's `LeaderScheduler` ran shard discovery on a hardcoded 1-minute interval. Because DynamoDB Streams shards roll over continuously, a newly opened child shard is not read until the next discovery pass — putting a ~1-minute floor on shard-rotation latency, which surfaces as high `EndToEndLatency` while `PipelineLatency` stays low.

This adds an optional `shard_discovery_interval` on the stream config, defaulting to 1 minute (no behavior change unless set). A 1-second minimum is enforced to avoid excessive `DescribeStream`/`ListShards` calls.

```yaml
stream:
  start_position: LATEST
  shard_discovery_interval: 15s   # default: 1m
```

### Issues Resolved
Resolves #7000

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
