### PR TITLE
feat(cloudwatch-logs): support dynamic per-entity grouping in sink

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/README.md
+++ b/data-prepper-plugins/cloudwatch-logs/README.md
@@ -90,6 +90,22 @@ pipeline:
   - `key_attributes` (Required when `entity` is configured) : A `Map<String, String>` of key attributes that uniquely identify the entity (for example `Type`, `Name`).
   - `attributes` (Optional) : A `Map<String, String>` of additional attributes describing the entity. Defaults to an empty map.
 
+  In dynamic mode the number of distinct entities cached and buffered concurrently is capped by an internal memory-safety limit; beyond it, further distinct keys collapse into a shared fallback group carrying no per-resource entity, and the overflow is logged.
+
+  ### Static vs dynamic entities
+
+  The entity is **dynamic** when any `key_attributes` or `attributes` value contains a `${...}` reference (a Data Prepper field reference such as `${/resourceId}`); otherwise it is **static**. No separate mode flag is required.
+
+  - Static: one constant entity is attached to every `PutLogEvents` request, exactly as configured.
+  - Dynamic: each value is interpolated against the event, and the sink partitions buffered events by their resolved key attributes, sending one `PutLogEvents` request per distinct entity. This is how a stream carrying logs for many resources (for example Azure diagnostic logs keyed by `resourceId`) gets one correct entity per resource. An event missing a templated field resolves that reference to an empty string and shares a group with other such events.
+
+  ```yaml
+  entity:
+    key_attributes:
+      Type: "Azure::Resource"
+      Identifier: "${/resourceId}"
+  ```
+
   AWS-owned limits — maximum number of entries, allowed key names (such as `Type`, `ResourceType`, `Identifier`, `Name`, `Environment`), and key/value length caps — are enforced by CloudWatch at request time and are intentionally not mirrored here. Violations are surfaced via the `cloudWatchLogsEntityRejected` metric and a log warning. See the [AWS Entity API docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_Entity.html) for the current contract.
 
 ## Buffer Type Configuration

--- a/data-prepper-plugins/cloudwatch-logs/README.md
+++ b/data-prepper-plugins/cloudwatch-logs/README.md
@@ -89,6 +89,24 @@ pipeline:
 
   - `key_attributes` (Required when `entity` is configured) : A `Map<String, String>` of key attributes that uniquely identify the entity (for example `Type`, `Name`).
   - `attributes` (Optional) : A `Map<String, String>` of additional attributes describing the entity. Defaults to an empty map.
+  - `max_cardinality` (Optional) : An integer bounding how many entities are buffered **concurrently** in dynamic mode. Defaults to 1000. (Min = 1). Ignored in static mode, where there is only ever one entity.
+
+  Each concurrently buffered entity holds its own buffer, so `max_cardinality` multiplied by `max_request_size` is the worst-case buffered footprint — that is what to size it against. A group is released once its buffer has been drained and it has been idle past `log_send_interval`, so the bound applies to entities active at one time rather than to how many distinct keys have ever been seen. If the bound is reached anyway, further distinct keys collapse into a shared fallback group carrying no per-resource entity; that is logged once and counted by `cloudWatchLogsEntityOverflowEvents`.
+
+  ### Static vs dynamic entities
+
+  The entity is **dynamic** when any `key_attributes` or `attributes` value contains a `${...}` reference — either a Data Prepper field reference such as `${/resourceId}` or an expression such as `${getMetadata("resourceId")}`; otherwise it is **static**. No separate mode flag is required.
+
+  - Static: one constant entity is attached to every `PutLogEvents` request, exactly as configured.
+  - Dynamic: each value is interpolated against the event, and the sink partitions buffered events by their resolved key attributes, sending one `PutLogEvents` request per distinct entity. This is how a stream carrying logs for many resources (for example Azure diagnostic logs keyed by `resourceId`) gets one correct entity per resource. An event missing a templated field resolves that reference to an empty string and shares a group with other such events.
+
+  ```yaml
+  entity:
+    key_attributes:
+      Type: "Azure::Resource"
+      Identifier: "${/resourceId}"
+    max_cardinality: 2000
+  ```
 
   AWS-owned limits — maximum number of entries, allowed key names (such as `Type`, `ResourceType`, `Identifier`, `Name`, `Environment`), and key/value length caps — are enforced by CloudWatch at request time and are intentionally not mirrored here. Violations are surfaced via the `cloudWatchLogsEntityRejected` metric and a log warning. See the [AWS Entity API docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_Entity.html) for the current contract.
 
@@ -115,6 +133,12 @@ threshold parameters.
 * `cloudWatchLogsThrottled` - The number of `PutLogEvents` attempts that failed due to throttling (HTTP 429). Each retry that receives a throttle response increments this counter independently.
 * `cloudWatchLogsAccessDenied` - The number of requests or resource-creation attempts that failed due to insufficient IAM permissions. Covers both `PutLogEvents` access-denied responses and `CreateLogGroup`/`CreateLogStream` permission failures when `create_log_group` or `create_log_stream` is enabled.
 * `cloudWatchLogsResourceNotFound` - The number of `PutLogEvents` attempts that failed because the target log group or log stream does not exist. Only incremented when `create_log_group` and `create_log_stream` are both disabled — if the sink is configured to create resources, a resource-not-found error is internal control flow rather than an actionable user signal.
+* `cloudWatchLogsEntityGroupsCreated` - The number of buffer groups opened for a distinct resolved entity (dynamic entity mode only). Because idle groups are released and a returning entity opens a new group, this counts group churn over time; use `cloudWatchLogsEntityCardinality` for how many are active now. The shared overflow group is excluded so this stays a count of real entities.
+* `cloudWatchLogsEntityOverflowEvents` - The number of events that could not be given their own entity group because the concurrent-entity limit was already reached, and were sent in the shared fallback group with no entity instead. Any non-zero value means events are losing their per-resource entity attribution; reduce the cardinality of the templated `key_attributes`, or raise `max_cardinality`.
+
+### Gauges
+
+* `cloudWatchLogsEntityCardinality` - The number of entity buffer groups currently held, i.e. the entities being buffered right now (dynamic entity mode only). The shared overflow group is excluded, so this too stays a count of real entities. This rises and falls with live cardinality, and sitting at `max_cardinality` alongside a climbing `cloudWatchLogsEntityOverflowEvents` means events are collapsing into the fallback group.
 
 ## Developer Guide
 

