### PR TITLE
fix(s3): parse notifications with generated bucket tags

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3EventNotification.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3EventNotification.java
@@ -55,6 +55,7 @@ public class S3EventNotification {
     }
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class S3BucketEntity {
 
     private final String name;

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/S3EventNotificationParserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.model.Message;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -23,7 +22,7 @@ public class S3EventNotificationParserTest {
                     "\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:xyz\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
                     "\"responseElements\":{\"x-amz-request-id\":\"xyz\",\"x-amz-id-2\":\"xyz\"},\"s3\":{\"s3SchemaVersion\":\"1.0\"," +
                     "\"configurationId\":\"xyz\",\"bucket\":{\"name\":\"my-bucket\",\"ownerIdentity\":{\"principalId\":\"ABC\"}," +
-                    "\"arn\":\"arn:aws:s3:::my-bucket\", \"unknownField\":\"test\"},\"object\":{\"key\":\"path/to/myfile.log.gz\",\"size\":3159112,\"eTag\":\"abcd123\"," +
+                    "\"arn\":\"arn:aws:s3:::my-bucket\",\"awsGeneratedTags\":[\"tag1\"]},\"object\":{\"key\":\"path/to/myfile.log.gz\",\"size\":3159112,\"eTag\":\"abcd123\"," +
                     "\"sequencer\":\"000\",\"hasObjectAnnotation\":false}}}]}";
 
     public static final String SNS_BASED_MESSAGE = "{\n" +
@@ -39,7 +38,7 @@ public class S3EventNotificationParserTest {
             "  \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:notifications:abc\"\n" +
             "}";
 
-    private final ObjectMapper objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private Message message;
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
# fix(s3): parse notifications with generated bucket tags

### Description

Ignore unrecognized properties on S3 bucket notification entities so SQS-delivered S3 events containing `awsGeneratedTags` are parsed successfully.

### Issues Resolved

Fixes #7005

### Testing

- Attempted: `sandbox-run './gradlew :data-prepper-plugins:s3-source:test --tests "org.opensearch.dataprepper.plugins.source.s3.parser.S3EventNotificationParserTest"'`
- The sandbox could not run Gradle because no Java runtime was installed or configured (`JAVA_HOME is not set and no 'java' command could be found in your PATH`).
- Verified the final diff with `git diff --check`.

### Check List

- [x] Bug fix includes a regression test using an S3 notification with `awsGeneratedTags`.
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

### AI disclosure

This pull request was created through autonomous AI-agent work. @Dodothereal operates, monitors, and is accountable for this work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
