### PR TITLE
Add azure_federated authentication to Kafka source

### DIFF
--- a/data-prepper-plugins/kafka-plugins/README.md
+++ b/data-prepper-plugins/kafka-plugins/README.md
@@ -6,6 +6,8 @@ This source allows Data Prepper to use Kafka as source. This source reads record
 
 For usage and configuration, please refer to the documentation [here] (https://opensearch.org/docs/2.9/data-prepper/pipelines/configuration/sources/sources/kafka-source).
 
+The `azure_federated` SASL/OAUTHBEARER mechanism additionally lets the Kafka source consume from an Azure
+Event Hubs Kafka endpoint using AWS to Azure Entra workload-identity federation, with no stored secret.
 
 ## Developer guide
 

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -144,14 +144,6 @@ task integrationTest(type: Test) {
     systemProperty 'tests.kafka.authconfig.password', System.getProperty('tests.kafka.authconfig.password')
     systemProperty 'tests.kafka.authconfig.mechanism', System.getProperty('tests.kafka.authconfig.mechanism')
     systemProperty 'tests.kafka.kms_key', System.getProperty('tests.kafka.kms_key')
-    systemProperty 'tests.azure.eventhubs.bootstrap_servers', System.getProperty('tests.azure.eventhubs.bootstrap_servers')
-    systemProperty 'tests.azure.eventhubs.topic', System.getProperty('tests.azure.eventhubs.topic')
-    systemProperty 'tests.azure.tenant_id', System.getProperty('tests.azure.tenant_id')
-    systemProperty 'tests.azure.client_id', System.getProperty('tests.azure.client_id')
-    systemProperty 'tests.azure.token_endpoint', System.getProperty('tests.azure.token_endpoint')
-    systemProperty 'tests.azure.scope', System.getProperty('tests.azure.scope')
-    systemProperty 'tests.aws.sts_role_arn', System.getProperty('tests.aws.sts_role_arn')
-    systemProperty 'tests.aws.region', System.getProperty('tests.aws.region')
 
     filter {
         includeTestsMatching '*IT'

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation 'org.yaml:snakeyaml:2.2'
     testImplementation testLibs.spring.test
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    testImplementation 'org.hibernate.validator:hibernate-validator:8.0.2.Final'
     testImplementation project(':data-prepper-test:test-common')
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation project(':data-prepper-core')
@@ -143,6 +144,14 @@ task integrationTest(type: Test) {
     systemProperty 'tests.kafka.authconfig.password', System.getProperty('tests.kafka.authconfig.password')
     systemProperty 'tests.kafka.authconfig.mechanism', System.getProperty('tests.kafka.authconfig.mechanism')
     systemProperty 'tests.kafka.kms_key', System.getProperty('tests.kafka.kms_key')
+    systemProperty 'tests.azure.eventhubs.bootstrap_servers', System.getProperty('tests.azure.eventhubs.bootstrap_servers')
+    systemProperty 'tests.azure.eventhubs.topic', System.getProperty('tests.azure.eventhubs.topic')
+    systemProperty 'tests.azure.tenant_id', System.getProperty('tests.azure.tenant_id')
+    systemProperty 'tests.azure.client_id', System.getProperty('tests.azure.client_id')
+    systemProperty 'tests.azure.token_endpoint', System.getProperty('tests.azure.token_endpoint')
+    systemProperty 'tests.azure.scope', System.getProperty('tests.azure.scope')
+    systemProperty 'tests.aws.sts_role_arn', System.getProperty('tests.aws.sts_role_arn')
+    systemProperty 'tests.aws.region', System.getProperty('tests.aws.region')
 
     filter {
         includeTestsMatching '*IT'

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/admin/KafkaAdminAccessor.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/admin/KafkaAdminAccessor.java
@@ -31,7 +31,8 @@ public class KafkaAdminAccessor {
 
     public KafkaAdminAccessor(final KafkaClusterAuthConfig kafkaClusterAuthConfig, final List<String> consumerGroupIds) {
         Properties authProperties = new Properties();
-        KafkaSecurityConfigurer.setAuthProperties(authProperties, kafkaClusterAuthConfig, LOG);
+        // no AwsCredentialsSupplier on the admin path
+        KafkaSecurityConfigurer.setAuthProperties(authProperties, kafkaClusterAuthConfig, null, LOG);
         this.kafkaAdminClient = KafkaAdminClient.create(authProperties);
         this.topicEmptinessMetadata = new TopicEmptinessMetadata();
         this.consumerGroupIds = consumerGroupIds;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AwsCredentialsSupplierProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AwsCredentialsSupplierProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+
+public class AwsCredentialsSupplierProvider {
+    private static final AwsCredentialsSupplierProvider singleton = new AwsCredentialsSupplierProvider();
+
+    public static AwsCredentialsSupplierProvider getInstance() {
+        return singleton;
+    }
+
+    // set once before Kafka client construction; volatile suffices for cross-thread visibility
+    private volatile AwsCredentialsSupplier awsCredentialsSupplier;
+
+    // Used for testing only
+    protected AwsCredentialsSupplierProvider() {}
+
+    public AwsCredentialsSupplier getAwsCredentialsSupplier() {
+        return awsCredentialsSupplier;
+    }
+
+    public void set(final AwsCredentialsSupplier awsCredentialsSupplier) {
+        this.awsCredentialsSupplier = awsCredentialsSupplier;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandler.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AzureFederatedCallbackHandler implements AuthenticateCallbackHandler {
+    static final String OPT_REGION = "azureFederatedRegion";
+    static final String OPT_STS_ROLE_ARN = "azureFederatedStsRoleArn";
+    static final String OPT_TOKEN_ENDPOINT = "azureFederatedTokenEndpoint";
+    static final String OPT_CLIENT_ID = "azureFederatedClientId";
+    static final String OPT_SCOPE = "azureFederatedScope";
+    static final String OPT_STS_HEADER_OVERRIDES = "azureFederatedStsHeaderOverrides";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private AzureFederatedTokenProvider tokenProvider;
+
+    public AzureFederatedCallbackHandler() {
+    }
+
+    AzureFederatedCallbackHandler(final AzureFederatedTokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void configure(final Map<String, ?> configs, final String saslMechanism,
+                          final List<AppConfigurationEntry> jaasConfigEntries) {
+        if (!OAuthBearerLoginModule.OAUTHBEARER_MECHANISM.equals(saslMechanism)) {
+            throw new IllegalArgumentException("Unexpected SASL mechanism: " + saslMechanism);
+        }
+        final Map<String, String> options = (Map<String, String>) jaasConfigEntries.get(0).getOptions();
+        final Map<String, String> stsHeaderOverrides = decodeStsHeaderOverrides(options.get(OPT_STS_HEADER_OVERRIDES));
+        final AwsCredentialsSupplier awsCredentialsSupplier =
+                AwsCredentialsSupplierProvider.getInstance().getAwsCredentialsSupplier();
+        this.tokenProvider = new AzureFederatedTokenProvider(
+                options.get(OPT_REGION), options.get(OPT_STS_ROLE_ARN), options.get(OPT_TOKEN_ENDPOINT),
+                options.get(OPT_CLIENT_ID), options.get(OPT_SCOPE), stsHeaderOverrides, awsCredentialsSupplier);
+    }
+
+    private static Map<String, String> decodeStsHeaderOverrides(final String encoded) {
+        if (encoded == null || encoded.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        try {
+            final byte[] json = Base64.getDecoder().decode(encoded);
+            return OBJECT_MAPPER.readValue(json, new TypeReference<Map<String, String>>() {});
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to decode azure_federated STS header overrides", e);
+        }
+    }
+
+    @Override
+    public void handle(final Callback[] callbacks) throws UnsupportedCallbackException {
+        for (final Callback callback : callbacks) {
+            if (callback instanceof OAuthBearerTokenCallback) {
+                ((OAuthBearerTokenCallback) callback).token(tokenProvider.getToken());
+            } else {
+                throw new UnsupportedCallbackException(callback);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+    AzureFederatedTokenProvider getTokenProvider() {
+        return tokenProvider;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandler.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandler.java
@@ -27,12 +27,12 @@ import java.util.List;
 import java.util.Map;
 
 public class AzureFederatedCallbackHandler implements AuthenticateCallbackHandler {
-    static final String OPT_REGION = "azureFederatedRegion";
-    static final String OPT_STS_ROLE_ARN = "azureFederatedStsRoleArn";
-    static final String OPT_TOKEN_ENDPOINT = "azureFederatedTokenEndpoint";
-    static final String OPT_CLIENT_ID = "azureFederatedClientId";
-    static final String OPT_SCOPE = "azureFederatedScope";
-    static final String OPT_STS_HEADER_OVERRIDES = "azureFederatedStsHeaderOverrides";
+    public static final String OPT_REGION = "azureFederatedRegion";
+    public static final String OPT_STS_ROLE_ARN = "azureFederatedStsRoleArn";
+    public static final String OPT_TOKEN_ENDPOINT = "azureFederatedTokenEndpoint";
+    public static final String OPT_CLIENT_ID = "azureFederatedClientId";
+    public static final String OPT_SCOPE = "azureFederatedScope";
+    public static final String OPT_STS_HEADER_OVERRIDES = "azureFederatedStsHeaderOverrides";
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -86,6 +86,9 @@ public class AzureFederatedCallbackHandler implements AuthenticateCallbackHandle
 
     @Override
     public void close() {
+        if (tokenProvider != null) {
+            tokenProvider.close();
+        }
     }
 
     AzureFederatedTokenProvider getTokenProvider() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerToken.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerToken.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+
+import java.util.Set;
+
+public class AzureFederatedOAuthBearerToken implements OAuthBearerToken {
+    private final String value;
+    private final long lifetimeMs;
+    private final long startTimeMs;
+    private final String scope;
+    private final String principalName;
+
+    public AzureFederatedOAuthBearerToken(final String value, final long expiresInSeconds,
+                                          final String scope, final String principalName) {
+        this.value = value;
+        this.startTimeMs = System.currentTimeMillis();
+        this.lifetimeMs = this.startTimeMs + (expiresInSeconds * 1000L);
+        this.scope = scope;
+        this.principalName = principalName;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public long lifetimeMs() {
+        return lifetimeMs;
+    }
+
+    @Override
+    public Long startTimeMs() {
+        return startTimeMs;
+    }
+
+    @Override
+    public String principalName() {
+        return principalName;
+    }
+
+    @Override
+    public Set<String> scope() {
+        return scope == null ? Set.of() : Set.of(scope);
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProvider.java
@@ -139,6 +139,18 @@ public class AzureFederatedTokenProvider {
         return stsClient;
     }
 
+    public void close() {
+        lock.lock();
+        try {
+            if (stsClient != null) {
+                stsClient.close();
+                stsClient = null;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private static AwsCredentialsProvider baseCredentials(final String region, final String stsRoleArn,
                                                           final Map<String, String> stsHeaderOverrides,
                                                           final AwsCredentialsSupplier awsCredentialsSupplier) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProvider.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetWebIdentityTokenResponse;
+import software.amazon.awssdk.services.sts.model.OutboundWebIdentityFederationDisabledException;
+import software.amazon.awssdk.services.sts.model.StsException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
+
+public class AzureFederatedTokenProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(AzureFederatedTokenProvider.class);
+
+    private static final String STS_AUDIENCE = "api://AzureADTokenExchange";
+    private static final String SIGNING_ALGORITHM = "RS256";
+    private static final int JWT_DURATION_SECONDS = 300;
+    private static final String GRANT_TYPE = "client_credentials";
+    private static final String CLIENT_ASSERTION_TYPE =
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    private static final long SKEW_BUFFER_MS = 30_000L;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final String region;
+    private final String stsRoleArn;
+    private final String tokenEndpoint;
+    private final String clientId;
+    private final String scope;
+    private final Supplier<StsClient> stsClientSupplier;
+    private final HttpClient httpClient;
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private volatile CachedToken cached;
+    private volatile StsClient stsClient;
+
+    public AzureFederatedTokenProvider(final String region, final String stsRoleArn, final String tokenEndpoint,
+                                       final String clientId, final String scope,
+                                       final Map<String, String> stsHeaderOverrides,
+                                       final AwsCredentialsSupplier awsCredentialsSupplier) {
+        this(region, stsRoleArn, tokenEndpoint, clientId, scope, stsHeaderOverrides, awsCredentialsSupplier,
+                provider -> StsClient.builder()
+                        .region(Region.of(region))
+                        .credentialsProvider(provider)
+                        .build(),
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build());
+    }
+
+    AzureFederatedTokenProvider(final String region, final String stsRoleArn, final String tokenEndpoint,
+                                final String clientId, final String scope,
+                                final Map<String, String> stsHeaderOverrides,
+                                final AwsCredentialsSupplier awsCredentialsSupplier,
+                                final Function<AwsCredentialsProvider, StsClient> stsClientFactory,
+                                final HttpClient httpClient) {
+        this.region = region;
+        this.stsRoleArn = stsRoleArn;
+        this.tokenEndpoint = tokenEndpoint;
+        this.clientId = clientId;
+        this.scope = scope;
+        this.stsClientSupplier =
+                () -> stsClientFactory.apply(baseCredentials(region, stsRoleArn, stsHeaderOverrides, awsCredentialsSupplier));
+        this.httpClient = httpClient;
+    }
+
+    String getRegion() {
+        return region;
+    }
+
+    String getStsRoleArn() {
+        return stsRoleArn;
+    }
+
+    String getTokenEndpoint() {
+        return tokenEndpoint;
+    }
+
+    String getClientId() {
+        return clientId;
+    }
+
+    String getScope() {
+        return scope;
+    }
+
+    public AzureFederatedOAuthBearerToken getToken() {
+        final CachedToken current = cached;
+        if (current != null && current.isValid()) {
+            return current.token;
+        }
+        lock.lock();
+        try {
+            if (cached != null && cached.isValid()) {
+                return cached.token;
+            }
+            final AzureFederatedOAuthBearerToken token = exchange();
+            cached = new CachedToken(token);
+            return token;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private AzureFederatedOAuthBearerToken exchange() {
+        return postToAzure(mintAwsJwt());
+    }
+
+    private StsClient stsClient() {
+        if (stsClient == null) {
+            stsClient = stsClientSupplier.get();
+        }
+        return stsClient;
+    }
+
+    private static AwsCredentialsProvider baseCredentials(final String region, final String stsRoleArn,
+                                                          final Map<String, String> stsHeaderOverrides,
+                                                          final AwsCredentialsSupplier awsCredentialsSupplier) {
+        if (awsCredentialsSupplier == null) {
+            throw new RuntimeException("azure_federated requires an AWS credentials extension to be configured");
+        }
+        return awsCredentialsSupplier.getProvider(AwsCredentialsOptions.builder()
+                .withStsRoleArn(stsRoleArn)
+                .withRegion(Region.of(region))
+                .withStsHeaderOverrides(stsHeaderOverrides)
+                .build());
+    }
+
+    private String mintAwsJwt() {
+        try {
+            final GetWebIdentityTokenResponse response = stsClient().getWebIdentityToken(builder -> builder
+                    .audience(STS_AUDIENCE)
+                    .signingAlgorithm(SIGNING_ALGORITHM)
+                    .durationSeconds(JWT_DURATION_SECONDS));
+            return response.webIdentityToken();
+        } catch (final OutboundWebIdentityFederationDisabledException e) {
+            LOG.error(SENSITIVE, "AWS Outbound Identity Federation is not enabled for {}", identity());
+            throw new RuntimeException("AWS Outbound Identity Federation is not enabled for "
+                    + identity() + ". Enable it once per account.", e);
+        } catch (final StsException e) {
+            if (e.statusCode() == 403) {
+                LOG.error(SENSITIVE, "{} lacks sts:GetWebIdentityToken", identity());
+                throw new RuntimeException(identity()
+                        + " lacks sts:GetWebIdentityToken (AccessDenied). Add it to the role policy.", e);
+            }
+            throw new RuntimeException("STS GetWebIdentityToken failed for " + identity(), e);
+        } catch (final Exception e) {
+            throw new RuntimeException("AWS credential resolution failed for " + identity()
+                    + " (verify the AWS credentials/role configuration)", e);
+        }
+    }
+
+    private String identity() {
+        return stsRoleArn != null ? "Role " + stsRoleArn : "the resolved AWS credentials identity";
+    }
+
+    private AzureFederatedOAuthBearerToken postToAzure(final String awsJwt) {
+        final String form = "grant_type=" + encode(GRANT_TYPE)
+                + "&client_id=" + encode(clientId)
+                + "&client_assertion_type=" + encode(CLIENT_ASSERTION_TYPE)
+                + "&client_assertion=" + encode(awsJwt)
+                + "&scope=" + encode(scope);
+        try {
+            final HttpRequest request = HttpRequest.newBuilder(URI.create(tokenEndpoint))
+                    .timeout(Duration.ofSeconds(30))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(form))
+                    .build();
+            final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                final String aadsts = extractAadstsError(response.body());
+                LOG.error(SENSITIVE, "Azure token exchange failed: HTTP {} {}", response.statusCode(), aadsts);
+                throw new RuntimeException("Azure token exchange failed: HTTP " + response.statusCode() + " " + aadsts);
+            }
+            final JsonNode json = OBJECT_MAPPER.readTree(response.body());
+            final String accessToken = json.get("access_token").asText();
+            final long expiresIn = json.get("expires_in").asLong();
+            return new AzureFederatedOAuthBearerToken(accessToken, expiresIn, scope, clientId);
+        } catch (final IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException("Azure token exchange request failed to " + tokenEndpoint, e);
+        }
+    }
+
+    private String extractAadstsError(final String body) {
+        try {
+            final JsonNode json = OBJECT_MAPPER.readTree(body);
+            final String error = json.path("error").asText("");
+            final String description = json.path("error_description").asText("");
+            return (error + " " + description).trim();
+        } catch (final IOException e) {
+            return "";
+        }
+    }
+
+    private static String encode(final String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private final class CachedToken {
+        private final AzureFederatedOAuthBearerToken token;
+        private final long validUntilMs;
+
+        private CachedToken(final AzureFederatedOAuthBearerToken token) {
+            this.token = token;
+            this.validUntilMs = token.lifetimeMs() - SKEW_BUFFER_MS;
+        }
+
+        private boolean isValid() {
+            return System.currentTimeMillis() < validUntilMs;
+        }
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AuthConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AuthConfig.java
@@ -32,11 +32,19 @@ public class AuthConfig {
         @JsonProperty("aws_msk_iam")
         private AwsIamAuthConfig awsIamAuthConfig;
 
+        @Valid
+        @JsonProperty("azure_federated")
+        private AzureFederatedAuthConfig azureFederatedAuthConfig;
+
         @JsonProperty("ssl_endpoint_identification_algorithm")
         private String sslEndpointAlgorithm;
 
         public AwsIamAuthConfig getAwsIamAuthConfig() {
             return awsIamAuthConfig;
+        }
+
+        public AzureFederatedAuthConfig getAzureFederatedAuthConfig() {
+            return azureFederatedAuthConfig;
         }
 
         public PlainTextAuthConfig getPlainTextAuthConfig() {
@@ -55,9 +63,10 @@ public class AuthConfig {
             return sslEndpointAlgorithm;
         }
 
-        @AssertTrue(message = "Only one of AwsIam or oAuth or SCRAM or PlainText auth config must be specified")
+        @AssertTrue(message = "Only one of AwsIam, oAuth, SCRAM, PlainText or azure_federated auth config must be specified")
         public boolean hasOnlyOneConfig() {
-            return Stream.of(awsIamAuthConfig, plainTextAuthConfig, oAuthConfig, scramAuthConfig).filter(n -> n != null).count() == 1;
+            return Stream.of(awsIamAuthConfig, plainTextAuthConfig, oAuthConfig, scramAuthConfig, azureFederatedAuthConfig)
+                    .filter(n -> n != null).count() == 1;
         }
 
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfig.java
@@ -11,68 +11,31 @@
 package org.opensearch.dataprepper.plugins.kafka.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
-
-import java.net.URI;
-import java.net.URISyntaxException;
 
 public class AzureFederatedAuthConfig {
 
-    @NotNull(message = "azure_tenant_id is required for azure_federated authentication")
-    @JsonProperty("azure_tenant_id")
-    private String azureTenantId;
+    @NotNull(message = "client_id is required for azure_federated authentication")
+    @JsonProperty("client_id")
+    private String clientId;
 
-    @NotNull(message = "azure_client_id is required for azure_federated authentication")
-    @JsonProperty("azure_client_id")
-    private String azureClientId;
-
-    @NotNull(message = "azure_token_endpoint is required for azure_federated authentication")
-    @JsonProperty("azure_token_endpoint")
-    private String azureTokenEndpoint;
+    @NotNull(message = "token_endpoint is required for azure_federated authentication")
+    @JsonProperty("token_endpoint")
+    private String tokenEndpoint;
 
     @NotNull(message = "scope is required for azure_federated authentication")
     @JsonProperty("scope")
     private String scope;
 
-    public String getAzureTenantId() {
-        return azureTenantId;
+    public String getClientId() {
+        return clientId;
     }
 
-    public String getAzureClientId() {
-        return azureClientId;
-    }
-
-    public String getAzureTokenEndpoint() {
-        return azureTokenEndpoint;
+    public String getTokenEndpoint() {
+        return tokenEndpoint;
     }
 
     public String getScope() {
         return scope;
-    }
-
-    @AssertTrue(message = "azure_tenant_id must match the tenant in azure_token_endpoint")
-    public boolean isTenantConsistentWithEndpoint() {
-        // null fields are reported by their own @NotNull constraints
-        if (azureTenantId == null || azureTokenEndpoint == null) {
-            return true;
-        }
-        final String endpointTenant = extractTenantFromEndpoint(azureTokenEndpoint);
-        return azureTenantId.equals(endpointTenant);
-    }
-
-    private static String extractTenantFromEndpoint(final String endpoint) {
-        try {
-            final String path = new URI(endpoint).getPath();
-            if (path == null || path.isEmpty()) {
-                return null;
-            }
-            final String withoutLeadingSlash = path.startsWith("/") ? path.substring(1) : path;
-            final int nextSlash = withoutLeadingSlash.indexOf('/');
-            final String tenant = nextSlash < 0 ? withoutLeadingSlash : withoutLeadingSlash.substring(0, nextSlash);
-            return tenant.isEmpty() ? null : tenant;
-        } catch (final URISyntaxException e) {
-            return null;
-        }
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class AzureFederatedAuthConfig {
+
+    @NotNull(message = "azure_tenant_id is required for azure_federated authentication")
+    @JsonProperty("azure_tenant_id")
+    private String azureTenantId;
+
+    @NotNull(message = "azure_client_id is required for azure_federated authentication")
+    @JsonProperty("azure_client_id")
+    private String azureClientId;
+
+    @NotNull(message = "azure_token_endpoint is required for azure_federated authentication")
+    @JsonProperty("azure_token_endpoint")
+    private String azureTokenEndpoint;
+
+    @NotNull(message = "scope is required for azure_federated authentication")
+    @JsonProperty("scope")
+    private String scope;
+
+    public String getAzureTenantId() {
+        return azureTenantId;
+    }
+
+    public String getAzureClientId() {
+        return azureClientId;
+    }
+
+    public String getAzureTokenEndpoint() {
+        return azureTokenEndpoint;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    @AssertTrue(message = "azure_tenant_id must match the tenant in azure_token_endpoint")
+    public boolean isTenantConsistentWithEndpoint() {
+        // null fields are reported by their own @NotNull constraints
+        if (azureTenantId == null || azureTokenEndpoint == null) {
+            return true;
+        }
+        final String endpointTenant = extractTenantFromEndpoint(azureTokenEndpoint);
+        return azureTenantId.equals(endpointTenant);
+    }
+
+    private static String extractTenantFromEndpoint(final String endpoint) {
+        try {
+            final String path = new URI(endpoint).getPath();
+            if (path == null || path.isEmpty()) {
+                return null;
+            }
+            final String withoutLeadingSlash = path.startsWith("/") ? path.substring(1) : path;
+            final int nextSlash = withoutLeadingSlash.indexOf('/');
+            final String tenant = nextSlash < 0 ? withoutLeadingSlash : withoutLeadingSlash.substring(0, nextSlash);
+            return tenant.isEmpty() ? null : tenant;
+        } catch (final URISyntaxException e) {
+            return null;
+        }
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -90,7 +90,7 @@ public class KafkaCustomConsumerFactory {
                                                              final CompressionOption compressionConfig,
                                                              final boolean invokeCallbackOnExpiry) {
         Properties authProperties = new Properties();
-        KafkaSecurityConfigurer.setAuthProperties(authProperties, kafkaConsumerConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(authProperties, kafkaConsumerConfig, awsCredentialsSupplier, LOG);
         KafkaTopicConsumerMetrics topicMetrics = new KafkaTopicConsumerMetrics(topic.getName(), pluginMetrics, topicNameInMetrics);
 
         Properties consumerProperties = getConsumerProperties(kafkaConsumerConfig, topic, authProperties);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
@@ -82,7 +82,7 @@ public class KafkaCustomProducerFactory {
         prepareTopicAndSchema(kafkaProducerConfig, maxRequestSize);
         Properties properties = SinkPropertyConfigurer.getProducerProperties(kafkaProducerConfig);
         properties = Objects.requireNonNull(properties);
-        KafkaSecurityConfigurer.setAuthProperties(properties, kafkaProducerConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(properties, kafkaProducerConfig, awsCredentialsSupplier, LOG);
 
         TopicProducerConfig topic = kafkaProducerConfig.getTopic();
         KafkaDataConfig dataConfig = new KafkaDataConfigAdapter(keyFactory, topic);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -129,7 +129,7 @@ public class KafkaSource implements Source<Record<Event>> {
             setMdc();
             Properties authProperties = new Properties();
             KafkaSecurityConfigurer.setDynamicSaslClientCallbackHandler(authProperties, sourceConfig, pluginConfigObservable);
-            KafkaSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
+            KafkaSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, awsCredentialsSupplier, LOG);
             sourceConfig.getTopics().forEach(topic -> {
                 consumerGroupID = topic.getGroupId();
                 KafkaTopicConsumerMetrics topicMetrics = new KafkaTopicConsumerMetrics(topic.getName(), pluginMetrics, true);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfig.java
@@ -11,6 +11,7 @@ package org.opensearch.dataprepper.plugins.kafka.source;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
@@ -134,5 +135,14 @@ public class KafkaSourceConfig implements KafkaConsumerConfig {
 
     public void setAwsConfig(AwsConfig awsConfig) {
         this.awsConfig = awsConfig;
+    }
+
+    @AssertTrue(message = "azure_federated authentication requires aws.region to be set")
+    public boolean isAzureFederatedAwsConfigValid() {
+        if (authConfig == null || authConfig.getSaslAuthConfig() == null
+                || authConfig.getSaslAuthConfig().getAzureFederatedAuthConfig() == null) {
+            return true;
+        }
+        return awsConfig != null && awsConfig.getRegion() != null;
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.kafka.util;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.AwsCredentialsSupplierProvider;
+import org.opensearch.dataprepper.plugins.kafka.authenticator.AzureFederatedCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicSaslClientCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicBasicCredentialsProvider;
 import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
@@ -94,6 +95,8 @@ public class KafkaSecurityConfigurer {
     private static final String PLAIN_MECHANISM = "PLAIN";
     private static final String OAUTHBEARER_MECHANISM = "OAUTHBEARER";
 
+    private static final String SASL_SSL_PROTOCOL = "SASL_SSL";
+
     private static final String SASL_PLAINTEXT_PROTOCOL = "SASL_PLAINTEXT";
 
     private static final String PLAINTEXT_PROTOCOL = "PLAINTEXT";
@@ -140,7 +143,7 @@ public class KafkaSecurityConfigurer {
         properties.put(SASL_MECHANISM, "PLAIN");
         properties.put(SASL_JAAS_CONFIG, "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + username + "\" password=\"" + password + "\";");
         if (checkEncryptionType(encryptionConfig, EncryptionType.SSL)) {
-            properties.put(SECURITY_PROTOCOL, "SASL_SSL");
+            properties.put(SECURITY_PROTOCOL, SASL_SSL_PROTOCOL);
             setSecurityProtocolSSLProperties(properties, encryptionConfig);
         } else { // EncryptionType.NONE
             properties.put(SECURITY_PROTOCOL, "SASL_PLAINTEXT");
@@ -155,7 +158,7 @@ public class KafkaSecurityConfigurer {
         properties.put(SASL_MECHANISM, mechanism);
         properties.put(SASL_JAAS_CONFIG, "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + username + "\" password=\"" + password + "\";");
         if (checkEncryptionType(encryptionConfig, EncryptionType.SSL)) {
-            properties.put(SECURITY_PROTOCOL, "SASL_SSL");
+            properties.put(SECURITY_PROTOCOL, SASL_SSL_PROTOCOL);
             setSecurityProtocolSSLProperties(properties, encryptionConfig);
         } else { // EncryptionType.NONE
             properties.put(SECURITY_PROTOCOL, "SASL_PLAINTEXT");
@@ -235,7 +238,7 @@ public class KafkaSecurityConfigurer {
     }
 
     public static void setAwsIamAuthProperties(Properties properties, final AwsIamAuthConfig awsIamAuthConfig, final AwsConfig awsConfig) {
-        properties.put(SECURITY_PROTOCOL, "SASL_SSL");
+        properties.put(SECURITY_PROTOCOL, SASL_SSL_PROTOCOL);
         properties.put(SASL_MECHANISM, "AWS_MSK_IAM");
         properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS, "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
         if (awsIamAuthConfig == AwsIamAuthConfig.ROLE) {
@@ -266,21 +269,22 @@ public class KafkaSecurityConfigurer {
             throw new RuntimeException("azure_federated requires aws.region");
         }
         properties.put(SASL_MECHANISM, OAUTHBEARER_MECHANISM);
-        properties.put(SECURITY_PROTOCOL, "SASL_SSL");
+        properties.put(SECURITY_PROTOCOL, SASL_SSL_PROTOCOL);
         properties.put(SASL_CALLBACK_HANDLER_CLASS, AZURE_FEDERATED_HANDLER_CLASS);
         final StringBuilder jaas = new StringBuilder(
                 "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ");
-        appendJaasOption(jaas, "azureFederatedRegion", awsConfig.getRegion());
+        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_REGION, awsConfig.getRegion());
         if (Objects.nonNull(awsConfig.getStsRoleArn())) {
-            appendJaasOption(jaas, "azureFederatedStsRoleArn", awsConfig.getStsRoleArn());
+            appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_STS_ROLE_ARN, awsConfig.getStsRoleArn());
         }
         if (Objects.nonNull(awsConfig.getAwsStsHeaderOverrides()) && !awsConfig.getAwsStsHeaderOverrides().isEmpty()) {
-            appendJaasOption(jaas, "azureFederatedStsHeaderOverrides",
+            appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_STS_HEADER_OVERRIDES,
                     encodeStsHeaderOverrides(awsConfig.getAwsStsHeaderOverrides()));
         }
-        appendJaasOption(jaas, "azureFederatedTokenEndpoint", azureFederatedAuthConfig.getAzureTokenEndpoint());
-        appendJaasOption(jaas, "azureFederatedClientId", azureFederatedAuthConfig.getAzureClientId());
-        jaas.append("azureFederatedScope=\"").append(azureFederatedAuthConfig.getScope()).append("\";");
+        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_TOKEN_ENDPOINT, azureFederatedAuthConfig.getAzureTokenEndpoint());
+        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_CLIENT_ID, azureFederatedAuthConfig.getAzureClientId());
+        jaas.append(AzureFederatedCallbackHandler.OPT_SCOPE).append("=\"")
+                .append(azureFederatedAuthConfig.getScope()).append("\";");
         properties.put(SASL_JAAS_CONFIG, jaas.toString());
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
@@ -264,25 +264,32 @@ public class KafkaSecurityConfigurer {
     }
 
     private static void setAzureFederatedAuthProperties(final Properties properties,
-            final AzureFederatedAuthConfig azureFederatedAuthConfig, final AwsConfig awsConfig) {
-        if (Objects.isNull(awsConfig) || Objects.isNull(awsConfig.getRegion())) {
-            throw new RuntimeException("azure_federated requires aws.region");
+            final AzureFederatedAuthConfig azureFederatedAuthConfig, final AwsConfig awsConfig,
+            final AwsCredentialsSupplier awsCredentialsSupplier) {
+        final boolean hasAwsConfig = Objects.nonNull(awsConfig);
+        // Region may come from the pipeline aws config or, if absent there, the data-prepper-config.yaml default.
+        final String region = hasAwsConfig && Objects.nonNull(awsConfig.getRegion())
+                ? awsConfig.getRegion()
+                : awsCredentialsSupplier.getDefaultRegion().map(Region::id).orElse(null);
+        if (Objects.isNull(region)) {
+            throw new RuntimeException("azure_federated requires a region in the pipeline aws config or data-prepper-config.yaml");
         }
         properties.put(SASL_MECHANISM, OAUTHBEARER_MECHANISM);
         properties.put(SECURITY_PROTOCOL, SASL_SSL_PROTOCOL);
         properties.put(SASL_CALLBACK_HANDLER_CLASS, AZURE_FEDERATED_HANDLER_CLASS);
         final StringBuilder jaas = new StringBuilder(
                 "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ");
-        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_REGION, awsConfig.getRegion());
-        if (Objects.nonNull(awsConfig.getStsRoleArn())) {
+        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_REGION, region);
+        if (hasAwsConfig && Objects.nonNull(awsConfig.getStsRoleArn())) {
             appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_STS_ROLE_ARN, awsConfig.getStsRoleArn());
         }
-        if (Objects.nonNull(awsConfig.getAwsStsHeaderOverrides()) && !awsConfig.getAwsStsHeaderOverrides().isEmpty()) {
+        if (hasAwsConfig && Objects.nonNull(awsConfig.getAwsStsHeaderOverrides())
+                && !awsConfig.getAwsStsHeaderOverrides().isEmpty()) {
             appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_STS_HEADER_OVERRIDES,
                     encodeStsHeaderOverrides(awsConfig.getAwsStsHeaderOverrides()));
         }
-        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_TOKEN_ENDPOINT, azureFederatedAuthConfig.getAzureTokenEndpoint());
-        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_CLIENT_ID, azureFederatedAuthConfig.getAzureClientId());
+        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_TOKEN_ENDPOINT, azureFederatedAuthConfig.getTokenEndpoint());
+        appendJaasOption(jaas, AzureFederatedCallbackHandler.OPT_CLIENT_ID, azureFederatedAuthConfig.getClientId());
         jaas.append(AzureFederatedCallbackHandler.OPT_SCOPE).append("=\"")
                 .append(azureFederatedAuthConfig.getScope()).append("\";");
         properties.put(SASL_JAAS_CONFIG, jaas.toString());
@@ -441,7 +448,8 @@ public class KafkaSecurityConfigurer {
                 }  else if (Objects.nonNull(plainTextAuthConfig) && Objects.nonNull(kafkaClusterAuthConfig.getEncryptionConfig())) {
                     setPlainTextAuthProperties(properties, plainTextAuthConfig, kafkaClusterAuthConfig.getEncryptionConfig());
                 } else if (Objects.nonNull(saslAuthConfig.getAzureFederatedAuthConfig())) {
-                    setAzureFederatedAuthProperties(properties, saslAuthConfig.getAzureFederatedAuthConfig(), awsConfig);
+                    setAzureFederatedAuthProperties(properties, saslAuthConfig.getAzureFederatedAuthConfig(), awsConfig,
+                            awsCredentialsSupplier);
                 } else {
                     throw new RuntimeException("No SASL auth config specified");
                 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurer.java
@@ -4,13 +4,16 @@
  */
 package org.opensearch.dataprepper.plugins.kafka.util;
 
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
+import org.opensearch.dataprepper.plugins.kafka.authenticator.AwsCredentialsSupplierProvider;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicSaslClientCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicBasicCredentialsProvider;
 import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsIamAuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AzureFederatedAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaConnectionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaConsumerConfig;
@@ -41,10 +44,13 @@ import software.amazon.awssdk.regions.Region;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.services.glue.model.Compatibility;
 
 import org.slf4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -82,6 +88,9 @@ public class KafkaSecurityConfigurer {
             + "%s" + "' OAUTH_INTROSPECT_ENDPOINT='" + "%s" + "' " +
             "OAUTH_INTROSPECT_AUTHORIZATION='Basic " + "%s";
 
+    private static final String AZURE_FEDERATED_HANDLER_CLASS =
+            "org.opensearch.dataprepper.plugins.kafka.authenticator.AzureFederatedCallbackHandler";
+
     private static final String PLAIN_MECHANISM = "PLAIN";
     private static final String OAUTHBEARER_MECHANISM = "OAUTHBEARER";
 
@@ -96,6 +105,8 @@ public class KafkaSecurityConfigurer {
     private static final String CERTIFICATE_CONTENT = "certificateContent";
     private static final String SSL_TRUSTSTORE_LOCATION = "ssl.truststore.location";
     private static final String SSL_TRUSTSTORE_PASSWORD = "ssl.truststore.password";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static AwsCredentialsProvider mskCredentialsProvider;
     private static AwsCredentialsProvider awsGlueCredentialsProvider;
@@ -249,6 +260,43 @@ public class KafkaSecurityConfigurer {
         }
     }
 
+    private static void setAzureFederatedAuthProperties(final Properties properties,
+            final AzureFederatedAuthConfig azureFederatedAuthConfig, final AwsConfig awsConfig) {
+        if (Objects.isNull(awsConfig) || Objects.isNull(awsConfig.getRegion())) {
+            throw new RuntimeException("azure_federated requires aws.region");
+        }
+        properties.put(SASL_MECHANISM, OAUTHBEARER_MECHANISM);
+        properties.put(SECURITY_PROTOCOL, "SASL_SSL");
+        properties.put(SASL_CALLBACK_HANDLER_CLASS, AZURE_FEDERATED_HANDLER_CLASS);
+        final StringBuilder jaas = new StringBuilder(
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ");
+        appendJaasOption(jaas, "azureFederatedRegion", awsConfig.getRegion());
+        if (Objects.nonNull(awsConfig.getStsRoleArn())) {
+            appendJaasOption(jaas, "azureFederatedStsRoleArn", awsConfig.getStsRoleArn());
+        }
+        if (Objects.nonNull(awsConfig.getAwsStsHeaderOverrides()) && !awsConfig.getAwsStsHeaderOverrides().isEmpty()) {
+            appendJaasOption(jaas, "azureFederatedStsHeaderOverrides",
+                    encodeStsHeaderOverrides(awsConfig.getAwsStsHeaderOverrides()));
+        }
+        appendJaasOption(jaas, "azureFederatedTokenEndpoint", azureFederatedAuthConfig.getAzureTokenEndpoint());
+        appendJaasOption(jaas, "azureFederatedClientId", azureFederatedAuthConfig.getAzureClientId());
+        jaas.append("azureFederatedScope=\"").append(azureFederatedAuthConfig.getScope()).append("\";");
+        properties.put(SASL_JAAS_CONFIG, jaas.toString());
+    }
+
+    private static void appendJaasOption(final StringBuilder jaas, final String key, final String value) {
+        jaas.append(key).append("=\"").append(value).append("\" ");
+    }
+
+    private static String encodeStsHeaderOverrides(final Map<String, String> stsHeaderOverrides) {
+        try {
+            final String json = OBJECT_MAPPER.writeValueAsString(stsHeaderOverrides);
+            return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        } catch (final JsonProcessingException e) {
+            throw new RuntimeException("Failed to encode aws.sts_header_overrides for azure_federated", e);
+        }
+    }
+
     private static void configureMSKCredentialsProvider(final AuthConfig authConfig, final AwsConfig awsConfig) {
         mskCredentialsProvider = DefaultCredentialsProvider.create();
         if (Objects.nonNull(authConfig) && Objects.nonNull(authConfig.getSaslAuthConfig()) &&
@@ -352,7 +400,11 @@ public class KafkaSecurityConfigurer {
             }
         }
     }
-    public static void setAuthProperties(final Properties properties, final KafkaClusterAuthConfig kafkaClusterAuthConfig, final Logger log) {
+    public static void setAuthProperties(final Properties properties, final KafkaClusterAuthConfig kafkaClusterAuthConfig,
+                                         final AwsCredentialsSupplier awsCredentialsSupplier, final Logger log) {
+        if (awsCredentialsSupplier != null) {
+            AwsCredentialsSupplierProvider.getInstance().set(awsCredentialsSupplier);
+        }
         final AwsConfig awsConfig = kafkaClusterAuthConfig.getAwsConfig();
         final AuthConfig authConfig = kafkaClusterAuthConfig.getAuthConfig();
         final EncryptionConfig encryptionConfig = kafkaClusterAuthConfig.getEncryptionConfig();
@@ -384,6 +436,8 @@ public class KafkaSecurityConfigurer {
                     setScramAuthProperties(properties, scramAuthConfig, kafkaClusterAuthConfig.getEncryptionConfig());
                 }  else if (Objects.nonNull(plainTextAuthConfig) && Objects.nonNull(kafkaClusterAuthConfig.getEncryptionConfig())) {
                     setPlainTextAuthProperties(properties, plainTextAuthConfig, kafkaClusterAuthConfig.getEncryptionConfig());
+                } else if (Objects.nonNull(saslAuthConfig.getAzureFederatedAuthConfig())) {
+                    setAzureFederatedAuthProperties(properties, saslAuthConfig.getAzureFederatedAuthConfig(), awsConfig);
                 } else {
                     throw new RuntimeException("No SASL auth config specified");
                 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/SinkPropertyConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/SinkPropertyConfigurer.java
@@ -316,7 +316,8 @@ public class SinkPropertyConfigurer {
     public static Properties getPropertiesForAdminClient(final KafkaProducerConfig kafkaProducerConfig) {
         Properties properties = new Properties();
         setCommonServerProperties(properties, kafkaProducerConfig);
-        KafkaSecurityConfigurer.setAuthProperties(properties, kafkaProducerConfig, LOG);
+        // the admin/topic-creation path has no AwsCredentialsSupplier to provide
+        KafkaSecurityConfigurer.setAuthProperties(properties, kafkaProducerConfig, null, LOG);
         properties.put(TopicConfig.RETENTION_MS_CONFIG,kafkaProducerConfig.getTopic().getRetentionPeriod());
         return properties;
     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AwsCredentialsSupplierProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AwsCredentialsSupplierProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+
+class AwsCredentialsSupplierProviderTest {
+
+    @Test
+    void getInstance_returnsSameSingleton() {
+        assertThat(AwsCredentialsSupplierProvider.getInstance(),
+                sameInstance(AwsCredentialsSupplierProvider.getInstance()));
+    }
+
+    @Test
+    void get_beforeSet_isNull() {
+        // fresh instance via the protected test ctor to avoid cross-test static leakage
+        final AwsCredentialsSupplierProvider provider = new AwsCredentialsSupplierProvider() {};
+        assertThat(provider.getAwsCredentialsSupplier(), nullValue());
+    }
+
+    @Test
+    void set_thenGet_returnsSuppliedInstance() {
+        final AwsCredentialsSupplierProvider provider = new AwsCredentialsSupplierProvider() {};
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        provider.set(supplier);
+        assertThat(provider.getAwsCredentialsSupplier(), sameInstance(supplier));
+    }
+
+    @Test
+    void set_overwritesPrevious() {
+        final AwsCredentialsSupplierProvider provider = new AwsCredentialsSupplierProvider() {};
+        final AwsCredentialsSupplier first = mock(AwsCredentialsSupplier.class);
+        final AwsCredentialsSupplier second = mock(AwsCredentialsSupplier.class);
+        provider.set(first);
+        provider.set(second);
+        assertThat(provider.getAwsCredentialsSupplier(), sameInstance(second));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandlerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandlerTest.java
@@ -160,4 +160,21 @@ class AzureFederatedCallbackHandlerTest {
         assertThrows(UnsupportedCallbackException.class,
                 () -> handler.handle(new Callback[] {unsupported}));
     }
+
+    @Test
+    void close_withProvider_closesTokenProvider() {
+        final AzureFederatedTokenProvider provider = mock(AzureFederatedTokenProvider.class);
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler(provider);
+
+        handler.close();
+
+        verify(provider).close();
+    }
+
+    @Test
+    void close_withoutConfiguredProvider_isNoOp() {
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler();
+
+        handler.close();
+    }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandlerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedCallbackHandlerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AzureFederatedCallbackHandlerTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String STS_ROLE_ARN = "arn:aws:iam::123456789012:role/eh-federation";
+    private static final String TOKEN_ENDPOINT =
+            "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token";
+    private static final String CLIENT_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String SCOPE = "https://my-namespace.servicebus.windows.net/.default";
+
+    private Map<String, String> jaasOptions() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("azureFederatedRegion", REGION);
+        options.put("azureFederatedStsRoleArn", STS_ROLE_ARN);
+        options.put("azureFederatedTokenEndpoint", TOKEN_ENDPOINT);
+        options.put("azureFederatedClientId", CLIENT_ID);
+        options.put("azureFederatedScope", SCOPE);
+        return options;
+    }
+
+    private List<AppConfigurationEntry> jaasEntries(final Map<String, String> options) {
+        return List.of(new AppConfigurationEntry(
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options));
+    }
+
+    @AfterEach
+    void resetSupplier() {
+        AwsCredentialsSupplierProvider.getInstance().set(null);
+    }
+
+    @Test
+    void configure_buildsProviderFromJaasOptionKeys() {
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler();
+
+        handler.configure(Map.of(), OAuthBearerLoginModule.OAUTHBEARER_MECHANISM, jaasEntries(jaasOptions()));
+
+        final AzureFederatedTokenProvider provider = handler.getTokenProvider();
+        assertThat(provider.getRegion(), equalTo(REGION));
+        assertThat(provider.getStsRoleArn(), equalTo(STS_ROLE_ARN));
+        assertThat(provider.getTokenEndpoint(), equalTo(TOKEN_ENDPOINT));
+        assertThat(provider.getClientId(), equalTo(CLIENT_ID));
+        assertThat(provider.getScope(), equalTo(SCOPE));
+    }
+
+    @Test
+    void configure_readsSupplierFromSingleton_andPassesItToProvider() {
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        final RuntimeException sentinel = new RuntimeException("supplier-was-consulted");
+        when(supplier.getProvider(any(AwsCredentialsOptions.class))).thenThrow(sentinel);
+        AwsCredentialsSupplierProvider.getInstance().set(supplier);
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler();
+
+        handler.configure(Map.of(), OAuthBearerLoginModule.OAUTHBEARER_MECHANISM, jaasEntries(jaasOptions()));
+        // provider construction is lazy; the supplier is consulted when the token is first minted
+        final RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> handler.getTokenProvider().getToken());
+
+        assertThat(thrown.getCause().getMessage(), containsString("supplier-was-consulted"));
+        verify(supplier).getProvider(any(AwsCredentialsOptions.class));
+    }
+
+    @Test
+    void configure_withStsHeaderOverridesOption_decodesAndPassesThemToProvider() throws Exception {
+        final Map<String, String> stsHeaderOverrides = Map.of(
+                "x-amz-source-arn", "arn:aws:osis:us-east-1:123456789012:pipeline/p",
+                "x-amz-source-account", "123456789012");
+        final String encoded = Base64.getEncoder().encodeToString(
+                new ObjectMapper().writeValueAsString(stsHeaderOverrides).getBytes(StandardCharsets.UTF_8));
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+        AwsCredentialsSupplierProvider.getInstance().set(supplier);
+        final Map<String, String> options = jaasOptions();
+        options.put("azureFederatedStsHeaderOverrides", encoded);
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler();
+
+        handler.configure(Map.of(), OAuthBearerLoginModule.OAUTHBEARER_MECHANISM, jaasEntries(options));
+        try {
+            handler.getTokenProvider().getToken();
+        } catch (final RuntimeException ignored) {
+            // token minting hits STS/network after credential resolution; the supplier is still consulted first
+        }
+
+        final ArgumentCaptor<AwsCredentialsOptions> captor =
+                ArgumentCaptor.forClass(AwsCredentialsOptions.class);
+        verify(supplier).getProvider(captor.capture());
+        assertThat(captor.getValue().getStsHeaderOverrides(), equalTo(stsHeaderOverrides));
+    }
+
+    @Test
+    void configure_withWrongMechanism_throwsIllegalArgumentException() {
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> handler.configure(Map.of(), "SCRAM-SHA-512", jaasEntries(jaasOptions())));
+    }
+
+    @Test
+    void handle_withOAuthBearerTokenCallback_setsTokenFromProvider() throws Exception {
+        final AzureFederatedTokenProvider provider = mock(AzureFederatedTokenProvider.class);
+        final AzureFederatedOAuthBearerToken token =
+                new AzureFederatedOAuthBearerToken("access-token", 3600L, SCOPE, CLIENT_ID);
+        when(provider.getToken()).thenReturn(token);
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler(provider);
+        final OAuthBearerTokenCallback callback = new OAuthBearerTokenCallback();
+
+        handler.handle(new Callback[] {callback});
+
+        assertThat(callback.token(), sameInstance(token));
+    }
+
+    @Test
+    void handle_withUnsupportedCallback_throwsUnsupportedCallbackException() {
+        final AzureFederatedTokenProvider provider = mock(AzureFederatedTokenProvider.class);
+        final AzureFederatedCallbackHandler handler = new AzureFederatedCallbackHandler(provider);
+        final Callback unsupported = new NameCallback("prompt");
+
+        assertThrows(UnsupportedCallbackException.class,
+                () -> handler.handle(new Callback[] {unsupported}));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerTokenTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerTokenTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+class AzureFederatedOAuthBearerTokenTest {
+
+    private static final String TOKEN_VALUE = "eyJ0eXAiOiJKV1Qif-a-fake-access-token";
+    private static final String SCOPE = "https://my-namespace.servicebus.windows.net/.default";
+    private static final String PRINCIPAL = "11111111-1111-1111-1111-111111111111";
+
+    @Test
+    void lifetimeMs_isAbsoluteEpochExpiry_notTheRawDuration() {
+        final long expiresInSeconds = 3600L;
+        final long before = System.currentTimeMillis();
+
+        final AzureFederatedOAuthBearerToken token =
+                new AzureFederatedOAuthBearerToken(TOKEN_VALUE, expiresInSeconds, SCOPE, PRINCIPAL);
+
+        final long after = System.currentTimeMillis();
+
+        assertThat(token.lifetimeMs(), greaterThan(after));
+        assertThat(token.lifetimeMs(), greaterThanOrEqualTo(before + expiresInSeconds * 1000L));
+        assertThat(token.lifetimeMs(), lessThanOrEqualTo(after + expiresInSeconds * 1000L));
+    }
+
+    @Test
+    void startTimeMs_isTheIssueInstant() {
+        final long before = System.currentTimeMillis();
+
+        final AzureFederatedOAuthBearerToken token =
+                new AzureFederatedOAuthBearerToken(TOKEN_VALUE, 3600L, SCOPE, PRINCIPAL);
+
+        final long after = System.currentTimeMillis();
+
+        assertThat(token.startTimeMs(), greaterThanOrEqualTo(before));
+        assertThat(token.startTimeMs(), lessThanOrEqualTo(after));
+    }
+
+    @Test
+    void valueAndPrincipalAndScope_areReturnedVerbatim() {
+        final AzureFederatedOAuthBearerToken token =
+                new AzureFederatedOAuthBearerToken(TOKEN_VALUE, 3600L, SCOPE, PRINCIPAL);
+
+        assertThat(token.value(), equalTo(TOKEN_VALUE));
+        assertThat(token.principalName(), equalTo(PRINCIPAL));
+        assertThat(token.scope(), contains(SCOPE));
+    }
+
+    @Test
+    void scope_isEmptyWhenNull() {
+        final AzureFederatedOAuthBearerToken token =
+                new AzureFederatedOAuthBearerToken(TOKEN_VALUE, 3600L, null, PRINCIPAL);
+
+        assertThat(token.scope().isEmpty(), equalTo(true));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -300,5 +301,29 @@ class AzureFederatedTokenProviderTest {
                         Collections.emptyMap(), null).getToken());
 
         assertThat(e.getCause().getMessage(), containsString("requires an AWS credentials extension"));
+    }
+
+    @Test
+    void close_afterStsClientCreated_closesStsClient() throws IOException, InterruptedException {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response =
+                httpResponse(200, "{\"access_token\":\"azure-access-token\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+        final AzureFederatedTokenProvider provider = providerWith(stsClient, httpClient);
+        provider.getToken();
+
+        provider.close();
+
+        verify(stsClient).close();
+    }
+
+    @Test
+    void close_whenStsClientNeverCreated_isNoOp() {
+        final AzureFederatedTokenProvider provider = providerWith(stsClient, httpClient);
+
+        provider.close();
+
+        verify(stsClient, never()).close();
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.authenticator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetWebIdentityTokenResponse;
+import software.amazon.awssdk.services.sts.model.OutboundWebIdentityFederationDisabledException;
+import software.amazon.awssdk.services.sts.model.StsException;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AzureFederatedTokenProviderTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String STS_ROLE_ARN = "arn:aws:iam::123456789012:role/eh-federation";
+    private static final String TOKEN_ENDPOINT =
+            "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token";
+    private static final String CLIENT_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String SCOPE = "https://my-namespace.servicebus.windows.net/.default";
+    private static final String AWS_JWT = "aws.web.identity.jwt";
+
+    private StsClient stsClient;
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        stsClient = mock(StsClient.class);
+        httpClient = mock(HttpClient.class);
+    }
+
+    private AzureFederatedTokenProvider providerWith(final StsClient sts, final HttpClient http) {
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+        return new AzureFederatedTokenProvider(REGION, STS_ROLE_ARN, TOKEN_ENDPOINT, CLIENT_ID, SCOPE,
+                Collections.emptyMap(), supplier, provider -> sts, http);
+    }
+
+    private void stubWebIdentityTokenSuccess() {
+        when(stsClient.getWebIdentityToken(any(java.util.function.Consumer.class)))
+                .thenReturn(GetWebIdentityTokenResponse.builder().webIdentityToken(AWS_JWT).build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpResponse<String> httpResponse(final int status, final String body) {
+        final HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(status);
+        when(response.body()).thenReturn(body);
+        return response;
+    }
+
+    @Test
+    void getToken_onSuccess_parsesAccessTokenAndExpiry() throws IOException, InterruptedException {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response =
+                httpResponse(200, "{\"access_token\":\"azure-access-token\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        final AzureFederatedOAuthBearerToken token = providerWith(stsClient, httpClient).getToken();
+
+        assertThat(token.value(), equalTo("azure-access-token"));
+        assertThat(token.lifetimeMs(), greaterThan(System.currentTimeMillis()));
+        assertThat(token.principalName(), equalTo(CLIENT_ID));
+    }
+
+    @Test
+    void getToken_onNon200_throwsWithHttpStatusAndAadstsCode() throws IOException, InterruptedException {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response = httpResponse(401,
+                "{\"error\":\"invalid_client\",\"error_description\":\"AADSTS700016: Application not found\"}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        final RuntimeException e = assertThrows(RuntimeException.class,
+                () -> providerWith(stsClient, httpClient).getToken());
+
+        assertThat(e.getMessage(), containsString("401"));
+        assertThat(e.getMessage(), containsString("AADSTS700016"));
+    }
+
+    @Test
+    void getToken_whenGetWebIdentityToken403_throwsAccessDeniedMessage() {
+        when(stsClient.getWebIdentityToken(any(java.util.function.Consumer.class)))
+                .thenThrow(StsException.builder().statusCode(403).message("AccessDenied").build());
+
+        final RuntimeException e = assertThrows(RuntimeException.class,
+                () -> providerWith(stsClient, httpClient).getToken());
+
+        assertThat(e.getMessage(), containsString(STS_ROLE_ARN));
+        assertThat(e.getMessage(), containsString("sts:GetWebIdentityToken"));
+    }
+
+    @Test
+    void getToken_whenOutboundFederationDisabled_throwsEnableFederationMessage() {
+        when(stsClient.getWebIdentityToken(any(java.util.function.Consumer.class)))
+                .thenThrow(OutboundWebIdentityFederationDisabledException.builder().message("disabled").build());
+
+        final RuntimeException e = assertThrows(RuntimeException.class,
+                () -> providerWith(stsClient, httpClient).getToken());
+
+        assertThat(e.getMessage(), containsString("Outbound"));
+    }
+
+    @Test
+    void getToken_isSingleFlight_runsExchangeExactlyOnceUnderConcurrency() throws Exception {
+        final AtomicInteger stsCalls = new AtomicInteger(0);
+        when(stsClient.getWebIdentityToken(any(java.util.function.Consumer.class)))
+                .thenAnswer(invocation -> {
+                    stsCalls.incrementAndGet();
+                    return GetWebIdentityTokenResponse.builder().webIdentityToken(AWS_JWT).build();
+                });
+        final HttpResponse<String> response =
+                httpResponse(200, "{\"access_token\":\"azure-access-token\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        final AzureFederatedTokenProvider provider = providerWith(stsClient, httpClient);
+        final int threads = 8;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                start.await();
+                return provider.getToken();
+            });
+        }
+        start.countDown();
+        pool.shutdown();
+        assertThat(pool.awaitTermination(10, TimeUnit.SECONDS), equalTo(true));
+
+        verify(stsClient, times(1)).getWebIdentityToken(any(java.util.function.Consumer.class));
+        assertThat(stsCalls.get(), equalTo(1));
+    }
+
+    @Test
+    void getToken_buildsStsClientOnce_acrossMultipleExchanges() throws IOException, InterruptedException {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response =
+                httpResponse(200, "{\"access_token\":\"azure-access-token\",\"expires_in\":0}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+        final AtomicInteger supplierCalls = new AtomicInteger(0);
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+        final AzureFederatedTokenProvider provider = new AzureFederatedTokenProvider(
+                REGION, STS_ROLE_ARN, TOKEN_ENDPOINT, CLIENT_ID, SCOPE, Collections.emptyMap(), supplier,
+                provider2 -> {
+                    supplierCalls.incrementAndGet();
+                    return stsClient;
+                }, httpClient);
+
+        provider.getToken();
+        provider.getToken();
+
+        assertThat(supplierCalls.get(), equalTo(1));
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    @Test
+    void getToken_resolvesCredentialsThroughSupplier_withRoleAndRegion() throws Exception {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response = httpResponse(200, "{\"access_token\":\"t\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+
+        new AzureFederatedTokenProvider(REGION, STS_ROLE_ARN, TOKEN_ENDPOINT, CLIENT_ID, SCOPE,
+                Collections.emptyMap(), supplier, provider -> stsClient, httpClient).getToken();
+
+        final ArgumentCaptor<AwsCredentialsOptions> captor =
+                ArgumentCaptor.forClass(AwsCredentialsOptions.class);
+        verify(supplier).getProvider(captor.capture());
+        assertThat(captor.getValue().getStsRoleArn(), equalTo(STS_ROLE_ARN));
+        assertThat(captor.getValue().getRegion().id(), equalTo(REGION));
+    }
+
+    @Test
+    void getToken_passesStsHeaderOverridesToSupplier() throws Exception {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response = httpResponse(200, "{\"access_token\":\"t\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+        final Map<String, String> stsHeaderOverrides = Map.of(
+                "x-amz-source-arn", "arn:aws:osis:us-east-1:123456789012:pipeline/p",
+                "x-amz-source-account", "123456789012");
+
+        new AzureFederatedTokenProvider(REGION, STS_ROLE_ARN, TOKEN_ENDPOINT, CLIENT_ID, SCOPE,
+                stsHeaderOverrides, supplier, provider -> stsClient, httpClient).getToken();
+
+        final ArgumentCaptor<AwsCredentialsOptions> captor =
+                ArgumentCaptor.forClass(AwsCredentialsOptions.class);
+        verify(supplier).getProvider(captor.capture());
+        assertThat(captor.getValue().getStsHeaderOverrides(), equalTo(stsHeaderOverrides));
+    }
+
+    @Test
+    void getToken_withNullRole_stillResolvesThroughSupplierAndMints() throws Exception {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response = httpResponse(200, "{\"access_token\":\"t\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+
+        // null role is a valid outcome (role supplied out of band) — must NOT throw
+        final AzureFederatedOAuthBearerToken token = new AzureFederatedTokenProvider(
+                REGION, null, TOKEN_ENDPOINT, CLIENT_ID, SCOPE, Collections.emptyMap(), supplier,
+                provider -> stsClient, httpClient)
+                .getToken();
+
+        assertThat(token.value(), equalTo("t"));
+    }
+
+    @Test
+    void getToken_whenGetWebIdentityToken403WithNullRole_usesStableIdentifierNotNullLiteral() {
+        when(stsClient.getWebIdentityToken(any(java.util.function.Consumer.class)))
+                .thenThrow(StsException.builder().statusCode(403).message("AccessDenied").build());
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+
+        final RuntimeException e = assertThrows(RuntimeException.class, () ->
+                new AzureFederatedTokenProvider(REGION, null, TOKEN_ENDPOINT, CLIENT_ID, SCOPE,
+                        Collections.emptyMap(), supplier, provider -> stsClient, httpClient).getToken());
+
+        assertThat(e.getMessage(), not(containsString("null")));
+        assertThat(e.getMessage(), containsString("sts:GetWebIdentityToken"));
+    }
+
+    @Test
+    void getToken_whenCredentialResolutionThrowsNonSdkException_surfacesActionableMessage() {
+        // simulate a non-SDK failure surfacing at the credential-materialization point
+        when(stsClient.getWebIdentityToken(any(java.util.function.Consumer.class)))
+                .thenThrow(new RuntimeException("com.amazonaws delegation assume failed"));
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(mock(AwsCredentialsProvider.class));
+
+        final RuntimeException e = assertThrows(RuntimeException.class, () ->
+                new AzureFederatedTokenProvider(REGION, STS_ROLE_ARN, TOKEN_ENDPOINT, CLIENT_ID, SCOPE,
+                        Collections.emptyMap(), supplier, provider -> stsClient, httpClient).getToken());
+
+        assertThat(e.getMessage(), containsString("AWS credential resolution failed"));
+    }
+
+    @Test
+    void getToken_withNullSupplier_throwsExtensionRequired() {
+        final RuntimeException e = assertThrows(RuntimeException.class, () ->
+                new AzureFederatedTokenProvider(REGION, STS_ROLE_ARN, TOKEN_ENDPOINT, CLIENT_ID, SCOPE,
+                        Collections.emptyMap(), null).getToken());
+
+        assertThat(e.getCause().getMessage(), containsString("requires an AWS credentials extension"));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AuthConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AuthConfigTest.java
@@ -131,4 +131,34 @@ class AuthConfigTest {
         assertThat(authConfig.getSaslAuthConfig().getOAuthConfig(), equalTo(testOAuthConfig));
     }
 
+    @Test
+    void testSaslAuthConfigWithAzureFederated() throws NoSuchFieldException, IllegalAccessException {
+        final AuthConfig.SaslAuthConfig localSaslAuthConfig = new AuthConfig.SaslAuthConfig();
+        final AzureFederatedAuthConfig azureFederatedAuthConfig = new AzureFederatedAuthConfig();
+        setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "azureFederatedAuthConfig", azureFederatedAuthConfig);
+        setField(AuthConfig.class, authConfig, "saslAuthConfig", localSaslAuthConfig);
+        assertThat(authConfig.getSaslAuthConfig().getAzureFederatedAuthConfig(), equalTo(azureFederatedAuthConfig));
+    }
+
+    @Test
+    void hasOnlyOneConfig_azureFederatedAlone_isTrue() throws NoSuchFieldException, IllegalAccessException {
+        final AuthConfig.SaslAuthConfig localSaslAuthConfig = new AuthConfig.SaslAuthConfig();
+        setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "azureFederatedAuthConfig", new AzureFederatedAuthConfig());
+        assertThat(localSaslAuthConfig.hasOnlyOneConfig(), equalTo(true));
+    }
+
+    @Test
+    void hasOnlyOneConfig_azureFederatedWithAnotherMechanism_isFalse() throws NoSuchFieldException, IllegalAccessException {
+        final AuthConfig.SaslAuthConfig localSaslAuthConfig = new AuthConfig.SaslAuthConfig();
+        setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "azureFederatedAuthConfig", new AzureFederatedAuthConfig());
+        setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "scramAuthConfig", new ScramAuthConfig());
+        assertThat(localSaslAuthConfig.hasOnlyOneConfig(), equalTo(false));
+    }
+
+    @Test
+    void azureFederatedAuthConfigField_hasValidAnnotation_soNestedNotNullsCascade() throws NoSuchFieldException {
+        final java.lang.reflect.Field field = AuthConfig.SaslAuthConfig.class.getDeclaredField("azureFederatedAuthConfig");
+        assertThat(field.getAnnotation(jakarta.validation.Valid.class), notNullValue());
+    }
+
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfigTest.java
@@ -32,7 +32,6 @@ class AzureFederatedAuthConfigTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private static final String TENANT_ID = "00000000-0000-0000-0000-000000000000";
     private static final String CLIENT_ID = "11111111-1111-1111-1111-111111111111";
     private static final String TOKEN_ENDPOINT =
             "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token";
@@ -50,32 +49,25 @@ class AzureFederatedAuthConfigTest {
     }
 
     @Test
-    void allFourFieldsDeserializeAndGettersReturnThemVerbatim() {
+    void allFieldsDeserializeAndGettersReturnThemVerbatim() {
         final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(fullConfig(), AzureFederatedAuthConfig.class);
 
         assertThat(config, notNullValue());
-        assertThat(config.getAzureTenantId(), equalTo(TENANT_ID));
-        assertThat(config.getAzureClientId(), equalTo(CLIENT_ID));
-        assertThat(config.getAzureTokenEndpoint(), equalTo(TOKEN_ENDPOINT));
+        assertThat(config.getClientId(), equalTo(CLIENT_ID));
+        assertThat(config.getTokenEndpoint(), equalTo(TOKEN_ENDPOINT));
         assertThat(config.getScope(), equalTo(SCOPE));
     }
 
     @Test
-    void azureTenantIdIsRequired() {
-        assertMissingFieldIsRejected("azure_tenant_id", "azureTenantId",
-                "azure_tenant_id is required for azure_federated authentication");
+    void clientIdIsRequired() {
+        assertMissingFieldIsRejected("client_id", "clientId",
+                "client_id is required for azure_federated authentication");
     }
 
     @Test
-    void azureClientIdIsRequired() {
-        assertMissingFieldIsRejected("azure_client_id", "azureClientId",
-                "azure_client_id is required for azure_federated authentication");
-    }
-
-    @Test
-    void azureTokenEndpointIsRequired() {
-        assertMissingFieldIsRejected("azure_token_endpoint", "azureTokenEndpoint",
-                "azure_token_endpoint is required for azure_federated authentication");
+    void tokenEndpointIsRequired() {
+        assertMissingFieldIsRejected("token_endpoint", "tokenEndpoint",
+                "token_endpoint is required for azure_federated authentication");
     }
 
     @Test
@@ -85,39 +77,12 @@ class AzureFederatedAuthConfigTest {
     }
 
     @Test
-    void tenantMatchingEndpoint_isValid() {
+    void allFieldsPresent_isValid() {
         final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(fullConfig(), AzureFederatedAuthConfig.class);
 
         final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
 
         assertThat(violations, empty());
-    }
-
-    @Test
-    void tenantNotMatchingEndpoint_isRejected() {
-        final Map<String, String> yaml = fullConfig();
-        yaml.put("azure_tenant_id", "99999999-9999-9999-9999-999999999999");
-        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(yaml, AzureFederatedAuthConfig.class);
-
-        final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
-
-        assertThat(violations, hasSize(1));
-        final ConstraintViolation<AzureFederatedAuthConfig> violation = violations.iterator().next();
-        assertThat(violation.getPropertyPath().toString(), equalTo("tenantConsistentWithEndpoint"));
-        assertThat(violation.getMessage(), equalTo("azure_tenant_id must match the tenant in azure_token_endpoint"));
-    }
-
-    @Test
-    void tenantConsistency_notCheckedWhenEndpointMissing() {
-        final Map<String, String> yaml = fullConfig();
-        yaml.remove("azure_token_endpoint");
-        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(yaml, AzureFederatedAuthConfig.class);
-
-        final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
-
-        assertThat(violations, hasSize(1));
-        final ConstraintViolation<AzureFederatedAuthConfig> violation = violations.iterator().next();
-        assertThat(violation.getPropertyPath().toString(), equalTo("azureTokenEndpoint"));
     }
 
     private void assertMissingFieldIsRejected(final String jsonProperty, final String propertyPath,
@@ -136,9 +101,8 @@ class AzureFederatedAuthConfigTest {
 
     private Map<String, String> fullConfig() {
         final Map<String, String> yaml = new HashMap<>();
-        yaml.put("azure_tenant_id", TENANT_ID);
-        yaml.put("azure_client_id", CLIENT_ID);
-        yaml.put("azure_token_endpoint", TOKEN_ENDPOINT);
+        yaml.put("client_id", CLIENT_ID);
+        yaml.put("token_endpoint", TOKEN_ENDPOINT);
         yaml.put("scope", SCOPE);
         return yaml;
     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AzureFederatedAuthConfigTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+
+class AzureFederatedAuthConfigTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String TENANT_ID = "00000000-0000-0000-0000-000000000000";
+    private static final String CLIENT_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String TOKEN_ENDPOINT =
+            "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token";
+    private static final String SCOPE = "https://my-namespace.servicebus.windows.net/.default";
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        validator = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory()
+                .getValidator();
+    }
+
+    @Test
+    void allFourFieldsDeserializeAndGettersReturnThemVerbatim() {
+        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(fullConfig(), AzureFederatedAuthConfig.class);
+
+        assertThat(config, notNullValue());
+        assertThat(config.getAzureTenantId(), equalTo(TENANT_ID));
+        assertThat(config.getAzureClientId(), equalTo(CLIENT_ID));
+        assertThat(config.getAzureTokenEndpoint(), equalTo(TOKEN_ENDPOINT));
+        assertThat(config.getScope(), equalTo(SCOPE));
+    }
+
+    @Test
+    void azureTenantIdIsRequired() {
+        assertMissingFieldIsRejected("azure_tenant_id", "azureTenantId",
+                "azure_tenant_id is required for azure_federated authentication");
+    }
+
+    @Test
+    void azureClientIdIsRequired() {
+        assertMissingFieldIsRejected("azure_client_id", "azureClientId",
+                "azure_client_id is required for azure_federated authentication");
+    }
+
+    @Test
+    void azureTokenEndpointIsRequired() {
+        assertMissingFieldIsRejected("azure_token_endpoint", "azureTokenEndpoint",
+                "azure_token_endpoint is required for azure_federated authentication");
+    }
+
+    @Test
+    void scopeIsRequired() {
+        assertMissingFieldIsRejected("scope", "scope",
+                "scope is required for azure_federated authentication");
+    }
+
+    @Test
+    void tenantMatchingEndpoint_isValid() {
+        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(fullConfig(), AzureFederatedAuthConfig.class);
+
+        final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
+
+        assertThat(violations, empty());
+    }
+
+    @Test
+    void tenantNotMatchingEndpoint_isRejected() {
+        final Map<String, String> yaml = fullConfig();
+        yaml.put("azure_tenant_id", "99999999-9999-9999-9999-999999999999");
+        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(yaml, AzureFederatedAuthConfig.class);
+
+        final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
+
+        assertThat(violations, hasSize(1));
+        final ConstraintViolation<AzureFederatedAuthConfig> violation = violations.iterator().next();
+        assertThat(violation.getPropertyPath().toString(), equalTo("tenantConsistentWithEndpoint"));
+        assertThat(violation.getMessage(), equalTo("azure_tenant_id must match the tenant in azure_token_endpoint"));
+    }
+
+    @Test
+    void tenantConsistency_notCheckedWhenEndpointMissing() {
+        final Map<String, String> yaml = fullConfig();
+        yaml.remove("azure_token_endpoint");
+        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(yaml, AzureFederatedAuthConfig.class);
+
+        final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
+
+        assertThat(violations, hasSize(1));
+        final ConstraintViolation<AzureFederatedAuthConfig> violation = violations.iterator().next();
+        assertThat(violation.getPropertyPath().toString(), equalTo("azureTokenEndpoint"));
+    }
+
+    private void assertMissingFieldIsRejected(final String jsonProperty, final String propertyPath,
+                                              final String expectedMessage) {
+        final Map<String, String> yaml = fullConfig();
+        yaml.remove(jsonProperty);
+        final AzureFederatedAuthConfig config = OBJECT_MAPPER.convertValue(yaml, AzureFederatedAuthConfig.class);
+
+        final Set<ConstraintViolation<AzureFederatedAuthConfig>> violations = validator.validate(config);
+
+        assertThat(violations, hasSize(1));
+        final ConstraintViolation<AzureFederatedAuthConfig> violation = violations.iterator().next();
+        assertThat(violation.getPropertyPath().toString(), equalTo(propertyPath));
+        assertThat(violation.getMessage(), equalTo(expectedMessage));
+    }
+
+    private Map<String, String> fullConfig() {
+        final Map<String, String> yaml = new HashMap<>();
+        yaml.put("azure_tenant_id", TENANT_ID);
+        yaml.put("azure_client_id", CLIENT_ID);
+        yaml.put("azure_token_endpoint", TOKEN_ENDPOINT);
+        yaml.put("scope", SCOPE);
+        return yaml;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfigTest.java
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AzureFederatedAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.IsolationLevel;
@@ -33,6 +36,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
@@ -111,5 +115,60 @@ class KafkaSourceConfigTest {
 	void test_default_acknowledgements_timeout() {
 		kafkaSourceConfig = new KafkaSourceConfig();
 		assertEquals(KafkaSourceConfig.DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT, kafkaSourceConfig.getAcknowledgementsTimeout());
+	}
+
+	@Test
+	void isAzureFederatedAwsConfigValid_withStsRoleArnAndRegion_isTrue() throws NoSuchFieldException, IllegalAccessException {
+		final KafkaSourceConfig config = buildAzureFederatedConfig("us-east-1", "arn:aws:iam::123456789012:role/eh-federation");
+		assertTrue(config.isAzureFederatedAwsConfigValid());
+	}
+
+	@Test
+	void isAzureFederatedAwsConfigValid_withoutStsRoleArn_isTrue() throws NoSuchFieldException, IllegalAccessException {
+		// region-only is valid: the role may be supplied out of band rather than in pipeline config
+		final KafkaSourceConfig config = buildAzureFederatedConfig("us-east-1", null);
+		assertTrue(config.isAzureFederatedAwsConfigValid());
+	}
+
+	@Test
+	void isAzureFederatedAwsConfigValid_withoutRegion_isFalse() throws NoSuchFieldException, IllegalAccessException {
+		final KafkaSourceConfig config = buildAzureFederatedConfig(null, "arn:aws:iam::123456789012:role/eh-federation");
+		assertFalse(config.isAzureFederatedAwsConfigValid());
+	}
+
+	@Test
+	void isAzureFederatedAwsConfigValid_withoutAwsConfig_isFalse() throws NoSuchFieldException, IllegalAccessException {
+		final AuthConfig.SaslAuthConfig saslAuthConfig = new AuthConfig.SaslAuthConfig();
+		setField(AuthConfig.SaslAuthConfig.class, saslAuthConfig, "azureFederatedAuthConfig", new AzureFederatedAuthConfig());
+		final AuthConfig authConfig = new AuthConfig();
+		setField(AuthConfig.class, authConfig, "saslAuthConfig", saslAuthConfig);
+		final KafkaSourceConfig config = new KafkaSourceConfig();
+		setField(KafkaSourceConfig.class, config, "authConfig", authConfig);
+		assertFalse(config.isAzureFederatedAwsConfigValid());
+	}
+
+	@Test
+	void isAzureFederatedAwsConfigValid_withoutAzureFederated_isTrue() {
+		final KafkaSourceConfig config = new KafkaSourceConfig();
+		assertTrue(config.isAzureFederatedAwsConfigValid());
+	}
+
+	private KafkaSourceConfig buildAzureFederatedConfig(final String region, final String stsRoleArn)
+			throws NoSuchFieldException, IllegalAccessException {
+		final AuthConfig.SaslAuthConfig saslAuthConfig = new AuthConfig.SaslAuthConfig();
+		setField(AuthConfig.SaslAuthConfig.class, saslAuthConfig, "azureFederatedAuthConfig", new AzureFederatedAuthConfig());
+		final AuthConfig authConfig = new AuthConfig();
+		setField(AuthConfig.class, authConfig, "saslAuthConfig", saslAuthConfig);
+		final AwsConfig awsConfig = new AwsConfig();
+		if (region != null) {
+			setField(AwsConfig.class, awsConfig, "region", region);
+		}
+		if (stsRoleArn != null) {
+			setField(AwsConfig.class, awsConfig, "stsRoleArn", stsRoleArn);
+		}
+		final KafkaSourceConfig config = new KafkaSourceConfig();
+		setField(KafkaSourceConfig.class, config, "authConfig", authConfig);
+		setField(KafkaSourceConfig.class, config, "awsConfig", awsConfig);
+		return config;
 	}
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -1,7 +1,9 @@
 package org.opensearch.dataprepper.plugins.kafka.util;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,13 +13,17 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObserver;
+import org.opensearch.dataprepper.plugins.kafka.authenticator.AwsCredentialsSupplierProvider;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicBasicCredentialsProvider;
 import org.opensearch.dataprepper.plugins.kafka.authenticator.DynamicSaslClientCallbackHandler;
 import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsCredentialsConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AzureFederatedAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaConnectionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.source.KafkaSourceConfig;
@@ -39,6 +45,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -60,6 +69,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 @ExtendWith(MockitoExtension.class)
 public class KafkaSecurityConfigurerTest {
@@ -84,11 +98,16 @@ public class KafkaSecurityConfigurerTest {
     @Captor
     private ArgumentCaptor<PluginConfigObserver> pluginConfigObserverArgumentCaptor;
 
+    @AfterEach
+    void resetAwsCredentialsSupplierSingleton() {
+        AwsCredentialsSupplierProvider.getInstance().set(null);
+    }
+
     @Test
     public void testSetAuthPropertiesWithSaslPlainCertificate() throws Exception {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-sasl-ssl-certificate-content.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("sasl.mechanism"), is("PLAIN"));
         assertThat(props.getProperty("security.protocol"), is("SASL_SSL"));
         assertThat(props.getProperty("certificateContent"), is("CERTIFICATE_DATA"));
@@ -101,7 +120,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesWithNoAuthSsl() throws Exception {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-no-auth-ssl.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("sasl.mechanism"), is(nullValue()));
         assertThat(props.getProperty("security.protocol"), is("SSL"));
         assertThat(props.getProperty("certificateContent"), is("CERTIFICATE_DATA"));
@@ -111,7 +130,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesWithNoAuthSslNone() throws Exception {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-no-auth-ssl-none.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("sasl.mechanism"), is(nullValue()));
         assertThat(props.getProperty("security.protocol"), is(nullValue()));
         assertThat(props.getProperty("certificateContent"), is(nullValue()));
@@ -122,7 +141,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesWithNoAuthInsecure() throws Exception {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-auth-insecure.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("sasl.mechanism"), is("PLAIN"));
         assertThat(props.getProperty("security.protocol"), is("SASL_PLAINTEXT"));
         assertThat(props.getProperty("certificateContent"), is(nullValue()));
@@ -132,7 +151,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesAuthSslWithTrustStore() throws Exception {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-sasl-ssl-truststore.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("sasl.mechanism"), is("PLAIN"));
         assertThat(props.getProperty("security.protocol"), is("SASL_SSL"));
         assertThat(props.getProperty("certificateContent"), is(nullValue()));
@@ -145,7 +164,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesAuthSslWithNoCertContentNoTrustStore() throws Exception {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-sasl-ssl-no-cert-content-no-truststore.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("sasl.mechanism"), is("PLAIN"));
         assertThat(props.getProperty("security.protocol"), is("SASL_SSL"));
         assertThat(props.getProperty("certificateContent"), is(nullValue()));
@@ -158,7 +177,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesBootstrapServersWithSaslIAMRole() throws IOException {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-bootstrap-servers-sasl-iam-role.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("bootstrap.servers"), is("localhost:9092"));
         assertThat(props.getProperty("sasl.mechanism"), is("AWS_MSK_IAM"));
         assertThat(props.getProperty("sasl.jaas.config"),
@@ -177,7 +196,7 @@ public class KafkaSecurityConfigurerTest {
     public void testSetAuthPropertiesBootstrapServersWithSaslIAMDefault() throws IOException {
         final Properties props = new Properties();
         final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-bootstrap-servers-sasl-iam-default.yaml");
-        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         assertThat(props.getProperty("bootstrap.servers"), is("localhost:9092"));
         assertThat(props.getProperty("sasl.jaas.config"), is("software.amazon.msk.auth.iam.IAMLoginModule required;"));
         assertThat(props.getProperty("sasl.mechanism"), is("AWS_MSK_IAM"));
@@ -205,7 +224,7 @@ public class KafkaSecurityConfigurerTest {
         when(kafkaClient.getBootstrapBrokers(any(GetBootstrapBrokersRequest.class))).thenReturn(response);
         try (MockedStatic<KafkaClient> mockedKafkaClient = mockStatic(KafkaClient.class)) {
             mockedKafkaClient.when(KafkaClient::builder).thenReturn(kafkaClientBuilder);
-            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         }
         assertThat(props.getProperty("bootstrap.servers"), is(testMSKEndpoint));
         assertThat(props.getProperty("sasl.mechanism"), is("AWS_MSK_IAM"));
@@ -243,7 +262,7 @@ public class KafkaSecurityConfigurerTest {
 
             RuntimeException thrown = org.junit.jupiter.api.Assertions.assertThrows(
                     RuntimeException.class,
-                    () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG)
+                    () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG)
             );
 
             assertThat(thrown.getMessage(), is("Access denied when calling STS to get bootstrap server information from MSK. " +
@@ -278,7 +297,7 @@ public class KafkaSecurityConfigurerTest {
 
         try (MockedStatic<KafkaClient> mockedKafkaClient = mockStatic(KafkaClient.class)) {
             mockedKafkaClient.when(KafkaClient::builder).thenReturn(kafkaClientBuilder);
-            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         }
 
         assertThat(props.getProperty("bootstrap.servers"), is(testMSKEndpoint));
@@ -300,7 +319,7 @@ public class KafkaSecurityConfigurerTest {
         when(kafkaClient.getBootstrapBrokers(any(GetBootstrapBrokersRequest.class))).thenReturn(response);
         try (MockedStatic<KafkaClient> mockedKafkaClient = mockStatic(KafkaClient.class)) {
             mockedKafkaClient.when(KafkaClient::builder).thenReturn(kafkaClientBuilder);
-            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
         }
         assertThat(props.getProperty("bootstrap.servers"), is(testMSKEndpoint));
         assertThat(props.getProperty("sasl.mechanism"), is("PLAIN"));
@@ -430,7 +449,7 @@ public class KafkaSecurityConfigurerTest {
             when(mockBuilder.build()).thenReturn(stsAssumeRoleCredentialsProvider);
             mockedProvider.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(mockBuilder);
             
-            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
             
             verify(mockBuilder).refreshRequest(any(AssumeRoleRequest.class));
         }
@@ -448,7 +467,7 @@ public class KafkaSecurityConfigurerTest {
             when(stsCredentialsProviderBuilder.build()).thenReturn(stsAssumeRoleCredentialsProvider);
             mockedProvider.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(stsCredentialsProviderBuilder);
             
-            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, LOG);
+            KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
 
             final ArgumentCaptor<AssumeRoleRequest> assumeRoleRequestArgumentCaptor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
             verify(stsCredentialsProviderBuilder).refreshRequest(assumeRoleRequestArgumentCaptor.capture());
@@ -471,6 +490,223 @@ public class KafkaSecurityConfigurerTest {
             assertThat(overrideConfiguration.headers().get(headerName2).size(), equalTo(1));
             assertThat(overrideConfiguration.headers().get(headerName2), hasItem(headerValue2));
         }
+    }
+
+    @Test
+    void testSetAuthPropertiesWithAzureFederated() throws IOException {
+        final Properties props = new Properties();
+        final KafkaSourceConfig kafkaSourceConfig = createKafkaSinkConfig("kafka-pipeline-azure-federated.yaml");
+
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
+
+        assertThat(props.getProperty("sasl.mechanism"), is("OAUTHBEARER"));
+        assertThat(props.getProperty("security.protocol"), is("SASL_SSL"));
+        assertThat(props.getProperty("sasl.login.callback.handler.class"),
+                is("org.opensearch.dataprepper.plugins.kafka.authenticator.AzureFederatedCallbackHandler"));
+        final String jaasConfig = props.getProperty("sasl.jaas.config");
+        assertThat(jaasConfig, notNullValue());
+        assertThat(jaasConfig, containsString("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required"));
+        assertThat(jaasConfig, containsString("azureFederatedRegion=\"us-east-1\""));
+        assertThat(jaasConfig, containsString("azureFederatedStsRoleArn=\"arn:aws:iam::123456789012:role/eh-federation\""));
+        assertThat(jaasConfig, containsString(
+                "azureFederatedTokenEndpoint=\"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token\""));
+        assertThat(jaasConfig, containsString("azureFederatedClientId=\"11111111-1111-1111-1111-111111111111\""));
+        assertThat(jaasConfig, containsString("azureFederatedScope=\"https://my-namespace.servicebus.windows.net/.default\""));
+    }
+
+    @Test
+    void testSetAuthPropertiesWithAzureFederated_differentConfigsProduceDifferentJaasConfig() throws IOException {
+        final Properties firstProps = new Properties();
+        KafkaSecurityConfigurer.setAuthProperties(firstProps,
+                createKafkaSinkConfig("kafka-pipeline-azure-federated.yaml"), null, LOG);
+        final Properties secondProps = new Properties();
+        KafkaSecurityConfigurer.setAuthProperties(secondProps,
+                createKafkaSinkConfig("kafka-pipeline-azure-federated-other-tenant.yaml"), null, LOG);
+
+        assertThat(firstProps.getProperty("sasl.jaas.config"),
+                is(not(secondProps.getProperty("sasl.jaas.config"))));
+    }
+
+    @Test
+    void testSetAuthPropertiesWithAzureFederated_nullAwsConfig_throws() throws Exception {
+        final KafkaSourceConfig kafkaSourceConfig = azureFederatedSourceConfig(null);
+
+        final Properties props = new Properties();
+        final RuntimeException e = assertThrows(RuntimeException.class,
+                () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG));
+        assertThat(e.getMessage(), is("azure_federated requires aws.region"));
+    }
+
+    @Test
+    void testSetAuthPropertiesWithAzureFederated_missingRegion_throws() throws Exception {
+        final AwsConfig awsConfig = new AwsConfig();
+        setField(AwsConfig.class, awsConfig, "stsRoleArn", "arn:aws:iam::123456789012:role/eh-federation");
+        final KafkaSourceConfig kafkaSourceConfig = azureFederatedSourceConfig(awsConfig);
+
+        final Properties props = new Properties();
+        final RuntimeException e = assertThrows(RuntimeException.class,
+                () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG));
+        assertThat(e.getMessage(), is("azure_federated requires aws.region"));
+    }
+
+    @Test
+    void testSetAuthPropertiesWithAzureFederated_missingStsRoleArn_omitsRoleJaasOption() throws Exception {
+        final KafkaSourceConfig kafkaSourceConfig = azureFederatedConfig("us-east-1", null,
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        final Properties props = new Properties();
+
+        KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG);
+
+        final String jaas = props.getProperty("sasl.jaas.config");
+        assertThat(jaas, containsString("OAuthBearerLoginModule"));
+        assertThat(jaas, not(containsString("azureFederatedStsRoleArn")));
+        assertThat(jaas, not(containsString("null")));
+    }
+
+    @Test
+    void setAuthProperties_azureFederatedWithoutRole_omitsRoleJaasOption() throws Exception {
+        final KafkaSourceConfig config = azureFederatedConfig("us-east-1", null,
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        final Properties properties = new Properties();
+
+        KafkaSecurityConfigurer.setAuthProperties(properties, config, mock(AwsCredentialsSupplier.class), LOG);
+
+        final String jaas = properties.getProperty("sasl.jaas.config");
+        assertThat(jaas, containsString("OAuthBearerLoginModule"));
+        assertThat(jaas, not(containsString("azureFederatedStsRoleArn")));
+        assertThat(jaas, not(containsString("null")));
+    }
+
+    @Test
+    void setAuthProperties_azureFederatedWithRole_includesRoleJaasOption() throws Exception {
+        final KafkaSourceConfig config = azureFederatedConfig("us-east-1",
+                "arn:aws:iam::123456789012:role/eh-federation",
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        final Properties properties = new Properties();
+
+        KafkaSecurityConfigurer.setAuthProperties(properties, config, mock(AwsCredentialsSupplier.class), LOG);
+
+        assertThat(properties.getProperty("sasl.jaas.config"),
+                containsString("azureFederatedStsRoleArn=\"arn:aws:iam::123456789012:role/eh-federation\""));
+    }
+
+    @Test
+    void setAuthProperties_populatesSupplierSingleton() throws Exception {
+        final KafkaSourceConfig config = azureFederatedConfig("us-east-1", null,
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+
+        KafkaSecurityConfigurer.setAuthProperties(new Properties(), config, supplier, LOG);
+
+        assertThat(AwsCredentialsSupplierProvider.getInstance().getAwsCredentialsSupplier(),
+                sameInstance(supplier));
+    }
+
+    @Test
+    void setAuthProperties_withNullSupplier_doesNotThrow() throws Exception {
+        final KafkaSourceConfig config = azureFederatedConfig("us-east-1", null,
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        AwsCredentialsSupplierProvider.getInstance().set(null);
+
+        KafkaSecurityConfigurer.setAuthProperties(new Properties(), config, null, LOG);
+        assertThat(AwsCredentialsSupplierProvider.getInstance().getAwsCredentialsSupplier(), nullValue());
+    }
+
+    @Test
+    void setAuthProperties_azureFederatedWithStsHeaderOverrides_encodesThemInJaas() throws Exception {
+        final Map<String, String> stsHeaderOverrides = Map.of(
+                "x-amz-source-arn", "arn:aws:osis:us-east-1:123456789012:pipeline/p",
+                "x-amz-source-account", "quoted \"value\" with spaces");
+        final KafkaSourceConfig config = azureFederatedConfig("us-east-1",
+                "arn:aws:iam::123456789012:role/eh-federation",
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default", stsHeaderOverrides);
+        final Properties properties = new Properties();
+
+        KafkaSecurityConfigurer.setAuthProperties(properties, config, mock(AwsCredentialsSupplier.class), LOG);
+
+        final String jaas = properties.getProperty("sasl.jaas.config");
+        assertThat(jaas, containsString("azureFederatedStsHeaderOverrides=\""));
+        final String encoded = jaas.replaceAll(".*azureFederatedStsHeaderOverrides=\"([^\"]*)\".*", "$1");
+        final String decodedJson = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+        final Map<String, String> decoded = new ObjectMapper()
+                .readValue(decodedJson, new TypeReference<Map<String, String>>() {});
+        assertThat(decoded, equalTo(stsHeaderOverrides));
+    }
+
+    @Test
+    void setAuthProperties_azureFederatedWithoutStsHeaderOverrides_omitsJaasOption() throws Exception {
+        final KafkaSourceConfig config = azureFederatedConfig("us-east-1",
+                "arn:aws:iam::123456789012:role/eh-federation",
+                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        final Properties properties = new Properties();
+
+        KafkaSecurityConfigurer.setAuthProperties(properties, config, mock(AwsCredentialsSupplier.class), LOG);
+
+        assertThat(properties.getProperty("sasl.jaas.config"),
+                not(containsString("azureFederatedStsHeaderOverrides")));
+    }
+
+    private KafkaSourceConfig azureFederatedConfig(final String region, final String stsRoleArn, final String tenantId,
+            final String clientId, final String tokenEndpoint, final String scope)
+            throws NoSuchFieldException, IllegalAccessException {
+        return azureFederatedConfig(region, stsRoleArn, tenantId, clientId, tokenEndpoint, scope, null);
+    }
+
+    private KafkaSourceConfig azureFederatedConfig(final String region, final String stsRoleArn, final String tenantId,
+            final String clientId, final String tokenEndpoint, final String scope,
+            final Map<String, String> stsHeaderOverrides)
+            throws NoSuchFieldException, IllegalAccessException {
+        final AzureFederatedAuthConfig azureFederatedAuthConfig = new AzureFederatedAuthConfig();
+        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "azureTenantId", tenantId);
+        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "azureClientId", clientId);
+        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "azureTokenEndpoint", tokenEndpoint);
+        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "scope", scope);
+        final AuthConfig.SaslAuthConfig localSaslAuthConfig = new AuthConfig.SaslAuthConfig();
+        setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "azureFederatedAuthConfig", azureFederatedAuthConfig);
+        final AuthConfig localAuthConfig = new AuthConfig();
+        setField(AuthConfig.class, localAuthConfig, "saslAuthConfig", localSaslAuthConfig);
+        final AwsConfig awsConfig = new AwsConfig();
+        setField(AwsConfig.class, awsConfig, "region", region);
+        if (stsRoleArn != null) {
+            setField(AwsConfig.class, awsConfig, "stsRoleArn", stsRoleArn);
+        }
+        if (stsHeaderOverrides != null) {
+            setField(AwsConfig.class, awsConfig, "awsStsHeaderOverrides", stsHeaderOverrides);
+        }
+        final KafkaSourceConfig kafkaSourceConfig = new KafkaSourceConfig();
+        setField(KafkaSourceConfig.class, kafkaSourceConfig, "authConfig", localAuthConfig);
+        setField(KafkaSourceConfig.class, kafkaSourceConfig, "awsConfig", awsConfig);
+        kafkaSourceConfig.setBootStrapServers(List.of("broker:9093"));
+        return kafkaSourceConfig;
+    }
+
+    private KafkaSourceConfig azureFederatedSourceConfig(final AwsConfig awsConfig)
+            throws NoSuchFieldException, IllegalAccessException {
+        final AuthConfig.SaslAuthConfig localSaslAuthConfig = new AuthConfig.SaslAuthConfig();
+        setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "azureFederatedAuthConfig",
+                new AzureFederatedAuthConfig());
+        final AuthConfig localAuthConfig = new AuthConfig();
+        setField(AuthConfig.class, localAuthConfig, "saslAuthConfig", localSaslAuthConfig);
+        final KafkaSourceConfig kafkaSourceConfig = new KafkaSourceConfig();
+        setField(KafkaSourceConfig.class, kafkaSourceConfig, "authConfig", localAuthConfig);
+        if (awsConfig != null) {
+            setField(KafkaSourceConfig.class, kafkaSourceConfig, "awsConfig", awsConfig);
+        }
+        return kafkaSourceConfig;
     }
 
     private KafkaSourceConfig createKafkaSinkConfig(final String fileName) throws IOException {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSecurityConfigurerTest.java
@@ -50,6 +50,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -528,31 +529,52 @@ public class KafkaSecurityConfigurerTest {
     }
 
     @Test
-    void testSetAuthPropertiesWithAzureFederated_nullAwsConfig_throws() throws Exception {
+    void testSetAuthPropertiesWithAzureFederated_nullAwsConfig_noDefaultRegion_throws() throws Exception {
         final KafkaSourceConfig kafkaSourceConfig = azureFederatedSourceConfig(null);
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getDefaultRegion()).thenReturn(Optional.empty());
 
         final Properties props = new Properties();
         final RuntimeException e = assertThrows(RuntimeException.class,
-                () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG));
-        assertThat(e.getMessage(), is("azure_federated requires aws.region"));
+                () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, supplier, LOG));
+        assertThat(e.getMessage(),
+                is("azure_federated requires a region in the pipeline aws config or data-prepper-config.yaml"));
     }
 
     @Test
-    void testSetAuthPropertiesWithAzureFederated_missingRegion_throws() throws Exception {
+    void testSetAuthPropertiesWithAzureFederated_missingRegion_noDefaultRegion_throws() throws Exception {
         final AwsConfig awsConfig = new AwsConfig();
         setField(AwsConfig.class, awsConfig, "stsRoleArn", "arn:aws:iam::123456789012:role/eh-federation");
         final KafkaSourceConfig kafkaSourceConfig = azureFederatedSourceConfig(awsConfig);
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getDefaultRegion()).thenReturn(Optional.empty());
 
         final Properties props = new Properties();
         final RuntimeException e = assertThrows(RuntimeException.class,
-                () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, null, LOG));
-        assertThat(e.getMessage(), is("azure_federated requires aws.region"));
+                () -> KafkaSecurityConfigurer.setAuthProperties(props, kafkaSourceConfig, supplier, LOG));
+        assertThat(e.getMessage(),
+                is("azure_federated requires a region in the pipeline aws config or data-prepper-config.yaml"));
+    }
+
+    @Test
+    void testSetAuthPropertiesWithAzureFederated_regionFromDefaultRegion() throws Exception {
+        final KafkaSourceConfig config = azureFederatedConfig(null, null,
+                "11111111-1111-1111-1111-111111111111",
+                "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "https://ns.servicebus.windows.net/.default");
+        final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
+        when(supplier.getDefaultRegion()).thenReturn(Optional.of(Region.US_WEST_2));
+
+        final Properties props = new Properties();
+        KafkaSecurityConfigurer.setAuthProperties(props, config, supplier, LOG);
+
+        assertThat(props.getProperty("sasl.jaas.config"), containsString("azureFederatedRegion=\"us-west-2\""));
     }
 
     @Test
     void testSetAuthPropertiesWithAzureFederated_missingStsRoleArn_omitsRoleJaasOption() throws Exception {
         final KafkaSourceConfig kafkaSourceConfig = azureFederatedConfig("us-east-1", null,
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default");
         final Properties props = new Properties();
@@ -568,7 +590,7 @@ public class KafkaSecurityConfigurerTest {
     @Test
     void setAuthProperties_azureFederatedWithoutRole_omitsRoleJaasOption() throws Exception {
         final KafkaSourceConfig config = azureFederatedConfig("us-east-1", null,
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default");
         final Properties properties = new Properties();
@@ -585,7 +607,7 @@ public class KafkaSecurityConfigurerTest {
     void setAuthProperties_azureFederatedWithRole_includesRoleJaasOption() throws Exception {
         final KafkaSourceConfig config = azureFederatedConfig("us-east-1",
                 "arn:aws:iam::123456789012:role/eh-federation",
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default");
         final Properties properties = new Properties();
@@ -599,7 +621,7 @@ public class KafkaSecurityConfigurerTest {
     @Test
     void setAuthProperties_populatesSupplierSingleton() throws Exception {
         final KafkaSourceConfig config = azureFederatedConfig("us-east-1", null,
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default");
         final AwsCredentialsSupplier supplier = mock(AwsCredentialsSupplier.class);
@@ -613,7 +635,7 @@ public class KafkaSecurityConfigurerTest {
     @Test
     void setAuthProperties_withNullSupplier_doesNotThrow() throws Exception {
         final KafkaSourceConfig config = azureFederatedConfig("us-east-1", null,
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default");
         AwsCredentialsSupplierProvider.getInstance().set(null);
@@ -629,7 +651,7 @@ public class KafkaSecurityConfigurerTest {
                 "x-amz-source-account", "quoted \"value\" with spaces");
         final KafkaSourceConfig config = azureFederatedConfig("us-east-1",
                 "arn:aws:iam::123456789012:role/eh-federation",
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default", stsHeaderOverrides);
         final Properties properties = new Properties();
@@ -649,7 +671,7 @@ public class KafkaSecurityConfigurerTest {
     void setAuthProperties_azureFederatedWithoutStsHeaderOverrides_omitsJaasOption() throws Exception {
         final KafkaSourceConfig config = azureFederatedConfig("us-east-1",
                 "arn:aws:iam::123456789012:role/eh-federation",
-                "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
                 "https://login.microsoftonline.com/t/oauth2/v2.0/token",
                 "https://ns.servicebus.windows.net/.default");
         final Properties properties = new Properties();
@@ -660,20 +682,19 @@ public class KafkaSecurityConfigurerTest {
                 not(containsString("azureFederatedStsHeaderOverrides")));
     }
 
-    private KafkaSourceConfig azureFederatedConfig(final String region, final String stsRoleArn, final String tenantId,
+    private KafkaSourceConfig azureFederatedConfig(final String region, final String stsRoleArn,
             final String clientId, final String tokenEndpoint, final String scope)
             throws NoSuchFieldException, IllegalAccessException {
-        return azureFederatedConfig(region, stsRoleArn, tenantId, clientId, tokenEndpoint, scope, null);
+        return azureFederatedConfig(region, stsRoleArn, clientId, tokenEndpoint, scope, null);
     }
 
-    private KafkaSourceConfig azureFederatedConfig(final String region, final String stsRoleArn, final String tenantId,
+    private KafkaSourceConfig azureFederatedConfig(final String region, final String stsRoleArn,
             final String clientId, final String tokenEndpoint, final String scope,
             final Map<String, String> stsHeaderOverrides)
             throws NoSuchFieldException, IllegalAccessException {
         final AzureFederatedAuthConfig azureFederatedAuthConfig = new AzureFederatedAuthConfig();
-        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "azureTenantId", tenantId);
-        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "azureClientId", clientId);
-        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "azureTokenEndpoint", tokenEndpoint);
+        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "clientId", clientId);
+        setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "tokenEndpoint", tokenEndpoint);
         setField(AzureFederatedAuthConfig.class, azureFederatedAuthConfig, "scope", scope);
         final AuthConfig.SaslAuthConfig localSaslAuthConfig = new AuthConfig.SaslAuthConfig();
         setField(AuthConfig.SaslAuthConfig.class, localSaslAuthConfig, "azureFederatedAuthConfig", azureFederatedAuthConfig);

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated-other-tenant.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated-other-tenant.yaml
@@ -15,9 +15,8 @@ log-pipeline :
         authentication:
           sasl:
             azure_federated:
-              azure_tenant_id: "22222222-2222-2222-2222-222222222222"
-              azure_client_id: "33333333-3333-3333-3333-333333333333"
-              azure_token_endpoint: "https://login.microsoftonline.com/22222222-2222-2222-2222-222222222222/oauth2/v2.0/token"
+              client_id: "33333333-3333-3333-3333-333333333333"
+              token_endpoint: "https://login.microsoftonline.com/22222222-2222-2222-2222-222222222222/oauth2/v2.0/token"
               scope: "https://other-namespace.servicebus.windows.net/.default"
         aws:
           region: us-west-2

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated-other-tenant.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated-other-tenant.yaml
@@ -1,0 +1,29 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+log-pipeline :
+  source:
+     kafka:
+        bootstrap_servers:
+          - "other-namespace.servicebus.windows.net:9093"
+        encryption:
+          type: "SSL"
+        authentication:
+          sasl:
+            azure_federated:
+              azure_tenant_id: "22222222-2222-2222-2222-222222222222"
+              azure_client_id: "33333333-3333-3333-3333-333333333333"
+              azure_token_endpoint: "https://login.microsoftonline.com/22222222-2222-2222-2222-222222222222/oauth2/v2.0/token"
+              scope: "https://other-namespace.servicebus.windows.net/.default"
+        aws:
+          region: us-west-2
+          sts_role_arn: "arn:aws:iam::999999999999:role/other-eh-federation"
+        topics:
+        - name: "quickstart-events"
+          group_id: "groupdID1"
+  sink:
+    stdout:

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated.yaml
@@ -1,0 +1,29 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+log-pipeline :
+  source:
+     kafka:
+        bootstrap_servers:
+          - "my-namespace.servicebus.windows.net:9093"
+        encryption:
+          type: "SSL"
+        authentication:
+          sasl:
+            azure_federated:
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: "11111111-1111-1111-1111-111111111111"
+              azure_token_endpoint: "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token"
+              scope: "https://my-namespace.servicebus.windows.net/.default"
+        aws:
+          region: us-east-1
+          sts_role_arn: "arn:aws:iam::123456789012:role/eh-federation"
+        topics:
+        - name: "quickstart-events"
+          group_id: "groupdID1"
+  sink:
+    stdout:

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-azure-federated.yaml
@@ -15,9 +15,8 @@ log-pipeline :
         authentication:
           sasl:
             azure_federated:
-              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
-              azure_client_id: "11111111-1111-1111-1111-111111111111"
-              azure_token_endpoint: "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token"
+              client_id: "11111111-1111-1111-1111-111111111111"
+              token_endpoint: "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token"
               scope: "https://my-namespace.servicebus.windows.net/.default"
         aws:
           region: us-east-1


### PR DESCRIPTION
### Description

Enables the Kafka source to consume from Azure Event Hubs by federating an AWS identity to Azure Active Directory for OAuth, so no Azure client secret is stored in the pipeline. At runtime the source resolves AWS credentials through Data Prepper's standard AWS configuration, obtains an AWS web-identity token and exchanges it at the Azure Entra token endpoint for a short-lived access token used as the SASL/OAUTHBEARER credential. Credentials use Data Prepper's standard AWS configuration, so one pipeline works across AWS credential setups.
 
### Issues Resolved
Resolves #7007

### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
