### PR TITLE
fix(s3-source): Log full stack trace in S3ObjectWorker buffer write error

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
@@ -214,7 +214,7 @@ class S3ObjectWorker implements S3ObjectHandler {
                         saveStateCounter.getAndIncrement();
                     }
                 } catch (final Exception e) {
-                    LOG.error("Failed writing S3 objects to buffer due to: {}", e.getMessage());
+                    LOG.error("Failed writing S3 objects to buffer.", e);
                 }
             });
 


### PR DESCRIPTION

The existing error log only prints e.getMessage() which is null for exceptions like NullPointerException, making the error impossible to diagnose. Log the full exception with stack trace instead.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
