### PR TITLE
feat(split-event): Add split_when conditional parameter

### DIFF
--- a/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessor.java
+++ b/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessor.java
@@ -10,12 +10,14 @@
 
 package org.opensearch.dataprepper.plugins.processor.splitevent;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
@@ -34,11 +36,21 @@ public class SplitEventProcessor extends AbstractProcessor<Record<Event>, Record
 
     private final String field;
     private final Function<String, String[]> splitter;
+    private final String splitWhen;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public SplitEventProcessor(final PluginMetrics pluginMetrics, final SplitEventProcessorConfig config) {
+    public SplitEventProcessor(final PluginMetrics pluginMetrics, final SplitEventProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.field = config.getField();
+        this.splitWhen = config.getSplitWhen();
+        this.expressionEvaluator = expressionEvaluator;
+
+        if (splitWhen != null && !expressionEvaluator.isValidExpressionStatement(splitWhen)) {
+            throw new InvalidPluginConfigurationException(
+                    String.format("split_when \"%s\" is not a valid expression statement. " +
+                            "See https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/ for valid expression syntax", splitWhen));
+        }
 
         final String delimiter = config.getDelimiter();
         final String delimiterRegex = config.getDelimiterRegex();
@@ -66,6 +78,11 @@ public class SplitEventProcessor extends AbstractProcessor<Record<Event>, Record
         final Collection<Record<Event>> newRecords = new ArrayList<>();
         for (final Record<Event> record : records) {
             final Event recordEvent = record.getData();
+
+            if (splitWhen != null && !expressionEvaluator.evaluateConditional(splitWhen, recordEvent)) {
+                newRecords.add(record);
+                continue;
+            }
 
             if (!recordEvent.containsKey(field)) {
                 newRecords.add(record);

--- a/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
+++ b/data-prepper-plugins/split-event-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorConfig.java
@@ -18,6 +18,8 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
+import org.opensearch.dataprepper.model.annotations.ExampleValues;
+import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.annotations.ValidRegex;
 
 @JsonPropertyOrder
@@ -53,6 +55,16 @@ public class SplitEventProcessorConfig {
         return !(hasDelimiter && hasRegex);
     }
 
+    @JsonProperty("split_when")
+    @JsonPropertyDescription("A <a href=\"https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/\">conditional expression</a>, " +
+            "such as <code>contains(/body, \"\\n\")</code>, that will be evaluated to determine whether the processor will be " +
+            "run on the event. By default, all events will be processed. If the condition evaluates to <code>false</code>, " +
+            "the event passes through unchanged.")
+    @ExampleValues({
+            @Example(value = "contains(/body, \"\\n\")", description = "Only splits the event if the body field contains a newline character.")
+    })
+    private String splitWhen;
+
     public String getField() {
         return field;
     }
@@ -63,5 +75,9 @@ public class SplitEventProcessorConfig {
 
     public String getDelimiter() {
         return delimiter;
+    }
+
+    public String getSplitWhen() {
+        return splitWhen;
     }
 }

--- a/data-prepper-plugins/split-event-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorTest.java
+++ b/data-prepper-plugins/split-event-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/splitevent/SplitEventProcessorTest.java
@@ -18,11 +18,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.ArrayList;
@@ -51,6 +53,9 @@ class SplitEventProcessorTest {
     @Mock
     private AcknowledgementSet mockAcknowledgementSet;
 
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
     private SplitEventProcessor splitEventProcessor;
 
     private Record<Event> createTestRecord(final Map<String, Object> data) {
@@ -67,7 +72,7 @@ class SplitEventProcessorTest {
     private SplitEventProcessor createNoDelimiterProcessor() {
         when(mockConfig.getDelimiter()).thenReturn(null);
         when(mockConfig.getDelimiterRegex()).thenReturn(null);
-        return new SplitEventProcessor(pluginMetrics, mockConfig);
+        return new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }
 
     @BeforeEach
@@ -75,7 +80,7 @@ class SplitEventProcessorTest {
         when(mockConfig.getField()).thenReturn("k1");
         when(mockConfig.getDelimiter()).thenReturn(" ");
 
-        splitEventProcessor = new SplitEventProcessor(pluginMetrics, mockConfig);
+        splitEventProcessor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }
 
     private static Stream<Arguments> provideMaps() {
@@ -129,7 +134,7 @@ class SplitEventProcessorTest {
         final Record<Event> record = createTestRecord(testData);
         when(mockConfig.getDelimiter()).thenReturn(";");
 
-        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig);
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords, hasSize(2));
@@ -145,7 +150,7 @@ class SplitEventProcessorTest {
         when(mockConfig.getDelimiter()).thenReturn(null);
         when(mockConfig.getDelimiterRegex()).thenReturn("\\s+");
 
-        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig);
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords, hasSize(2));
@@ -161,7 +166,7 @@ class SplitEventProcessorTest {
         when(mockConfig.getDelimiter()).thenReturn(null);
         when(mockConfig.getDelimiterRegex()).thenReturn(":");
 
-        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig);
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords, hasSize(2));
@@ -173,7 +178,7 @@ class SplitEventProcessorTest {
     void testFailureWithBothDelimiterRegexAndDelimiterDefined() {
         when(mockConfig.getDelimiter()).thenReturn(" ");
         when(mockConfig.getDelimiterRegex()).thenReturn("\\s+");
-        assertThrows(IllegalArgumentException.class, () -> new SplitEventProcessor(pluginMetrics, mockConfig));
+        assertThrows(IllegalArgumentException.class, () -> new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator));
     }
 
     @Test
@@ -572,7 +577,7 @@ class SplitEventProcessorTest {
     void testEmptyOrNullDelimiterCombinationsEnterArrayMode(final String delimiter, final String delimiterRegex) {
         when(mockConfig.getDelimiter()).thenReturn(delimiter);
         when(mockConfig.getDelimiterRegex()).thenReturn(delimiterRegex);
-        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig);
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap<>();
         testData.put("k1", List.of("x", "y"));
@@ -602,7 +607,7 @@ class SplitEventProcessorTest {
     void testNonEmptyDelimiterWithNullRegex() {
         when(mockConfig.getDelimiter()).thenReturn(",");
         when(mockConfig.getDelimiterRegex()).thenReturn(null);
-        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig);
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
 
         final Map<String, Object> testData = new HashMap<>();
         testData.put("k1", "a,b");
@@ -613,5 +618,78 @@ class SplitEventProcessorTest {
         assertThat(results, hasSize(2));
         assertThat(results.get(0).getData().get("k1", Object.class), equalTo("a"));
         assertThat(results.get(1).getData().get("k1", Object.class), equalTo("b"));
+    }
+
+    @Test
+    void testSplitWhenConditionTrue_splitIsApplied() {
+        final String splitWhen = "/k2 == \"split\"";
+        when(mockConfig.getSplitWhen()).thenReturn(splitWhen);
+        when(mockConfig.getDelimiter()).thenReturn(" ");
+        when(expressionEvaluator.isValidExpressionStatement(splitWhen)).thenReturn(true);
+
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("k1", "v1 v2");
+        testData.put("k2", "split");
+        final Record<Event> record = createTestRecord(testData);
+
+        when(expressionEvaluator.evaluateConditional(splitWhen, record.getData())).thenReturn(true);
+
+        final List<Record<Event>> results = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(results, hasSize(2));
+        assertThat(results.get(0).getData().get("k1", Object.class), equalTo("v1"));
+        assertThat(results.get(1).getData().get("k1", Object.class), equalTo("v2"));
+    }
+
+    @Test
+    void testSplitWhenConditionFalse_eventPassesThrough() {
+        final String splitWhen = "/k2 == \"split\"";
+        when(mockConfig.getSplitWhen()).thenReturn(splitWhen);
+        when(mockConfig.getDelimiter()).thenReturn(" ");
+        when(expressionEvaluator.isValidExpressionStatement(splitWhen)).thenReturn(true);
+
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("k1", "v1 v2");
+        testData.put("k2", "no-split");
+        final Record<Event> record = createTestRecord(testData);
+
+        when(expressionEvaluator.evaluateConditional(splitWhen, record.getData())).thenReturn(false);
+
+        final List<Record<Event>> results = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getData().get("k1", String.class), equalTo("v1 v2"));
+    }
+
+    @Test
+    void testSplitWhenInvalidExpression_throwsInvalidPluginConfigurationException() {
+        final String invalidExpression = "invalid expression";
+        when(mockConfig.getSplitWhen()).thenReturn(invalidExpression);
+        when(expressionEvaluator.isValidExpressionStatement(invalidExpression)).thenReturn(false);
+
+        assertThrows(InvalidPluginConfigurationException.class,
+                () -> new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator));
+    }
+
+    @Test
+    void testSplitWhenNull_allEventsProcessed() {
+        when(mockConfig.getSplitWhen()).thenReturn(null);
+        when(mockConfig.getDelimiter()).thenReturn(" ");
+
+        final SplitEventProcessor processor = new SplitEventProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("k1", "v1 v2");
+        final Record<Event> record = createTestRecord(testData);
+
+        final List<Record<Event>> results = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(results, hasSize(2));
+        assertThat(results.get(0).getData().get("k1", Object.class), equalTo("v1"));
+        assertThat(results.get(1).getData().get("k1", Object.class), equalTo("v2"));
     }
 }


### PR DESCRIPTION
Add split_when parameter to the split_event processor, consistent with the conditional expression pattern used by other processors (e.g., delete_when, add_when, parse_when). When split_when evaluates to false, the event passes through unchanged.

Closes #6992
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR: https://github.com/opensearch-project/documentation-website/pull/12818
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
