### PR TITLE
Fix PostgreSQL joins feature emitting documents with empty _id

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/converter/RecordConverter.java
@@ -93,16 +93,26 @@ public abstract class RecordConverter {
         eventMetadata.setAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreateTimeEpochMillis);
         eventMetadata.setAttribute(EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
 
-        if (joinMetadataEnricher != null && joinMetadataEnricher.isJoinTable(tableName)) {
-            final boolean isDelete = bulkAction == OpenSearchBulkActions.DELETE;
-            joinMetadataEnricher.enrich(event, tableName, columnNames, isDelete);
+        if (joinMetadataEnricher != null) {
+            // Resolve the table name used for join matching. The join config uses schema-qualified
+            // names for PostgreSQL (e.g., "public.locations") but bare names for MySQL (e.g., "orders").
+            // Try schema-qualified first, then fall back to bare table name for MySQL compatibility.
+            final String qualifiedTableName = schemaName != null ? schemaName + "." + tableName : null;
+            final String joinTableName = (qualifiedTableName != null && joinMetadataEnricher.isJoinTable(qualifiedTableName))
+                    ? qualifiedTableName
+                    : (joinMetadataEnricher.isJoinTable(tableName) ? tableName : null);
 
-            // For child tables, override S3 partition key to use the join key (parent key value)
-            // so related parent and child events land in the same S3 folder
-            final String joinPrimaryKey = (String) eventMetadata.getAttribute(MetadataKeyAttributes.JOIN_PRIMARY_KEY_METADATA);
-            if (joinPrimaryKey != null) {
-                final String joinPartitionKey = s3Prefix + S3_PATH_DELIMITER + S3_BUFFER_PREFIX + S3_PATH_DELIMITER + hashKeyToPartition(joinPrimaryKey);
-                eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, joinPartitionKey);
+            if (joinTableName != null) {
+                final boolean isDelete = bulkAction == OpenSearchBulkActions.DELETE;
+                joinMetadataEnricher.enrich(event, joinTableName, columnNames, isDelete);
+
+                // For child tables, override S3 partition key to use the join key (parent key value)
+                // so related parent and child events land in the same S3 folder
+                final String joinPrimaryKey = (String) eventMetadata.getAttribute(MetadataKeyAttributes.JOIN_PRIMARY_KEY_METADATA);
+                if (joinPrimaryKey != null) {
+                    final String joinPartitionKey = s3Prefix + S3_PATH_DELIMITER + S3_BUFFER_PREFIX + S3_PATH_DELIMITER + hashKeyToPartition(joinPrimaryKey);
+                    eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, joinPartitionKey);
+                }
             }
         }
 

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/converter/StreamRecordConverterTest.java
@@ -11,7 +11,10 @@ import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.plugins.source.rds.configuration.JoinRelation;
 import org.opensearch.dataprepper.plugins.source.rds.model.StreamEventType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Map;
@@ -21,6 +24,7 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.BULK_ACTION_METADATA_ATTRIBUTE;
@@ -32,6 +36,7 @@ import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKe
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.JOIN_PRIMARY_KEY_METADATA;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.RecordConverter.S3_BUFFER_PREFIX;
 import static org.opensearch.dataprepper.plugins.source.rds.converter.RecordConverter.STREAM_INGESTION_TYPE;
@@ -125,5 +130,126 @@ class StreamRecordConverterTest {
 
     private StreamRecordConverter createObjectUnderTest() {
         return new StreamRecordConverter(s3Prefix, random.nextInt(1000) + 1);
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JoinRelation createRelation(String parent, String child,
+                                        Object parentKey, Object childKey,
+                                        Object childPrimaryKey, String joinType) {
+        try {
+            Map<String, Object> map = Map.of(
+                    "parent", parent, "child", child,
+                    "parent_key", parentKey, "child_key", childKey,
+                    "child_primary_key", childPrimaryKey, "join_type", joinType);
+            return MAPPER.convertValue(map, JoinRelation.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void test_convert_with_schema_qualified_join_table_enriches_metadata_for_postgresql() {
+        // Simulates PostgreSQL path: schema-qualified names in config, bare table name in runtime
+        final JoinRelation relation = createRelation(
+                "public.locations", "public.evses",
+                "id", "location_id", "id", "one_to_many");
+        final JoinMetadataEnricher enricher = new JoinMetadataEnricher(List.of(relation));
+        streamRecordConverter.setJoinMetadataEnricher(enricher);
+
+        final Map<String, Object> childRowData = Map.of("id", "evse-001", "location_id", "loc-001", "status", "available");
+        final Event testEvent = TestEventFactory.getTestEventFactory().eventBuilder(EventBuilder.class)
+                .withEventType("event")
+                .withData(childRowData)
+                .build();
+
+        // PostgreSQL passes schemaName="public", tableName="evses" (bare)
+        final Event result = streamRecordConverter.convert(
+                testEvent, "postgres", "public", "evses",
+                OpenSearchBulkActions.INDEX, List.of("id"),
+                System.currentTimeMillis(), 1000L,
+                StreamEventType.INSERT,
+                List.of("id", "location_id", "status"));
+
+        // Join metadata should be enriched using the qualified name "public.evses"
+        assertThat(result.getMetadata().getAttribute(JOIN_PRIMARY_KEY_METADATA), is("loc-001"));
+        assertThat(result.getMetadata().getAttribute(JoinMetadataEnricher.JOIN_IS_PARENT_METADATA), is("false"));
+        assertThat(result.getMetadata().getAttribute(JoinMetadataEnricher.JOIN_TABLE_METADATA), is("public.evses"));
+    }
+
+    @Test
+    void test_convert_with_schema_qualified_join_parent_table_enriches_metadata_for_postgresql() {
+        final JoinRelation relation = createRelation(
+                "public.locations", "public.evses",
+                "id", "location_id", "id", "one_to_many");
+        final JoinMetadataEnricher enricher = new JoinMetadataEnricher(List.of(relation));
+        streamRecordConverter.setJoinMetadataEnricher(enricher);
+
+        final Map<String, Object> parentRowData = Map.of("id", "loc-001", "name", "Station Alpha", "latitude", 55.67);
+        final Event testEvent = TestEventFactory.getTestEventFactory().eventBuilder(EventBuilder.class)
+                .withEventType("event")
+                .withData(parentRowData)
+                .build();
+
+        // PostgreSQL passes schemaName="public", tableName="locations" (bare)
+        final Event result = streamRecordConverter.convert(
+                testEvent, "postgres", "public", "locations",
+                OpenSearchBulkActions.INDEX, List.of("id"),
+                System.currentTimeMillis(), 1000L,
+                StreamEventType.INSERT,
+                List.of("id", "name", "latitude"));
+
+        // Join metadata should be enriched using the qualified name "public.locations"
+        assertThat(result.getMetadata().getAttribute(JOIN_PRIMARY_KEY_METADATA), is("loc-001"));
+        assertThat(result.getMetadata().getAttribute(JoinMetadataEnricher.JOIN_IS_PARENT_METADATA), is("true"));
+        assertThat(result.getMetadata().getAttribute(JoinMetadataEnricher.JOIN_TABLE_METADATA), is("public.locations"));
+    }
+
+    @Test
+    void test_convert_with_bare_join_table_enriches_metadata_for_mysql() {
+        // Simulates MySQL path: bare table names in config, bare table name in runtime
+        final JoinRelation relation = createRelation(
+                "orders", "order_items",
+                "order_id", "order_id", "item_id", "one_to_many");
+        final JoinMetadataEnricher enricher = new JoinMetadataEnricher(List.of(relation));
+        streamRecordConverter.setJoinMetadataEnricher(enricher);
+
+        final Map<String, Object> childRowData = Map.of("item_id", "item-1", "order_id", "ord-1", "product", "Widget");
+        final Event testEvent = TestEventFactory.getTestEventFactory().eventBuilder(EventBuilder.class)
+                .withEventType("event")
+                .withData(childRowData)
+                .build();
+
+        // MySQL passes schemaName="my_db" (same as databaseName), tableName="order_items" (bare)
+        final Event result = streamRecordConverter.convert(
+                testEvent, "my_db", "my_db", "order_items",
+                OpenSearchBulkActions.INDEX, List.of("item_id"),
+                System.currentTimeMillis(), 1000L,
+                StreamEventType.INSERT,
+                List.of("item_id", "order_id", "product"));
+
+        // Join metadata should be enriched using the bare name "order_items"
+        assertThat(result.getMetadata().getAttribute(JOIN_PRIMARY_KEY_METADATA), is("ord-1"));
+        assertThat(result.getMetadata().getAttribute(JoinMetadataEnricher.JOIN_IS_PARENT_METADATA), is("false"));
+        assertThat(result.getMetadata().getAttribute(JoinMetadataEnricher.JOIN_TABLE_METADATA), is("order_items"));
+    }
+
+    @Test
+    void test_convert_without_join_enricher_does_not_set_join_metadata() {
+        // No join enricher set — should not set any join metadata
+        final Map<String, Object> rowData = Map.of("id", "loc-001", "name", "Station Alpha");
+        final Event testEvent = TestEventFactory.getTestEventFactory().eventBuilder(EventBuilder.class)
+                .withEventType("event")
+                .withData(rowData)
+                .build();
+
+        final Event result = streamRecordConverter.convert(
+                testEvent, "postgres", "public", "locations",
+                OpenSearchBulkActions.INDEX, List.of("id"),
+                System.currentTimeMillis(), 1000L,
+                StreamEventType.INSERT,
+                List.of("id", "name"));
+
+        assertThat(result.getMetadata().getAttribute(JOIN_PRIMARY_KEY_METADATA), is(nullValue()));
     }
 }


### PR DESCRIPTION
### Description

Fixes a bug where the RDS source `joins` feature is non-functional for PostgreSQL engines. When joins is configured with schema-qualified table names (e.g., `public.orders`), the `JoinMetadataEnricher` never matches events at runtime because the `LogicalReplicationEventProcessor` passes bare table names (e.g., `orders`) to `RecordConverter.convert()`.

This causes:
- Join metadata (`_primary_key`, `_table`, `_is_parent`, `_fields`, etc.) to never be set on any event
- All events to be emitted as separate documents instead of being merged into parent documents
- The S3 sub-pipeline's OpenSearch sink to fail with `action_request_validation_exception: id is missing` because `document_id: "${getMetadata(\"_primary_key\")}"` resolves to empty string

**Root cause:** `RecordConverter.convert()` passed only the bare `tableName` to `JoinMetadataEnricher.isJoinTable()`, but the enricher stores table names exactly as configured (schema-qualified for PostgreSQL). The bare name never matched.

**Fix:** Construct the schema-qualified name (`schemaName + "." + tableName`) and try matching that first, falling back to the bare table name for MySQL compatibility (MySQL has no schema layer and uses bare table names in both config and runtime).

This fix covers both the stream and export code paths since both go through `RecordConverter.convert()`.

### Testing

Reproduced the issue locally against an Aurora PostgreSQL cluster with a joins configuration using schema-qualified table names (`public.parent_table`, `public.child_table`) and confirmed the fix. Also confirmed the there's no issue on MySQL with joins config.

Unit tests added covering:
- PostgreSQL path: schema-qualified table names match correctly
- MySQL path: bare table names still match (no regression)
- No-enricher path: no join metadata set when joins is not configured

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).