### PR TITLE
Match OpenSearch shard routing in pull-ingestion IndexRouter

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouter.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Determines the shard (partition) for a given document and index.
@@ -50,20 +49,28 @@ public class IndexRouter {
             throw new IllegalStateException("IndexRouter has not been initialized");
         }
         final int numberOfShards = indexShardProvider.getNumberOfShards(indexName);
-        return calculateShard(routingValue, numberOfShards);
+        final int routingNumShards = indexShardProvider.getNumberOfRoutingShards(indexName);
+        final int routingFactor = routingNumShards / numberOfShards;
+        return calculateShard(routingValue, routingNumShards, routingFactor);
     }
 
-    static int calculateShard(final String routingValue, final int numberOfShards) {
+    static int calculateShard(final String routingValue, final int routingNumShards, final int routingFactor) {
         final int hash = murmur3Hash(routingValue);
-        return Math.floorMod(hash, numberOfShards);
+        return Math.floorMod(hash, routingNumShards) / routingFactor;
     }
 
     /**
      * Murmur3 hash matching OpenSearch's Murmur3HashFunction.hash(String).
-     * 32-bit Murmur3 with seed 0, operating on the UTF-8 bytes of the input.
+     * 32-bit Murmur3 with seed 0, operating on the UTF-16 little-endian bytes of the input
+     * (low byte then high byte for each char), the same byte layout OpenSearch hashes.
      */
     static int murmur3Hash(final String routing) {
-        final byte[] bytes = routing.getBytes(StandardCharsets.UTF_8);
+        final byte[] bytes = new byte[routing.length() * 2];
+        for (int i = 0; i < routing.length(); i++) {
+            final char c = routing.charAt(i);
+            bytes[i * 2] = (byte) c;
+            bytes[i * 2 + 1] = (byte) (c >>> 8);
+        }
         return murmur3_32(bytes, 0, bytes.length, 0);
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouter.java
@@ -34,6 +34,13 @@ public class IndexRouter {
     public void initialize(final String indexName) throws IOException {
         this.indexName = indexName;
         indexShardProvider.getNumberOfShards(indexName);
+        final int routingPartitionSize = indexShardProvider.getRoutingPartitionSize(indexName);
+        if (routingPartitionSize > 1) {
+            throw new UnsupportedOperationException(String.format(
+                    "routing-partitioned indices (routing_partition_size=%d) are not supported by pull-based ingestion; "
+                            + "shard routing for index '%s' would require the document id to compute the partition offset",
+                    routingPartitionSize, indexName));
+        }
         initialized = true;
     }
 
@@ -50,6 +57,11 @@ public class IndexRouter {
         }
         final int numberOfShards = indexShardProvider.getNumberOfShards(indexName);
         final int routingNumShards = indexShardProvider.getNumberOfRoutingShards(indexName);
+        if (routingNumShards < numberOfShards) {
+            throw new IllegalStateException(String.format(
+                    "number_of_routing_shards (%d) must be >= number_of_shards (%d) for index '%s'",
+                    routingNumShards, numberOfShards, indexName));
+        }
         final int routingFactor = routingNumShards / numberOfShards;
         return calculateShard(routingValue, routingNumShards, routingFactor);
     }
@@ -63,6 +75,7 @@ public class IndexRouter {
      * Murmur3 hash matching OpenSearch's Murmur3HashFunction.hash(String).
      * 32-bit Murmur3 with seed 0, operating on the UTF-16 little-endian bytes of the input
      * (low byte then high byte for each char), the same byte layout OpenSearch hashes.
+     * See https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/routing/Murmur3HashFunction.java
      */
     static int murmur3Hash(final String routing) {
         final byte[] bytes = new byte[routing.length() * 2];

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProvider.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProvider.java
@@ -37,6 +37,10 @@ public class IndexShardProvider {
         return getSettings(indexName).numberOfShards();
     }
 
+    public int getNumberOfRoutingShards(final String indexName) throws IOException {
+        return getSettings(indexName).routingNumShards();
+    }
+
     public String getIngestionTopic(final String indexName) throws IOException {
         return getSettings(indexName).ingestionTopic();
     }
@@ -72,26 +76,38 @@ public class IndexShardProvider {
         if (shardsNode.isMissingNode()) {
             throw new IllegalStateException("number_of_shards not found in settings for index: " + indexName);
         }
+        final int numberOfShards = Integer.parseInt(shardsNode.asText());
+
+        final JsonNode routingShardsNode = indexNode.path("number_of_routing_shards");
+        final int routingNumShards = routingShardsNode.isMissingNode()
+                ? numberOfShards
+                : Integer.parseInt(routingShardsNode.asText());
 
         final JsonNode topicNode = indexNode.path("ingestion_source").path("param").path("topic");
         if (topicNode.isMissingNode()) {
             throw new IllegalStateException("ingestion_source.param.topic not found in settings for index: " + indexName);
         }
 
-        return new IndexIngestionSettings(Integer.parseInt(shardsNode.asText()), topicNode.asText());
+        return new IndexIngestionSettings(numberOfShards, routingNumShards, topicNode.asText());
     }
 
     static class IndexIngestionSettings {
         private final int numberOfShards;
+        private final int routingNumShards;
         private final String ingestionTopic;
 
-        IndexIngestionSettings(final int numberOfShards, final String ingestionTopic) {
+        IndexIngestionSettings(final int numberOfShards, final int routingNumShards, final String ingestionTopic) {
             this.numberOfShards = numberOfShards;
+            this.routingNumShards = routingNumShards;
             this.ingestionTopic = ingestionTopic;
         }
 
         int numberOfShards() {
             return numberOfShards;
+        }
+
+        int routingNumShards() {
+            return routingNumShards;
         }
 
         String ingestionTopic() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProvider.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProvider.java
@@ -41,6 +41,10 @@ public class IndexShardProvider {
         return getSettings(indexName).routingNumShards();
     }
 
+    public int getRoutingPartitionSize(final String indexName) throws IOException {
+        return getSettings(indexName).routingPartitionSize();
+    }
+
     public String getIngestionTopic(final String indexName) throws IOException {
         return getSettings(indexName).ingestionTopic();
     }
@@ -78,29 +82,35 @@ public class IndexShardProvider {
         if (shardsNode.isMissingNode()) {
             throw new IllegalStateException("number_of_shards not found in settings for index: " + indexName);
         }
-        final int numberOfShards = Integer.parseInt(shardsNode.asText());
+        final int numberOfShards = shardsNode.asInt();
 
         final JsonNode routingShardsNode = metadataNode.path("routing_num_shards");
         final int routingNumShards = routingShardsNode.isMissingNode()
                 ? numberOfShards
                 : routingShardsNode.asInt();
 
+        final JsonNode partitionSizeNode = indexNode.path("routing_partition_size");
+        final int routingPartitionSize = partitionSizeNode.isMissingNode() ? 1 : partitionSizeNode.asInt();
+
         final JsonNode topicNode = indexNode.path("ingestion_source").path("param").path("topic");
         if (topicNode.isMissingNode()) {
             throw new IllegalStateException("ingestion_source.param.topic not found in settings for index: " + indexName);
         }
 
-        return new IndexIngestionSettings(numberOfShards, routingNumShards, topicNode.asText());
+        return new IndexIngestionSettings(numberOfShards, routingNumShards, routingPartitionSize, topicNode.asText());
     }
 
     static class IndexIngestionSettings {
         private final int numberOfShards;
         private final int routingNumShards;
+        private final int routingPartitionSize;
         private final String ingestionTopic;
 
-        IndexIngestionSettings(final int numberOfShards, final int routingNumShards, final String ingestionTopic) {
+        IndexIngestionSettings(final int numberOfShards, final int routingNumShards,
+                               final int routingPartitionSize, final String ingestionTopic) {
             this.numberOfShards = numberOfShards;
             this.routingNumShards = routingNumShards;
+            this.routingPartitionSize = routingPartitionSize;
             this.ingestionTopic = ingestionTopic;
         }
 
@@ -110,6 +120,10 @@ public class IndexShardProvider {
 
         int routingNumShards() {
             return routingNumShards;
+        }
+
+        int routingPartitionSize() {
+            return routingPartitionSize;
         }
 
         String ingestionTopic() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProvider.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProvider.java
@@ -63,14 +63,16 @@ public class IndexShardProvider {
     }
 
     private IndexIngestionSettings fetchSettings(final String indexName) throws IOException {
-        final Request request = new Request("GET", "/" + indexName + "/_settings");
+        final Request request = new Request("GET", "/_cluster/state/metadata/" + indexName);
         final Response response = restHighLevelClient.getLowLevelClient().performRequest(request);
         final JsonNode root = OBJECT_MAPPER.readTree(response.getEntity().getContent());
 
-        final JsonNode indexNode = root.path(indexName).path("settings").path("index");
-        if (indexNode.isMissingNode()) {
-            throw new IllegalStateException("No settings found for index: " + indexName);
+        final JsonNode metadataNode = root.path("metadata").path("indices").path(indexName);
+        if (metadataNode.isMissingNode()) {
+            throw new IllegalStateException("No metadata found for index: " + indexName);
         }
+
+        final JsonNode indexNode = metadataNode.path("settings").path("index");
 
         final JsonNode shardsNode = indexNode.path("number_of_shards");
         if (shardsNode.isMissingNode()) {
@@ -78,10 +80,10 @@ public class IndexShardProvider {
         }
         final int numberOfShards = Integer.parseInt(shardsNode.asText());
 
-        final JsonNode routingShardsNode = indexNode.path("number_of_routing_shards");
+        final JsonNode routingShardsNode = metadataNode.path("routing_num_shards");
         final int routingNumShards = routingShardsNode.isMissingNode()
                 ? numberOfShards
-                : Integer.parseInt(routingShardsNode.asText());
+                : routingShardsNode.asInt();
 
         final JsonNode topicNode = indexNode.path("ingestion_source").path("param").path("topic");
         if (topicNode.isMissingNode()) {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouterTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouterTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +73,7 @@ class IndexRouterTest {
     @Test
     void getShardForRouting_returns_valid_partition() throws IOException {
         when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(shardCount);
+        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(shardCount);
         final IndexRouter objectUnderTest = createObjectUnderTest();
         objectUnderTest.initialize(indexName);
 
@@ -85,6 +87,7 @@ class IndexRouterTest {
     @Test
     void getShardForRouting_is_deterministic() throws IOException {
         when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(shardCount);
+        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(shardCount);
         final IndexRouter objectUnderTest = createObjectUnderTest();
         objectUnderTest.initialize(indexName);
 
@@ -96,11 +99,12 @@ class IndexRouterTest {
     @ParameterizedTest
     @CsvSource({
             "1, 0",
-            "5, 1",
-            "12, 1"
+            "5, 4",
+            "12, 9"
     })
     void getShardForRouting_known_values_for_abc123(final int shardCount, final int expectedShard) throws IOException {
         when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(shardCount);
+        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(shardCount);
         final IndexRouter objectUnderTest = createObjectUnderTest();
         objectUnderTest.initialize(indexName);
 
@@ -108,15 +112,51 @@ class IndexRouterTest {
     }
 
     @Test
-    void getShardForRouting_calls_provider_each_time() throws IOException {
-        when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(5, 10);
+    void murmur3Hash_matches_opensearch_known_values() {
+        assertThat(IndexRouter.murmur3Hash("hell"), equalTo(0x5a0cb7c3));
+        assertThat(IndexRouter.murmur3Hash("hello"), equalTo(0xd7c31989));
+        assertThat(IndexRouter.murmur3Hash("hello w"), equalTo(0x22ab2984));
+        assertThat(IndexRouter.murmur3Hash("hello wo"), equalTo(0xdf0ca123));
+        assertThat(IndexRouter.murmur3Hash("hello wor"), equalTo(0xe7744d61));
+        assertThat(IndexRouter.murmur3Hash("The quick brown fox jumps over the lazy dog"), equalTo(0xe07db09c));
+        assertThat(IndexRouter.murmur3Hash("The quick brown fox jumps over the lazy cog"), equalTo(0x4e63d2ad));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "abc123, 5, 1, 4",
+            "abc123, 10, 2, 4",
+            "abc123, 12, 1, 9",
+            "abc123, 12, 4, 2",
+            "hello, 5, 1, 1",
+            "hello, 10, 2, 0",
+            "hell, 12, 1, 3"
+    })
+    void calculateShard_matches_opensearch_scaled_formula(final String routingValue, final int routingNumShards,
+                                                          final int routingFactor, final int expectedShard) {
+        assertThat(IndexRouter.calculateShard(routingValue, routingNumShards, routingFactor), equalTo(expectedShard));
+    }
+
+    @Test
+    void getShardForRouting_scales_by_routing_factor_when_routing_num_shards_exceeds_shards() throws IOException {
+        when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(5);
+        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(10);
         final IndexRouter objectUnderTest = createObjectUnderTest();
         objectUnderTest.initialize(indexName);
 
-        final int firstResult = objectUnderTest.getShardForRouting("abc123");
-        final int secondResult = objectUnderTest.getShardForRouting("abc123");
+        assertThat(objectUnderTest.getShardForRouting("abc123"), equalTo(4));
+    }
 
-        assertThat(firstResult, equalTo(IndexRouter.calculateShard("abc123", 5)));
-        assertThat(secondResult, equalTo(IndexRouter.calculateShard("abc123", 10)));
+    @Test
+    void getShardForRouting_calls_provider_each_time() throws IOException {
+        when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(shardCount);
+        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(shardCount);
+        final IndexRouter objectUnderTest = createObjectUnderTest();
+        objectUnderTest.initialize(indexName);
+
+        objectUnderTest.getShardForRouting("abc123");
+        objectUnderTest.getShardForRouting("abc123");
+
+        verify(indexShardProvider, times(2)).getNumberOfRoutingShards(indexName);
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouterTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexRouterTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -148,15 +147,25 @@ class IndexRouterTest {
     }
 
     @Test
-    void getShardForRouting_calls_provider_each_time() throws IOException {
-        when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(shardCount);
-        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(shardCount);
+    void getShardForRouting_uses_refetched_routing_shard_count_each_call() throws IOException {
+        when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(5);
+        when(indexShardProvider.getNumberOfRoutingShards(indexName)).thenReturn(5, 10);
         final IndexRouter objectUnderTest = createObjectUnderTest();
         objectUnderTest.initialize(indexName);
 
-        objectUnderTest.getShardForRouting("abc123");
-        objectUnderTest.getShardForRouting("abc123");
+        final int firstResult = objectUnderTest.getShardForRouting("hello");
+        final int secondResult = objectUnderTest.getShardForRouting("hello");
 
-        verify(indexShardProvider, times(2)).getNumberOfRoutingShards(indexName);
+        assertThat(firstResult, equalTo(IndexRouter.calculateShard("hello", 5, 1)));
+        assertThat(secondResult, equalTo(IndexRouter.calculateShard("hello", 10, 2)));
+    }
+
+    @Test
+    void initialize_throws_for_routing_partitioned_index() throws IOException {
+        when(indexShardProvider.getNumberOfShards(indexName)).thenReturn(shardCount);
+        when(indexShardProvider.getRoutingPartitionSize(indexName)).thenReturn(4);
+        final IndexRouter objectUnderTest = createObjectUnderTest();
+
+        assertThrows(UnsupportedOperationException.class, () -> objectUnderTest.initialize(indexName));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProviderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProviderTest.java
@@ -50,18 +50,41 @@ class IndexShardProviderTest {
     private String indexName;
     private String topicName;
     private int shardCount;
+    private int routingShardCount;
 
     @BeforeEach
     void setUp() {
         indexName = UUID.randomUUID().toString();
         topicName = UUID.randomUUID().toString();
         shardCount = 5;
+        routingShardCount = 20;
 
         when(restHighLevelClient.getLowLevelClient()).thenReturn(restClient);
     }
 
     private IndexShardProvider createObjectUnderTest() {
         return new IndexShardProvider(restHighLevelClient);
+    }
+
+    private String buildSettingsResponseWithRoutingShards() {
+        return "{\n" +
+                "  \"" + indexName + "\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"ingestion_source\": {\n" +
+                "          \"type\": \"kafka\",\n" +
+                "          \"param\": {\n" +
+                "            \"bootstrap_servers\": \"kafka:9092\",\n" +
+                "            \"topic\": \"" + topicName + "\"\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"number_of_shards\": \"" + shardCount + "\",\n" +
+                "        \"number_of_routing_shards\": \"" + routingShardCount + "\",\n" +
+                "        \"number_of_replicas\": \"1\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
     }
 
     private String buildSettingsResponse() {
@@ -96,6 +119,20 @@ class IndexShardProviderTest {
         mockSettingsResponse(buildSettingsResponse());
 
         assertThat(createObjectUnderTest().getIngestionTopic(indexName), equalTo(topicName));
+    }
+
+    @Test
+    void getNumberOfRoutingShards_fetches_from_cluster() throws IOException {
+        mockSettingsResponse(buildSettingsResponseWithRoutingShards());
+
+        assertThat(createObjectUnderTest().getNumberOfRoutingShards(indexName), equalTo(routingShardCount));
+    }
+
+    @Test
+    void getNumberOfRoutingShards_falls_back_to_number_of_shards_when_absent() throws IOException {
+        mockSettingsResponse(buildSettingsResponse());
+
+        assertThat(createObjectUnderTest().getNumberOfRoutingShards(indexName), equalTo(shardCount));
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProviderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProviderTest.java
@@ -68,19 +68,23 @@ class IndexShardProviderTest {
 
     private String buildSettingsResponseWithRoutingShards() {
         return "{\n" +
-                "  \"" + indexName + "\": {\n" +
-                "    \"settings\": {\n" +
-                "      \"index\": {\n" +
-                "        \"ingestion_source\": {\n" +
-                "          \"type\": \"kafka\",\n" +
-                "          \"param\": {\n" +
-                "            \"bootstrap_servers\": \"kafka:9092\",\n" +
-                "            \"topic\": \"" + topicName + "\"\n" +
+                "  \"metadata\": {\n" +
+                "    \"indices\": {\n" +
+                "      \"" + indexName + "\": {\n" +
+                "        \"routing_num_shards\": " + routingShardCount + ",\n" +
+                "        \"settings\": {\n" +
+                "          \"index\": {\n" +
+                "            \"ingestion_source\": {\n" +
+                "              \"type\": \"kafka\",\n" +
+                "              \"param\": {\n" +
+                "                \"bootstrap_servers\": \"kafka:9092\",\n" +
+                "                \"topic\": \"" + topicName + "\"\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"number_of_shards\": \"" + shardCount + "\",\n" +
+                "            \"number_of_replicas\": \"1\"\n" +
                 "          }\n" +
-                "        },\n" +
-                "        \"number_of_shards\": \"" + shardCount + "\",\n" +
-                "        \"number_of_routing_shards\": \"" + routingShardCount + "\",\n" +
-                "        \"number_of_replicas\": \"1\"\n" +
+                "        }\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +
@@ -89,18 +93,22 @@ class IndexShardProviderTest {
 
     private String buildSettingsResponse() {
         return "{\n" +
-                "  \"" + indexName + "\": {\n" +
-                "    \"settings\": {\n" +
-                "      \"index\": {\n" +
-                "        \"ingestion_source\": {\n" +
-                "          \"type\": \"kafka\",\n" +
-                "          \"param\": {\n" +
-                "            \"bootstrap_servers\": \"kafka:9092\",\n" +
-                "            \"topic\": \"" + topicName + "\"\n" +
+                "  \"metadata\": {\n" +
+                "    \"indices\": {\n" +
+                "      \"" + indexName + "\": {\n" +
+                "        \"settings\": {\n" +
+                "          \"index\": {\n" +
+                "            \"ingestion_source\": {\n" +
+                "              \"type\": \"kafka\",\n" +
+                "              \"param\": {\n" +
+                "                \"bootstrap_servers\": \"kafka:9092\",\n" +
+                "                \"topic\": \"" + topicName + "\"\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"number_of_shards\": \"" + shardCount + "\",\n" +
+                "            \"number_of_replicas\": \"1\"\n" +
                 "          }\n" +
-                "        },\n" +
-                "        \"number_of_shards\": \"" + shardCount + "\",\n" +
-                "        \"number_of_replicas\": \"1\"\n" +
+                "        }\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +
@@ -177,7 +185,7 @@ class IndexShardProviderTest {
 
     @Test
     void getNumberOfShards_throws_when_settings_missing() throws IOException {
-        mockSettingsResponse("{\"" + indexName + "\": {\"settings\": {}}}");
+        mockSettingsResponse("{\"metadata\": {\"indices\": {\"" + indexName + "\": {\"settings\": {\"index\": {}}}}}}");
 
         assertThrows(IllegalStateException.class, () -> createObjectUnderTest().getNumberOfShards(indexName));
     }
@@ -185,10 +193,14 @@ class IndexShardProviderTest {
     @Test
     void getIngestionTopic_throws_when_ingestion_source_missing() throws IOException {
         final String noIngestionSource = "{\n" +
-                "  \"" + indexName + "\": {\n" +
-                "    \"settings\": {\n" +
-                "      \"index\": {\n" +
-                "        \"number_of_shards\": \"" + shardCount + "\"\n" +
+                "  \"metadata\": {\n" +
+                "    \"indices\": {\n" +
+                "      \"" + indexName + "\": {\n" +
+                "        \"settings\": {\n" +
+                "          \"index\": {\n" +
+                "            \"number_of_shards\": \"" + shardCount + "\"\n" +
+                "          }\n" +
+                "        }\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProviderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/pull_ingestion/IndexShardProviderTest.java
@@ -144,6 +144,24 @@ class IndexShardProviderTest {
     }
 
     @Test
+    void getRoutingPartitionSize_defaults_to_one_when_absent() throws IOException {
+        mockSettingsResponse(buildSettingsResponse());
+
+        assertThat(createObjectUnderTest().getRoutingPartitionSize(indexName), equalTo(1));
+    }
+
+    @Test
+    void getRoutingPartitionSize_fetches_from_cluster() throws IOException {
+        final String json = "{\"metadata\": {\"indices\": {\"" + indexName + "\": {\"settings\": {\"index\": {"
+                + "\"number_of_shards\": \"" + shardCount + "\","
+                + "\"routing_partition_size\": \"4\","
+                + "\"ingestion_source\": {\"param\": {\"topic\": \"" + topicName + "\"}}}}}}}}";
+        mockSettingsResponse(json);
+
+        assertThat(createObjectUnderTest().getRoutingPartitionSize(indexName), equalTo(4));
+    }
+
+    @Test
     void getNumberOfShards_caches_result() throws IOException {
         mockSettingsResponse(buildSettingsResponse());
 


### PR DESCRIPTION
### Description
The pull-ingestion IndexRouter computed the Murmur3 hash over UTF-8 bytes, but OpenSearch's Murmur3HashFunction.hash(String) hashes UTF-16 little-endian bytes, so documents could be routed to a different partition than the shard OpenSearch places them on. The shard calculation also used floorMod(hash, numberOfShards) instead of OpenSearch's floorMod(hash, routingNumShards) / routingFactor, diverging whenever number_of_routing_shards differs from number_of_shards. 

Hash the UTF-16 little-endian bytes, source number_of_routing_shards from the index settings (falling back to number_of_shards), and scale by routingFactor so partition assignment matches OpenSearch's OperationRouting.generateShardId. Adds a cross-check against OpenSearch's authoritative Murmur3HashFunction known values and known-answer shard tests.
 
### Issues Resolved
Resolves #6993 
 
### Check List
- [ X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [ X ] New functionality has javadoc added
- [ X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
