### PR TITLE
Add SQS source URL format validation and require External ID when role ARN is configured

### DIFF
--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/AwsAuthenticationOptions.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/AwsAuthenticationOptions.java
@@ -11,6 +11,7 @@
  package org.opensearch.dataprepper.plugins.source.sqs;
 
  import com.fasterxml.jackson.annotation.JsonProperty;
+ import jakarta.validation.constraints.AssertTrue;
  import jakarta.validation.constraints.Size;
  import software.amazon.awssdk.arns.Arn;
  import software.amazon.awssdk.regions.Region;
@@ -70,5 +71,14 @@
 
      public Map<String, String> getAwsStsHeaderOverrides() {
          return awsStsHeaderOverrides;
+     }
+
+     @AssertTrue(message = "sts_external_id is required when sts_role_arn is specified to prevent confused deputy attacks. " +
+             "See https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html")
+     public boolean isExternalIdProvidedWhenRoleArnSet() {
+         if (awsStsRoleArn == null) {
+             return true;
+         }
+         return awsStsExternalId != null && !awsStsExternalId.isBlank();
      }
  }

--- a/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/QueueConfig.java
+++ b/data-prepper-plugins/sqs-source/src/main/java/org/opensearch/dataprepper/plugins/source/sqs/QueueConfig.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.time.Duration;
 import org.opensearch.dataprepper.model.annotations.UsesDataPrepperPlugin;
 import org.opensearch.dataprepper.model.codec.InputCodec;
@@ -34,6 +35,8 @@ public class QueueConfig {
 
     @JsonProperty("url")
     @NotNull
+    @Pattern(regexp = "^https://sqs\\.[a-z0-9-]+\\.amazonaws\\.com(\\.cn)?/\\d{12}/[a-zA-Z0-9_-]+$",
+            message = "url must be a valid Amazon SQS queue URL: https://sqs.<region>.amazonaws.com/<12-digit-account-id>/<queue-name>")
     private String url;
 
     @JsonProperty("workers") 

--- a/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/AwsAuthenticationOptionsTest.java
+++ b/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/AwsAuthenticationOptionsTest.java
@@ -138,4 +138,31 @@ class AwsAuthenticationOptionsTest {
             field.setAccessible(false);
         }
     }
+
+    @Test
+    void isExternalIdProvidedWhenRoleArnSet_returns_true_when_no_role_arn() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", null);
+        assertThat(awsAuthenticationOptions.isExternalIdProvidedWhenRoleArnSet(), equalTo(true));
+    }
+
+    @Test
+    void isExternalIdProvidedWhenRoleArnSet_returns_true_when_role_arn_and_external_id_present() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:role/SampleRole");
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", "my-external-id");
+        assertThat(awsAuthenticationOptions.isExternalIdProvidedWhenRoleArnSet(), equalTo(true));
+    }
+
+    @Test
+    void isExternalIdProvidedWhenRoleArnSet_returns_false_when_role_arn_set_but_external_id_null() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:role/SampleRole");
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", null);
+        assertThat(awsAuthenticationOptions.isExternalIdProvidedWhenRoleArnSet(), equalTo(false));
+    }
+
+    @Test
+    void isExternalIdProvidedWhenRoleArnSet_returns_false_when_role_arn_set_but_external_id_blank() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:role/SampleRole");
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", "   ");
+        assertThat(awsAuthenticationOptions.isExternalIdProvidedWhenRoleArnSet(), equalTo(false));
+    }
 }

--- a/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/QueueConfigTest.java
+++ b/data-prepper-plugins/sqs-source/src/test/java/org/opensearch/dataprepper/plugins/source/sqs/QueueConfigTest.java
@@ -11,13 +11,20 @@
 package org.opensearch.dataprepper.plugins.source.sqs;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import java.time.Duration;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QueueConfigTest {
+
+    private static final Pattern SQS_URL_PATTERN = Pattern.compile(
+            "^https://sqs\\.[a-z0-9-]+\\.amazonaws\\.com(\\.cn)?/\\d{12}/[a-zA-Z0-9_-]+$");
 
     @Test
     void testDefaultValues() {
@@ -33,5 +40,31 @@ public class QueueConfigTest {
         assertEquals(Duration.ofHours(2), queueConfig.getVisibilityDuplicateProtectionTimeout(),
                 "Visibility duplicate protection timeout should default to 2 hours");
         assertNull(queueConfig.getWaitTime(), "Wait time should default to null");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue",
+            "https://sqs.eu-west-1.amazonaws.com/987654321098/my-queue-name",
+            "https://sqs.ap-southeast-1.amazonaws.com/111222333444/Queue_With_Underscores",
+            "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/ChinaQueue"
+    })
+    void valid_sqs_url_matches_pattern(final String validUrl) {
+        assertTrue(SQS_URL_PATTERN.matcher(validUrl).matches(),
+                "Expected valid SQS URL to match pattern: " + validUrl);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+            "http://sqs.us-east-1.amazonaws.com/123456789012/MyQueue",
+            "https://evil.com/sqs.us-east-1.amazonaws.com/123456789012/MyQueue",
+            "https://sqs.us-east-1.amazonaws.com/12345/MyQueue",
+            "https://s3.us-east-1.amazonaws.com/mybucket/mykey",
+            "ftp://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+    })
+    void invalid_sqs_url_does_not_match_pattern(final String invalidUrl) {
+        assertFalse(SQS_URL_PATTERN.matcher(invalidUrl).matches(),
+                "Expected invalid SQS URL to not match pattern: " + invalidUrl);
     }
 }


### PR DESCRIPTION
### Description

Add input validation to the SQS source plugin to address two security concerns:

1. **URL format validation (`QueueConfig`):** Add `@Pattern` annotation to the `url` field to enforce that queue URLs match the canonical SQS endpoint format (`https://sqs.<region>.amazonaws.com/<12-digit-account-id>/<queue-name>`). This prevents arbitrary URLs from being submitted as queue configurations, mitigating potential Server-Side Request Forgery (SSRF) vectors.

2. **External ID requirement (`AwsAuthenticationOptions`):** Add `@AssertTrue` validation that requires `sts_external_id` to be present and non-blank when `sts_role_arn` is configured. This mitigates the confused deputy problem where a pipeline could be configured to assume another account's IAM role without proper authorization.

Both validations include corresponding unit tests.

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).