### PR TITLE
Add Kafka source consumer config properties

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/CommonTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/CommonTopicConfig.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 public abstract class CommonTopicConfig implements TopicConfig {
     static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofSeconds(10);
     static final Duration DEFAULT_RECONNECT_BACKOFF = Duration.ofSeconds(10);
+    static final Duration DEFAULT_METADATA_MAX_AGE = Duration.ofMillis(300000);
 
     @JsonProperty("name")
     @NotNull
@@ -31,6 +32,8 @@ public abstract class CommonTopicConfig implements TopicConfig {
     @JsonProperty("reconnect_backoff")
     private Duration reconnectBackoff = DEFAULT_RECONNECT_BACKOFF;
 
+    @JsonProperty("metadata_max_age")
+    private Duration metadataMaxAge = DEFAULT_METADATA_MAX_AGE;
 
     @Override
     public Duration getRetryBackoff() {
@@ -40,6 +43,11 @@ public abstract class CommonTopicConfig implements TopicConfig {
     @Override
     public Duration getReconnectBackoff() {
         return reconnectBackoff;
+    }
+
+    @Override
+    public Duration getMetadataMaxAge() {
+        return metadataMaxAge;
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaConsumerConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaConsumerConfig.java
@@ -18,7 +18,11 @@ public interface KafkaConsumerConfig extends KafkaConnectionConfig {
     boolean getAcknowledgementsEnabled();
 
     Duration getAcknowledgementsTimeout();
-    
+
+    default boolean getAcknowledgementsExpiryResetEnabled() {
+        return false;
+    }
+
     SchemaConfig getSchemaConfig();
 
     List<? extends TopicConfig> getTopics();

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -28,4 +28,6 @@ public interface TopicConfig {
     Duration getRetryBackoff();
 
     Duration getReconnectBackoff();
+
+    Duration getMetadataMaxAge();
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -182,6 +182,9 @@ public class KafkaCustomConsumerFactory {
         properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, topicConfig.getFetchMaxWait());
         properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, (int)topicConfig.getFetchMinBytes());
         properties.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+        if (Objects.nonNull(topicConfig.getMetadataMaxAge())) {
+            properties.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, topicConfig.getMetadataMaxAge().toMillis());
+        }
         if (topicConfig instanceof KafkaIsolationLevelConfig) {
             IsolationLevel isolationLevel = ((KafkaIsolationLevelConfig) topicConfig).getIsolationLevel();
             if (isolationLevel != null) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -30,6 +30,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.kafka.common.KafkaMdc;
 import org.opensearch.dataprepper.plugins.kafka.common.aws.AwsContext;
 import org.opensearch.dataprepper.plugins.kafka.common.thread.KafkaPluginThreadFactory;
@@ -163,7 +164,8 @@ public class KafkaSource implements Source<Record<Event>> {
 
                         }
                         consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
-                                acknowledgementSetManager, null, topicMetrics, PauseConsumePredicate.noPause());
+                                acknowledgementSetManager, null, topicMetrics, PauseConsumePredicate.noPause(),
+                                CompressionOption.NONE, sourceConfig.getAcknowledgementsExpiryResetEnabled());
                         allTopicConsumers.add(consumer);
 
                         executorService.submit(consumer);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceConfig.java
@@ -37,6 +37,7 @@ public class KafkaSourceConfig implements KafkaConsumerConfig {
     private List<String> bootStrapServers;
 
     @JsonProperty("topics")
+    @Valid
     @NotNull
     @Size(min = 1, max = 10, message = "The number of Topics should be between 1 and 10")
     private List<SourceTopicConfig> topics;
@@ -62,6 +63,9 @@ public class KafkaSourceConfig implements KafkaConsumerConfig {
     @JsonProperty("acknowledgments_timeout")
     private Duration acknowledgementsTimeout = DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT;
 
+    @JsonProperty("acknowledgments_expiry_reset")
+    private Boolean acknowledgementsExpiryResetEnabled = false;
+
     @JsonProperty("client_dns_lookup")
     private String clientDnsLookup;
 
@@ -77,6 +81,11 @@ public class KafkaSourceConfig implements KafkaConsumerConfig {
     @Override
     public Duration getAcknowledgementsTimeout() {
         return acknowledgementsTimeout;
+    }
+
+    @Override
+    public boolean getAcknowledgementsExpiryResetEnabled() {
+        return acknowledgementsExpiryResetEnabled;
     }
 
     public List<? extends TopicConsumerConfig> getTopics() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfig.java
@@ -7,7 +7,9 @@ package org.opensearch.dataprepper.plugins.kafka.source;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.kafka.configuration.CommonTopicConfig;
@@ -42,7 +44,7 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
 
     @JsonProperty("commit_interval")
     @Valid
-    @Size(min = 1)
+    @DurationMin(seconds = 1)
     private Duration commitInterval = DEFAULT_COMMIT_INTERVAL;
 
     @JsonProperty("key_mode")
@@ -60,12 +62,12 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
 
     @JsonProperty("workers")
     @Valid
-    @Size(min = 1, max = 200, message = "Number of worker threads should lies between 1 and 200")
+    @Range(min = 1, max = 200, message = "Number of worker threads should lie between 1 and 200")
     private Integer workers = DEFAULT_NUM_OF_WORKERS;
 
     @JsonProperty("session_timeout")
     @Valid
-    @Size(min = 1)
+    @DurationMin(seconds = 1)
     private Duration sessionTimeOut = DEFAULT_SESSION_TIMEOUT;
 
     @JsonProperty("auto_offset_reset")
@@ -82,7 +84,7 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
 
     @JsonProperty("heart_beat_interval")
     @Valid
-    @Size(min = 1)
+    @DurationMin(seconds = 1)
     private Duration heartBeatInterval= DEFAULT_HEART_BEAT_INTERVAL_DURATION;
 
     @JsonProperty("auto_commit")
@@ -96,7 +98,7 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
 
     @JsonProperty("fetch_max_wait")
     @Valid
-    @Size(min = 1)
+    @Min(1)
     private Integer fetchMaxWait = DEFAULT_FETCH_MAX_WAIT;
 
     @JsonProperty("fetch_min_bytes")


### PR DESCRIPTION
### Description

 Adds two Kafka source consumer properties and fixes source topic validation:

 - `metadata_max_age` (default 300000ms) — maps to `metadata.max.age.ms`; controls how quickly the consumer detects new partitions.
- `acknowledgments_expiry_reset` (default false) — re-delivers an expired ack set instead of silently ignoring it; backward compatible.
- Replaces misapplied `@Size` constraints on `SourceTopicConfig` Duration/Integer fields with `@DurationMin`/`@Range`/`@Min`, and adds `@Valid` on `topics` so nested validation runs.

 ### Issues Resolved

Resolves #7073

  ### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0
  license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).