### PR TITLE
fix(opensearch-sink): Do not send 409 document already exists errors to DLQ

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -1093,6 +1093,105 @@ class OpenSearchSinkIT {
 
     @Test
     @Timeout(value = 50, unit = TimeUnit.SECONDS)
+    void testOpenSearchBulkActionsCreate_DocumentAlreadyExists_DoesNotSendToDlqOrCountAsError() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-create-conflict-alias";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
+        final String testIdField = "someId";
+        final String testId = "duplicate-doc-id";
+
+        final Map<String, Object> metadata = initializeConfigurationMetadata(null, testIndexAlias, testTemplateFile);
+        metadata.put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        metadata.put(IndexConfiguration.ACTION, OpenSearchBulkActions.CREATE.toString());
+        metadata.put(IndexConfiguration.DROP_VERSION_CONFLICTS, true);
+        final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfigByMetadata(metadata);
+        final OpenSearchSink sink = createObjectUnderTest(openSearchSinkConfig, true);
+
+        // First create: should succeed normally
+        final List<Record<Event>> firstCreateRecords = Collections.singletonList(
+                jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "data", "original")));
+        sink.output(firstCreateRecords);
+
+        // Verify document was created
+        final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        assertThat(retSources.size(), equalTo(1));
+
+        // Second create with same ID: should trigger 409 version_conflict_engine_exception
+        // but should NOT be counted as a document error or sent to DLQ (drop_version_conflicts=true)
+        final List<Record<Event>> secondCreateRecords = Collections.singletonList(
+                jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "data", "duplicate")));
+        sink.output(secondCreateRecords);
+
+        // Verify document count hasn't changed (no duplicate was created)
+        final List<Map<String, Object>> retSourcesAfterDuplicate = getSearchResponseDocSources(testIndexAlias);
+        assertThat(retSourcesAfterDuplicate.size(), equalTo(1));
+
+        // Verify no document errors were counted - the 409 on create should be treated as success
+        final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+        assertThat(documentErrorsMeasurements.size(), equalTo(1));
+        assertThat(documentErrorsMeasurements.get(0).getValue(), closeTo(0.0, 0));
+
+        // Verify the version conflict metric was incremented
+        final List<Measurement> versionConflictMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_VERSION_CONFLICT_ERRORS).toString());
+        assertThat(versionConflictMeasurements.size(), equalTo(1));
+        assertThat(versionConflictMeasurements.get(0).getValue(), closeTo(1.0, 0));
+    }
+
+    @Test
+    @Timeout(value = 50, unit = TimeUnit.SECONDS)
+    void testOpenSearchBulkActionsCreate_DocumentAlreadyExists_CountsAsErrorWhenDropVersionConflictsDisabled() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-create-conflict-error-alias";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
+        final String testIdField = "someId";
+        final String testId = "duplicate-doc-id-error";
+
+        final Map<String, Object> metadata = initializeConfigurationMetadata(null, testIndexAlias, testTemplateFile);
+        metadata.put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        metadata.put(IndexConfiguration.ACTION, OpenSearchBulkActions.CREATE.toString());
+        final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfigByMetadata(metadata);
+        final OpenSearchSink sink = createObjectUnderTest(openSearchSinkConfig, true);
+
+        // First create: should succeed normally
+        final List<Record<Event>> firstCreateRecords = Collections.singletonList(
+                jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "data", "original")));
+        sink.output(firstCreateRecords);
+
+        // Verify document was created
+        final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        assertThat(retSources.size(), equalTo(1));
+
+        // Second create with same ID: should trigger 409 version_conflict_engine_exception
+        // Without drop_version_conflicts, this SHOULD be counted as a document error
+        final List<Record<Event>> secondCreateRecords = Collections.singletonList(
+                jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "data", "duplicate")));
+        sink.output(secondCreateRecords);
+
+        // Verify document count hasn't changed
+        final List<Map<String, Object>> retSourcesAfterDuplicate = getSearchResponseDocSources(testIndexAlias);
+        assertThat(retSourcesAfterDuplicate.size(), equalTo(1));
+
+        // Verify the 409 WAS counted as a document error
+        final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+        assertThat(documentErrorsMeasurements.size(), equalTo(1));
+        assertThat(documentErrorsMeasurements.get(0).getValue(), closeTo(1.0, 0));
+
+        // Verify the version conflict metric was NOT incremented (it only increments when conflicts are dropped)
+        final List<Measurement> versionConflictMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_VERSION_CONFLICT_ERRORS).toString());
+        assertThat(versionConflictMeasurements.size(), equalTo(1));
+        assertThat(versionConflictMeasurements.get(0).getValue(), closeTo(0.0, 0));
+    }
+
+    @Test
+    @Timeout(value = 50, unit = TimeUnit.SECONDS)
     void testOpenSearchBulkActionsCreateWithExpression() throws IOException, InterruptedException {
         final String testIndexAlias = "test-alias";
         final String testTemplateFile = Objects.requireNonNull(
@@ -1835,7 +1934,7 @@ class OpenSearchSinkIT {
         final String templateName = dataStreamName + "-template";
         final File tempDirectory = Files.createTempDirectory("").toFile();
         final String dlqFile = tempDirectory.getAbsolutePath() + "/test-dlq.txt";
-        
+
         try {
             // Create an index template for the data stream first
             final Request createTemplateRequest = new Request(HttpMethod.PUT, "/_index_template/" + templateName);
@@ -1852,30 +1951,30 @@ class OpenSearchSinkIT {
                     "}";
             createTemplateRequest.setJsonEntity(templateBody);
             client.performRequest(createTemplateRequest);
-            
+
             // Create a data stream
             final Request createDataStreamRequest = new Request(HttpMethod.PUT, "/_data_stream/" + dataStreamName);
             client.performRequest(createDataStreamRequest);
-            
+
             // Initialize sink AFTER creating the data stream so detection works
             Map<String, Object> metadata = initializeConfigurationMetadata(null, dataStreamName, null);
             metadata.put(RetryConfiguration.DLQ_FILE, dlqFile);
             final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfigByMetadata(metadata);
             final OpenSearchSink sink = createObjectUnderTest(openSearchSinkConfig, true);
-            
+
             // Test that the data stream is detected
             final String testIdField = "someId";
             final String testId = "foo";
             final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
-            
+
             sink.output(testRecords);
-            
+
             // Wait for indexing to complete
             Thread.sleep(2000);
-            
+
             // Verify the document was written to the data stream
             final List<Map<String, Object>> retSources = getSearchResponseDocSources(dataStreamName);
-            assertThat("Expected 1 document in data stream " + dataStreamName + " but found " + retSources.size(), 
+            assertThat("Expected 1 document in data stream " + dataStreamName + " but found " + retSources.size(),
                        retSources.size(), equalTo(1));
         } catch (Exception e) {
             throw e;
@@ -1887,7 +1986,7 @@ class OpenSearchSinkIT {
             } catch (IOException e) {
                 // Ignore cleanup errors
             }
-            
+
             // Clean up the index template
             final Request deleteTemplateRequest = new Request(HttpMethod.DELETE, "/_index_template/" + templateName);
             try {
@@ -1895,7 +1994,7 @@ class OpenSearchSinkIT {
             } catch (IOException e) {
                 // Ignore cleanup errors
             }
-            
+
             // Clean up DLQ
             FileUtils.deleteQuietly(tempDirectory);
         }
@@ -2241,7 +2340,7 @@ class OpenSearchSinkIT {
         final String templateName = dataStreamName + "-template";
         final File tempDirectory = Files.createTempDirectory("").toFile();
         final String dlqFile = tempDirectory.getAbsolutePath() + "/test-dlq.txt";
-        
+
         try {
             // Create an index template for the data stream
             final Request createTemplateRequest = new Request(HttpMethod.PUT, "/_index_template/" + templateName);
@@ -2259,11 +2358,11 @@ class OpenSearchSinkIT {
                     "}";
             createTemplateRequest.setJsonEntity(templateBody);
             client.performRequest(createTemplateRequest);
-            
+
             // Create the data stream
             final Request createDataStreamRequest = new Request(HttpMethod.PUT, "/_data_stream/" + dataStreamName);
             client.performRequest(createDataStreamRequest);
-            
+
             // Initialize sink with document_id configuration
             final String testIdField = "someId";
             final String testId = "duplicate-id";
@@ -2272,32 +2371,32 @@ class OpenSearchSinkIT {
             metadata.put(RetryConfiguration.DLQ_FILE, dlqFile);
             final OpenSearchSinkConfig openSearchSinkConfig = generateOpenSearchSinkConfigByMetadata(metadata);
             final OpenSearchSink sink = createObjectUnderTest(openSearchSinkConfig, true);
-            
+
             // Write first document with value "first"
             final String firstDoc = "{\"" + testIdField + "\": \"" + testId + "\", \"value\": \"first\"}";
             final List<Record<Event>> firstRecords = Collections.singletonList(jsonStringToRecord(firstDoc));
             sink.output(firstRecords);
-            
+
             // Wait for indexing
             Thread.sleep(1000);
-            
+
             // Write second document with same ID but value "second"
             final String secondDoc = "{\"" + testIdField + "\": \"" + testId + "\", \"value\": \"second\"}";
             final List<Record<Event>> secondRecords = Collections.singletonList(jsonStringToRecord(secondDoc));
             sink.output(secondRecords);
-            
-            
+
+
             // Wait for indexing to complete
             Thread.sleep(2000);
-            
+
             // Verify only one document exists
             final List<Map<String, Object>> retSources = getSearchResponseDocSources(dataStreamName);
             assertThat("Expected exactly 1 document due to first-write-wins", retSources.size(), equalTo(1));
-            
+
             // Verify the document has the FIRST value (first-write-wins)
             final Map<String, Object> document = retSources.get(0);
             assertThat("Expected first write to win", document.get("value"), equalTo("first"));
-            
+
         } finally {
             // Clean up
             final Request deleteDataStreamRequest = new Request(HttpMethod.DELETE, "/_data_stream/" + dataStreamName);
@@ -2306,14 +2405,14 @@ class OpenSearchSinkIT {
             } catch (IOException e) {
                 // Ignore cleanup errors
             }
-            
+
             final Request deleteTemplateRequest = new Request(HttpMethod.DELETE, "/_index_template/" + templateName);
             try {
                 client.performRequest(deleteTemplateRequest);
             } catch (IOException e) {
                 // Ignore cleanup errors
             }
-            
+
             FileUtils.deleteQuietly(tempDirectory);
         }
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngester.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkIngester.java
@@ -237,7 +237,8 @@ public class BulkIngester implements Ingester {
                 pipeline,
                 PLUGIN_NAME,
                 openSearchSinkConfig.getIndexConfiguration().getQueryOnBulkFailures() ? existingDocumentQueryManager : null,
-                isExternalVersionType(versionType));
+                isExternalVersionType(versionType),
+                openSearchSinkConfig.getIndexConfiguration().getDropVersionConflicts());
 
         final IndexCache indexCache = new IndexCache();
         final DataStreamDetector dataStreamDetector = new DataStreamDetector(openSearchClient, indexCache);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -268,7 +268,7 @@ public final class BulkRetryStrategy {
         if (isDeleteOperationWithNotFoundError(bulkItemResponse)) {
             return canRetryDeleteNotFoundOperation(bulkItemResponse, attemptNumber);
         }
-        
+
         return isGenerallyRetryableOperation(bulkItemResponse);
     }
 
@@ -279,7 +279,7 @@ public final class BulkRetryStrategy {
 
     private boolean canRetryDeleteNotFoundOperation(final BulkResponseItem bulkItemResponse, final int attemptNumber) {
         if (attemptNumber > DELETE_404_MAX_RETRIES) {
-            LOG.info("DELETE operation for index '{}' reached maximum retry limit ({}) for 404 errors, sending to DLQ", 
+            LOG.info("DELETE operation for index '{}' reached maximum retry limit ({}) for 404 errors, sending to DLQ",
                     bulkItemResponse.index(), DELETE_404_MAX_RETRIES);
             return false;
         }
@@ -295,7 +295,7 @@ public final class BulkRetryStrategy {
                                                                   final BulkResponse bulkResponse,
                                                                   final Exception exceptionFromRequest) {
         final boolean doRetry = (Objects.isNull(exceptionFromRequest)) ? canRetry(bulkResponse) : canRetry(exceptionFromRequest);
-        if (!Objects.isNull(bulkResponse) && attemptNumber == 1) { 
+        if (!Objects.isNull(bulkResponse) && attemptNumber == 1) {
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                 if (!isItemInError(bulkItemResponse)) {
                     sentDocumentsOnFirstAttemptCounter.increment();
@@ -303,7 +303,7 @@ public final class BulkRetryStrategy {
             }
         }
         if (doRetry) {
-            if (attemptNumber % 5 == 1) { 
+            if (attemptNumber % 5 == 1) {
                 LOG.warn("Bulk Operation Failed. Number of retries {}. Retrying... ", attemptNumber - 1, exceptionFromRequest);
                 if (exceptionFromRequest == null) {
                     for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
@@ -326,11 +326,10 @@ public final class BulkRetryStrategy {
         if (failure == null) {
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                 if(isItemInError(bulkItemResponse)) {
-                    // Skip logging the error for version conflicts when using external versioning
-                    final ErrorCause error = bulkItemResponse.error();
-                    if (isExternalVersioning && error != null && VERSION_CONFLICT_EXCEPTION_TYPE.equals(error.type())) {
+                    if (isSkippableConflictError(bulkItemResponse)) {
                         continue;
                     }
+                    final ErrorCause error = bulkItemResponse.error();
                     LOG.warn("index = {}, operation = {}, status = {}, error = {}", bulkItemResponse.index(), bulkItemResponse.operationType(), bulkItemResponse.status(), error != null ? error.reason() : "");
                 }
             }
@@ -411,11 +410,9 @@ public final class BulkRetryStrategy {
 
                     if (canRetryItem(bulkItemResponse, attemptNumber)) {
                         requestToReissue.addOperation(bulkOperation);
-                    } else if (isExternalVersioning && bulkItemResponse.error() != null && VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
+                    } else if (isSkippableConflictError(bulkItemResponse)) {
                         documentsVersionConflictErrors.increment();
                         LOG.debug("Index: {}, Received version conflict from OpenSearch: {}", bulkItemResponse.index(), bulkItemResponse.error().reason());
-                        // When using external versioning, version conflicts are expected and not true errors.
-                        // Release the eventHandle without counting as a document error.
                         bulkOperation.releaseEventHandle(true);
                     } else {
                         nonRetryableFailures.add(FailedBulkOperation.builder()
@@ -452,11 +449,9 @@ public final class BulkRetryStrategy {
             final BulkResponseItem bulkItemResponse = itemResponses.get(i);
             final BulkOperationWrapper bulkOperation = accumulatingBulkRequest.getOperationAt(i);
             if (isItemInError(bulkItemResponse)) {
-                if (isExternalVersioning && bulkItemResponse.error() != null && VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
+                if (isSkippableConflictError(bulkItemResponse)) {
                     documentsVersionConflictErrors.increment();
                     LOG.debug("Index: {}, Received version conflict from OpenSearch: {}", bulkOperation.getIndex(), bulkItemResponse.error().reason());
-                    // When using external versioning, version conflicts are expected and not true errors.
-                    // Release the eventHandle without counting as a document error.
                     bulkOperation.releaseEventHandle(true);
                 } else {
                     failures.add(FailedBulkOperation.builder()
@@ -517,5 +512,23 @@ public final class BulkRetryStrategy {
         }
 
         return false;
+    }
+
+    /**
+     * Determines whether a version conflict error on a bulk response item is acceptable
+     * and should not be treated as a failure or sent to the DLQ.
+     *
+     * A version conflict is acceptable when:
+     * 1. External versioning is used - conflicts indicate the document already has a newer version
+     * 2. The operation is a 'create' and the document already exists - the 409 conflict means
+     *    the document was already successfully written
+     */
+    private boolean isSkippableConflictError(final BulkResponseItem bulkItemResponse) {
+        final ErrorCause error = bulkItemResponse.error();
+        if (error == null || !VERSION_CONFLICT_EXCEPTION_TYPE.equals(error.type())) {
+            return false;
+        }
+
+        return isExternalVersioning || OperationType.Create.equals(bulkItemResponse.operationType());
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -333,7 +333,6 @@ public final class BulkRetryStrategy {
                     if (shouldDropVersionConflict(error)) {
                         continue;
                     }
-                    final ErrorCause error = bulkItemResponse.error();
                     LOG.warn("index = {}, operation = {}, status = {}, error = {}", bulkItemResponse.index(), bulkItemResponse.operationType(), bulkItemResponse.status(), error != null ? error.reason() : "");
                 }
             }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -137,6 +137,7 @@ public final class BulkRetryStrategy {
     private final Counter documentsDuplicates;
     private final ExistingDocumentQueryManager existingDocumentQueryManager;
     private final boolean isExternalVersioning;
+    private final boolean dropVersionConflicts;
     private static final Logger LOG = LoggerFactory.getLogger(BulkRetryStrategy.class);
 
     static class BulkOperationRequestResponse {
@@ -169,9 +170,11 @@ public final class BulkRetryStrategy {
                              final String pipelineName,
                              final String pluginName,
                              final ExistingDocumentQueryManager existingDocumentQueryManager,
-                             final boolean isExternalVersioning) {
+                             final boolean isExternalVersioning,
+                             final boolean dropVersionConflicts) {
         this.existingDocumentQueryManager = existingDocumentQueryManager;
         this.isExternalVersioning = isExternalVersioning;
+        this.dropVersionConflicts = dropVersionConflicts;
         this.requestFunction = requestFunction;
         this.logFailure = logFailure;
         this.successfulOperationsHandler = successfulOperationsHandler;
@@ -326,7 +329,8 @@ public final class BulkRetryStrategy {
         if (failure == null) {
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                 if(isItemInError(bulkItemResponse)) {
-                    if (isSkippableConflictError(bulkItemResponse)) {
+                    final ErrorCause error = bulkItemResponse.error();
+                    if (shouldDropVersionConflict(error)) {
                         continue;
                     }
                     final ErrorCause error = bulkItemResponse.error();
@@ -410,7 +414,7 @@ public final class BulkRetryStrategy {
 
                     if (canRetryItem(bulkItemResponse, attemptNumber)) {
                         requestToReissue.addOperation(bulkOperation);
-                    } else if (isSkippableConflictError(bulkItemResponse)) {
+                    } else if (shouldDropVersionConflict(bulkItemResponse.error())) {
                         documentsVersionConflictErrors.increment();
                         LOG.debug("Index: {}, Received version conflict from OpenSearch: {}", bulkItemResponse.index(), bulkItemResponse.error().reason());
                         bulkOperation.releaseEventHandle(true);
@@ -449,7 +453,7 @@ public final class BulkRetryStrategy {
             final BulkResponseItem bulkItemResponse = itemResponses.get(i);
             final BulkOperationWrapper bulkOperation = accumulatingBulkRequest.getOperationAt(i);
             if (isItemInError(bulkItemResponse)) {
-                if (isSkippableConflictError(bulkItemResponse)) {
+                if (shouldDropVersionConflict(bulkItemResponse.error())) {
                     documentsVersionConflictErrors.increment();
                     LOG.debug("Index: {}, Received version conflict from OpenSearch: {}", bulkOperation.getIndex(), bulkItemResponse.error().reason());
                     bulkOperation.releaseEventHandle(true);
@@ -515,20 +519,18 @@ public final class BulkRetryStrategy {
     }
 
     /**
-     * Determines whether a version conflict error on a bulk response item is acceptable
-     * and should not be treated as a failure or sent to the DLQ.
+     * Determines whether a version conflict error on a bulk response item should be dropped
+     * (treated as success) rather than sent to the DLQ.
      *
-     * A version conflict is acceptable when:
+     * A version conflict is dropped when:
      * 1. External versioning is used - conflicts indicate the document already has a newer version
-     * 2. The operation is a 'create' and the document already exists - the 409 conflict means
-     *    the document was already successfully written
+     * 2. The drop_version_conflicts configuration option is enabled
      */
-    private boolean isSkippableConflictError(final BulkResponseItem bulkItemResponse) {
-        final ErrorCause error = bulkItemResponse.error();
+    private boolean shouldDropVersionConflict(final ErrorCause error) {
         if (error == null || !VERSION_CONFLICT_EXCEPTION_TYPE.equals(error.type())) {
             return false;
         }
 
-        return isExternalVersioning || OperationType.Create.equals(bulkItemResponse.operationType());
+        return isExternalVersioning || dropVersionConflicts;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/configuration/OpenSearchSinkConfig.java
@@ -207,6 +207,10 @@ public class OpenSearchSinkConfig {
     private DlqConfiguration dlq;
 
     @Getter
+    @JsonProperty("drop_version_conflicts")
+    private boolean dropVersionConflicts = false;
+
+    @Getter
     @JsonProperty("query_lookup")
     private QueryForExistingDocumentConfiguration queryExistingConfiguration;
 
@@ -373,4 +377,3 @@ public class OpenSearchSinkConfig {
         return indexAlias == null || !indexAlias.contains("${");
     }
 }
-

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -81,6 +81,7 @@ public class IndexConfiguration {
     public static final String AWS_OPTION = "aws";
     public static final String DOCUMENT_ROOT_KEY = "document_root_key";
     public static final String DOCUMENT_VERSION_EXPRESSION = "document_version";
+    public static final String DROP_VERSION_CONFLICTS = "drop_version_conflicts";
 
     private IndexType indexType;
     private TemplateType templateType;
@@ -122,6 +123,8 @@ public class IndexConfiguration {
     private final boolean queryOnBulkFailures;
 
     private final Integer queryAsyncDocumentLimit;
+
+    private final boolean dropVersionConflicts;
 
     private static final String S3_PREFIX = "s3://";
 
@@ -192,6 +195,7 @@ public class IndexConfiguration {
         this.queryActionOnFound = builder.actionOnFound;
         this.queryDuration = builder.queryDuration;
         this.queryAsyncDocumentLimit = builder.queryAsyncLimit;
+        this.dropVersionConflicts = builder.dropVersionConflicts;
     }
 
     private void determineIndexType(Builder builder) {
@@ -288,7 +292,8 @@ public class IndexConfiguration {
                 .withNormalizeIndex(openSearchSinkConfig.isNormalizeIndex())
                 .withIsmPolicyFile(openSearchSinkConfig.getIsmPolicyFile())
                 .withDocumentRootKey(openSearchSinkConfig.getDocumentRootKey())
-                .withDistributionVersion(openSearchSinkConfig.getDistributionVersion());
+                .withDistributionVersion(openSearchSinkConfig.getDistributionVersion())
+                .withDropVersionConflicts(openSearchSinkConfig.isDropVersionConflicts());
 
         final AwsAuthenticationConfiguration awsConfig = openSearchSinkConfig.getAwsAuthenticationOptions();
         if (awsConfig != null && awsConfig.getSemanticEnrichmentConfig() != null) {
@@ -455,6 +460,10 @@ public class IndexConfiguration {
 
     public Integer getQueryAsyncDocumentLimit() {return queryAsyncDocumentLimit; }
 
+    public boolean getDropVersionConflicts() {
+        return dropVersionConflicts;
+    }
+
     /**
      * This method is used in the creation of IndexConfiguration object. It takes in the template file path
      * or index type and returns the index template read from the file or specific to index type or returns an
@@ -565,6 +574,7 @@ public class IndexConfiguration {
         private SemanticEnrichmentConfig semanticEnrichmentConfig;
         private Integer queryAsyncLimit;
         private String semanticEnrichmentResourceName;
+        private boolean dropVersionConflicts;
 
         public Builder withIndexAlias(final String indexAlias) {
             checkArgument(indexAlias != null, "indexAlias cannot be null.");
@@ -812,6 +822,11 @@ public class IndexConfiguration {
 
         public Builder withSemanticEnrichmentResourceName(final String resourceName) {
             this.semanticEnrichmentResourceName = resourceName;
+            return this;
+        }
+
+        public Builder withDropVersionConflicts(final boolean dropVersionConflicts) {
+            this.dropVersionConflicts = dropVersionConflicts;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -290,7 +290,7 @@ public class BulkRetryStrategyTests {
         final String testIndex = "delete-404-retry-limit";
         final FakeClient client = new FakeClient(testIndex);
         client.deleteNotFoundMaxRetries = true;
-        
+
         numEventsSucceeded = 0;
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
@@ -303,18 +303,18 @@ public class BulkRetryStrategyTests {
 
         bulkRetryStrategy.execute(accumulatingBulkRequest);
 
-        assertEquals("DELETE+404 should retry exactly 3 times before giving up", 3, client.attempt); 
+        assertEquals("DELETE+404 should retry exactly 3 times before giving up", 3, client.attempt);
         assertEquals("No events should succeed", 0, numEventsSucceeded);
         assertEquals("DELETE+404 operation should be sent to DLQ after max retries", 1, numEventsFailed);
     }
 
-    
+
     @Test
     public void testDeleteNotFound_MixedWithSuccessfulOperations() throws Exception {
         final String testIndex = "mixed-delete-404-test";
         final FakeClient client = new FakeClient(testIndex);
         client.deleteNotFoundMixed = true;
-        
+
         numEventsSucceeded = 0;
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
@@ -324,7 +324,7 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final DeleteOperation deleteOperation = new DeleteOperation.Builder().index(testIndex).id("delete-404-test").build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
-        
+
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().delete(deleteOperation).build(), eventHandle2));
@@ -341,7 +341,7 @@ public class BulkRetryStrategyTests {
         final String testIndex = "other-404-test";
         final FakeClient client = new FakeClient(testIndex);
         client.indexNotFoundTest = true;
-        
+
         numEventsSucceeded = 0;
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
@@ -364,7 +364,7 @@ public class BulkRetryStrategyTests {
         final String testIndex = "retry-isolation-test";
         final FakeClient client = new FakeClient(testIndex);
         client.retryCountIsolationTest = true;
-        
+
         numEventsSucceeded = 0;
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
@@ -373,7 +373,7 @@ public class BulkRetryStrategyTests {
 
         final DeleteOperation deleteOperation = new DeleteOperation.Builder().index(testIndex).id("delete-404-test").build();
         final IndexOperation<SerializedJson> indexOperation = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
-        
+
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().delete(deleteOperation).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation).build(), eventHandle2));
@@ -388,7 +388,7 @@ public class BulkRetryStrategyTests {
         final String testIndex = "delete-404-with-others-test";
         final FakeClient client = new FakeClient(testIndex);
         client.deleteNotFoundWithOthers = true;
-        
+
         numEventsSucceeded = 0;
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
@@ -397,7 +397,7 @@ public class BulkRetryStrategyTests {
 
         final DeleteOperation deleteOperation = new DeleteOperation.Builder().index(testIndex).id("delete-404-test").build();
         final IndexOperation<SerializedJson> indexOperation = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
-        
+
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().delete(deleteOperation).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation).build(), eventHandle2));
@@ -781,7 +781,7 @@ public class BulkRetryStrategyTests {
     }
 
     @Test
-    public void testExecute_VersionConflictIncrementsDocumentErrors_WhenNotExternalVersioning() throws Exception {
+    public void testExecute_VersionConflictIncrementsDocumentErrors_WhenConflictShouldNotBeIgnored() throws Exception {
         final String testIndex = "version-conflict-index";
         final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction = mock(RequestFunction.class);
         final Supplier<AccumulatingBulkRequest> bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
@@ -839,6 +839,119 @@ public class BulkRetryStrategyTests {
         assertEquals(1, successMeasurements.size());
         assertEquals(1.0, successMeasurements.get(0).getValue(), 0);
     }
+
+    @Test
+    public void testExecute_CreateActionDocumentAlreadyExists_DoesNotIncrementDocumentErrors() throws Exception {
+        final String testIndex = "create-conflict-index";
+        final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction = mock(RequestFunction.class);
+        final Supplier<AccumulatingBulkRequest> bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
+
+        // Use default (non-external versioning)
+        final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
+                requestFunction, logFailureConsumer, bulkRequestSupplier);
+
+        final IndexOperation<SerializedJson> indexOp1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOp2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOp3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
+
+        final BulkOperationWrapper wrapper1 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp1).build(), eventHandle1);
+        final BulkOperationWrapper wrapper2 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp2).build(), eventHandle2);
+        final BulkOperationWrapper wrapper3 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp3).build(), eventHandle3);
+
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
+        accumulatingBulkRequest.addOperation(wrapper1);
+        accumulatingBulkRequest.addOperation(wrapper2);
+        accumulatingBulkRequest.addOperation(wrapper3);
+
+        // Response: 1 success, 1 document-already-exists conflict (create action), 1 bad request
+        final BulkResponseItem successItem = successItemResponse(testIndex);
+        final BulkResponseItem createConflictItem = createOperationConflictErrorItemResponse();
+        final BulkResponseItem badRequestItem = badRequestItemResponse(testIndex);
+        final List<BulkResponseItem> responseItems = Arrays.asList(successItem, createConflictItem, badRequestItem);
+
+        final BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.errors()).thenReturn(true);
+        when(bulkResponse.items()).thenReturn(responseItems);
+        when(requestFunction.apply(any())).thenReturn(bulkResponse);
+
+        numEventsSucceeded = 0;
+        numEventsFailed = 0;
+        bulkRetryStrategy.execute(accumulatingBulkRequest);
+
+        // Document-already-exists conflict on create should NOT be counted as a document error
+        final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+        assertEquals(1, documentErrorsMeasurements.size());
+        assertEquals(1.0, documentErrorsMeasurements.get(0).getValue(), 0);
+
+        // Should be counted in the version conflict metric
+        final List<Measurement> versionConflictMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_VERSION_CONFLICT_ERRORS).toString());
+        assertEquals(1, versionConflictMeasurements.size());
+        assertEquals(1.0, versionConflictMeasurements.get(0).getValue(), 0);
+
+        // Success metric should count the 1 successful document
+        final List<Measurement> successMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
+        assertEquals(1, successMeasurements.size());
+        assertEquals(1.0, successMeasurements.get(0).getValue(), 0);
+
+        // Document-already-exists event handle should be released with true (success)
+        verify(eventHandle2).release(true);
+    }
+
+    @Test
+    public void testExecute_CreateActionDocumentAlreadyExists_DoesNotSendToDlq() throws Exception {
+        final String testIndex = "create-conflict-dlq-index";
+        final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction = mock(RequestFunction.class);
+        final Supplier<AccumulatingBulkRequest> bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
+
+        // Use default (non-external versioning)
+        final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTest(
+                requestFunction, logFailureConsumer, bulkRequestSupplier);
+
+        final IndexOperation<SerializedJson> indexOp1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOp2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
+
+        final BulkOperationWrapper wrapper1 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp1).build(), eventHandle1);
+        final BulkOperationWrapper wrapper2 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp2).build(), eventHandle2);
+
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
+        accumulatingBulkRequest.addOperation(wrapper1);
+        accumulatingBulkRequest.addOperation(wrapper2);
+
+        // Response: 1 success, 1 document-already-exists conflict (create action)
+        final BulkResponseItem successItem = successItemResponse(testIndex);
+        final BulkResponseItem createConflictItem = createOperationConflictErrorItemResponse();
+        final List<BulkResponseItem> responseItems = Arrays.asList(successItem, createConflictItem);
+
+        final BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.errors()).thenReturn(true);
+        when(bulkResponse.items()).thenReturn(responseItems);
+        when(requestFunction.apply(any())).thenReturn(bulkResponse);
+
+        numEventsSucceeded = 0;
+        numEventsFailed = 0;
+        bulkRetryStrategy.execute(accumulatingBulkRequest);
+
+        // No events should have failed (nothing sent to DLQ)
+        assertEquals(0, numEventsFailed);
+
+        // No document errors
+        final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+        assertEquals(1, documentErrorsMeasurements.size());
+        assertEquals(0.0, documentErrorsMeasurements.get(0).getValue(), 0);
+
+        // Event handle released with success
+        verify(eventHandle2).release(true);
+    }
+
+
 
     @Test
     public void testExecute_DeleteNotFound_RetriesAndSucceeds() throws Exception {
@@ -1357,6 +1470,18 @@ public class BulkRetryStrategyTests {
         return customBulkFailureResponse(RestStatus.CONFLICT, VERSION_CONFLICT_EXCEPTION_TYPE);
     }
 
+    private static BulkResponseItem createOperationConflictErrorItemResponse() {
+        final ErrorCause errorCause = mock(ErrorCause.class);
+        lenient().when(errorCause.type()).thenReturn(VERSION_CONFLICT_EXCEPTION_TYPE);
+        lenient().when(errorCause.reason()).thenReturn("[test-index][_doc][1]: document already exists");
+        final BulkResponseItem badResponse = mock(BulkResponseItem.class);
+        lenient().when(badResponse.status()).thenReturn(RestStatus.CONFLICT.getStatus());
+        lenient().when(badResponse.error()).thenReturn(errorCause);
+        lenient().when(badResponse.operationType()).thenReturn(OperationType.Create);
+        lenient().when(badResponse.index()).thenReturn("test-index");
+        return badResponse;
+    }
+
     private static BulkResponseItem customBulkFailureResponse(final String index, final RestStatus restStatus) {
         final ErrorCause errorCause = mock(ErrorCause.class);
         final BulkResponseItem badResponse = mock(BulkResponseItem.class);
@@ -1556,7 +1681,7 @@ public class BulkRetryStrategyTests {
 
         private BulkResponse bulkDeleteNotFoundResponse(final BulkRequest bulkRequest) {
             final int requestSize = bulkRequest.operations().size();
-            assert requestSize == 1; 
+            assert requestSize == 1;
             final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
                     deleteNotFoundItemResponse(index));
             return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
@@ -1564,18 +1689,18 @@ public class BulkRetryStrategyTests {
 
         private BulkResponse bulkDeleteNotFoundMixedResponse(final BulkRequest bulkRequest) {
             final int requestSize = bulkRequest.operations().size();
-            
+
             if (attempt == 1) {
                 assert requestSize == 3;
                 final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
-                        successItemResponse(index),     
-                        deleteNotFoundItemResponse(index), 
-                        successItemResponse(index));     
+                        successItemResponse(index),
+                        deleteNotFoundItemResponse(index),
+                        successItemResponse(index));
                 return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
             } else if (attempt <= 3) {
                 assert requestSize == 1;
                 final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
-                        deleteNotFoundItemResponse(index)); 
+                        deleteNotFoundItemResponse(index));
                 return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
             } else {
                 assert requestSize == 0;
@@ -1593,11 +1718,11 @@ public class BulkRetryStrategyTests {
 
         private BulkResponse bulkRetryCountIsolationResponse(final BulkRequest bulkRequest) {
             final int requestSize = bulkRequest.operations().size();
-            
+
             if (attempt == 1) {
                 assert requestSize == 2;
                 final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
-                        deleteNotFoundItemResponse(index),     
+                        deleteNotFoundItemResponse(index),
                         internalServerErrorItemResponse(index));
                 return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
             } else if (attempt <= 3) {
@@ -1618,38 +1743,38 @@ public class BulkRetryStrategyTests {
                     return new BulkResponse.Builder().items(bulkItemResponses).errors(false).took(10).build();
                 }
             }
-            
+
             return new BulkResponse.Builder().items(Arrays.asList()).errors(false).took(10).build();
         }
 
         private BulkResponse bulkDeleteNotFoundWithOthersResponse(final BulkRequest bulkRequest) {
             final int requestSize = bulkRequest.operations().size();
-            
+
             if (attempt == 1) {
                 assert requestSize == 2;
                 final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
                         deleteNotFoundItemResponse(index),
-                        internalServerErrorItemResponse(index));   
+                        internalServerErrorItemResponse(index));
                 return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
             } else if (attempt <= 3) {
                 if (requestSize == 2) {
                     final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
-                            deleteNotFoundItemResponse(index),     
+                            deleteNotFoundItemResponse(index),
                             internalServerErrorItemResponse(index));
                     return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
                 } else if (requestSize == 1) {
                     final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
-                            successItemResponse(index)); 
+                            successItemResponse(index));
                     return new BulkResponse.Builder().items(bulkItemResponses).errors(false).took(10).build();
                 }
             } else {
                 if (requestSize >= 1) {
                     final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
-                            successItemResponse(index)); 
+                            successItemResponse(index));
                     return new BulkResponse.Builder().items(bulkItemResponses).errors(false).took(10).build();
                 }
             }
-            
+
             return new BulkResponse.Builder().items(Arrays.asList()).errors(false).took(10).build();
         }
     }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -145,6 +145,7 @@ public class BulkRetryStrategyTests {
                 PIPELINE_NAME,
                 PLUGIN_NAME,
                 null,
+                false,
                 false);
     }
 
@@ -173,6 +174,7 @@ public class BulkRetryStrategyTests {
                 PIPELINE_NAME,
                 PLUGIN_NAME,
                 null,
+                false,
                 false);
     }
 
@@ -202,6 +204,7 @@ public class BulkRetryStrategyTests {
                 PIPELINE_NAME,
                 PLUGIN_NAME,
                 existingDocumentQueryManager,
+                false,
                 false);
     }
 
@@ -229,6 +232,35 @@ public class BulkRetryStrategyTests {
                 PIPELINE_NAME,
                 PLUGIN_NAME,
                 null,
+                true,
+                false);
+    }
+
+    public BulkRetryStrategy createObjectUnderTestWithDropVersionConflicts(
+            final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction,
+            final BiConsumer<List<FailedBulkOperation>, Throwable> logFailure,
+            final Supplier<AccumulatingBulkRequest> bulkRequestSupplier
+    ) {
+        return new BulkRetryStrategy(
+                requestFunction,
+                logFailure,
+                (operations) -> {
+                    for (BulkOperationWrapper operation: operations) {
+                        if (operation.getEvent() != null) {
+                            operation.getEvent().getEventHandle().release(true);
+                        }
+                        if (operation.getEventHandle() != null) {
+                            operation.getEventHandle().release(true);
+                        }
+                    }
+                },
+                pluginMetrics,
+                Integer.MAX_VALUE,
+                bulkRequestSupplier,
+                PIPELINE_NAME,
+                PLUGIN_NAME,
+                null,
+                false,
                 true);
     }
 
@@ -719,7 +751,7 @@ public class BulkRetryStrategyTests {
     }
 
     @Test
-    public void testExecute_VersionConflictDoesNotIncrementDocumentErrors() throws Exception {
+    public void testExecute_VersionConflict_DoesNotIncrementDocumentErrors_WhenExternalVersioning() throws Exception {
         final String testIndex = "version-conflict-index";
         final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction = mock(RequestFunction.class);
         final Supplier<AccumulatingBulkRequest> bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
@@ -763,6 +795,72 @@ public class BulkRetryStrategyTests {
         assertEquals(1.0, documentErrorsMeasurements.get(0).getValue(), 0);
 
         // Version conflict should be counted in its own metric
+        final List<Measurement> versionConflictMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_VERSION_CONFLICT_ERRORS).toString());
+        assertEquals(1, versionConflictMeasurements.size());
+        assertEquals(1.0, versionConflictMeasurements.get(0).getValue(), 0);
+
+        // Success metric should count the 1 successful document
+        final List<Measurement> successMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
+        assertEquals(1, successMeasurements.size());
+        assertEquals(1.0, successMeasurements.get(0).getValue(), 0);
+
+        // Version conflict event handle should be released with true (success)
+        verify(eventHandle2).release(true);
+    }
+
+    @Test
+    public void testExecute_VersionConflict_DoesNotIncrementDocumentErrorsOrSendToDlq_WhenDropVersionConflictsEnabled() throws Exception {
+        final String testIndex = "create-conflict-index";
+        final RequestFunction<AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest>, BulkResponse> requestFunction = mock(RequestFunction.class);
+        final Supplier<AccumulatingBulkRequest> bulkRequestSupplier = () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
+
+        // Use drop_version_conflicts=true to enable dropping version conflicts
+        final BulkRetryStrategy bulkRetryStrategy = createObjectUnderTestWithDropVersionConflicts(
+                requestFunction, logFailureConsumer, bulkRequestSupplier);
+
+        final IndexOperation<SerializedJson> indexOp1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOp2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOp3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
+
+        final BulkOperationWrapper wrapper1 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp1).build(), eventHandle1);
+        final BulkOperationWrapper wrapper2 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp2).build(), eventHandle2);
+        final BulkOperationWrapper wrapper3 = new BulkOperationWrapper(new BulkOperation.Builder().index(indexOp3).build(), eventHandle3);
+
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
+        accumulatingBulkRequest.addOperation(wrapper1);
+        accumulatingBulkRequest.addOperation(wrapper2);
+        accumulatingBulkRequest.addOperation(wrapper3);
+
+        // Response: 1 success, 1 version conflict, 1 bad request
+        final BulkResponseItem successItem = successItemResponse(testIndex);
+        final BulkResponseItem versionConflictItem = versionConflictErrorItemResponse();
+        final BulkResponseItem badRequestItem = badRequestItemResponse(testIndex);
+        final List<BulkResponseItem> responseItems = Arrays.asList(successItem, versionConflictItem, badRequestItem);
+
+        final BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.errors()).thenReturn(true);
+        when(bulkResponse.items()).thenReturn(responseItems);
+        when(requestFunction.apply(any())).thenReturn(bulkResponse);
+
+        numEventsSucceeded = 0;
+        numEventsFailed = 0;
+        bulkRetryStrategy.execute(accumulatingBulkRequest);
+
+        // Only the bad request should be sent to DLQ, not the version conflict
+        assertEquals(1, numEventsFailed);
+
+        // Version conflict should NOT be counted as a document error (only bad request counts)
+        final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+        assertEquals(1, documentErrorsMeasurements.size());
+        assertEquals(1.0, documentErrorsMeasurements.get(0).getValue(), 0);
+
+        // Should be counted in the version conflict metric
         final List<Measurement> versionConflictMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(BulkRetryStrategy.DOCUMENTS_VERSION_CONFLICT_ERRORS).toString());


### PR DESCRIPTION
### Description

When using the 'create' action and a document already exists, OpenSearch returns a 409 conflict with version_conflict_engine_exception. Previously this was treated as a failure and sent to the DLQ. Now it is treated the same as external versioning conflicts - the document is marked as success and not sent to the DLQ.

 
### Issues Resolved
Resolves #7037
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.  -  https://github.com/opensearch-project/documentation-website/issues/12896
  - [ ] New functionality has javadoc added  -  **N/A**
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
