### PR TITLE
feat(flatten): Add configurable flatten_separator parameter

### DIFF
--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessor.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessor.java
@@ -75,7 +75,10 @@ public class FlattenProcessor extends AbstractProcessor<Record<Event>, Record<Ev
 
                 // adds ignoreReservedCharacters() so that dots in keys are ignored during flattening
                 // e.g., {"a.b": {"c": 1}} will be flattened as expected: {"a.b.c": 1}; otherwise, flattened result will be {"[\"a.b\"]c": 1}
-                Map<String, Object> flattenedJson = new JsonFlattener(sourceJson).ignoreReservedCharacters().flattenAsMap();
+                Map<String, Object> flattenedJson = new JsonFlattener(sourceJson)
+                        .ignoreReservedCharacters()
+                        .withSeparator(config.getFlattenSeparator().charAt(0))
+                        .flattenAsMap();
 
                 if (config.isRemoveProcessedFields()) {
                     final Map<String, Object> sourceMap = recordEvent.get(config.getSource(), Map.class);

--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.model.annotations.ExampleValues;
 import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
@@ -81,6 +82,18 @@ public class FlattenProcessorConfig {
     })
     private String flattenWhen;
 
+    @JsonProperty("flatten_separator")
+    @JsonPropertyDescription("The character used to join nested key names into flattened keys. " +
+            "For example, if the separator is <code>\"_\"</code>, a nested field <code>{\"a\": {\"b\": 1}}</code> " +
+            "becomes <code>{\"a_b\": 1}</code>. Default is <code>\".\"</code>.")
+    @ExampleValues({
+        @Example(value = "_", description = "Uses underscore as the separator, producing keys like 'parent_child'."),
+        @Example(value = ".", description = "Default behavior, producing keys like 'parent.child'.")
+    })
+    @NotNull(message = "flatten_separator must not be null.")
+    @Size(min = 1, max = 1, message = "flatten_separator must be exactly one character.")
+    private String flattenSeparator = ".";
+
     public String getSource() {
         return source;
     }
@@ -107,6 +120,10 @@ public class FlattenProcessorConfig {
 
     public String getFlattenWhen() {
         return flattenWhen;
+    }
+
+    public String getFlattenSeparator() {
+        return flattenSeparator;
     }
 
     public List<String> getTagsOnFailure() {

--- a/data-prepper-plugins/flatten-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorTest.java
+++ b/data-prepper-plugins/flatten-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorTest.java
@@ -58,6 +58,7 @@ class FlattenProcessorTest {
         lenient().when(mockConfig.getFlattenWhen()).thenReturn(null);
         lenient().when(mockConfig.getTagsOnFailure()).thenReturn(new ArrayList<>());
         lenient().when(mockConfig.getExcludeKeys()).thenReturn(new ArrayList<>());
+        lenient().when(mockConfig.getFlattenSeparator()).thenReturn(".");
     }
 
     @Test
@@ -471,5 +472,54 @@ class FlattenProcessorTest {
 
         assertThat(resultData.containsKey("list1[0].list2[1].value"), is(true));
         assertThat(resultData.get("list1[0].list2[1].value"), is("value2"));
+    }
+
+    @Test
+    void testFlattenWithCustomSeparator() {
+        when(mockConfig.getFlattenSeparator()).thenReturn("_");
+
+        final FlattenProcessor processor = createObjectUnderTest();
+
+        final Map<String, Object> testData = Map.of(
+                "key1", "val1",
+                "key2", Map.of("key3", "val2", "key4", Map.of("key5", "val3"))
+        );
+
+        final Record<Event> testRecord = createTestRecord(testData);
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        Map<String, Object> resultData = resultEvent.get("", Map.class);
+
+        assertThat(resultData.containsKey("key1"), is(true));
+        assertThat(resultData.get("key1"), is("val1"));
+
+        assertThat(resultData.containsKey("key2_key3"), is(true));
+        assertThat(resultData.get("key2_key3"), is("val2"));
+
+        assertThat(resultData.containsKey("key2_key4_key5"), is(true));
+        assertThat(resultData.get("key2_key4_key5"), is("val3"));
+    }
+
+    @Test
+    void testFlattenWithDefaultSeparatorProducesDotSeparatedKeys() {
+        final FlattenProcessor processor = createObjectUnderTest();
+
+        final Map<String, Object> testData = Map.of(
+                "parent", Map.of("child", "value")
+        );
+
+        final Record<Event> testRecord = createTestRecord(testData);
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        Map<String, Object> resultData = resultEvent.get("", Map.class);
+
+        assertThat(resultData.containsKey("parent.child"), is(true));
+        assertThat(resultData.get("parent.child"), is("value"));
     }
 }


### PR DESCRIPTION
Add flatten_separator parameter to the flatten processor to allow configuring the character used to join nested key names. Previously hardcoded to ".", now supports any single character (e.g., "_", "-").

Default remains "." for backward compatibility. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR: https://github.com/opensearch-project/documentation-website/pull/12879
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
