### PR TITLE
Fix/datafile scheduler decrement race

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -111,11 +111,15 @@ public class DataFileScheduler implements Runnable {
             runLoader.whenComplete(completeDataLoader(dataFilePartition));
         } else {
             runLoader.whenComplete((v, ex) -> {
+                numOfWorkers.decrementAndGet();
                 if (ex != null) {
                     LOG.error("There was an exception while processing an S3 data file: {}", ex);
-                    coordinator.giveUpPartition(dataFilePartition);
+                    try {
+                        coordinator.giveUpPartition(dataFilePartition);
+                    } catch (final Exception e) {
+                        LOG.error("Failed to give up partition for data file {}", dataFilePartition.getKey(), e);
+                    }
                 }
-                numOfWorkers.decrementAndGet();
             });
         }
         numOfWorkers.incrementAndGet();

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
@@ -197,7 +197,7 @@ public class ExportScheduler implements Runnable {
 
         // Currently, we need to maintain a global state to track the overall progress.
         // So that we can easily tell if all the export files are loaded
-        LoadStatus loadStatus = new LoadStatus(totalFiles.get(), 0, totalRecords.get(), 0);
+        LoadStatus loadStatus = new LoadStatus(dataFileInfo.size(), 0, totalRecords.get(), 0);
         enhancedSourceCoordinator.createPartition(new GlobalState(exportArn, Optional.of(loadStatus.toMap())));
 
         dataFileInfo.forEach((key, size) -> {

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileScheduler.ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileScheduler.EXPORT_S3_OBJECTS_PROCESSED_COUNT;
@@ -276,5 +277,42 @@ class DataFileSchedulerTest {
         executorService.shutdown();
         future.cancel(true);
         assertThat(executorService.awaitTermination(1000, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+
+    @Test
+    void run_with_acknowledgments_decrements_numOfWorkers_even_when_giveUpPartition_throws() throws InterruptedException {
+        given(coordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE))
+                .willReturn(Optional.of(dataFilePartition))
+                .willReturn(Optional.of(dataFilePartition))
+                .willReturn(Optional.empty());
+        given(dynamoDBSourceConfig.isAcknowledgmentsEnabled()).willReturn(true);
+
+        final Duration dataFileAcknowledgmentTimeout = Duration.ofSeconds(30);
+        given(dynamoDBSourceConfig.getDataFileAcknowledgmentTimeout()).willReturn(dataFileAcknowledgmentTimeout);
+
+        // Loader throws exception to trigger giveUpPartition path
+        given(loaderFactory.createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class), any(AcknowledgementSet.class), any(Duration.class)))
+                .willReturn(() -> { throw new RuntimeException("Connection reset"); });
+
+        // giveUpPartition throws - simulating the silent failure
+        lenient().doThrow(new RuntimeException("DDB conditional check failed"))
+                .when(coordinator).giveUpPartition(any(EnhancedSourcePartition.class));
+
+        // Mock acknowledgement set
+        final AcknowledgementSet ackSet = mock(AcknowledgementSet.class);
+        given(acknowledgementSetManager.create(any(Consumer.class), any(Duration.class))).willReturn(ackSet);
+
+        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        final Future<?> future = executorService.submit(() -> scheduler.run());
+        Thread.sleep(3000);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(executorService.awaitTermination(2000, TimeUnit.MILLISECONDS), equalTo(true));
+
+        // Despite giveUpPartition throwing, the scheduler should still acquire more partitions
+        // (proving numOfWorkers was decremented and didn't get stuck at 1)
+        verify(coordinator, atLeast(2)).acquireAvailablePartition(DataFilePartition.PARTITION_TYPE);
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.ExportProgressState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.ExportSummary;
+import org.opensearch.dataprepper.plugins.source.dynamodb.model.LoadStatus;
 import org.opensearch.dataprepper.plugins.source.dynamodb.utils.DynamoDBSourceAggregateMetrics;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeExportRequest;
@@ -184,6 +185,12 @@ class ExportSchedulerTest {
         assertThat(createdPartitions.get(0), instanceOf(GlobalState.class));
         assertThat(createdPartitions.get(1), instanceOf(DataFilePartition.class));
         assertThat(createdPartitions.get(2), instanceOf(DataFilePartition.class));
+
+        // Verify the GlobalState LoadStatus has accurate totalFiles count
+        GlobalState globalState = (GlobalState) createdPartitions.get(0);
+        LoadStatus loadStatus = LoadStatus.fromMap(globalState.getProgressState().get());
+        assertThat(loadStatus.getTotalFiles(), equalTo(2));
+        assertThat(loadStatus.getLoadedFiles(), equalTo(0));
 
         // Complete the export partition
         verify(coordinator).completePartition(any(EnhancedSourcePartition.class));


### PR DESCRIPTION
### Description
This change fixes a potential failure in the data file scheduler for DynamoDB source exports where they will stop grabbing work and need to be restarted. This failure can happen only on the error path where the processing fails for some other reason, so cannot happen in the happy path. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
