### PR TITLE
Fix JSON Pointer escape handling in JacksonEvent

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -426,7 +426,7 @@ public class JacksonEvent implements Event {
         }
 
         if (!baseNode.isMissingNode()) {
-            ((ObjectNode) baseNode).remove(leafKey);
+            ((ObjectNode) baseNode).remove(JacksonEventKey.unescapeJsonPointerToken(leafKey));
         }
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -197,7 +198,18 @@ class JacksonEventKey implements EventKey {
     }
 
     private List<String> toKeyPathList() {
-        return Collections.unmodifiableList(Arrays.asList(trimmedKey.split(SEPARATOR, -1)));
+        return Collections.unmodifiableList(
+                Arrays.stream(trimmedKey.split(SEPARATOR, -1))
+                      .map(JacksonEventKey::unescapeJsonPointerToken)
+                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Unescapes a single JSON Pointer reference token.
+     * The two escape sequences must be applied in order: ~1 → / before ~0 → ~.
+     */
+    static String unescapeJsonPointerToken(final String token) {
+        return token.replace("~1", "/").replace("~0", "~");
     }
 
     private static JsonPointer toJsonPointer(final String key) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -182,7 +182,12 @@ class JacksonEventKeyTest {
                     arguments("a/b", List.of("a", "b")),
                     arguments("a/b/", List.of("a", "b")),
                     arguments("a/b/c", List.of("a", "b", "c")),
-                    arguments("a/b/c/", List.of("a", "b", "c"))
+                    arguments("a/b/c/", List.of("a", "b", "c")),
+                    // JSON Pointer escape sequences: ~1 → /, ~0 → ~
+                    arguments("z~1y", List.of("z/y")),
+                    arguments("a~0b", List.of("a~b")),
+                    arguments("parent/z~1y", List.of("parent", "z/y")),
+                    arguments("a~0b~1c", List.of("a~b/c"))
             );
         }
     }
@@ -303,5 +308,26 @@ class JacksonEventKeyTest {
         final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, eventAction);
 
         assertThat(objectUnderTest.toString(), equalTo(testKey));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            // plain token — no escapes, returned unchanged
+            "foo,          foo",
+            // ~1 → /
+            "z~1y,         z/y",
+            // ~0 → ~
+            "a~0b,         a~b",
+            // ordering: ~1 applied before ~0, so ~01 → ~1 (not /)
+            "~01,          ~1",
+            // combined: ~0 and ~1 in same token
+            "a~0b~1c,      a~b/c",
+            // multiple ~1 in one token
+            "a~1b~1c,      a/b/c",
+            // multiple ~0 in one token
+            "a~0~0b,       a~~b",
+    }, ignoreLeadingAndTrailingWhitespace = true)
+    void unescapeJsonPointerToken_returns_expected_result(final String token, final String expected) {
+        assertThat(JacksonEventKey.unescapeJsonPointerToken(token), equalTo(expected));
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 
@@ -488,14 +489,13 @@ public class JacksonEventTest {
 
     @Test
     public void testDelete_withJsonPointerEscapedSlash_deletesLiteralKeyName() {
-        // pre-populate the event with a literal "z/y" key via toMap round-trip, then delete it
+        // z~1y is JSON Pointer encoding for the literal key name "z/y"; delete("z~1y") must target that field
         final String value = "some_value";
-        // Use Jackson ObjectNode directly to set a raw field name of "z/y"
-        ((com.fasterxml.jackson.databind.node.ObjectNode) event.getJsonNode()).put("z/y", value);
+        ((ObjectNode) event.getJsonNode()).put("z/y", value);
 
         event.delete("z~1y");
 
-        assertThat("literal key 'z/y' should be deleted", event.get("z~1y", String.class), is(nullValue()));
+        assertThat(event.get("z~1y", String.class), is(nullValue()));
     }
 
     @ParameterizedTest

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -445,6 +445,58 @@ public class JacksonEventTest {
         assertThat(result, is(notNullValue()));
         assertThat(result, is(equalTo(value)));
     }
+    @Test
+    public void testPut_withJsonPointerEscapedSlash_storesLiteralKeyName() {
+        // z~1y is JSON Pointer encoding for the literal key name "z/y"
+        // put("z~1y", value) must store a single field whose name is "z/y", not nest under "z"
+        final String value = "some_value";
+
+        event.put("z~1y", value);
+
+        final Map<String, Object> map = event.toMap();
+        assertThat("literal key 'z/y' should exist", map.containsKey("z/y"), is(true));
+        assertThat("escaped key 'z~1y' must NOT be stored literally", map.containsKey("z~1y"), is(false));
+        assertThat("must not create a nested object under 'z'", map.containsKey("z"), is(false));
+    }
+
+    @Test
+    public void testPut_withJsonPointerEscapedTilde_storesLiteralKeyName() {
+        // a~0b is JSON Pointer encoding for the literal key name "a~b"
+        final String value = "some_value";
+
+        event.put("a~0b", value);
+
+        final Map<String, Object> map = event.toMap();
+        assertThat("literal key 'a~b' should exist", map.containsKey("a~b"), is(true));
+        assertThat("escaped key 'a~0b' must NOT be stored literally", map.containsKey("a~0b"), is(false));
+    }
+
+    @Test
+    public void testPut_withJsonPointerEscapedSlash_inNestedPath_storesLiteralFieldName() {
+        // parent/z~1y — the intermediate segment "parent" is plain, leaf "z~1y" → "z/y"
+        final String value = "some_value";
+
+        event.put("parent/z~1y", value);
+
+        final Map<String, Object> map = event.toMap();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> parent = (Map<String, Object>) map.get("parent");
+        assertThat("parent node must exist", parent, is(notNullValue()));
+        assertThat("literal key 'z/y' should exist under parent", parent.containsKey("z/y"), is(true));
+        assertThat("escaped key 'z~1y' must NOT be stored literally", parent.containsKey("z~1y"), is(false));
+    }
+
+    @Test
+    public void testDelete_withJsonPointerEscapedSlash_deletesLiteralKeyName() {
+        // pre-populate the event with a literal "z/y" key via toMap round-trip, then delete it
+        final String value = "some_value";
+        // Use Jackson ObjectNode directly to set a raw field name of "z/y"
+        ((com.fasterxml.jackson.databind.node.ObjectNode) event.getJsonNode()).put("z/y", value);
+
+        event.delete("z~1y");
+
+        assertThat("literal key 'z/y' should be deleted", event.get("z~1y", String.class), is(nullValue()));
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"foo", "/foo", "/foo/", "foo/"})


### PR DESCRIPTION
### Description
This change centralizes JSON Pointer token decoding in `JacksonEventKey` so escaped reference tokens are handled consistently across event operations.

Previously, escaped JSON Pointer tokens (for example `~1` for `/` and `~0` for `~`) were not decoded when processing event keys. As a result:

- `put("z~1y", value)` created a field named `z~1y` instead of the literal key `z/y`.
- `delete("z~1y")` could not delete a field named `z/y`.

This change introduces a shared JSON Pointer token unescaping method in `JacksonEventKey` and applies it when parsing event key paths. The delete path is also updated to use the same decoding for the leaf key, providing consistent behavior across operations.

This implementation also addresses the underlying JSON Pointer decoding issue discussed in #5953 by fixing it in the shared `JacksonEventKey` implementation instead of only in the delete path. Since an existing PR already targets #5953, I'm referencing it here rather than marking it as resolved.
 
### Issues Resolved
Resolves #6150
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
