### PR TITLE
Add integration test verifying processors work with empty, null, and …

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/EmptyProcessorIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/EmptyProcessorIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.EmptyProcessor;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+/**
+ * Integration test verifying that a processor with no mandatory configuration
+ * works correctly when configured as:
+ * <ul>
+ *   <li>bare key (empty): {@code empty_processor:}</li>
+ *   <li>explicit null: {@code empty_processor: null}</li>
+ *   <li>explicit empty string: {@code empty_processor: ''}</li>
+ * </ul>
+ *
+ * The pipeline configures 3 instances of {@code empty_processor}. Each instance
+ * increments a counter on every event it processes. After all processors run,
+ * the counter should equal 3 — proving all three configuration forms produce
+ * valid, functioning processor instances.
+ *
+ * @see EmptyProcessor
+ */
+class EmptyProcessorIT {
+    private static final String IN_MEMORY_IDENTIFIER = "EmptyProcessorIT";
+    private static final String PIPELINE_CONFIGURATION_UNDER_TEST = "empty-processor-pipeline.yaml";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(PIPELINE_CONFIGURATION_UNDER_TEST)
+                .build();
+
+        dataPrepperTestRunner.start();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void pipeline_with_single_record_has_count_equal_to_3() {
+        final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final Record<Event> eventRecord = new Record<>(event);
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, Collections.singletonList(eventRecord));
+
+        await().atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+                });
+
+        final List<Record<Event>> records = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(records.size(), equalTo(1));
+
+        final Integer count = records.get(0).getData().get(EmptyProcessor.COUNT_KEY, Integer.class);
+        assertThat("All 3 empty_processor instances (bare key, null, empty string) should have processed the event",
+                count, equalTo(3));
+    }
+
+    @Test
+    void pipeline_with_single_batch_of_records() {
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecords);
+
+        await().atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+                });
+
+        final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(sinkRecords.size(), equalTo(recordsToCreate));
+
+        for (final Record<Event> record : sinkRecords) {
+            final Integer count = record.getData().get(EmptyProcessor.COUNT_KEY, Integer.class);
+            assertThat("Each record should be processed by all 3 empty_processor instances",
+                    count, equalTo(3));
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/EmptyProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/EmptyProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collection;
+
+/**
+ * A test processor with no mandatory configuration parameters.
+ * Each instance increments a "empty_processor_count" field on the event.
+ * <p>
+ * This processor is used in integration tests to verify that plugins
+ * configured as a bare key, explicit null, or explicit empty string
+ * all result in valid processor instances that process events.
+ * <p>
+ * If 3 instances are configured in the pipeline, after processing
+ * the "empty_processor_count" field on each event should equal 3.
+ */
+@DataPrepperPlugin(name = "empty_processor", pluginType = Processor.class, pluginConfigurationType = EmptyProcessorConfig.class)
+public class EmptyProcessor implements Processor<Record<Event>, Record<Event>> {
+    public static final String COUNT_KEY = "empty_processor_count";
+
+    @DataPrepperPluginConstructor
+    public EmptyProcessor(final EmptyProcessorConfig config) {
+    }
+
+    @Override
+    public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
+        for (final Record<Event> record : records) {
+            final Integer currentCount = record.getData().get(COUNT_KEY, Integer.class);
+            record.getData().put(COUNT_KEY, (currentCount == null ? 0 : currentCount) + 1);
+        }
+        return records;
+    }
+
+    @Override
+    public void prepareForShutdown() {
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/EmptyProcessorConfig.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/EmptyProcessorConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+/**
+ * Configuration for {@link EmptyProcessor}.
+ * This processor has no mandatory configuration parameters,
+ * allowing it to be configured as a bare key, null, or empty string.
+ */
+public class EmptyProcessorConfig {
+}

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/empty-processor-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/empty-processor-pipeline.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+empty-processor-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: EmptyProcessorIT
+
+  processor:
+    - empty_processor:
+    - empty_processor: null
+    - empty_processor: ''
+
+  sink:
+    - in_memory:
+        testing_key: EmptyProcessorIT


### PR DESCRIPTION
### Description

Add integration test verifying that processors with no mandatory configuration work correctly when configured as a bare key (`empty_processor:`), explicit null (`empty_processor: null`), or explicit empty string (`empty_processor: ''`).

Jackson YAML 2.21 changed bare key deserialization from `null` to `""`. This test ensures Data Prepper's plugin framework handles all three forms correctly by creating a simple `EmptyProcessor` that increments a counter on each event. The pipeline configures 3 instances and asserts the final count equals 3.

### Issues Resolved

Resolves #6915 (follow-up: integration test coverage for empty string plugin configuration)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
