### PR TITLE
Feature/aggregate sum action

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -42,6 +42,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
     * [append](#append)
     * [count](#count)
     * [histogram](#histogram)
+    * [sum](#sum)
     * [rate_limiter](#rate_limiter)
     * [percent_sampler](#percent_sampler)
     * [tail_sampler](#tail_sampler)
@@ -157,6 +158,24 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
       If raw output format is used, the following event will be created and processed by the rest of the pipeline when the group is concluded:
       ```json
         {"request":"/index.html","aggr._max":0.55,"aggr._min":0.15,"aggr._buckets":[0.0, 0.25, 0.5],"sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "aggr._bucket_counts":[0,2,1,1],"aggr._count":4,"aggr._key":"latency","aggr._startTime":"2022-12-14T06:39:06.081Z","aggr._sum":1.15}
+      ```
+
+### <a name="sum"></a>
+* `sum`: Sums the numeric value of a configured `key` for events belonging to the same group and generates a new event with the total. All events that make up the combined Event will be dropped.
+    * It supports the following config options
+       * `key` (Required): name of the numeric field in the events to sum
+       * `metric_name`: metric name to use when the OTel metrics format is used, default name is `sum`
+       * `count_key`: key name to use for storing the number of events that contributed to the sum in `raw` output format, default name is `aggr._count`
+       * `output_format`: `otel_metrics` (default, outputs OTel metrics SUM type with the total as value) or `raw` (JSON with the total and `count_key`)
+    * Given the following three Events with `identification_keys: ["sourceIp", "destination_ip"]` and `key` as `bytes_out`:
+      ```json
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes_out": 1234 }
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes_out": 4321 }
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes_out": 100 }
+      ```
+      The following Event will be created and processed by the rest of the pipeline when the group is concluded:
+      ```json
+        {"kind":"SUM","name":"sum","value":5655.0,"isMonotonic":false,"sourceIp":"127.0.0.1","destinationIp":"192.168.0.1"}
       ```
 
 ### <a name="rate_limiter"></a>

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateAction.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils.convertUnixNanosToISO8601;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
@@ -34,7 +35,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 
 /**
  * Sums the numeric value of a configured key for events in the same group and emits the total on concludeGroup.
@@ -46,6 +47,7 @@ public class SumAggregateAction implements AggregateAction {
     private static final String SUM_KEY = "aggr._sum";
     private static final String START_TIME_KEY = "aggr._start_time";
     private static final String END_TIME_KEY = "aggr._end_time";
+    private static final Set<String> RESERVED_GROUP_STATE_KEYS = Set.of(EXEMPLAR_KEY, SUM_KEY, START_TIME_KEY, END_TIME_KEY);
     static final String EVENT_TYPE = "event";
     static final String SUM_METRIC_DESCRIPTION = "Sum of the events";
     static final String SUM_METRIC_UNIT = "1";
@@ -60,6 +62,10 @@ public class SumAggregateAction implements AggregateAction {
         this.countKey = sumAggregateActionConfig.getCountKey();
         this.outputFormat = sumAggregateActionConfig.getOutputFormat();
         this.metricName = sumAggregateActionConfig.getMetricName();
+        if (RESERVED_GROUP_STATE_KEYS.contains(countKey)) {
+            throw new InvalidPluginConfigurationException(
+                    String.format("count_key \"%s\" collides with a key reserved internally by the sum action", countKey));
+        }
     }
 
     public Exemplar createExemplar(final Event event, final double value) {
@@ -117,7 +123,6 @@ public class SumAggregateAction implements AggregateAction {
         }
         return AggregateActionResponse.nullEventResponse();
     }
-    
 
     @Override
     public AggregateActionOutput concludeGroup(final AggregateActionInput aggregateActionInput) {
@@ -132,7 +137,7 @@ public class SumAggregateAction implements AggregateAction {
         final Exemplar exemplar = (Exemplar) groupState.remove(EXEMPLAR_KEY);
         groupState.remove(END_TIME_KEY);
         if (outputFormat == OutputFormat.RAW) {
-            groupState.put(START_TIME_KEY, startTime.atZone(ZoneId.of(ZoneId.systemDefault().toString())).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
+            groupState.put(START_TIME_KEY, startTime.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
             event = JacksonEvent.builder()
                     .withEventType(EVENT_TYPE)
                     .withData(groupState)

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateAction.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import org.opensearch.dataprepper.model.metric.JacksonSum;
+import org.opensearch.dataprepper.model.metric.Exemplar;
+import org.opensearch.dataprepper.model.metric.DefaultExemplar;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCommonUtils.convertUnixNanosToISO8601;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.trace.Span;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionOutput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor;
+import static org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor.getTimeNanos;
+import org.opensearch.dataprepper.plugins.processor.aggregate.GroupState;
+import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Sums the numeric value of a configured key for events in the same group and emits the total on concludeGroup.
+ */
+@DataPrepperPlugin(name = "sum", pluginType = AggregateAction.class, pluginConfigurationType = SumAggregateActionConfig.class)
+public class SumAggregateAction implements AggregateAction {
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    private static final String EXEMPLAR_KEY = "__exemplar";
+    private static final String SUM_KEY = "aggr._sum";
+    private static final String START_TIME_KEY = "aggr._start_time";
+    private static final String END_TIME_KEY = "aggr._end_time";
+    static final String EVENT_TYPE = "event";
+    static final String SUM_METRIC_DESCRIPTION = "Sum of the events";
+    static final String SUM_METRIC_UNIT = "1";
+    private final String key;
+    private final String countKey;
+    private final OutputFormat outputFormat;
+    private final String metricName;
+
+    @DataPrepperPluginConstructor
+    public SumAggregateAction(final SumAggregateActionConfig sumAggregateActionConfig) {
+        this.key = sumAggregateActionConfig.getKey();
+        this.countKey = sumAggregateActionConfig.getCountKey();
+        this.outputFormat = sumAggregateActionConfig.getOutputFormat();
+        this.metricName = sumAggregateActionConfig.getMetricName();
+    }
+
+    public Exemplar createExemplar(final Event event, final double value) {
+        final long curTimeNanos = getTimeNanos(Instant.now());
+        final Map<String, Object> attributes = event.toMap();
+        String spanId = null;
+        String traceId = null;
+        if (event instanceof Span) {
+            final Span span = (Span) event;
+            spanId = span.getSpanId();
+            traceId = span.getTraceId();
+        }
+        return new DefaultExemplar(convertUnixNanosToISO8601(curTimeNanos), value, spanId, traceId, attributes);
+    }
+
+    @Override
+    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
+        final Number value = event.get(key, Number.class);
+        if (value == null) {
+            return AggregateActionResponse.nullEventResponse();
+        }
+        final double doubleValue = value.doubleValue();
+
+        Instant eventStartTime = Instant.now();
+        Instant eventEndTime = eventStartTime;
+        final Object startTime = event.get(START_TIME_KEY, Object.class);
+        final Object endTime = event.get(END_TIME_KEY, Object.class);
+        if (startTime != null) {
+            eventStartTime = AggregateProcessor.convertObjectToInstant(startTime);
+        }
+        if (endTime != null) {
+            eventEndTime = AggregateProcessor.convertObjectToInstant(endTime);
+        }
+
+        if (groupState.get(SUM_KEY) == null) {
+            groupState.putAll(aggregateActionInput.getIdentificationKeys());
+            groupState.put(SUM_KEY, doubleValue);
+            groupState.put(countKey, 1);
+            groupState.put(EXEMPLAR_KEY, createExemplar(event, doubleValue));
+            groupState.put(START_TIME_KEY, eventStartTime);
+            groupState.put(END_TIME_KEY, eventEndTime);
+        } else {
+            final double sum = (double) groupState.get(SUM_KEY);
+            groupState.put(SUM_KEY, sum + doubleValue);
+            groupState.put(countKey, (Integer) groupState.get(countKey) + 1);
+            final Instant groupStartTime = (Instant) groupState.get(START_TIME_KEY);
+            final Instant groupEndTime = (Instant) groupState.get(END_TIME_KEY);
+            if (eventStartTime.isBefore(groupStartTime)) {
+                groupState.put(START_TIME_KEY, eventStartTime);
+            }
+            if (eventEndTime.isAfter(groupEndTime)) {
+                groupState.put(END_TIME_KEY, eventEndTime);
+            }
+        }
+        return AggregateActionResponse.nullEventResponse();
+    }
+    
+
+    @Override
+    public AggregateActionOutput concludeGroup(final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
+        if (groupState.isEmpty()) {
+            return null;
+        }
+
+        Event event;
+        final Instant startTime = (Instant) groupState.get(START_TIME_KEY);
+        final Instant endTime = (Instant) groupState.get(END_TIME_KEY);
+        final Exemplar exemplar = (Exemplar) groupState.remove(EXEMPLAR_KEY);
+        groupState.remove(END_TIME_KEY);
+        if (outputFormat == OutputFormat.RAW) {
+            groupState.put(START_TIME_KEY, startTime.atZone(ZoneId.of(ZoneId.systemDefault().toString())).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
+            event = JacksonEvent.builder()
+                    .withEventType(EVENT_TYPE)
+                    .withData(groupState)
+                    .withEventHandle(aggregateActionInput.getEventHandle())
+                    .build();
+        } else {
+            final double sumValue = (double) groupState.get(SUM_KEY);
+            groupState.remove(SUM_KEY);
+            groupState.remove(countKey);
+            groupState.remove(START_TIME_KEY);
+            final Map<String, Object> attr = new HashMap<>();
+            groupState.forEach((k, v) -> attr.put((String) k, v));
+            final JacksonSum sum = JacksonSum.builder()
+                    .withName(metricName)
+                    .withDescription(SUM_METRIC_DESCRIPTION)
+                    .withTime(convertUnixNanosToISO8601(getTimeNanos(endTime)))
+                    .withStartTime(convertUnixNanosToISO8601(getTimeNanos(startTime)))
+                    .withIsMonotonic(false)
+                    .withUnit(SUM_METRIC_UNIT)
+                    .withAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA.name())
+                    .withValue(sumValue)
+                    .withExemplars(List.of(exemplar))
+                    .withAttributes(attr)
+                    .withEventHandle(aggregateActionInput.getEventHandle())
+                    .build(false);
+            event = (Event) sum;
+        }
+
+        return new AggregateActionOutput(List.of(event));
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.validation.constraints.NotNull;
+
+@JsonPropertyOrder
+@JsonClassDescription("The <code>sum</code> action sums the numeric value of a configured <code>key</code> for events that belong to the same " +
+        "group and generates a new event with the values of the <code>identification_keys</code> and the accumulated sum.")
+public class SumAggregateActionConfig {
+    static final String SUM_METRIC_NAME = "sum";
+    public static final String DEFAULT_COUNT_KEY = "aggr._count";
+
+    @JsonPropertyDescription("Name of the field in the events to sum. The value of this field must be numeric.")
+    @JsonProperty("key")
+    @NotNull
+    String key;
+
+    @JsonPropertyDescription("Format of the aggregated event. otel_metrics is the default output format, which outputs in OTel metrics SUM type with the total as value. " +
+            "raw outputs a JSON object with the total and the count of events that contributed to it.")
+    @JsonProperty(value = "output_format", defaultValue = "otel_metrics")
+    OutputFormat outputFormat = OutputFormat.OTEL_METRICS;
+
+    @JsonPropertyDescription("Metric name to be used when the OTel metrics format is used. The default value is <code>sum</code>.")
+    @JsonProperty(value = "metric_name", defaultValue = SUM_METRIC_NAME)
+    String metricName = SUM_METRIC_NAME;
+
+    @JsonPropertyDescription("The key in the aggregate event that will have the number of events that contributed to the sum. Default name is <code>aggr._count</code>.")
+    @JsonProperty(value = "count_key", defaultValue = DEFAULT_COUNT_KEY)
+    String countKey = DEFAULT_COUNT_KEY;
+
+    public String getKey() {
+        return key;
+    }
+
+    public OutputFormat getOutputFormat() {
+        return outputFormat;
+    }
+
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public String getCountKey() {
+        return countKey;
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionConfigTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.opensearch.dataprepper.plugins.processor.aggregate.actions.SumAggregateActionConfig.DEFAULT_COUNT_KEY;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ExtendWith(MockitoExtension.class)
+public class SumAggregateActionConfigTests {
+    private SumAggregateActionConfig sumAggregateActionConfig;
+
+    private SumAggregateActionConfig createObjectUnderTest() {
+        return new SumAggregateActionConfig();
+    }
+
+    @BeforeEach
+    void setup() {
+        sumAggregateActionConfig = createObjectUnderTest();
+    }
+
+    @Test
+    void testDefault() {
+        assertThat(sumAggregateActionConfig.getCountKey(), equalTo(DEFAULT_COUNT_KEY));
+        assertThat(sumAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS));
+        assertThat(sumAggregateActionConfig.getMetricName(), equalTo(SumAggregateActionConfig.SUM_METRIC_NAME));
+    }
+
+    @Test
+    void testValidConfig() throws NoSuchFieldException, IllegalAccessException {
+        final String testKey = UUID.randomUUID().toString();
+        setField(SumAggregateActionConfig.class, sumAggregateActionConfig, "key", testKey);
+        assertThat(sumAggregateActionConfig.getKey(), equalTo(testKey));
+
+        final String testCountKey = UUID.randomUUID().toString();
+        setField(SumAggregateActionConfig.class, sumAggregateActionConfig, "countKey", testCountKey);
+        assertThat(sumAggregateActionConfig.getCountKey(), equalTo(testCountKey));
+
+        final OutputFormat testOutputFormat = OutputFormat.RAW;
+        setField(SumAggregateActionConfig.class, sumAggregateActionConfig, "outputFormat", testOutputFormat);
+        assertThat(sumAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.RAW));
+
+        final String testName = UUID.randomUUID().toString();
+        setField(SumAggregateActionConfig.class, sumAggregateActionConfig, "metricName", testName);
+        assertThat(sumAggregateActionConfig.getMetricName(), equalTo(testName));
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import org.junit.jupiter.api.Test;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.metric.Exemplar;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
+import org.opensearch.dataprepper.model.trace.Span;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionOutput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionTestUtils;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SumAggregateActionTest {
+    private AggregateAction sumAggregateAction;
+
+    private AggregateAction createObjectUnderTest(final SumAggregateActionConfig config) {
+        return new SumAggregateAction(config);
+    }
+
+    private SumAggregateActionConfig createConfig(final String key) throws NoSuchFieldException, IllegalAccessException {
+        final SumAggregateActionConfig config = new SumAggregateActionConfig();
+        setField(SumAggregateActionConfig.class, config, "key", key);
+        return config;
+    }
+
+    @Test
+    void testSumAggregationWithEmptyGroupStateReturnsNull() throws NoSuchFieldException, IllegalAccessException {
+        sumAggregateAction = createObjectUnderTest(createConfig(UUID.randomUUID().toString()));
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Map.of());
+        final AggregateActionOutput actionOutput = sumAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(actionOutput, equalTo(null));
+    }
+
+    @Test
+    void testHandleEventWithMissingKeyReturnsNullEventAndDoesNotStartGroup() throws NoSuchFieldException, IllegalAccessException {
+        final String key = UUID.randomUUID().toString();
+        sumAggregateAction = createObjectUnderTest(createConfig(key));
+        final Map<Object, Object> eventMap = Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final Event testEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+
+        final AggregateActionResponse response = sumAggregateAction.handleEvent(testEvent, aggregateActionInput);
+        assertThat(response.getEvent(), equalTo(null));
+
+        final AggregateActionOutput actionOutput = sumAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(actionOutput, equalTo(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void testSumAggregateRawFormat(final int testCount) throws NoSuchFieldException, IllegalAccessException {
+        final String key = UUID.randomUUID().toString();
+        final SumAggregateActionConfig config = createConfig(key);
+        setField(SumAggregateActionConfig.class, config, "outputFormat", OutputFormat.RAW);
+        sumAggregateAction = createObjectUnderTest(config);
+
+        final String identificationKey = UUID.randomUUID().toString();
+        final String identificationValue = UUID.randomUUID().toString();
+        final Map<Object, Object> eventMap = Collections.singletonMap(identificationKey, identificationValue);
+        final Event testEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+
+        double expectedSum = 0;
+        for (int i = 0; i < testCount; i++) {
+            final int value = i + 1;
+            expectedSum += value;
+            testEvent.put(key, value);
+            final AggregateActionResponse response = sumAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(response.getEvent(), equalTo(null));
+        }
+
+        final AggregateActionOutput actionOutput = sumAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+        final Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap(identificationKey, identificationValue));
+        expectedEventMap.put("aggr._sum", expectedSum);
+        expectedEventMap.put(SumAggregateActionConfig.DEFAULT_COUNT_KEY, testCount);
+        expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
+        assertThat(result.get(0).toMap(), hasKey("aggr._start_time"));
+        assertThat(result.get(0).toMap(), not(hasKey("aggr._end_time")));
+        assertThat(result.get(0).toMap(), not(hasKey("__exemplar")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void testSumAggregateOTelFormat(final int testCount) throws NoSuchFieldException, IllegalAccessException {
+        final String key = UUID.randomUUID().toString();
+        final SumAggregateActionConfig config = createConfig(key);
+        final String testName = UUID.randomUUID().toString();
+        setField(SumAggregateActionConfig.class, config, "metricName", testName);
+        sumAggregateAction = createObjectUnderTest(config);
+
+        final String identificationKey = UUID.randomUUID().toString();
+        final String identificationValue = UUID.randomUUID().toString();
+        final Map<Object, Object> eventMap = Collections.singletonMap(identificationKey, identificationValue);
+        final Event testEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+
+        double expectedSum = 0;
+        for (int i = 0; i < testCount; i++) {
+            final double value = i + 0.5;
+            expectedSum += value;
+            testEvent.put(key, value);
+            final AggregateActionResponse response = sumAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(response.getEvent(), equalTo(null));
+        }
+
+        final AggregateActionOutput actionOutput = sumAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+        final Map<String, Object> expectedEventMap = new HashMap<>();
+        expectedEventMap.put("value", expectedSum);
+        expectedEventMap.put("name", testName);
+        expectedEventMap.put("description", "Sum of the events");
+        expectedEventMap.put("isMonotonic", false);
+        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
+        expectedEventMap.put("unit", "1");
+        expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
+        assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
+        final JacksonMetric metric = (JacksonMetric) result.get(0);
+        assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
+        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey("time"));
+
+        final List<Map<String, Object>> exemplars = (List<Map<String, Object>>) result.get(0).toMap().get("exemplars");
+        assertThat(exemplars.size(), equalTo(1));
+        final Map<String, Object> exemplar = exemplars.get(0);
+        final Map<String, Object> attributes = (Map<String, Object>) exemplar.get("attributes");
+        assertThat(attributes.get(identificationKey), equalTo(identificationValue));
+        assertTrue(attributes.containsKey(key));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void testSumAggregateWithMultipleGroups(final int testCount) throws NoSuchFieldException, IllegalAccessException {
+        final String key = UUID.randomUUID().toString();
+        sumAggregateAction = createObjectUnderTest(createConfig(key));
+
+        final String key1 = "key-" + UUID.randomUUID();
+        final String value1 = UUID.randomUUID().toString();
+        final String key2 = "key-" + UUID.randomUUID();
+        final String value2 = UUID.randomUUID().toString();
+        final Map<Object, Object> eventMap = Collections.singletonMap(key1, value1);
+        final Event testEvent = JacksonEvent.builder().withEventType("event").withData(eventMap).build();
+        final Map<Object, Object> eventMap2 = Collections.singletonMap(key2, value2);
+        final Event testEvent2 = JacksonEvent.builder().withEventType("event").withData(eventMap2).build();
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+        final AggregateActionInput aggregateActionInput2 = new AggregateActionTestUtils.TestAggregateActionInput(eventMap2);
+
+        double expectedSum1 = 0;
+        double expectedSum2 = 0;
+        for (int i = 0; i < testCount; i++) {
+            expectedSum1 += i;
+            expectedSum2 += i * 2;
+            testEvent.put(key, (double) i);
+            testEvent2.put(key, (double) (i * 2));
+            sumAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            sumAggregateAction.handleEvent(testEvent2, aggregateActionInput2);
+        }
+
+        final AggregateActionOutput actionOutput1 = sumAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(actionOutput1.getEvents().get(0).toMap().get("value"), equalTo(expectedSum1));
+
+        final AggregateActionOutput actionOutput2 = sumAggregateAction.concludeGroup(aggregateActionInput2);
+        assertThat(actionOutput2.getEvents().get(0).toMap().get("value"), equalTo(expectedSum2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void testSumAggregateOTelFormatWithStartAndEndTimesInTheEvent(final int testCount) throws NoSuchFieldException, IllegalAccessException {
+        final String key = UUID.randomUUID().toString();
+        sumAggregateAction = createObjectUnderTest(createConfig(key));
+
+        final String identificationKey = UUID.randomUUID().toString();
+        final String identificationValue = UUID.randomUUID().toString();
+        final Instant testTime = Instant.ofEpochSecond(Instant.now().getEpochSecond());
+        final Map<Object, Object> eventMap = Collections.singletonMap(identificationKey, identificationValue);
+        final Event testEvent = JacksonEvent.builder().withEventType("event").withData(eventMap).build();
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+        final Random random = new Random();
+
+        double expectedSum = 0;
+        for (int i = 0; i < testCount; i++) {
+            final double value = i + 1;
+            expectedSum += value;
+            testEvent.put(key, value);
+            // the last event reports the earliest start time and the latest end time seen so far,
+            // forcing both the "earlier start" and "later end" group update branches to run
+            final Instant sTime = (i == testCount - 1) ? testTime : testTime.plusSeconds(10 + random.nextInt(5));
+            final Instant eTime = (i == testCount - 1) ? testTime.plusSeconds(200) : testTime.plusSeconds(50 + random.nextInt(45));
+            testEvent.put("aggr._start_time", (i % 2 == 0) ? sTime : sTime.toString());
+            testEvent.put("aggr._end_time", (i % 2 == 0) ? eTime : eTime.toString());
+            final AggregateActionResponse response = sumAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(response.getEvent(), equalTo(null));
+        }
+
+        final AggregateActionOutput actionOutput = sumAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).toMap().get("value"), equalTo(expectedSum));
+        assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
+        assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(200).toString()));
+    }
+
+    @Test
+    void testCreateExemplarWithSpanEventUsesSpanIdAndTraceId() throws NoSuchFieldException, IllegalAccessException {
+        final SumAggregateAction action = new SumAggregateAction(createConfig(UUID.randomUUID().toString()));
+        final Span spanEvent = mock(Span.class);
+        final String spanId = UUID.randomUUID().toString();
+        final String traceId = UUID.randomUUID().toString();
+        when(spanEvent.getSpanId()).thenReturn(spanId);
+        when(spanEvent.getTraceId()).thenReturn(traceId);
+        when(spanEvent.toMap()).thenReturn(Map.of());
+
+        final Exemplar exemplar = action.createExemplar(spanEvent, 42.0);
+
+        assertThat(exemplar.getSpanId(), equalTo(spanId));
+        assertThat(exemplar.getTraceId(), equalTo(traceId));
+        assertThat(exemplar.getValue(), equalTo(42.0));
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/SumAggregateActionTest.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.metric.Exemplar;
 import org.opensearch.dataprepper.model.metric.JacksonMetric;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.trace.Span;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +27,7 @@ import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionRes
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionTestUtils;
 
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -244,6 +246,15 @@ public class SumAggregateActionTest {
         assertThat(result.get(0).toMap().get("value"), equalTo(expectedSum));
         assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
         assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(200).toString()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"__exemplar", "aggr._sum", "aggr._start_time", "aggr._end_time"})
+    void testConstructorThrowsWhenCountKeyCollidesWithReservedKey(final String reservedKey) throws NoSuchFieldException, IllegalAccessException {
+        final SumAggregateActionConfig config = createConfig(UUID.randomUUID().toString());
+        setField(SumAggregateActionConfig.class, config, "countKey", reservedKey);
+
+        assertThrows(InvalidPluginConfigurationException.class, () -> new SumAggregateAction(config));
     }
 
     @Test


### PR DESCRIPTION
### Description
Adds a `sum` aggregate action that sums a numeric field across events in the same group and emits the total as an OTel Sum metric (or a raw event). Modeled on the existing `count` action.

Getting a per-group field sum today means emitting a `histogram` and using only its `_sum` output, which also produces `_bucket`, `_count`, `_min`, and `_max` series plus per-event bucket bookkeeping, just to get one scalar. A first-class `sum` action gives one config, one time series, and correct OTel Sum semantics.

A few decisions worth flagging for review:

- **`isMonotonic=false`.** Unlike an event count, an arbitrary summed field isn't guaranteed non-negative, so the emitted Sum is non-monotonic.
- **Numeric parsing.** The issue suggests borrowing `HistogramAggregateAction`'s explicit type branching. I used `Number.doubleValue()` directly instead: for every `Number` subtype (including the boxed primitives histogram branches on) `doubleValue()` returns the identical result (it's `(double) primitiveValue` in the JDK), and histogram's own fallback routes everything else through the same call. The branching would be equivalent but redundant here. Happy to match histogram if you'd prefer consistency across the two actions.
- **Optional `count_key`.** In `raw` output mode the event also carries the number of events that contributed to the sum. Defaults to `aggr._count`.

### Issues Resolved
Resolves #7024

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

README updated in this PR. Happy to file a docs-website issue if maintainers want one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.