### PR TITLE
fix(dynamodb-source): Decrement numOfWorkers before giveUpPartition too prevent scheduler stall

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -111,11 +111,15 @@ public class DataFileScheduler implements Runnable {
             runLoader.whenComplete(completeDataLoader(dataFilePartition));
         } else {
             runLoader.whenComplete((v, ex) -> {
+                numOfWorkers.decrementAndGet();
                 if (ex != null) {
                     LOG.error("There was an exception while processing an S3 data file: {}", ex);
-                    coordinator.giveUpPartition(dataFilePartition);
+                    try {
+                        coordinator.giveUpPartition(dataFilePartition);
+                    } catch (final Exception e) {
+                        LOG.error("Failed to give up partition for data file {}", dataFilePartition.getKey(), e);
+                    }
                 }
-                numOfWorkers.decrementAndGet();
             });
         }
         numOfWorkers.incrementAndGet();

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileScheduler.ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileScheduler.EXPORT_S3_OBJECTS_PROCESSED_COUNT;
@@ -276,5 +277,42 @@ class DataFileSchedulerTest {
         executorService.shutdown();
         future.cancel(true);
         assertThat(executorService.awaitTermination(1000, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+
+    @Test
+    void run_with_acknowledgments_decrements_numOfWorkers_even_when_giveUpPartition_throws() throws InterruptedException {
+        given(coordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE))
+                .willReturn(Optional.of(dataFilePartition))
+                .willReturn(Optional.of(dataFilePartition))
+                .willReturn(Optional.empty());
+        given(dynamoDBSourceConfig.isAcknowledgmentsEnabled()).willReturn(true);
+
+        final Duration dataFileAcknowledgmentTimeout = Duration.ofSeconds(30);
+        given(dynamoDBSourceConfig.getDataFileAcknowledgmentTimeout()).willReturn(dataFileAcknowledgmentTimeout);
+
+        // Loader throws exception to trigger giveUpPartition path
+        given(loaderFactory.createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class), any(AcknowledgementSet.class), any(Duration.class)))
+                .willReturn(() -> { throw new RuntimeException("Connection reset"); });
+
+        // giveUpPartition throws - simulating the silent failure
+        lenient().doThrow(new RuntimeException("DDB conditional check failed"))
+                .when(coordinator).giveUpPartition(any(EnhancedSourcePartition.class));
+
+        // Mock acknowledgement set
+        final AcknowledgementSet ackSet = mock(AcknowledgementSet.class);
+        given(acknowledgementSetManager.create(any(Consumer.class), any(Duration.class))).willReturn(ackSet);
+
+        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        final Future<?> future = executorService.submit(() -> scheduler.run());
+        Thread.sleep(3000);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(executorService.awaitTermination(2000, TimeUnit.MILLISECONDS), equalTo(true));
+
+        // Despite giveUpPartition throwing, the scheduler should still acquire more partitions
+        // (proving numOfWorkers was decremented and didn't get stuck at 1)
+        verify(coordinator, atLeast(2)).acquireAvailablePartition(DataFilePartition.PARTITION_TYPE);
     }
 }


### PR DESCRIPTION

When a DataFileLoader completes with an exception and acknowledgments are enabled, the whenComplete callback previously called giveUpPartition before decrementing numOfWorkers. If giveUpPartition threw an unchecked exception, the decrement was skipped and numOfWorkers stayed at MAX_JOB_COUNT permanently, preventing the DataFileScheduler from acquiring any new partitions.

This fix moves the decrement before giveUpPartition and wraps the giveUpPartition call in a try/catch. The counter is always decremented regardless of whether partition release succeeds, ensuring the scheduler can continue acquiring work.

### Description
[Describe what this change achieves]
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
