### PR TITLE
Fix azure_federated Kafka auth after token refresh

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerToken.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerToken.java
@@ -30,6 +30,18 @@ public class AzureFederatedOAuthBearerToken implements OAuthBearerToken {
         this.principalName = principalName;
     }
 
+    /**
+     * Copies an existing token, preserving its original absolute lifetime rather than recomputing
+     * it from the current time.
+     */
+    AzureFederatedOAuthBearerToken(final AzureFederatedOAuthBearerToken other) {
+        this.value = other.value;
+        this.startTimeMs = other.startTimeMs;
+        this.lifetimeMs = other.lifetimeMs;
+        this.scope = other.scope;
+        this.principalName = other.principalName;
+    }
+
     @Override
     public String value() {
         return value;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProvider.java
@@ -113,12 +113,12 @@ public class AzureFederatedTokenProvider {
     public AzureFederatedOAuthBearerToken getToken() {
         final CachedToken current = cached;
         if (current != null && current.isValid()) {
-            return current.token;
+            return current.newTokenInstance();
         }
         lock.lock();
         try {
             if (cached != null && cached.isValid()) {
-                return cached.token;
+                return cached.newTokenInstance();
             }
             final AzureFederatedOAuthBearerToken token = exchange();
             cached = new CachedToken(token);
@@ -248,6 +248,16 @@ public class AzureFederatedTokenProvider {
 
         private boolean isValid() {
             return System.currentTimeMillis() < validUntilMs;
+        }
+
+        /**
+         * Returns a distinct token instance carrying the cached credential's value and its
+         * original absolute lifetime. Kafka identifies tokens on the Subject by instance identity
+         * during re-login, so each callback must receive a new instance - while preserving the
+         * lifetime so refresh scheduling does not drift forward on every call.
+         */
+        private AzureFederatedOAuthBearerToken newTokenInstance() {
+            return new AzureFederatedOAuthBearerToken(token);
         }
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerTokenTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerTokenTest.java
@@ -70,4 +70,19 @@ class AzureFederatedOAuthBearerTokenTest {
 
         assertThat(token.scope().isEmpty(), equalTo(true));
     }
+
+    @Test
+    void copyConstructor_preservesFieldsAndOriginalExpiry() {
+        // A token copy must keep the original expiry, or Kafka's refresh scheduling drifts forward.
+        final AzureFederatedOAuthBearerToken original =
+                new AzureFederatedOAuthBearerToken(TOKEN_VALUE, 3600L, SCOPE, PRINCIPAL);
+
+        final AzureFederatedOAuthBearerToken copy = new AzureFederatedOAuthBearerToken(original);
+
+        assertThat(copy.startTimeMs(), equalTo(original.startTimeMs()));
+        assertThat(copy.lifetimeMs(), equalTo(original.lifetimeMs()));
+        assertThat(copy.value(), equalTo(TOKEN_VALUE));
+        assertThat(copy.principalName(), equalTo(PRINCIPAL));
+        assertThat(copy.scope(), contains(SCOPE));
+    }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerTokenTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedOAuthBearerTokenTest.java
@@ -12,6 +12,9 @@ package org.opensearch.dataprepper.plugins.kafka.authenticator;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -74,15 +77,19 @@ class AzureFederatedOAuthBearerTokenTest {
     @Test
     void copyConstructor_preservesFieldsAndOriginalExpiry() {
         // A token copy must keep the original expiry, or Kafka's refresh scheduling drifts forward.
+        final String value = UUID.randomUUID().toString();
+        final String scope = UUID.randomUUID().toString();
+        final String principal = UUID.randomUUID().toString();
+        final long expiresInSeconds = ThreadLocalRandom.current().nextInt(1, 86_400);
         final AzureFederatedOAuthBearerToken original =
-                new AzureFederatedOAuthBearerToken(TOKEN_VALUE, 3600L, SCOPE, PRINCIPAL);
+                new AzureFederatedOAuthBearerToken(value, expiresInSeconds, scope, principal);
 
         final AzureFederatedOAuthBearerToken copy = new AzureFederatedOAuthBearerToken(original);
 
         assertThat(copy.startTimeMs(), equalTo(original.startTimeMs()));
         assertThat(copy.lifetimeMs(), equalTo(original.lifetimeMs()));
-        assertThat(copy.value(), equalTo(TOKEN_VALUE));
-        assertThat(copy.principalName(), equalTo(PRINCIPAL));
-        assertThat(copy.scope(), contains(SCOPE));
+        assertThat(copy.value(), equalTo(value));
+        assertThat(copy.principalName(), equalTo(principal));
+        assertThat(copy.scope(), contains(scope));
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -199,6 +200,30 @@ class AzureFederatedTokenProviderTest {
 
         assertThat(supplierCalls.get(), equalTo(1));
         verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    @Test
+    void getToken_whileCached_returnsDistinctInstancesWithSameValueAndLifetime() throws IOException, InterruptedException {
+        stubWebIdentityTokenSuccess();
+        final HttpResponse<String> response =
+                httpResponse(200, "{\"access_token\":\"azure-access-token\",\"expires_in\":3599}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+        final AzureFederatedTokenProvider provider = providerWith(stsClient, httpClient);
+
+        final AzureFederatedOAuthBearerToken first = provider.getToken();
+        final AzureFederatedOAuthBearerToken second = provider.getToken();
+
+        // Kafka's OAUTHBEARER re-login identifies tokens on the Subject by instance identity;
+        // reusing one instance makes commit() a no-op and the subsequent logout() empties the
+        // Subject. Each call must therefore return a new instance.
+        assertThat(second, not(sameInstance(first)));
+        // The exchange must not repeat while cached, so the fresh instance carries the same value
+        // and the same absolute lifetime rather than a lifetime recomputed from "now".
+        verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertThat(second.value(), equalTo(first.value()));
+        assertThat(second.lifetimeMs(), equalTo(first.lifetimeMs()));
+        assertThat(second.startTimeMs(), equalTo(first.startTimeMs()));
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/authenticator/AzureFederatedTokenProviderTest.java
@@ -31,9 +31,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -205,8 +207,10 @@ class AzureFederatedTokenProviderTest {
     @Test
     void getToken_whileCached_returnsDistinctInstancesWithSameValueAndLifetime() throws IOException, InterruptedException {
         stubWebIdentityTokenSuccess();
+        final String accessToken = UUID.randomUUID().toString();
+        final int expiresIn = ThreadLocalRandom.current().nextInt(1, 86_400);
         final HttpResponse<String> response =
-                httpResponse(200, "{\"access_token\":\"azure-access-token\",\"expires_in\":3599}");
+                httpResponse(200, "{\"access_token\":\"" + accessToken + "\",\"expires_in\":" + expiresIn + "}");
         when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn(response);
         final AzureFederatedTokenProvider provider = providerWith(stsClient, httpClient);
@@ -221,6 +225,7 @@ class AzureFederatedTokenProviderTest {
         // The exchange must not repeat while cached, so the fresh instance carries the same value
         // and the same absolute lifetime rather than a lifetime recomputed from "now".
         verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertThat(second.value(), equalTo(accessToken));
         assertThat(second.value(), equalTo(first.value()));
         assertThat(second.lifetimeMs(), equalTo(first.lifetimeMs()));
         assertThat(second.startTimeMs(), equalTo(first.startTimeMs()));


### PR DESCRIPTION
  ### Description
 
 Fix the `azure_federated` Kafka source so it keeps authenticating after the first OAuth token refresh. `AzureFederatedTokenProvider.getToken()` now returns a new token instance on each call through a copy constructor, while the cache still holds the access-token value and its absolute expiry. This keeps a distinct object on the SASL Subject for every re-login, and it does not repeat the STS or Azure token exchange or change Kafka's refresh schedule.

### Issues Resolved
  Resolves #7039 

### Check List
 - [x] New functionality includes testing.
 - [ ] New functionality has a documentation issue. Please link to it in this PR.
 - [ ] New functionality has javadoc added
 - [x] Commits are signed with a real name per the DCO

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).