--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsIT.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import org.opensearch.dataprepper.plugins.dlq.s3.S3DlqProvider;
 import org.opensearch.dataprepper.plugins.dlq.s3.S3DlqWriterConfig;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -285,7 +286,9 @@ public class CloudWatchLogsIT {
     }
 
     private CloudWatchLogsSink createObjectUnderTest() {
-        return new CloudWatchLogsSink(pluginSetting, pluginMetrics, pluginFactory, cloudWatchLogsSinkConfig, awsCredentialsSupplier);
+        // These tests configure a static entity (or none), so the evaluator is never consulted.
+        return new CloudWatchLogsSink(pluginSetting, pluginMetrics, pluginFactory, cloudWatchLogsSinkConfig,
+                awsCredentialsSupplier, mock(ExpressionEvaluator.class));
     }
     
     private String createLogStream(final String logGroupName) {

--- a/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsMetricsIT.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsMetricsIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -283,7 +284,8 @@ public class CloudWatchLogsMetricsIT {
         final PluginFactory pluginFactory = mock(PluginFactory.class);
 
         final CloudWatchLogsSink sink = new CloudWatchLogsSink(
-                pluginSetting, pluginMetrics, pluginFactory, config, awsCredentialsSupplier);
+                pluginSetting, pluginMetrics, pluginFactory, config, awsCredentialsSupplier,
+                mock(ExpressionEvaluator.class));
         sink.doInitialize();
 
         final Collection<Record<Event>> records = createRecords(1);
@@ -346,7 +348,9 @@ public class CloudWatchLogsMetricsIT {
 
         final PluginFactory pluginFactory = mock(PluginFactory.class);
 
-        return new CloudWatchLogsSink(pluginSetting, pluginMetrics, pluginFactory, config, awsCredentialsSupplier);
+        // These tests configure a static entity (or none), so the evaluator is never consulted.
+        return new CloudWatchLogsSink(pluginSetting, pluginMetrics, pluginFactory, config, awsCredentialsSupplier,
+                mock(ExpressionEvaluator.class));
     }
 
     private Collection<Record<Event>> createRecords(final int count) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -22,6 +23,7 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatch
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsMetrics;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsService;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsClientFactory;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.EntityResolver;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.AwsConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatchLogsSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.EntityConfig;
@@ -46,6 +48,7 @@ import java.util.concurrent.Executors;
 public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(CloudWatchLogsSink.class);
 
+    // Also keeps the cardinality gauge's weak reference to the service from being collected.
     private final CloudWatchLogsService cloudWatchLogsService;
     private DlqPushHandler dlqPushHandler = null;
     private volatile boolean isInitialized;
@@ -55,7 +58,8 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
                               final PluginMetrics pluginMetrics,
                               final PluginFactory pluginFactory,
                               final CloudWatchLogsSinkConfig cloudWatchLogsSinkConfig,
-                              final AwsCredentialsSupplier awsCredentialsSupplier) {
+                              final AwsCredentialsSupplier awsCredentialsSupplier,
+                              final ExpressionEvaluator expressionEvaluator) {
         super(pluginSetting);
 
         AwsConfig awsConfig = cloudWatchLogsSinkConfig.getAwsConfig();
@@ -90,10 +94,19 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
         Executor executor = Executors.newFixedThreadPool(cloudWatchLogsSinkConfig.getWorkers());
 
         final EntityConfig entityConfig = cloudWatchLogsSinkConfig.getEntityConfig();
-        final Entity entity = entityConfig == null ? null : Entity.builder()
+        final boolean dynamicEntity = entityConfig != null && entityConfig.isDynamic(expressionEvaluator);
+
+        final Entity staticEntity = (entityConfig == null || dynamicEntity) ? null : Entity.builder()
                 .keyAttributes(entityConfig.getKeyAttributes())
                 .attributes(entityConfig.getAttributes())
                 .build();
+
+        // The same evaluator that classified this config as dynamic has to do the interpolating, or
+        // expression-valued attributes would resolve to an empty string instead of being evaluated.
+        final EntityResolver entityResolver = dynamicEntity
+                ? new EntityResolver(entityConfig.getKeyAttributes(), entityConfig.getAttributes(),
+                        expressionEvaluator)
+                : null;
 
         CloudWatchLogsDispatcher cloudWatchLogsDispatcher = CloudWatchLogsDispatcher.builder()
                 .cloudWatchLogsClient(cloudWatchLogsClient)
@@ -106,17 +119,27 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
                 .executor(executor)
                 .createLogGroup(cloudWatchLogsSinkConfig.getCreateLogGroup())
                 .createLogStream(cloudWatchLogsSinkConfig.getCreateLogStream())
-                .entity(entity)
+                .entity(staticEntity)
                 .build();
 
-        Buffer buffer;
-        try {
-            buffer = bufferFactory.getBuffer();
-        } catch (NullPointerException e) {
-            throw new InvalidBufferTypeException("Error loading buffer!");
+        if (dynamicEntity) {
+            cloudWatchLogsService = new CloudWatchLogsService(bufferFactory, cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                    cloudWatchLogsDispatcher, dlqPushHandler, true, entityResolver,
+                    entityConfig.getMaxCardinality());
+            // Gauged on the service: the group count is the number of entities actually being buffered
+            // right now, and it falls again as groups go idle rather than only ever climbing.
+            cloudWatchLogsMetrics.registerEntityCardinalityGauge(cloudWatchLogsService,
+                    CloudWatchLogsService::activeEntityGroupCount);
+        } else {
+            Buffer buffer;
+            try {
+                buffer = bufferFactory.getBuffer();
+            } catch (NullPointerException e) {
+                throw new InvalidBufferTypeException("Error loading buffer!");
+            }
+            cloudWatchLogsService = new CloudWatchLogsService(buffer, cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                    cloudWatchLogsDispatcher, dlqPushHandler, true);
         }
-
-        cloudWatchLogsService = new CloudWatchLogsService(buffer, cloudWatchLogsMetrics, cloudWatchLogsLimits, cloudWatchLogsDispatcher, dlqPushHandler, true);
     }
 
     @Override

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -22,6 +23,7 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatch
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsMetrics;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsService;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.CloudWatchLogsClientFactory;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client.EntityResolver;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.AwsConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatchLogsSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.EntityConfig;
@@ -49,13 +51,16 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
     private final CloudWatchLogsService cloudWatchLogsService;
     private DlqPushHandler dlqPushHandler = null;
     private volatile boolean isInitialized;
+    // Retained so the cardinality gauge's weak reference to the resolver is not collected.
+    private final EntityResolver entityResolver;
 
     @DataPrepperPluginConstructor
     public CloudWatchLogsSink(final PluginSetting pluginSetting,
                               final PluginMetrics pluginMetrics,
                               final PluginFactory pluginFactory,
                               final CloudWatchLogsSinkConfig cloudWatchLogsSinkConfig,
-                              final AwsCredentialsSupplier awsCredentialsSupplier) {
+                              final AwsCredentialsSupplier awsCredentialsSupplier,
+                              final ExpressionEvaluator expressionEvaluator) {
         super(pluginSetting);
 
         AwsConfig awsConfig = cloudWatchLogsSinkConfig.getAwsConfig();
@@ -90,10 +95,20 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
         Executor executor = Executors.newFixedThreadPool(cloudWatchLogsSinkConfig.getWorkers());
 
         final EntityConfig entityConfig = cloudWatchLogsSinkConfig.getEntityConfig();
-        final Entity entity = entityConfig == null ? null : Entity.builder()
+        final boolean dynamicEntity = entityConfig != null && entityConfig.isDynamic(expressionEvaluator);
+
+        final Entity staticEntity = (entityConfig == null || dynamicEntity) ? null : Entity.builder()
                 .keyAttributes(entityConfig.getKeyAttributes())
                 .attributes(entityConfig.getAttributes())
                 .build();
+
+        if (dynamicEntity) {
+            entityResolver = new EntityResolver(entityConfig.getKeyAttributes(), entityConfig.getAttributes(),
+                    EntityResolver.MAX_ENTITY_CARDINALITY);
+            cloudWatchLogsMetrics.registerEntityCardinalityGauge(entityResolver, EntityResolver::cacheSize);
+        } else {
+            entityResolver = null;
+        }
 
         CloudWatchLogsDispatcher cloudWatchLogsDispatcher = CloudWatchLogsDispatcher.builder()
                 .cloudWatchLogsClient(cloudWatchLogsClient)
@@ -106,17 +121,22 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
                 .executor(executor)
                 .createLogGroup(cloudWatchLogsSinkConfig.getCreateLogGroup())
                 .createLogStream(cloudWatchLogsSinkConfig.getCreateLogStream())
-                .entity(entity)
+                .entity(staticEntity)
                 .build();
 
-        Buffer buffer;
-        try {
-            buffer = bufferFactory.getBuffer();
-        } catch (NullPointerException e) {
-            throw new InvalidBufferTypeException("Error loading buffer!");
+        if (dynamicEntity) {
+            cloudWatchLogsService = new CloudWatchLogsService(bufferFactory, cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                    cloudWatchLogsDispatcher, dlqPushHandler, true, entityResolver);
+        } else {
+            Buffer buffer;
+            try {
+                buffer = bufferFactory.getBuffer();
+            } catch (NullPointerException e) {
+                throw new InvalidBufferTypeException("Error loading buffer!");
+            }
+            cloudWatchLogsService = new CloudWatchLogsService(buffer, cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                    cloudWatchLogsDispatcher, dlqPushHandler, true);
         }
-
-        cloudWatchLogsService = new CloudWatchLogsService(buffer, cloudWatchLogsMetrics, cloudWatchLogsLimits, cloudWatchLogsDispatcher, dlqPushHandler, true);
     }
 
     @Override

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
@@ -78,14 +78,25 @@ public class CloudWatchLogsDispatcher {
         return logEventList;
     }
 
+    /**
+     * Dispatches using the entity configured on this dispatcher (static entity mode).
+     */
     public void dispatchLogs(List<InputLogEvent> inputLogEvents, List<EventHandle> eventHandles) {
+        dispatchLogs(inputLogEvents, eventHandles, entity);
+    }
+
+    /**
+     * Dispatches using an explicitly supplied entity. Used by dynamic-entity mode where each
+     * buffer group carries its own resolved entity
+     */
+    public void dispatchLogs(List<InputLogEvent> inputLogEvents, List<EventHandle> eventHandles, final Entity requestEntity) {
         final PutLogEventsRequest.Builder requestBuilder = PutLogEventsRequest.builder()
                 .logEvents(inputLogEvents)
                 .logGroupName(logGroup)
                 .logStreamName(logStream);
 
-        if (entity != null) {
-            requestBuilder.entity(entity);
+        if (requestEntity != null) {
+            requestBuilder.entity(requestEntity);
         }
 
         final PutLogEventsRequest putLogEventsRequest = requestBuilder.build();

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
@@ -9,6 +9,8 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
+import java.util.function.ToDoubleFunction;
+
 /**
  * Class is meant to abstract the metric book-keeping of
  * CloudWatchLogs metrics so that multiple instances
@@ -28,6 +30,8 @@ public class CloudWatchLogsMetrics {
     public static final String CLOUDWATCH_LOGS_ACCESS_DENIED = "cloudWatchLogsAccessDenied";
     public static final String CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND = "cloudWatchLogsResourceNotFound";
     public static final String CLOUDWATCH_LOGS_THROTTLED = "cloudWatchLogsThrottled";
+    public static final String CLOUDWATCH_LOGS_ENTITY_GROUPS_CREATED = "cloudWatchLogsEntityGroupsCreated";
+    public static final String CLOUDWATCH_LOGS_ENTITY_CARDINALITY = "cloudWatchLogsEntityCardinality";
     private final Counter logEventSuccessCounter;
     private final Counter logEventFailCounter;
     private final Counter requestSuccessCount;
@@ -39,10 +43,13 @@ public class CloudWatchLogsMetrics {
     private final Counter accessDeniedCounter;
     private final Counter resourceNotFoundCounter;
     private final Counter throttledCounter;
+    private final Counter entityGroupsCreatedCounter;
     private final DistributionSummary logSizeMetric;
     private final DistributionSummary requestSizeMetric;
+    private final PluginMetrics pluginMetrics;
 
     public CloudWatchLogsMetrics(final PluginMetrics pluginMetrics) {
+        this.pluginMetrics = pluginMetrics;
         this.logEventSuccessCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_EVENTS_SUCCEEDED);
         this.requestFailCount = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED);
         this.requestMultiFailCount = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUEST_MULTI_FAILED);
@@ -54,6 +61,7 @@ public class CloudWatchLogsMetrics {
         this.accessDeniedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ACCESS_DENIED);
         this.resourceNotFoundCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND);
         this.throttledCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED);
+        this.entityGroupsCreatedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_GROUPS_CREATED);
         this.logSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_LOG_SIZE);
         this.requestSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_REQUEST_SIZE);
     }
@@ -100,6 +108,22 @@ public class CloudWatchLogsMetrics {
 
     public void increaseThrottledCounter(int value) {
         throttledCounter.increment(value);
+    }
+
+    /**
+     * Counts how many distinct entity buffer groups have been created (dynamic-entity mode).
+     * A steadily climbing count signals rising entity cardinality.
+     */
+    public void increaseEntityGroupsCreatedCounter(int value) {
+        entityGroupsCreatedCounter.increment(value);
+    }
+
+    /**
+     * Registers a gauge reporting the current live entity cardinality (e.g. resolver cache size).
+     * The gauge holds a weak reference to {@code stateObject}, so the caller must retain it.
+     */
+    public <T> void registerEntityCardinalityGauge(final T stateObject, final ToDoubleFunction<T> valueFunction) {
+        pluginMetrics.gauge(CLOUDWATCH_LOGS_ENTITY_CARDINALITY, stateObject, valueFunction);
     }
 
     public void recordLogSize(int value) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetrics.java
@@ -9,6 +9,8 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
+import java.util.function.ToDoubleFunction;
+
 /**
  * Class is meant to abstract the metric book-keeping of
  * CloudWatchLogs metrics so that multiple instances
@@ -28,6 +30,9 @@ public class CloudWatchLogsMetrics {
     public static final String CLOUDWATCH_LOGS_ACCESS_DENIED = "cloudWatchLogsAccessDenied";
     public static final String CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND = "cloudWatchLogsResourceNotFound";
     public static final String CLOUDWATCH_LOGS_THROTTLED = "cloudWatchLogsThrottled";
+    public static final String CLOUDWATCH_LOGS_ENTITY_GROUPS_CREATED = "cloudWatchLogsEntityGroupsCreated";
+    public static final String CLOUDWATCH_LOGS_ENTITY_CARDINALITY = "cloudWatchLogsEntityCardinality";
+    public static final String CLOUDWATCH_LOGS_ENTITY_OVERFLOW_EVENTS = "cloudWatchLogsEntityOverflowEvents";
     private final Counter logEventSuccessCounter;
     private final Counter logEventFailCounter;
     private final Counter requestSuccessCount;
@@ -39,10 +44,14 @@ public class CloudWatchLogsMetrics {
     private final Counter accessDeniedCounter;
     private final Counter resourceNotFoundCounter;
     private final Counter throttledCounter;
+    private final Counter entityGroupsCreatedCounter;
+    private final Counter entityOverflowEventsCounter;
     private final DistributionSummary logSizeMetric;
     private final DistributionSummary requestSizeMetric;
+    private final PluginMetrics pluginMetrics;
 
     public CloudWatchLogsMetrics(final PluginMetrics pluginMetrics) {
+        this.pluginMetrics = pluginMetrics;
         this.logEventSuccessCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_EVENTS_SUCCEEDED);
         this.requestFailCount = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_FAILED);
         this.requestMultiFailCount = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUEST_MULTI_FAILED);
@@ -54,6 +63,8 @@ public class CloudWatchLogsMetrics {
         this.accessDeniedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ACCESS_DENIED);
         this.resourceNotFoundCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND);
         this.throttledCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED);
+        this.entityGroupsCreatedCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_GROUPS_CREATED);
+        this.entityOverflowEventsCounter = pluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_OVERFLOW_EVENTS);
         this.logSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_LOG_SIZE);
         this.requestSizeMetric = pluginMetrics.summary(CLOUDWATCH_LOGS_REQUEST_SIZE);
     }
@@ -100,6 +111,33 @@ public class CloudWatchLogsMetrics {
 
     public void increaseThrottledCounter(int value) {
         throttledCounter.increment(value);
+    }
+
+    /**
+     * Counts entity buffer groups created for a real resolved entity (dynamic-entity mode). The shared
+     * overflow group is excluded so this stays a count of genuine entities; see
+     * {@link #increaseEntityOverflowEventsCounter(int)} for the overflow bucket.
+     */
+    public void increaseEntityGroupsCreatedCounter(int value) {
+        entityGroupsCreatedCounter.increment(value);
+    }
+
+    /**
+     * Counts events that could not be given their own entity group because the cardinality bound was
+     * already reached, and were buffered in the shared fallback group with no entity instead. Any
+     * non-zero value means events are losing their per-resource entity attribution.
+     */
+    public void increaseEntityOverflowEventsCounter(int value) {
+        entityOverflowEventsCounter.increment(value);
+    }
+
+    /**
+     * Registers a gauge reporting the number of entity buffer groups currently held, i.e. the live
+     * entity cardinality. The gauge holds a weak reference to {@code stateObject}, so the caller must
+     * retain it for as long as the metric should be reported.
+     */
+    public <T> void registerEntityCardinalityGauge(final T stateObject, final ToDoubleFunction<T> valueFunction) {
+        pluginMetrics.gauge(CLOUDWATCH_LOGS_ENTITY_CARDINALITY, stateObject, valueFunction);
     }
 
     public void recordLogSize(int value) {

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
@@ -9,17 +9,24 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.Buffer;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.BufferFactory;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.SinkStopWatch;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsSinkUtils;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
 import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -33,31 +40,116 @@ import java.util.concurrent.locks.ReentrantLock;
  * </ol>
  */
 public class CloudWatchLogsService {
+    private static final Logger LOG = LoggerFactory.getLogger(CloudWatchLogsService.class);
+
     private final CloudWatchLogsDispatcher cloudWatchLogsDispatcher;
-    private final Buffer buffer;
+    private final BufferFactory bufferFactory;
     private final CloudWatchLogsLimits cloudWatchLogsLimits;
     private CloudWatchLogsMetrics cloudWatchLogsMetrics;
-    private final SinkStopWatch sinkStopWatch;
     private final ReentrantLock processLock;
     private final DlqPushHandler dlqPushHandler;
     private final boolean dropIfDlqNotConfigured;
+
+    /**
+     * Whether events are partitioned per resolved entity. False in static mode, where
+     * {@link #entityResolver} is null and the dispatcher's own entity is used for every request.
+     */
+    private final boolean dynamic;
+
+    /**
+     * Resolves each event's entity key, and builds the entity for a newly opened group. Null in static
+     * mode.
+     */
+    private final EntityResolver entityResolver;
+
+    /**
+     * Bound on entity groups held concurrently in dynamic mode; see
+     * {@link org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.EntityConfig#getMaxCardinality()}.
+     * Unused in static mode, where there is only ever the shared group.
+     */
+    private final int maxEntityCardinality;
+
+    /**
+     * The per-entity buffer groups, keyed by resolved entity. Empty in static mode.
+     *
+     * <p>Mutated only while holding {@link #processLock}. Concurrent so that
+     * {@link #activeEntityGroupCount()}, which the cardinality gauge samples from the metrics thread,
+     * never reads the map mid-rehash.
+     */
+    private final Map<EntityResolver.ResolvedKey, LogGroupBuffer> groups = new ConcurrentHashMap<>();
+
+    /**
+     * The one group that carries no per-entity attribution: the only group in static mode, and the
+     * overflow group in dynamic mode once {@link #maxEntityCardinality} is reached.
+     *
+     * <p>Held here rather than in {@link #groups} on purpose. It is never evicted — it has no entity to
+     * go stale — so keeping it in the map would permanently consume one of the cardinality slots it
+     * exists to absorb overflow from. With {@code max_cardinality} of 1 that was fatal: the first
+     * overflow would take the single slot and every subsequent event, of every key, would overflow into
+     * it forever. Created lazily, and read and written only while holding {@link #processLock}.
+     */
+    private LogGroupBuffer sharedGroup;
+
+    /**
+     * Whether the cardinality-bound warning has already been emitted. Overflow is counted on every event
+     * but logged only once, so a sustained high-cardinality stream cannot flood the logs. Guarded by
+     * {@link #processLock}.
+     */
+    private boolean overflowLogged = false;
+
+    /**
+     * Static-entity constructor. Preserves the original behavior: a single buffer, and one entity for
+     * every request. The cardinality bound is irrelevant without a resolver, since static mode only ever
+     * holds the shared group.
+     *
+     * @param buffer the single buffer all events are written to
+     * @param cloudWatchLogsMetrics the sink's metrics
+     * @param cloudWatchLogsLimits the batch size, request size, and flush interval thresholds
+     * @param cloudWatchLogsDispatcher dispatches staged events, supplying its own configured entity
+     * @param dlqPushHandler handler for events that cannot be sent, or null
+     * @param dropIfDlqNotConfigured whether to drop oversized events when no DLQ is configured
+     */
     public CloudWatchLogsService(final Buffer buffer,
                                  final CloudWatchLogsMetrics cloudWatchLogsMetrics,
                                  final CloudWatchLogsLimits cloudWatchLogsLimits,
                                  final CloudWatchLogsDispatcher cloudWatchLogsDispatcher,
                                  final DlqPushHandler dlqPushHandler,
                                  final boolean dropIfDlqNotConfigured) {
+        this(new SingleBufferFactory(buffer), cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                cloudWatchLogsDispatcher, dlqPushHandler, dropIfDlqNotConfigured, null, 0);
+    }
 
-        this.buffer = buffer;
+    /**
+     * Dynamic-entity constructor. Events are partitioned by their resolved entity, one buffer and so one
+     * {@code PutLogEvents} request per entity.
+     *
+     * @param bufferFactory supplies a fresh buffer for each entity group
+     * @param cloudWatchLogsMetrics the sink's metrics
+     * @param cloudWatchLogsLimits the batch size, request size, and flush interval thresholds
+     * @param cloudWatchLogsDispatcher dispatches staged events with the group's resolved entity
+     * @param dlqPushHandler handler for events that cannot be sent, or null
+     * @param dropIfDlqNotConfigured whether to drop oversized events when no DLQ is configured
+     * @param entityResolver resolves entity keys and entities, or null for static mode
+     * @param maxEntityCardinality maximum number of entity groups held at one time
+     */
+    public CloudWatchLogsService(final BufferFactory bufferFactory,
+                                 final CloudWatchLogsMetrics cloudWatchLogsMetrics,
+                                 final CloudWatchLogsLimits cloudWatchLogsLimits,
+                                 final CloudWatchLogsDispatcher cloudWatchLogsDispatcher,
+                                 final DlqPushHandler dlqPushHandler,
+                                 final boolean dropIfDlqNotConfigured,
+                                 final EntityResolver entityResolver,
+                                 final int maxEntityCardinality) {
+        this.bufferFactory = bufferFactory;
         this.cloudWatchLogsLimits = cloudWatchLogsLimits;
-
         this.cloudWatchLogsMetrics = cloudWatchLogsMetrics;
-        processLock = new ReentrantLock();
-        sinkStopWatch = new SinkStopWatch();
-
+        this.processLock = new ReentrantLock();
         this.cloudWatchLogsDispatcher = cloudWatchLogsDispatcher;
         this.dlqPushHandler = dlqPushHandler;
         this.dropIfDlqNotConfigured = dropIfDlqNotConfigured;
+        this.entityResolver = entityResolver;
+        this.dynamic = entityResolver != null;
+        this.maxEntityCardinality = maxEntityCardinality;
     }
 
     /**
@@ -65,28 +157,21 @@ public class CloudWatchLogsService {
      * @param logs Collection of Record events.
      */
     public void processLogEvents(final Collection<Record<Event>> logs) {
-        sinkStopWatch.startIfNotRunning();
-        if (logs.isEmpty() && buffer.getEventCount() > 0) {
-            processLock.lock();
-            try {
-                if (cloudWatchLogsLimits.isTimeLimitReached(sinkStopWatch.getElapsedTimeInSeconds())) {
-                    stageLogEvents();
-                }
-            } finally {
-                processLock.unlock();
-            }
+        if (logs.isEmpty()) {
+            sweepGroups();
             return;
         }
 
         final List<DlqObject> dlqObjects = new ArrayList<>();
         for (Record<Event> log : logs) {
-            String logString = log.getData().toJsonString();
+            final Event event = log.getData();
+            String logString = event.toJsonString();
             int logLength = logString.length();
 
             cloudWatchLogsMetrics.recordLogSize(logLength);
             if (cloudWatchLogsLimits.isGreaterThanMaxEventSize(logLength)) {
                 final String failureMessage = String.format("Event blocked due to Max Size restriction! Event Size : %s", (logLength + CloudWatchLogsLimits.APPROXIMATE_LOG_EVENT_OVERHEAD_SIZE));
-                DlqObject dlqObject = CloudWatchLogsSinkUtils.createDlqObject(0, log.getData().getEventHandle(), logString, failureMessage, dlqPushHandler, dropIfDlqNotConfigured);
+                DlqObject dlqObject = CloudWatchLogsSinkUtils.createDlqObject(0, event.getEventHandle(), logString, failureMessage, dlqPushHandler, dropIfDlqNotConfigured);
                 if (dlqObject != null) {
                     dlqObjects.add(dlqObject);
                 } else if (dropIfDlqNotConfigured) {
@@ -95,39 +180,188 @@ public class CloudWatchLogsService {
                 continue;
             }
 
-            long time = sinkStopWatch.getElapsedTimeInSeconds();
-
             processLock.lock();
             try {
+                final LogGroupBuffer group = groupFor(event);
+                group.stopWatch.startIfNotRunning();
+
+                final Buffer buffer = group.buffer;
                 int bufferSize = buffer.getBufferSize();
                 int bufferEventCount = buffer.getEventCount();
-                if (cloudWatchLogsLimits.maxRequestSizeLimitExceeds(logLength + bufferSize, bufferEventCount+1)) {
-                    stageLogEvents();
+                if (cloudWatchLogsLimits.maxRequestSizeLimitExceeds(logLength + bufferSize, bufferEventCount + 1)) {
+                    stageLogEvents(group);
                 }
-                addToBuffer(log.getData().getEventHandle(), logString);
+                addToBuffer(buffer, event.getEventHandle(), logString);
                 bufferEventCount = buffer.getEventCount();
-                if (cloudWatchLogsLimits.isMaxEventCountLimitReached(bufferEventCount)) {
-                    stageLogEvents();
+                // The time limit is checked here, not only on an empty poll, because a group that keeps
+                // receiving events but never reaches the count or size threshold would otherwise sit
+                // unsent for as long as the pipeline stays busy.
+                if (cloudWatchLogsLimits.isMaxEventCountLimitReached(bufferEventCount)
+                        || cloudWatchLogsLimits.isTimeLimitReached(group.stopWatch.getElapsedTimeInSeconds())) {
+                    stageLogEvents(group);
                 }
-
             } finally {
                 processLock.unlock();
             }
         }
+
+        // Groups that received nothing in this batch still have to honour the flush interval, so every
+        // batch ends with a sweep rather than only empty polls triggering one.
+        sweepGroups();
         CloudWatchLogsSinkUtils.handleDlqObjects(dlqObjects, dlqPushHandler);
     }
 
-    private void stageLogEvents() {
-        sinkStopWatch.stopAndReset();
+    /**
+     * Resolves (creating if necessary) the buffer group for an event. Must be called while
+     * holding {@code processLock}.
+     */
+    private LogGroupBuffer groupFor(final Event event) {
+        if (!dynamic) {
+            return sharedGroup();
+        }
+
+        // Only the key attributes are interpolated per event; the entity itself is built below, once,
+        // when a new group is opened. Events whose key attributes interpolate to the same value share a
+        // group, and so one PLE request.
+        final EntityResolver.ResolvedKey resolvedKey = entityResolver.resolveKey(event);
+        LogGroupBuffer group = groups.get(resolvedKey);
+        if (group != null) {
+            return group;
+        }
+
+        // Cap the groups held concurrently so a high-cardinality templated key cannot grow the groups
+        // map without limit. On overflow, route the event to the shared group, which carries no
+        // per-resource entity, rather than allocating a new group per distinct key. Because sweepGroups()
+        // evicts idle groups, this bound applies to entities active at the same time rather than every
+        // key seen since startup.
+        if (groups.size() >= maxEntityCardinality) {
+            // Counted per event, and separately from the groups-created counter, so that the loss of
+            // per-resource attribution is visible rather than mixed in with real entities.
+            cloudWatchLogsMetrics.increaseEntityOverflowEventsCounter(1);
+            if (!overflowLogged) {
+                overflowLogged = true;
+                LOG.warn("Entity cardinality bound of {} reached; events are being routed to a shared "
+                        + "fallback group with no entity until an existing group goes idle. Reduce the "
+                        + "cardinality of the templated entity key attributes, or raise the entity "
+                        + "max_cardinality.", maxEntityCardinality);
+            }
+            return sharedGroup();
+        }
+
+        // The only place an entity is built: once per group, not once per event.
+        group = new LogGroupBuffer(bufferFactory.getBuffer(), entityResolver.buildEntity(resolvedKey, event),
+                new SinkStopWatch());
+        groups.put(resolvedKey, group);
+        cloudWatchLogsMetrics.increaseEntityGroupsCreatedCounter(1);
+        return group;
+    }
+
+    /**
+     * The shared, entity-less group, created on first use. Must be called while holding
+     * {@code processLock}.
+     */
+    private LogGroupBuffer sharedGroup() {
+        if (sharedGroup == null) {
+            sharedGroup = new LogGroupBuffer(bufferFactory.getBuffer(), null, new SinkStopWatch());
+        }
+        return sharedGroup;
+    }
+
+    /**
+     * Flushes every group whose time limit has been reached and drops the entity groups left empty and
+     * idle. Evicting is what keeps the cardinality bound a measure of concurrently active entities: a key
+     * seen once would otherwise hold its slot, and its buffer, for the lifetime of the process.
+     */
+    private void sweepGroups() {
+        processLock.lock();
+        try {
+            final Iterator<LogGroupBuffer> iterator = groups.values().iterator();
+            while (iterator.hasNext()) {
+                final LogGroupBuffer group = iterator.next();
+                if (!cloudWatchLogsLimits.isTimeLimitReached(group.stopWatch.getElapsedTimeInSeconds())) {
+                    continue;
+                }
+                if (group.buffer.getEventCount() > 0) {
+                    stageLogEvents(group);
+                } else {
+                    // Safe to drop: staging hands the events and handles to the dispatcher before the
+                    // buffer is reset, so nothing in flight refers to this group.
+                    iterator.remove();
+                }
+            }
+            // The shared group is flushed but never dropped. It holds no entity that could go stale, and
+            // it lives outside `groups` so retaining it costs no cardinality slot.
+            if (sharedGroup != null && sharedGroup.buffer.getEventCount() > 0
+                    && cloudWatchLogsLimits.isTimeLimitReached(sharedGroup.stopWatch.getElapsedTimeInSeconds())) {
+                stageLogEvents(sharedGroup);
+            }
+        } finally {
+            processLock.unlock();
+        }
+    }
+
+    /**
+     * Number of entity buffer groups currently held, i.e. the entities being buffered right now. The
+     * shared group is excluded, so this stays a count of real entities. This is what the
+     * {@code cloudWatchLogsEntityCardinality} gauge reports.
+     *
+     * @return the number of entities currently being buffered
+     */
+    public int activeEntityGroupCount() {
+        return groups.size();
+    }
+
+    private void stageLogEvents(final LogGroupBuffer group) {
+        final Buffer buffer = group.buffer;
+        group.stopWatch.stopAndReset();
 
         List<InputLogEvent> inputLogEvents = cloudWatchLogsDispatcher.prepareInputLogEvents(buffer.getBufferedData());
-        cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles());
+        if (dynamic) {
+            // Dynamic mode supplies the group's resolved entity explicitly, one entity per request.
+            cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles(), group.entity);
+        } else {
+            // Static mode defers to the dispatcher's frozen entity so it is not overridden by null.
+            cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles());
+        }
         cloudWatchLogsMetrics.recordRequestSize(buffer.getBufferSize());
 
         buffer.resetBuffer();
     }
 
-    private void addToBuffer(final EventHandle logEventHandle, final String logString) {
+    private void addToBuffer(final Buffer buffer, final EventHandle logEventHandle, final String logString) {
         buffer.writeEvent(logEventHandle, logString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Holds one group's buffer, its resolved entity, and its own flush timer. The entity is null for the
+     * shared group, which carries no per-resource attribution.
+     */
+    private static final class LogGroupBuffer {
+        private final Buffer buffer;
+        private final Entity entity;
+        private final SinkStopWatch stopWatch;
+
+        private LogGroupBuffer(final Buffer buffer, final Entity entity, final SinkStopWatch stopWatch) {
+            this.buffer = buffer;
+            this.entity = entity;
+            this.stopWatch = stopWatch;
+        }
+    }
+
+    /**
+     * Adapts the legacy single-buffer static constructor to the group model by always handing back the
+     * one pre-built buffer. Static mode only ever opens the shared group, so it is only ever asked once.
+     */
+    private static final class SingleBufferFactory implements BufferFactory {
+        private final Buffer buffer;
+
+        private SingleBufferFactory(final Buffer buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public Buffer getBuffer() {
+            return buffer;
+        }
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsService.java
@@ -9,9 +9,11 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.Buffer;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.BufferFactory;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.SinkStopWatch;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsSinkUtils;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 import org.opensearch.dataprepper.plugins.dlq.DlqPushHandler;
 import org.opensearch.dataprepper.model.failures.DlqObject;
@@ -19,7 +21,9 @@ import org.opensearch.dataprepper.model.failures.DlqObject;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -33,31 +37,49 @@ import java.util.concurrent.locks.ReentrantLock;
  * </ol>
  */
 public class CloudWatchLogsService {
+    static final String STATIC_GROUP_KEY = "";
+
     private final CloudWatchLogsDispatcher cloudWatchLogsDispatcher;
-    private final Buffer buffer;
+    private final BufferFactory bufferFactory;
     private final CloudWatchLogsLimits cloudWatchLogsLimits;
     private CloudWatchLogsMetrics cloudWatchLogsMetrics;
-    private final SinkStopWatch sinkStopWatch;
     private final ReentrantLock processLock;
     private final DlqPushHandler dlqPushHandler;
     private final boolean dropIfDlqNotConfigured;
+
+    // Dynamic-entity configuration (null/false in static mode).
+    private final boolean dynamic;
+    private final EntityResolver entityResolver;
+
+    private final Map<String, LogGroupBuffer> groups = new LinkedHashMap<>();
+
+    // Static-entity constructor. Preserves the original behavior: a single buffer and one entity for each request
     public CloudWatchLogsService(final Buffer buffer,
                                  final CloudWatchLogsMetrics cloudWatchLogsMetrics,
                                  final CloudWatchLogsLimits cloudWatchLogsLimits,
                                  final CloudWatchLogsDispatcher cloudWatchLogsDispatcher,
                                  final DlqPushHandler dlqPushHandler,
                                  final boolean dropIfDlqNotConfigured) {
+        this(new SingleBufferFactory(buffer), cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                cloudWatchLogsDispatcher, dlqPushHandler, dropIfDlqNotConfigured, null);
+    }
 
-        this.buffer = buffer;
+    public CloudWatchLogsService(final BufferFactory bufferFactory,
+                                 final CloudWatchLogsMetrics cloudWatchLogsMetrics,
+                                 final CloudWatchLogsLimits cloudWatchLogsLimits,
+                                 final CloudWatchLogsDispatcher cloudWatchLogsDispatcher,
+                                 final DlqPushHandler dlqPushHandler,
+                                 final boolean dropIfDlqNotConfigured,
+                                 final EntityResolver entityResolver) {
+        this.bufferFactory = bufferFactory;
         this.cloudWatchLogsLimits = cloudWatchLogsLimits;
-
         this.cloudWatchLogsMetrics = cloudWatchLogsMetrics;
-        processLock = new ReentrantLock();
-        sinkStopWatch = new SinkStopWatch();
-
+        this.processLock = new ReentrantLock();
         this.cloudWatchLogsDispatcher = cloudWatchLogsDispatcher;
         this.dlqPushHandler = dlqPushHandler;
         this.dropIfDlqNotConfigured = dropIfDlqNotConfigured;
+        this.entityResolver = entityResolver;
+        this.dynamic = entityResolver != null;
     }
 
     /**
@@ -65,13 +87,10 @@ public class CloudWatchLogsService {
      * @param logs Collection of Record events.
      */
     public void processLogEvents(final Collection<Record<Event>> logs) {
-        sinkStopWatch.startIfNotRunning();
-        if (logs.isEmpty() && buffer.getEventCount() > 0) {
+        if (logs.isEmpty()) {
             processLock.lock();
             try {
-                if (cloudWatchLogsLimits.isTimeLimitReached(sinkStopWatch.getElapsedTimeInSeconds())) {
-                    stageLogEvents();
-                }
+                flushIdleGroups();
             } finally {
                 processLock.unlock();
             }
@@ -80,13 +99,14 @@ public class CloudWatchLogsService {
 
         final List<DlqObject> dlqObjects = new ArrayList<>();
         for (Record<Event> log : logs) {
-            String logString = log.getData().toJsonString();
+            final Event event = log.getData();
+            String logString = event.toJsonString();
             int logLength = logString.length();
 
             cloudWatchLogsMetrics.recordLogSize(logLength);
             if (cloudWatchLogsLimits.isGreaterThanMaxEventSize(logLength)) {
                 final String failureMessage = String.format("Event blocked due to Max Size restriction! Event Size : %s", (logLength + CloudWatchLogsLimits.APPROXIMATE_LOG_EVENT_OVERHEAD_SIZE));
-                DlqObject dlqObject = CloudWatchLogsSinkUtils.createDlqObject(0, log.getData().getEventHandle(), logString, failureMessage, dlqPushHandler, dropIfDlqNotConfigured);
+                DlqObject dlqObject = CloudWatchLogsSinkUtils.createDlqObject(0, event.getEventHandle(), logString, failureMessage, dlqPushHandler, dropIfDlqNotConfigured);
                 if (dlqObject != null) {
                     dlqObjects.add(dlqObject);
                 } else if (dropIfDlqNotConfigured) {
@@ -95,21 +115,22 @@ public class CloudWatchLogsService {
                 continue;
             }
 
-            long time = sinkStopWatch.getElapsedTimeInSeconds();
-
             processLock.lock();
             try {
+                final LogGroupBuffer group = groupFor(event);
+                group.stopWatch.startIfNotRunning();
+
+                final Buffer buffer = group.buffer;
                 int bufferSize = buffer.getBufferSize();
                 int bufferEventCount = buffer.getEventCount();
-                if (cloudWatchLogsLimits.maxRequestSizeLimitExceeds(logLength + bufferSize, bufferEventCount+1)) {
-                    stageLogEvents();
+                if (cloudWatchLogsLimits.maxRequestSizeLimitExceeds(logLength + bufferSize, bufferEventCount + 1)) {
+                    stageLogEvents(group);
                 }
-                addToBuffer(log.getData().getEventHandle(), logString);
+                addToBuffer(buffer, event.getEventHandle(), logString);
                 bufferEventCount = buffer.getEventCount();
                 if (cloudWatchLogsLimits.isMaxEventCountLimitReached(bufferEventCount)) {
-                    stageLogEvents();
+                    stageLogEvents(group);
                 }
-
             } finally {
                 processLock.unlock();
             }
@@ -117,17 +138,114 @@ public class CloudWatchLogsService {
         CloudWatchLogsSinkUtils.handleDlqObjects(dlqObjects, dlqPushHandler);
     }
 
-    private void stageLogEvents() {
-        sinkStopWatch.stopAndReset();
+    /**
+     * Resolves (creating if necessary) the buffer group for an event. Must be called while
+     * holding {@code processLock}.
+     */
+    private LogGroupBuffer groupFor(final Event event) {
+        if (!dynamic) {
+            LogGroupBuffer group = groups.get(STATIC_GROUP_KEY);
+            if (group == null) {
+                group = new LogGroupBuffer(bufferFactory.getBuffer(), null, new SinkStopWatch());
+                groups.put(STATIC_GROUP_KEY, group);
+            }
+            return group;
+        }
+
+        // Resolving interpolates the entity templates against the event; the key is the resolved key
+        // attributes, so events whose templates produce the same entity share a group (and one PLE
+        // request). Normalization, if enabled, is applied inside the resolver before the key is formed.
+        final EntityResolver.ResolvedEntity resolved = entityResolver.resolve(event);
+        String key = resolved.getKey();
+        LogGroupBuffer group = groups.get(key);
+        if (group != null) {
+            return group;
+        }
+
+        // Cap the number of buffer groups with the same bound the resolver uses for its entity cache,
+        // so a high-cardinality templated key cannot grow the groups map without limit. On overflow,
+        // route the event to a shared fallback group that carries no per-resource entity rather than
+        // allocating a new group per distinct key.
+        Entity entity = resolved.getEntity();
+        if (groups.size() >= entityResolver.maxCacheSize()) {
+            group = groups.get(STATIC_GROUP_KEY);
+            if (group != null) {
+                return group;
+            }
+            key = STATIC_GROUP_KEY;
+            entity = null;
+        }
+
+        group = new LogGroupBuffer(bufferFactory.getBuffer(), entity, new SinkStopWatch());
+        groups.put(key, group);
+        cloudWatchLogsMetrics.increaseEntityGroupsCreatedCounter(1);
+        return group;
+    }
+
+    /**
+     * Flushes any group whose time limit has been reached. Called on an empty poll so buffered
+     * events do not sit indefinitely below the size/count thresholds.
+     */
+    private void flushIdleGroups() {
+        for (final LogGroupBuffer group : groups.values()) {
+            if (group.buffer.getEventCount() > 0
+                    && cloudWatchLogsLimits.isTimeLimitReached(group.stopWatch.getElapsedTimeInSeconds())) {
+                stageLogEvents(group);
+            }
+        }
+    }
+
+    private void stageLogEvents(final LogGroupBuffer group) {
+        final Buffer buffer = group.buffer;
+        group.stopWatch.stopAndReset();
 
         List<InputLogEvent> inputLogEvents = cloudWatchLogsDispatcher.prepareInputLogEvents(buffer.getBufferedData());
-        cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles());
+        if (dynamic) {
+            // Dynamic mode supplies the group's resolved entity explicitly, one entity per request.
+            cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles(), group.entity);
+        } else {
+            // Static mode defers to the dispatcher's frozen entity so it is not overridden by null.
+            cloudWatchLogsDispatcher.dispatchLogs(inputLogEvents, buffer.getEventHandles());
+        }
         cloudWatchLogsMetrics.recordRequestSize(buffer.getBufferSize());
 
         buffer.resetBuffer();
     }
 
-    private void addToBuffer(final EventHandle logEventHandle, final String logString) {
+    private void addToBuffer(final Buffer buffer, final EventHandle logEventHandle, final String logString) {
         buffer.writeEvent(logEventHandle, logString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Holds the per-entity-group buffer, its resolved entity, and its own flush timer.
+     */
+    private static final class LogGroupBuffer {
+        private final Buffer buffer;
+        private final Entity entity;
+        private final SinkStopWatch stopWatch;
+
+        private LogGroupBuffer(final Buffer buffer, final Entity entity, final SinkStopWatch stopWatch) {
+            this.buffer = buffer;
+            this.entity = entity;
+            this.stopWatch = stopWatch;
+        }
+    }
+
+    /**
+     * Adapts the legacy single-buffer static constructor to the group model by handing back the
+     * one pre-built buffer the first time and fresh buffers thereafter (only relevant if the
+     * single static group is ever flushed and reused — the same buffer instance is reset in place).
+     */
+    private static final class SingleBufferFactory implements BufferFactory {
+        private final Buffer buffer;
+
+        private SingleBufferFactory(final Buffer buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public Buffer getBuffer() {
+            return buffer;
+        }
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolver.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolver.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolves a CloudWatch Logs Entity from an event by interpolating the configured
+ * {@code key_attributes}/{@code attributes} templates. Events resolving to the same key attributes
+ * share a group (one PutLogEvents request); the resolved key is returned alongside the entity so the
+ * caller keys its buffers with the same value the cache uses.
+ */
+public class EntityResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(EntityResolver.class);
+
+    /**
+     * Upper bound on distinct entities cached and buffer groups held concurrently: a memory-safety
+     * backstop against runaway key cardinality. Beyond it, events collapse into a shared fallback
+     * group carrying no per-resource entity.
+     */
+    public static final int MAX_ENTITY_CARDINALITY = 1000;
+
+    private final Map<String, String> keyAttributeTemplates;
+    private final Map<String, String> attributeTemplates;
+    private final int maxCacheSize;
+    private final ConcurrentHashMap<String, Entity> entityCache = new ConcurrentHashMap<>();
+    private volatile boolean cacheFullLogged = false;
+
+    public EntityResolver(final Map<String, String> keyAttributeTemplates,
+                          final Map<String, String> attributeTemplates,
+                          final int maxCacheSize) {
+        this.keyAttributeTemplates = keyAttributeTemplates;
+        this.attributeTemplates = attributeTemplates;
+        this.maxCacheSize = maxCacheSize;
+    }
+
+    /**
+     * Resolves the entity for an event and returns it with its grouping key (the resolved key
+     * attributes).
+     */
+    public ResolvedEntity resolve(final Event event) {
+        final Map<String, String> resolvedKeyAttributes = resolveTemplates(keyAttributeTemplates, event);
+        final String key = resolvedKeyAttributes.toString();
+
+        final Entity cached = entityCache.get(key);
+        if (cached != null) {
+            return new ResolvedEntity(key, cached);
+        }
+
+        final Entity entity = buildEntity(resolvedKeyAttributes, resolveTemplates(attributeTemplates, event));
+
+        // Bound the cache: only retain when there is room.
+        if (entityCache.size() < maxCacheSize) {
+            return new ResolvedEntity(key, entityCache.computeIfAbsent(key, k -> entity));
+        }
+
+        if (!cacheFullLogged) {
+            cacheFullLogged = true;
+            LOG.warn("Entity cache reached its limit of {} distinct entities; further keys will be "
+                    + "resolved on each flush without caching. Reduce the cardinality of the templated "
+                    + "entity key attributes.", maxCacheSize);
+        }
+        return new ResolvedEntity(key, entity);
+    }
+
+    private Entity buildEntity(final Map<String, String> resolvedKeyAttributes,
+                               final Map<String, String> resolvedAttributes) {
+        final Entity.Builder builder = Entity.builder().keyAttributes(resolvedKeyAttributes);
+        if (!resolvedAttributes.isEmpty()) {
+            builder.attributes(resolvedAttributes);
+        }
+        return builder.build();
+    }
+
+    /**
+     * A resolved entity paired with the grouping key it was resolved under.
+     */
+    public static final class ResolvedEntity {
+        private final String key;
+        private final Entity entity;
+
+        ResolvedEntity(final String key, final Entity entity) {
+            this.key = key;
+            this.entity = entity;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public Entity getEntity() {
+            return entity;
+        }
+    }
+
+    /**
+     * Interpolates {@code ${...}} references in each template value; missing keys resolve to an empty
+     * string (three-arg formatString) rather than throwing.
+     */
+    private Map<String, String> resolveTemplates(final Map<String, String> templates, final Event sampleEvent) {
+        final Map<String, String> resolved = new LinkedHashMap<>();
+        for (final Map.Entry<String, String> entry : templates.entrySet()) {
+            final String value = entry.getValue();
+            String interpolated;
+            try {
+                interpolated = sampleEvent.formatString(value, null, "");
+            } catch (final RuntimeException e) {
+                // Malformed template string ("${" with no closing brace, etc.). Fall back to the
+                // literal so a single bad value never aborts entity resolution for the whole group.
+                LOG.warn("Failed to resolve entity attribute template '{}': {}", value, e.getMessage());
+                interpolated = value;
+            }
+            resolved.put(entry.getKey(), interpolated);
+        }
+        return resolved;
+    }
+
+    /**
+     * Current number of distinct entities retained in the cache. Exposed for the cardinality gauge.
+     */
+    public int cacheSize() {
+        return entityCache.size();
+    }
+
+    /**
+     * The maximum number of distinct entities retained; the service uses the same bound to cap its
+     * buffer groups.
+     */
+    public int maxCacheSize() {
+        return maxCacheSize;
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolver.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolver.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Resolves a CloudWatch Logs Entity from an event by interpolating the configured
+ * {@code key_attributes}/{@code attributes} templates. Events whose key attributes interpolate to the
+ * same value share a buffer group, and so one PutLogEvents request.
+ *
+ * <p>Deliberately stateless. {@link CloudWatchLogsService} already keys its groups by {@link ResolvedKey}
+ * and each group holds its own entity, so caching entities here would be a second copy of the same
+ * mapping — and one that never evicts, unlike the groups map. Resolution is split in two instead: every
+ * event resolves a key, and only the creation of a new group builds an entity.
+ */
+public class EntityResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(EntityResolver.class);
+
+    private final Map<String, String> keyAttributeTemplates;
+    private final Map<String, String> attributeTemplates;
+    private final ExpressionEvaluator expressionEvaluator;
+
+    public EntityResolver(final Map<String, String> keyAttributeTemplates,
+                          final Map<String, String> attributeTemplates,
+                          final ExpressionEvaluator expressionEvaluator) {
+        this.keyAttributeTemplates = keyAttributeTemplates;
+        this.attributeTemplates = attributeTemplates;
+        this.expressionEvaluator = expressionEvaluator;
+    }
+
+    /**
+     * Resolves the grouping key for an event from the {@code key_attributes} templates. Runs for every
+     * event, so it interpolates only what the key needs.
+     */
+    public ResolvedKey resolveKey(final Event event) {
+        return new ResolvedKey(resolveTemplates(keyAttributeTemplates, event));
+    }
+
+    /**
+     * Builds the entity for an already-resolved key. Only called when a new buffer group is opened, so
+     * the {@code attributes} templates are interpolated once per group rather than once per event.
+     */
+    public Entity buildEntity(final ResolvedKey resolvedKey, final Event event) {
+        final Entity.Builder builder = Entity.builder().keyAttributes(resolvedKey.keyAttributes);
+        final Map<String, String> resolvedAttributes = resolveTemplates(attributeTemplates, event);
+        if (!resolvedAttributes.isEmpty()) {
+            builder.attributes(resolvedAttributes);
+        }
+        return builder.build();
+    }
+
+    /**
+     * The resolved key attributes of one entity, and the key {@link CloudWatchLogsService} groups
+     * buffers by.
+     *
+     * <p>Equality defers wholly to the resolved attribute map, so two events group together exactly when
+     * they describe the same entity. Note that map equality ignores iteration order, which is what we
+     * want: the same attributes listed in a different order are the same entity.
+     */
+    public static final class ResolvedKey {
+        private final Map<String, String> keyAttributes;
+
+        ResolvedKey(final Map<String, String> keyAttributes) {
+            this.keyAttributes = keyAttributes;
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof ResolvedKey)) {
+                return false;
+            }
+            return keyAttributes.equals(((ResolvedKey) other).keyAttributes);
+        }
+
+        @Override
+        public int hashCode() {
+            return keyAttributes.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return keyAttributes.toString();
+        }
+    }
+
+    /**
+     * Interpolates each template value against the event. Both {@code ${/field}} references and
+     * {@code ${expression()}} statements are supported; the evaluator is what makes the latter work, so
+     * it must be the same one that classified this config as dynamic. A reference to a field the event
+     * does not carry resolves to an empty string (three-arg formatString) rather than throwing.
+     */
+    private Map<String, String> resolveTemplates(final Map<String, String> templates, final Event sampleEvent) {
+        final Map<String, String> resolved = new LinkedHashMap<>();
+        for (final Map.Entry<String, String> entry : templates.entrySet()) {
+            final String value = entry.getValue();
+            String interpolated;
+            try {
+                interpolated = sampleEvent.formatString(value, expressionEvaluator, "");
+            } catch (final RuntimeException e) {
+                // Malformed template string ("${" with no closing brace, etc.) or a failed expression.
+                // Fall back to the literal so a single bad value never aborts entity resolution for the
+                // whole group, and log it so this is never a silent substitution.
+                LOG.warn("Failed to resolve entity attribute template '{}': {}", value, e.getMessage());
+                interpolated = value;
+            }
+            resolved.put(entry.getKey(), interpolated);
+        }
+        return resolved;
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfig.java
@@ -11,13 +11,25 @@
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Configuration for the CloudWatch Logs entity attached to PutLogEvents.
+ */
 public class EntityConfig {
+
+    /**
+     * Default bound on entities buffered concurrently in dynamic mode. A memory-safety backstop against
+     * runaway key cardinality: each concurrent entity holds its own buffer, so this multiplied by
+     * {@code max_request_size} is the worst-case buffered footprint.
+     */
+    public static final int DEFAULT_MAX_CARDINALITY = 1000;
 
     @JsonProperty("key_attributes")
     @NotEmpty
@@ -27,11 +39,51 @@ public class EntityConfig {
     @NotNull
     private Map<String, String> attributes = Collections.emptyMap();
 
+    @JsonProperty("max_cardinality")
+    @Min(1)
+    private int maxCardinality = DEFAULT_MAX_CARDINALITY;
+
     public Map<String, String> getKeyAttributes() {
         return Collections.unmodifiableMap(keyAttributes);
     }
 
     public Map<String, String> getAttributes() {
         return Collections.unmodifiableMap(attributes);
+    }
+
+    /**
+     * Maximum number of entities buffered at one time in dynamic mode. Beyond it, events collapse into a
+     * shared fallback group carrying no per-resource entity. Ignored in static mode, where there is only
+     * ever one group.
+     */
+    public int getMaxCardinality() {
+        return maxCardinality;
+    }
+
+    /**
+     * Dynamic when any {@code key_attributes}/{@code attributes} value is a Data Prepper format
+     * expression carrying a {@code ${...}} field reference or expression; otherwise static (one
+     * constant entity, original behavior).
+     */
+    public boolean isDynamic(final ExpressionEvaluator expressionEvaluator) {
+        return containsTemplate(keyAttributes, expressionEvaluator)
+                || containsTemplate(attributes, expressionEvaluator);
+    }
+
+    private static boolean containsTemplate(final Map<String, String> values,
+                                            final ExpressionEvaluator expressionEvaluator) {
+        if (values == null) {
+            return false;
+        }
+        for (final String value : values.values()) {
+            if (value == null) {
+                continue;
+            }
+            if (!expressionEvaluator.extractDynamicKeysFromFormatExpression(value).isEmpty()
+                    || !expressionEvaluator.extractDynamicExpressionsFromFormatExpression(value).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfig.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfig.java
@@ -13,10 +13,14 @@ package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Configuration for the CloudWatch Logs entity attached to PutLogEvents.
+ */
 public class EntityConfig {
 
     @JsonProperty("key_attributes")
@@ -33,5 +37,32 @@ public class EntityConfig {
 
     public Map<String, String> getAttributes() {
         return Collections.unmodifiableMap(attributes);
+    }
+
+    /**
+     * Dynamic when any {@code key_attributes}/{@code attributes} value is a Data Prepper format
+     * expression carrying a {@code ${...}} field reference or expression; otherwise static (one
+     * constant entity, original behavior).
+     */
+    public boolean isDynamic(final ExpressionEvaluator expressionEvaluator) {
+        return containsTemplate(keyAttributes, expressionEvaluator)
+                || containsTemplate(attributes, expressionEvaluator);
+    }
+
+    private static boolean containsTemplate(final Map<String, String> values,
+                                            final ExpressionEvaluator expressionEvaluator) {
+        if (values == null) {
+            return false;
+        }
+        for (final String value : values.values()) {
+            if (value == null) {
+                continue;
+            }
+            if (!expressionEvaluator.extractDynamicKeysFromFormatExpression(value).isEmpty()
+                    || !expressionEvaluator.extractDynamicExpressionsFromFormatExpression(value).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSinkTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
@@ -66,6 +67,7 @@ class CloudWatchLogsSinkTest {
     private Map<String, String> mockHeaderOverrides;
     private CloudWatchLogsMetrics mockCloudWatchLogsMetrics;
     private CloudWatchLogsClient mockClient;
+    private ExpressionEvaluator mockExpressionEvaluator;
     private static final String TEST_LOG_GROUP = "testLogGroup";
     private static final String TEST_LOG_STREAM= "testLogStream";
     private static final String TEST_PLUGIN_NAME = "testPluginName";
@@ -88,6 +90,7 @@ class CloudWatchLogsSinkTest {
         mockHeaderOverrides.put("X-Test-Header", "test-value");
         mockCloudWatchLogsMetrics = mock(CloudWatchLogsMetrics.class);
         mockClient = mock(CloudWatchLogsClient.class);
+        mockExpressionEvaluator = mock(ExpressionEvaluator.class);
         DistributionSummary summary = mock(DistributionSummary.class);
         when(mockPluginMetrics.summary(anyString())).thenReturn(summary);
 
@@ -106,7 +109,7 @@ class CloudWatchLogsSinkTest {
 
     CloudWatchLogsSink getTestCloudWatchSink() {
         return new CloudWatchLogsSink(mockPluginSetting, mockPluginMetrics, mockPluginFactory, mockCloudWatchLogsSinkConfig,
-                mockCredentialSupplier);
+                mockCredentialSupplier, mockExpressionEvaluator);
     }
 
     Collection<Record<Event>> getMockedRecords() {

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetricsTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsMetricsTest.java
@@ -3,9 +3,15 @@ package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
 import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.ToDoubleFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +29,8 @@ class CloudWatchLogsMetricsTest {
     private Counter mockAccessDeniedCounter;
     private Counter mockResourceNotFoundCounter;
     private Counter mockThrottledCounter;
+    private Counter mockEntityGroupsCreatedCounter;
+    private Counter mockEntityOverflowEventsCounter;
 
     @BeforeEach
     void setUp() {
@@ -36,6 +44,8 @@ class CloudWatchLogsMetricsTest {
         mockAccessDeniedCounter = mock(Counter.class);
         mockResourceNotFoundCounter = mock(Counter.class);
         mockThrottledCounter = mock(Counter.class);
+        mockEntityGroupsCreatedCounter = mock(Counter.class);
+        mockEntityOverflowEventsCounter = mock(Counter.class);
 
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_EVENTS_SUCCEEDED)).thenReturn(mockSuccessEventCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_REQUESTS_SUCCEEDED)).thenReturn(mockSuccessRequestCounter);
@@ -46,6 +56,8 @@ class CloudWatchLogsMetricsTest {
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ACCESS_DENIED)).thenReturn(mockAccessDeniedCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_RESOURCE_NOT_FOUND)).thenReturn(mockResourceNotFoundCounter);
         when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_THROTTLED)).thenReturn(mockThrottledCounter);
+        when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_GROUPS_CREATED)).thenReturn(mockEntityGroupsCreatedCounter);
+        when(mockPluginMetrics.counter(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_OVERFLOW_EVENTS)).thenReturn(mockEntityOverflowEventsCounter);
 
         testCloudWatchLogsMetrics = new CloudWatchLogsMetrics(mockPluginMetrics);
     }
@@ -107,5 +119,36 @@ class CloudWatchLogsMetricsTest {
     void WHEN_increase_throttled_counter_called_THEN_throttled_counter_increase_method_should_be_called() {
         testCloudWatchLogsMetrics.increaseThrottledCounter(1);
         verify(mockThrottledCounter, times(1)).increment(1);
+    }
+
+    @Test
+    void WHEN_increase_entity_groups_created_counter_called_THEN_entity_groups_created_counter_increase_method_should_be_called() {
+        testCloudWatchLogsMetrics.increaseEntityGroupsCreatedCounter(1);
+        verify(mockEntityGroupsCreatedCounter, times(1)).increment(1);
+    }
+
+    @Test
+    void WHEN_increase_entity_overflow_events_counter_called_THEN_entity_overflow_events_counter_increase_method_should_be_called() {
+        testCloudWatchLogsMetrics.increaseEntityOverflowEventsCounter(1);
+        verify(mockEntityOverflowEventsCounter, times(1)).increment(1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void WHEN_register_entity_cardinality_gauge_called_THEN_gauge_is_registered_and_samples_the_supplied_state() {
+        final AtomicInteger liveGroupCount = new AtomicInteger(3);
+
+        testCloudWatchLogsMetrics.registerEntityCardinalityGauge(liveGroupCount, AtomicInteger::get);
+
+        final ArgumentCaptor<ToDoubleFunction<AtomicInteger>> functionCaptor =
+                ArgumentCaptor.forClass(ToDoubleFunction.class);
+        verify(mockPluginMetrics, times(1)).gauge(eq(CloudWatchLogsMetrics.CLOUDWATCH_LOGS_ENTITY_CARDINALITY),
+                eq(liveGroupCount), functionCaptor.capture());
+
+        // The gauge has to read the state each time it is sampled rather than capture a value at
+        // registration, otherwise it would flatline instead of tracking live cardinality.
+        assertEquals(3.0, functionCaptor.getValue().applyAsDouble(liveGroupCount));
+        liveGroupCount.set(7);
+        assertEquals(7.0, functionCaptor.getValue().applyAsDouble(liveGroupCount));
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsServiceTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsServiceTest.java
@@ -7,7 +7,10 @@ package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
@@ -19,17 +22,24 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.Buffer;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.InMemoryBuffer;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.buffer.InMemoryBufferFactory;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatchLogsSinkConfig;
+import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.EntityConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.ThresholdConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -249,6 +259,243 @@ class CloudWatchLogsServiceTest {
         setUpThreadsProcessingLogsWithNormalSample(LARGE_THREAD_COUNT);
 
         verify(mockDispatcher, atLeast(LARGE_THREAD_COUNT)).dispatchLogs(any(List.class), any(List.class));
+    }
+
+    @Nested
+    class DynamicEntityMode {
+        private CloudWatchLogsService service;
+
+        private CloudWatchLogsService dynamicService(final EntityResolver entityResolver) {
+            return dynamicService(entityResolver, EntityConfig.DEFAULT_MAX_CARDINALITY);
+        }
+
+        private CloudWatchLogsService dynamicService(final EntityResolver entityResolver, final int maxCardinality) {
+            return new CloudWatchLogsService(inMemoryBufferFactory, cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                    mockDispatcher, null, true, entityResolver, maxCardinality);
+        }
+
+        private EntityResolver resourceIdResolver() {
+            final Map<String, String> keyAttributes = new LinkedHashMap<>();
+            keyAttributes.put("Type", "Service");
+            keyAttributes.put("Name", "${resourceId}");
+            // A plain field reference, so the evaluator is never consulted.
+            return new EntityResolver(keyAttributes, Map.of(), mock(ExpressionEvaluator.class));
+        }
+
+        private Collection<Record<Event>> recordsWithResourceId(final String resourceId, final int count) {
+            final ArrayList<Record<Event>> records = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                final Event event = JacksonLog.builder()
+                        .withData(Map.of("resourceId", resourceId, "seq", i))
+                        .withEventHandle(mock(EventHandle.class))
+                        .build();
+                records.add(new Record<>(event));
+            }
+            return records;
+        }
+
+        /**
+         * Limits whose flush interval is zero, so every group is immediately past its time limit. This is
+         * what lets the timer-driven paths be exercised without sleeping in a test.
+         */
+        private CloudWatchLogsLimits zeroFlushIntervalLimits() {
+            return new CloudWatchLogsLimits(thresholdConfig.getBatchSize(), thresholdConfig.getMaxEventSizeBytes(),
+                    thresholdConfig.getMaxRequestSizeBytes(), 0);
+        }
+
+        /**
+         * The {@code Name} key attribute of every entity dispatched so far. The shared group dispatches a
+         * null entity, which contributes no name.
+         */
+        private List<String> dispatchedEntityNames() {
+            final ArgumentCaptor<Entity> entityCaptor = ArgumentCaptor.forClass(Entity.class);
+            verify(mockDispatcher, atLeast(1)).dispatchLogs(any(List.class), any(List.class), entityCaptor.capture());
+            final List<String> names = new ArrayList<>();
+            for (final Entity entity : entityCaptor.getAllValues()) {
+                if (entity != null) {
+                    names.add(entity.keyAttributes().get("Name"));
+                }
+            }
+            return names;
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_events_share_a_resource_id_THEN_dispatch_carries_that_resolved_entity() {
+            service = dynamicService(resourceIdResolver());
+
+            service.processLogEvents(recordsWithResourceId("res-A", thresholdConfig.getBatchSize()));
+
+            assertThat(dispatchedEntityNames().contains("res-A"), equalTo(true));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_events_have_distinct_resource_ids_THEN_each_group_dispatches_its_own_entity() {
+            service = dynamicService(resourceIdResolver());
+
+            final Collection<Record<Event>> combined = new ArrayList<>();
+            combined.addAll(recordsWithResourceId("res-A", thresholdConfig.getBatchSize()));
+            combined.addAll(recordsWithResourceId("res-B", thresholdConfig.getBatchSize()));
+
+            service.processLogEvents(combined);
+
+            final List<String> dispatchedNames = dispatchedEntityNames();
+            assertThat(dispatchedNames.contains("res-A"), equalTo(true));
+            assertThat(dispatchedNames.contains("res-B"), equalTo(true));
+            // Each distinct key opens exactly one group.
+            verify(cloudWatchLogsMetrics, times(2)).increaseEntityGroupsCreatedCounter(eq(1));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_key_attributes_resolve_equal_THEN_one_group_serves_both_events() {
+            service = dynamicService(resourceIdResolver());
+
+            // Two separate events resolving to the same key attributes. ResolvedKey is the groups-map key,
+            // so its equals()/hashCode() are what make these share a group instead of opening two.
+            final Collection<Record<Event>> combined = new ArrayList<>();
+            combined.addAll(recordsWithResourceId("res-A", 1));
+            combined.addAll(recordsWithResourceId("res-A", 1));
+
+            service.processLogEvents(combined);
+
+            verify(cloudWatchLogsMetrics, times(1)).increaseEntityGroupsCreatedCounter(eq(1));
+            assertThat(service.activeEntityGroupCount(), equalTo(1));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_event_missing_templated_field_THEN_delivered_via_shared_group_with_empty_name() {
+            service = dynamicService(resourceIdResolver());
+
+            final ArrayList<Record<Event>> records = new ArrayList<>();
+            for (int i = 0; i < thresholdConfig.getBatchSize(); i++) {
+                final Event event = JacksonLog.builder()
+                        .withData(Map.of("someOtherField", "value", "seq", i))
+                        .withEventHandle(mock(EventHandle.class))
+                        .build();
+                records.add(new Record<>(event));
+            }
+
+            service.processLogEvents(records);
+
+            // The templated ${resourceId} is absent, so every such event resolves to the same key
+            // attributes ({Type=Service, Name=}) and shares one group. Events are still delivered; the
+            // resolved entity carries an empty Name rather than being dropped.
+            assertThat(dispatchedEntityNames().contains(""), equalTo(true));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_many_threads_process_distinct_resource_ids_THEN_all_dispatched_without_races() throws InterruptedException {
+            service = dynamicService(resourceIdResolver());
+
+            final int numberOfThreads = 50;
+            final Thread[] threads = new Thread[numberOfThreads];
+            for (int i = 0; i < numberOfThreads; i++) {
+                final String resourceId = "res-" + i;
+                threads[i] = new Thread(() ->
+                        service.processLogEvents(recordsWithResourceId(resourceId, thresholdConfig.getBatchSize())));
+                threads[i].start();
+            }
+            for (int i = 0; i < numberOfThreads; i++) {
+                threads[i].join();
+            }
+
+            verify(mockDispatcher, atLeast(numberOfThreads)).dispatchLogs(any(List.class), any(List.class), any(Entity.class));
+            verify(cloudWatchLogsMetrics, times(numberOfThreads)).increaseEntityGroupsCreatedCounter(eq(1));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_distinct_keys_exceed_max_cardinality_THEN_groups_are_bounded_and_overflow_uses_fallback() {
+            // Bound of 2: the first two distinct resource ids each open their own group; every further
+            // distinct id must reuse the shared fallback group rather than growing the groups map.
+            final int maxCardinality = 2;
+            service = dynamicService(resourceIdResolver(), maxCardinality);
+
+            final int distinctKeys = 5;
+            final Collection<Record<Event>> combined = new ArrayList<>();
+            for (int i = 0; i < distinctKeys; i++) {
+                combined.addAll(recordsWithResourceId("res-" + i, thresholdConfig.getBatchSize()));
+            }
+
+            service.processLogEvents(combined);
+
+            // Despite five distinct keys, group creation is bounded to maxCardinality. The shared fallback
+            // is deliberately not counted here, so this stays a count of real entities.
+            verify(cloudWatchLogsMetrics, times(maxCardinality)).increaseEntityGroupsCreatedCounter(eq(1));
+
+            // Every event of every overflowing key is counted, so the loss of attribution is visible.
+            final int overflowEvents = (distinctKeys - maxCardinality) * thresholdConfig.getBatchSize();
+            verify(cloudWatchLogsMetrics, times(overflowEvents)).increaseEntityOverflowEventsCounter(eq(1));
+
+            // The whole point of the fallback: overflow events must not be labelled with some arbitrary
+            // resource's id, so the entity dispatched for that group is null.
+            verify(mockDispatcher, atLeast(1)).dispatchLogs(any(List.class), any(List.class), isNull());
+            // The two in-bounds keys still dispatch their own real entities.
+            verify(mockDispatcher, atLeast(1)).dispatchLogs(any(List.class), any(List.class), any(Entity.class));
+        }
+
+        @Test
+        void GIVEN_max_cardinality_of_one_WHEN_overflow_has_happened_THEN_a_freed_slot_still_admits_a_new_entity() {
+            cloudWatchLogsLimits = zeroFlushIntervalLimits();
+            // The tightest possible bound, which is where holding the shared group inside the groups map
+            // used to be fatal: the first overflow would take the single slot and never release it, so
+            // every subsequent event of every key overflowed into it for the lifetime of the process.
+            service = dynamicService(resourceIdResolver(), 1);
+
+            final Collection<Record<Event>> combined = new ArrayList<>();
+            combined.addAll(recordsWithResourceId("res-A", thresholdConfig.getBatchSize()));
+            combined.addAll(recordsWithResourceId("res-B", thresholdConfig.getBatchSize()));
+            service.processLogEvents(combined);
+
+            // res-A took the slot and res-B overflowed. The end-of-batch sweep then dropped res-A's
+            // drained group, and the shared group lives outside the map so it holds no slot.
+            verify(cloudWatchLogsMetrics, times(1)).increaseEntityGroupsCreatedCounter(eq(1));
+            verify(cloudWatchLogsMetrics, times(thresholdConfig.getBatchSize()))
+                    .increaseEntityOverflowEventsCounter(eq(1));
+            assertThat(service.activeEntityGroupCount(), equalTo(0));
+
+            service.processLogEvents(recordsWithResourceId("res-C", thresholdConfig.getBatchSize()));
+
+            // So res-C gets a real group and its own entity, rather than being absorbed forever.
+            verify(cloudWatchLogsMetrics, times(2)).increaseEntityGroupsCreatedCounter(eq(1));
+            assertThat(dispatchedEntityNames().contains("res-C"), equalTo(true));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_a_group_is_left_empty_and_idle_THEN_its_slot_is_released_for_a_new_entity() {
+            cloudWatchLogsLimits = zeroFlushIntervalLimits();
+            // Bound of 1: without eviction res-A would hold the only slot for the lifetime of the process,
+            // and res-B would have to collapse into the null-entity fallback.
+            service = dynamicService(resourceIdResolver(), 1);
+
+            service.processLogEvents(recordsWithResourceId("res-A", thresholdConfig.getBatchSize()));
+
+            // res-A's buffer was drained and its group is past the flush interval, so the sweep dropped it.
+            assertThat(service.activeEntityGroupCount(), equalTo(0));
+
+            service.processLogEvents(recordsWithResourceId("res-B", thresholdConfig.getBatchSize()));
+
+            // Two real groups over the run even though only one could exist at a time, and no overflow.
+            verify(cloudWatchLogsMetrics, times(2)).increaseEntityGroupsCreatedCounter(eq(1));
+            verify(cloudWatchLogsMetrics, never()).increaseEntityOverflowEventsCounter(anyInt());
+
+            final List<String> dispatchedNames = dispatchedEntityNames();
+            assertThat(dispatchedNames.contains("res-A"), equalTo(true));
+            assertThat(dispatchedNames.contains("res-B"), equalTo(true));
+        }
+
+        @Test
+        void GIVEN_dynamic_mode_WHEN_a_group_stays_below_the_count_limit_THEN_the_timer_flushes_it_on_a_non_empty_batch() {
+            cloudWatchLogsLimits = zeroFlushIntervalLimits();
+            service = dynamicService(resourceIdResolver());
+
+            // Far below batchSize and nowhere near the request size limit, so only the time limit can
+            // trigger a flush. The batch is non-empty, so the empty-poll path is never reached.
+            final int eventCount = 3;
+            service.processLogEvents(recordsWithResourceId("res-A", eventCount));
+
+            // One dispatch per event, from the time-limit check in the hot path. Before that check existed
+            // these events would have sat in the buffer for as long as the pipeline kept delivering records.
+            verify(mockDispatcher, times(eventCount)).dispatchLogs(any(List.class), any(List.class), any(Entity.class));
+        }
     }
 
      private Record<Event> getLargeRecord(long size) {

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsServiceTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsServiceTest.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
@@ -22,12 +23,15 @@ import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.CloudWatch
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.config.ThresholdConfig;
 import org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.utils.CloudWatchLogsLimits;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -249,6 +253,132 @@ class CloudWatchLogsServiceTest {
         setUpThreadsProcessingLogsWithNormalSample(LARGE_THREAD_COUNT);
 
         verify(mockDispatcher, atLeast(LARGE_THREAD_COUNT)).dispatchLogs(any(List.class), any(List.class));
+    }
+
+    // --- Dynamic-entity mode -------------------------------------------------
+
+    private CloudWatchLogsService getDynamicService(final EntityResolver entityResolver) {
+        return new CloudWatchLogsService(inMemoryBufferFactory, cloudWatchLogsMetrics, cloudWatchLogsLimits,
+                mockDispatcher, null, true, entityResolver);
+    }
+
+    private EntityResolver resourceIdResolver() {
+        return resourceIdResolver(1000);
+    }
+
+    private EntityResolver resourceIdResolver(final int maxCardinality) {
+        final Map<String, String> keyAttributes = new java.util.LinkedHashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "${resourceId}");
+        return new EntityResolver(keyAttributes, Map.of(), maxCardinality);
+    }
+
+    private Collection<Record<Event>> recordsWithResourceId(final String resourceId, final int count) {
+        final ArrayList<Record<Event>> records = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            final Event event = JacksonLog.builder()
+                    .withData(Map.of("resourceId", resourceId, "seq", i))
+                    .withEventHandle(mock(EventHandle.class))
+                    .build();
+            records.add(new Record<>(event));
+        }
+        return records;
+    }
+
+    @Test
+    void GIVEN_dynamic_mode_WHEN_events_share_a_resource_id_THEN_dispatch_carries_that_resolved_entity() {
+        cloudWatchLogsService = getDynamicService(resourceIdResolver());
+
+        cloudWatchLogsService.processLogEvents(recordsWithResourceId("res-A", thresholdConfig.getBatchSize()));
+
+        final ArgumentCaptor<Entity> entityCaptor = ArgumentCaptor.forClass(Entity.class);
+        verify(mockDispatcher, atLeast(1)).dispatchLogs(any(List.class), any(List.class), entityCaptor.capture());
+        assertThat(entityCaptor.getValue().keyAttributes().get("Name"), equalTo("res-A"));
+    }
+
+    @Test
+    void GIVEN_dynamic_mode_WHEN_events_have_distinct_resource_ids_THEN_each_group_dispatches_its_own_entity() {
+        cloudWatchLogsService = getDynamicService(resourceIdResolver());
+
+        final Collection<Record<Event>> combined = new ArrayList<>();
+        combined.addAll(recordsWithResourceId("res-A", thresholdConfig.getBatchSize()));
+        combined.addAll(recordsWithResourceId("res-B", thresholdConfig.getBatchSize()));
+
+        cloudWatchLogsService.processLogEvents(combined);
+
+        final ArgumentCaptor<Entity> entityCaptor = ArgumentCaptor.forClass(Entity.class);
+        verify(mockDispatcher, atLeast(2)).dispatchLogs(any(List.class), any(List.class), entityCaptor.capture());
+        final List<String> dispatchedNames = new ArrayList<>();
+        for (final Entity entity : entityCaptor.getAllValues()) {
+            dispatchedNames.add(entity.keyAttributes().get("Name"));
+        }
+        assertThat(dispatchedNames.contains("res-A"), equalTo(true));
+        assertThat(dispatchedNames.contains("res-B"), equalTo(true));
+        // Each distinct key opens exactly one group.
+        verify(cloudWatchLogsMetrics, times(2)).increaseEntityGroupsCreatedCounter(eq(1));
+    }
+
+    @Test
+    void GIVEN_dynamic_mode_WHEN_event_missing_templated_field_THEN_delivered_via_shared_group_with_empty_name() {
+        cloudWatchLogsService = getDynamicService(resourceIdResolver());
+
+        final ArrayList<Record<Event>> records = new ArrayList<>();
+        for (int i = 0; i < thresholdConfig.getBatchSize(); i++) {
+            final Event event = JacksonLog.builder()
+                    .withData(Map.of("someOtherField", "value", "seq", i))
+                    .withEventHandle(mock(EventHandle.class))
+                    .build();
+            records.add(new Record<>(event));
+        }
+
+        cloudWatchLogsService.processLogEvents(records);
+
+        // The templated ${resourceId} is absent, so every such event resolves to the same key
+        // attributes ({Type=Service, Name=}) and shares one group. Events are still delivered; the
+        // resolved entity carries an empty Name rather than being dropped.
+        final ArgumentCaptor<Entity> entityCaptor = ArgumentCaptor.forClass(Entity.class);
+        verify(mockDispatcher, atLeast(1)).dispatchLogs(any(List.class), any(List.class), entityCaptor.capture());
+        assertThat(entityCaptor.getValue().keyAttributes().get("Name"), equalTo(""));
+    }
+
+    @Test
+    void GIVEN_dynamic_mode_WHEN_many_threads_process_distinct_resource_ids_THEN_all_dispatched_without_races() throws InterruptedException {
+        cloudWatchLogsService = getDynamicService(resourceIdResolver());
+
+        final int numberOfThreads = 50;
+        final Thread[] threads = new Thread[numberOfThreads];
+        for (int i = 0; i < numberOfThreads; i++) {
+            final String resourceId = "res-" + i;
+            threads[i] = new Thread(() ->
+                    cloudWatchLogsService.processLogEvents(recordsWithResourceId(resourceId, thresholdConfig.getBatchSize())));
+            threads[i].start();
+        }
+        for (int i = 0; i < numberOfThreads; i++) {
+            threads[i].join();
+        }
+
+        verify(mockDispatcher, atLeast(numberOfThreads)).dispatchLogs(any(List.class), any(List.class), any(Entity.class));
+        verify(cloudWatchLogsMetrics, times(numberOfThreads)).increaseEntityGroupsCreatedCounter(eq(1));
+    }
+
+    @Test
+    void GIVEN_dynamic_mode_WHEN_distinct_keys_exceed_max_cardinality_THEN_groups_are_bounded_and_overflow_uses_fallback() {
+        // Bound of 2: the first two distinct resource ids each open their own group; every further
+        // distinct id must reuse the shared fallback group rather than growing the groups map.
+        final int maxCardinality = 2;
+        cloudWatchLogsService = getDynamicService(resourceIdResolver(maxCardinality));
+
+        final Collection<Record<Event>> combined = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            combined.addAll(recordsWithResourceId("res-" + i, thresholdConfig.getBatchSize()));
+        }
+
+        cloudWatchLogsService.processLogEvents(combined);
+
+        // Despite five distinct keys, group creation is bounded: maxCardinality named groups plus
+        // one shared fallback group for the overflow. Without the bound this would be five.
+        verify(cloudWatchLogsMetrics, times(maxCardinality + 1)).increaseEntityGroupsCreatedCounter(eq(1));
+        verify(mockDispatcher, atLeast(1)).dispatchLogs(any(List.class), any(List.class), any(Entity.class));
     }
 
      private Record<Event> getLargeRecord(long size) {

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolverTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolverTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+class EntityResolverTest {
+
+    private Event eventWith(final Map<String, Object> data) {
+        return JacksonLog.builder().withData(data).build();
+    }
+
+    private Map<String, String> keyAttrTemplates() {
+        final Map<String, String> m = new LinkedHashMap<>();
+        m.put("Type", "Service");
+        m.put("Name", "${resourceId}");
+        return m;
+    }
+
+    @Test
+    void resolve_interpolatesTemplatesFromEvent() {
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), Map.of(), 100);
+        final Event event = eventWith(Map.of("resourceId", "/subscriptions/abc/resourceGroups/rg"));
+
+        final Entity entity = resolver.resolve(event).getEntity();
+
+        assertThat(entity.keyAttributes().get("Type"), equalTo("Service"));
+        assertThat(entity.keyAttributes().get("Name"), equalTo("/subscriptions/abc/resourceGroups/rg"));
+    }
+
+    @Test
+    void resolve_keyIsDerivedFromResolvedKeyAttributes() {
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), Map.of(), 100);
+
+        // Events whose templates interpolate to the same key attributes share a grouping key; those
+        // that differ get distinct keys.
+        final String keyA = resolver.resolve(eventWith(Map.of("resourceId", "res-a"))).getKey();
+        final String keyASecond = resolver.resolve(eventWith(Map.of("resourceId", "res-a"))).getKey();
+        final String keyB = resolver.resolve(eventWith(Map.of("resourceId", "res-b"))).getKey();
+
+        assertThat(keyASecond, equalTo(keyA));
+        assertThat(keyB, not(equalTo(keyA)));
+    }
+
+    @Test
+    void resolve_cachesEntityPerKey() {
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), Map.of(), 100);
+
+        final Entity first = resolver.resolve(eventWith(Map.of("resourceId", "res-1"))).getEntity();
+        final Entity second = resolver.resolve(eventWith(Map.of("resourceId", "res-1"))).getEntity();
+
+        // The second event resolves to the same key, so the cached instance is returned.
+        assertThat(second, sameInstance(first));
+        assertThat(second.keyAttributes().get("Name"), equalTo("res-1"));
+        assertThat(resolver.cacheSize(), equalTo(1));
+    }
+
+    @Test
+    void resolve_distinctKeysProduceDistinctEntities() {
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), Map.of(), 100);
+
+        final Entity a = resolver.resolve(eventWith(Map.of("resourceId", "res-a"))).getEntity();
+        final Entity b = resolver.resolve(eventWith(Map.of("resourceId", "res-b"))).getEntity();
+
+        assertThat(a.keyAttributes().get("Name"), equalTo("res-a"));
+        assertThat(b.keyAttributes().get("Name"), equalTo("res-b"));
+        assertThat(resolver.cacheSize(), equalTo(2));
+    }
+
+    @Test
+    void resolve_missingTemplateKeyFallsBackToEmptyString() {
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), Map.of(), 100);
+        final Event event = eventWith(Map.of("someOtherField", "value"));
+
+        final Entity entity = resolver.resolve(event).getEntity();
+
+        // ${resourceId} is absent → three-arg formatString substitutes the empty default, not a throw.
+        assertThat(entity.keyAttributes().get("Name"), equalTo(""));
+        assertThat(entity.keyAttributes().get("Type"), equalTo("Service"));
+    }
+
+    @Test
+    void resolve_resolvesAttributesInAdditionToKeyAttributes() {
+        final Map<String, String> attributes = Map.of("AWS.ServiceNameSource", "UserConfiguration");
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), attributes, 100);
+        final Event event = eventWith(Map.of("resourceId", "res-1"));
+
+        final Entity entity = resolver.resolve(event).getEntity();
+
+        assertThat(entity.attributes().get("AWS.ServiceNameSource"), equalTo("UserConfiguration"));
+    }
+
+    @Test
+    void resolve_stopsCachingBeyondMaxCardinalityButStillResolves() {
+        final EntityResolver resolver = new EntityResolver(keyAttrTemplates(), Map.of(), 2);
+
+        resolver.resolve(eventWith(Map.of("resourceId", "k1")));
+        resolver.resolve(eventWith(Map.of("resourceId", "k2")));
+        // Third distinct key exceeds the bound: still resolved, but not retained.
+        final Entity overflow = resolver.resolve(eventWith(Map.of("resourceId", "k3"))).getEntity();
+
+        assertThat(overflow.keyAttributes().get("Name"), equalTo("k3"));
+        assertThat(resolver.cacheSize(), equalTo(2));
+    }
+
+    @Test
+    void resolve_emitsTemplatedIdentifierVerbatim() {
+        final Map<String, String> keyAttributes = new LinkedHashMap<>();
+        keyAttributes.put("Identifier", "${resourceId}");
+        final EntityResolver resolver = new EntityResolver(keyAttributes, Map.of(), 100);
+        final Event event = eventWith(Map.of("resourceId", "/Subscriptions/ABC"));
+
+        final Entity entity = resolver.resolve(event).getEntity();
+
+        assertThat(entity.keyAttributes().get("Identifier"), equalTo("/Subscriptions/ABC"));
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolverTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/EntityResolverTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import software.amazon.awssdk.services.cloudwatchlogs.model.Entity;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EntityResolverTest {
+
+    private ExpressionEvaluator expressionEvaluator;
+
+    @BeforeEach
+    void setUp() {
+        // A field-reference-only evaluator: nothing is a valid expression statement, which is how the
+        // real evaluator behaves for plain ${field} templates.
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+    }
+
+    private Event eventWith(final Map<String, Object> data) {
+        return JacksonLog.builder().withData(data).build();
+    }
+
+    private Map<String, String> keyAttrTemplates() {
+        final Map<String, String> m = new LinkedHashMap<>();
+        m.put("Type", "Service");
+        m.put("Name", "${resourceId}");
+        return m;
+    }
+
+    private EntityResolver resolver(final Map<String, String> keyAttributes, final Map<String, String> attributes) {
+        return new EntityResolver(keyAttributes, attributes, expressionEvaluator);
+    }
+
+    private Entity resolveEntity(final EntityResolver resolver, final Event event) {
+        return resolver.buildEntity(resolver.resolveKey(event), event);
+    }
+
+    @Test
+    void resolve_interpolatesTemplatesFromEvent() {
+        final EntityResolver resolver = resolver(keyAttrTemplates(), Map.of());
+        final Event event = eventWith(Map.of("resourceId", "/subscriptions/abc/resourceGroups/rg"));
+
+        final Entity entity = resolveEntity(resolver, event);
+
+        assertThat(entity.keyAttributes().get("Type"), equalTo("Service"));
+        assertThat(entity.keyAttributes().get("Name"), equalTo("/subscriptions/abc/resourceGroups/rg"));
+    }
+
+    @Test
+    void resolveKey_keyIsDerivedFromResolvedKeyAttributes() {
+        final EntityResolver resolver = resolver(keyAttrTemplates(), Map.of());
+
+        // Events whose templates interpolate to the same key attributes share a grouping key; those
+        // that differ get distinct keys.
+        final EntityResolver.ResolvedKey keyA = resolver.resolveKey(eventWith(Map.of("resourceId", "res-a")));
+        final EntityResolver.ResolvedKey keyASecond = resolver.resolveKey(eventWith(Map.of("resourceId", "res-a")));
+        final EntityResolver.ResolvedKey keyB = resolver.resolveKey(eventWith(Map.of("resourceId", "res-b")));
+
+        assertThat(keyASecond, equalTo(keyA));
+        assertThat(keyB, not(equalTo(keyA)));
+    }
+
+    @Test
+    void resolvedKey_equalKeysAgreeOnHashCodeSoTheyCollapseToOneGroup() {
+        final EntityResolver resolver = resolver(keyAttrTemplates(), Map.of());
+
+        final EntityResolver.ResolvedKey first = resolver.resolveKey(eventWith(Map.of("resourceId", "res-a")));
+        final EntityResolver.ResolvedKey second = resolver.resolveKey(eventWith(Map.of("resourceId", "res-a")));
+
+        // ResolvedKey is used directly as a map key, so equals() without a matching hashCode() would
+        // silently open a second group for the same entity.
+        assertThat(second.hashCode(), equalTo(first.hashCode()));
+        assertThat(new HashMap<>(Map.of(first, "group")).get(second), equalTo("group"));
+    }
+
+    @Test
+    void resolvedKey_isNotEqualToOtherTypesOrNull() {
+        final EntityResolver.ResolvedKey key = resolver(keyAttrTemplates(), Map.of())
+                .resolveKey(eventWith(Map.of("resourceId", "res-a")));
+
+        assertThat(key.equals(key), equalTo(true));
+        assertThat(key.equals("not a key"), equalTo(false));
+        assertThat(key.equals(null), equalTo(false));
+    }
+
+    @Test
+    void resolvedKey_toStringShowsTheResolvedAttributes() {
+        final Map<String, String> keyAttributes = new LinkedHashMap<>();
+        keyAttributes.put("Name", "${resourceId}");
+        final EntityResolver.ResolvedKey key = resolver(keyAttributes, Map.of())
+                .resolveKey(eventWith(Map.of("resourceId", "res-a")));
+
+        assertThat(key.toString(), equalTo("{Name=res-a}"));
+    }
+
+    @Test
+    void resolve_distinctKeysProduceDistinctEntities() {
+        final EntityResolver resolver = resolver(keyAttrTemplates(), Map.of());
+
+        final Entity a = resolveEntity(resolver, eventWith(Map.of("resourceId", "res-a")));
+        final Entity b = resolveEntity(resolver, eventWith(Map.of("resourceId", "res-b")));
+
+        assertThat(a.keyAttributes().get("Name"), equalTo("res-a"));
+        assertThat(b.keyAttributes().get("Name"), equalTo("res-b"));
+    }
+
+    @Test
+    void resolve_missingTemplateKeyFallsBackToEmptyString() {
+        final EntityResolver resolver = resolver(keyAttrTemplates(), Map.of());
+        final Event event = eventWith(Map.of("someOtherField", "value"));
+
+        final Entity entity = resolveEntity(resolver, event);
+
+        // ${resourceId} is absent → three-arg formatString substitutes the empty default, not a throw.
+        assertThat(entity.keyAttributes().get("Name"), equalTo(""));
+        assertThat(entity.keyAttributes().get("Type"), equalTo("Service"));
+    }
+
+    @Test
+    void resolve_resolvesAttributesInAdditionToKeyAttributes() {
+        final Map<String, String> attributes = Map.of("AWS.ServiceNameSource", "UserConfiguration");
+        final EntityResolver resolver = resolver(keyAttrTemplates(), attributes);
+        final Event event = eventWith(Map.of("resourceId", "res-1"));
+
+        final Entity entity = resolveEntity(resolver, event);
+
+        assertThat(entity.attributes().get("AWS.ServiceNameSource"), equalTo("UserConfiguration"));
+    }
+
+    @Test
+    void resolve_emitsTemplatedIdentifierVerbatim() {
+        final Map<String, String> keyAttributes = new LinkedHashMap<>();
+        keyAttributes.put("Identifier", "${resourceId}");
+        final EntityResolver resolver = resolver(keyAttributes, Map.of());
+        final Event event = eventWith(Map.of("resourceId", "/Subscriptions/ABC"));
+
+        final Entity entity = resolveEntity(resolver, event);
+
+        assertThat(entity.keyAttributes().get("Identifier"), equalTo("/Subscriptions/ABC"));
+    }
+
+    @Test
+    void resolve_evaluatesExpressionValuedKeyAttributeThroughTheEvaluator() {
+        final String expression = "getMetadata(\"resourceId\")";
+        final Map<String, String> keyAttributes = new LinkedHashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "${" + expression + "}");
+
+        // An expression is not a field on the event, so resolution depends entirely on the evaluator.
+        when(expressionEvaluator.isValidExpressionStatement(eq(expression))).thenReturn(true);
+        when(expressionEvaluator.evaluate(eq(expression), any(Event.class))).thenReturn("res-from-metadata");
+
+        final EntityResolver resolver = resolver(keyAttributes, Map.of());
+        final Entity entity = resolveEntity(resolver, eventWith(Map.of("unrelated", "value")));
+
+        // With a null evaluator this silently resolved to "" and every event collapsed into one group.
+        assertThat(entity.keyAttributes().get("Name"), equalTo("res-from-metadata"));
+        assertThat(entity.keyAttributes().get("Type"), equalTo("Service"));
+    }
+
+    @Test
+    void resolveKey_expressionValuedKeyAttributesGroupByEvaluatedValue() {
+        final String expression = "getMetadata(\"resourceId\")";
+        final Map<String, String> keyAttributes = new LinkedHashMap<>();
+        keyAttributes.put("Name", "${" + expression + "}");
+
+        final Event first = eventWith(Map.of("seq", 1));
+        final Event second = eventWith(Map.of("seq", 2));
+        when(expressionEvaluator.isValidExpressionStatement(eq(expression))).thenReturn(true);
+        when(expressionEvaluator.evaluate(eq(expression), eq(first))).thenReturn("res-a");
+        when(expressionEvaluator.evaluate(eq(expression), eq(second))).thenReturn("res-b");
+
+        final EntityResolver resolver = resolver(keyAttributes, Map.of());
+
+        // The grouping key has to follow the evaluated value, otherwise expression-keyed entities would
+        // all share one group no matter which resource they describe.
+        assertThat(resolver.resolveKey(second), not(equalTo(resolver.resolveKey(first))));
+    }
+
+    @Test
+    void resolve_evaluatesExpressionValuedAttribute() {
+        final String expression = "getMetadata(\"source\")";
+        final Map<String, String> attributes = Map.of("AWS.ServiceNameSource", "${" + expression + "}");
+        when(expressionEvaluator.isValidExpressionStatement(eq(expression))).thenReturn(true);
+        when(expressionEvaluator.evaluate(eq(expression), any(Event.class))).thenReturn("UserConfiguration");
+
+        final EntityResolver resolver = resolver(keyAttrTemplates(), attributes);
+        final Entity entity = resolveEntity(resolver, eventWith(Map.of("resourceId", "res-1")));
+
+        // attributes are interpolated on the buildEntity path, so they need the evaluator too.
+        assertThat(entity.attributes().get("AWS.ServiceNameSource"), equalTo("UserConfiguration"));
+    }
+
+    @Test
+    void resolve_fallsBackToLiteralWhenTemplateIsMalformed() {
+        final Map<String, String> keyAttributes = new LinkedHashMap<>();
+        keyAttributes.put("Name", "${unclosed");
+        final EntityResolver resolver = resolver(keyAttributes, Map.of());
+
+        final Entity entity = resolveEntity(resolver, eventWith(Map.of("resourceId", "res-1")));
+
+        // formatString throws on a malformed template; the literal is kept rather than failing the batch.
+        assertThat(entity.keyAttributes().get("Name"), equalTo("${unclosed"));
+    }
+}

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfigTest.java
@@ -17,9 +17,12 @@ import jakarta.validation.Validator;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,13 +32,25 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class EntityConfigTest {
     private static final String KEY_ATTRIBUTES_FIELD = "keyAttributes";
     private static final String ATTRIBUTES_FIELD = "attributes";
+    private static final String MAX_CARDINALITY_FIELD = "maxCardinality";
+
+    private static Map<String, String> validKeyAttributes() {
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "my-app");
+        return keyAttributes;
+    }
 
     private ObjectMapper objectMapper;
     private Validator validator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +60,18 @@ class EntityConfigTest {
                 .messageInterpolator(new ParameterMessageInterpolator())
                 .buildValidatorFactory()
                 .getValidator();
+
+        // Mirror the real evaluator's contract: a value carrying a ${...} field reference yields a
+        // non-empty key list; a plain constant yields empty lists.
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+        when(expressionEvaluator.extractDynamicKeysFromFormatExpression(anyString()))
+                .thenAnswer(invocation -> {
+                    final String value = invocation.getArgument(0);
+                    return value != null && value.contains("${")
+                            ? List.of(value) : Collections.<String>emptyList();
+                });
+        when(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(anyString()))
+                .thenReturn(Collections.emptyList());
     }
 
     @Test
@@ -169,5 +196,104 @@ class EntityConfigTest {
 
         assertThrows(UnsupportedOperationException.class,
                 () -> entityConfig.getAttributes().put("new", "value"));
+    }
+
+    @Test
+    void GIVEN_new_entity_config_WHEN_dynamic_getters_called_SHOULD_return_defaults() {
+        final EntityConfig entityConfig = new EntityConfig();
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(false));
+    }
+
+    @Test
+    void GIVEN_templated_key_attributes_in_yaml_WHEN_deserialized_SHOULD_be_dynamic() {
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Azure::Resource");
+        keyAttributes.put("Identifier", "${resourceId}");
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("key_attributes", keyAttributes);
+
+        final EntityConfig entityConfig = objectMapper.convertValue(jsonMap, EntityConfig.class);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(true));
+    }
+
+    @Test
+    void GIVEN_no_templated_attributes_WHEN_is_dynamic_called_SHOULD_be_static() {
+        final EntityConfig entityConfig = new EntityConfig();
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(false));
+    }
+
+    @Test
+    void GIVEN_only_constant_key_attributes_WHEN_is_dynamic_called_SHOULD_be_static()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "my-app");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, keyAttributes);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(false));
+    }
+
+    @Test
+    void GIVEN_templated_key_attribute_WHEN_is_dynamic_called_SHOULD_be_dynamic()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Azure::Resource");
+        keyAttributes.put("Identifier", "${resourceId}");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, keyAttributes);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(true));
+    }
+
+    @Test
+    void GIVEN_new_entity_config_WHEN_get_max_cardinality_called_SHOULD_return_default() {
+        final EntityConfig entityConfig = new EntityConfig();
+
+        assertThat(entityConfig.getMaxCardinality(), equalTo(EntityConfig.DEFAULT_MAX_CARDINALITY));
+    }
+
+    @Test
+    void GIVEN_max_cardinality_in_yaml_WHEN_deserialized_SHOULD_override_the_default() {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("key_attributes", validKeyAttributes());
+        jsonMap.put("max_cardinality", 25);
+
+        final EntityConfig entityConfig = objectMapper.convertValue(jsonMap, EntityConfig.class);
+
+        assertThat(entityConfig.getMaxCardinality(), equalTo(25));
+    }
+
+    @Test
+    void GIVEN_max_cardinality_below_one_WHEN_validated_SHOULD_fail_Min_constraint()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, validKeyAttributes());
+        // Zero would mean every event overflows into the entity-less fallback group, which is never a
+        // useful configuration; the bound has to admit at least one entity.
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, MAX_CARDINALITY_FIELD, 0);
+
+        final Set<ConstraintViolation<EntityConfig>> violations = validator.validate(entityConfig);
+
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo(MAX_CARDINALITY_FIELD));
+    }
+
+    @Test
+    void GIVEN_templated_attribute_only_WHEN_is_dynamic_called_SHOULD_be_dynamic()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "my-app");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, keyAttributes);
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("AWS.ServiceNameSource", "${source}");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, ATTRIBUTES_FIELD, attributes);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(true));
     }
 }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfigTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/config/EntityConfigTest.java
@@ -17,9 +17,12 @@ import jakarta.validation.Validator;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,13 +32,24 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class EntityConfigTest {
     private static final String KEY_ATTRIBUTES_FIELD = "keyAttributes";
     private static final String ATTRIBUTES_FIELD = "attributes";
 
+    private static Map<String, String> validKeyAttributes() {
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "my-app");
+        return keyAttributes;
+    }
+
     private ObjectMapper objectMapper;
     private Validator validator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +59,18 @@ class EntityConfigTest {
                 .messageInterpolator(new ParameterMessageInterpolator())
                 .buildValidatorFactory()
                 .getValidator();
+
+        // Mirror the real evaluator's contract: a value carrying a ${...} field reference yields a
+        // non-empty key list; a plain constant yields empty lists.
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+        when(expressionEvaluator.extractDynamicKeysFromFormatExpression(anyString()))
+                .thenAnswer(invocation -> {
+                    final String value = invocation.getArgument(0);
+                    return value != null && value.contains("${")
+                            ? List.of(value) : Collections.<String>emptyList();
+                });
+        when(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(anyString()))
+                .thenReturn(Collections.emptyList());
     }
 
     @Test
@@ -169,5 +195,71 @@ class EntityConfigTest {
 
         assertThrows(UnsupportedOperationException.class,
                 () -> entityConfig.getAttributes().put("new", "value"));
+    }
+
+    @Test
+    void GIVEN_new_entity_config_WHEN_dynamic_getters_called_SHOULD_return_defaults() {
+        final EntityConfig entityConfig = new EntityConfig();
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(false));
+    }
+
+    @Test
+    void GIVEN_templated_key_attributes_in_yaml_WHEN_deserialized_SHOULD_be_dynamic() {
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Azure::Resource");
+        keyAttributes.put("Identifier", "${resourceId}");
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("key_attributes", keyAttributes);
+
+        final EntityConfig entityConfig = objectMapper.convertValue(jsonMap, EntityConfig.class);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(true));
+    }
+
+    @Test
+    void GIVEN_no_templated_attributes_WHEN_is_dynamic_called_SHOULD_be_static() {
+        final EntityConfig entityConfig = new EntityConfig();
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(false));
+    }
+
+    @Test
+    void GIVEN_only_constant_key_attributes_WHEN_is_dynamic_called_SHOULD_be_static()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "my-app");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, keyAttributes);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(false));
+    }
+
+    @Test
+    void GIVEN_templated_key_attribute_WHEN_is_dynamic_called_SHOULD_be_dynamic()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Azure::Resource");
+        keyAttributes.put("Identifier", "${resourceId}");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, keyAttributes);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(true));
+    }
+
+    @Test
+    void GIVEN_templated_attribute_only_WHEN_is_dynamic_called_SHOULD_be_dynamic()
+            throws NoSuchFieldException, IllegalAccessException {
+        final EntityConfig entityConfig = new EntityConfig();
+        final Map<String, String> keyAttributes = new HashMap<>();
+        keyAttributes.put("Type", "Service");
+        keyAttributes.put("Name", "my-app");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, KEY_ATTRIBUTES_FIELD, keyAttributes);
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("AWS.ServiceNameSource", "${source}");
+        ReflectivelySetField.setField(EntityConfig.class, entityConfig, ATTRIBUTES_FIELD, attributes);
+
+        assertThat(entityConfig.isDynamic(expressionEvaluator), equalTo(true));
     }
 }


### PR DESCRIPTION
The CloudWatch Logs sink attached a single static entity to every PutLogEvents request. This is insufficient when one pipeline carries logs from many sources (e.g. Azure diagnostic logs, one per resourceId), because PutLogEvents accepts exactly one entity per request, so all resources collapse into the same entity and per-resource attribution is lost.

Add a dynamic entity mode, enabled by setting entity.source_field. When set, the sink partitions buffered events by that field's value and sends one request per group, each carrying its own entity resolved from ${...} templates in key_attributes/attributes. Entities are cached in a bounded map (max_cardinality); missing source fields fall back to a default group so events are never dropped. Adds entity-groups-created and entity-cardinality metrics.

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #7032
 
### Check List
- [y] New functionality includes testing.
- [y] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [y] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
