### PR TITLE
fix(rds-source): Use null-safe comparison for CDC update event column values

### DIFF
--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetector.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -96,7 +97,7 @@ public class CascadingActionDetector {
                 // Find out for this row, which columns are changing
                 LOG.debug("Checking for updated columns");
                 final Map<String, Object> updatedColumnsAndValues = IntStream.range(0, row.getKey().length)
-                        .filter(i -> !row.getKey()[i].equals(row.getValue()[i]))
+                        .filter(i -> !Objects.equals(row.getKey()[i], row.getValue()[i]))
                         .mapToObj(i -> tableMetadata.getColumnNames().get(i))
                         .collect(Collectors.toMap(
                                 column -> column,

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListener.java
@@ -350,7 +350,7 @@ public class BinlogEventListener implements BinaryLogClient.EventListener {
             final int columnCount = Math.min(columnNames.size(), row.getKey().length);
             for (int i = 0; i < columnCount; i++) {
                 if (tableMetadata.getPrimaryKeys().contains(columnNames.get(i)) &&
-                        !row.getKey()[i].equals(row.getValue()[i])) {
+                        !Objects.equals(row.getKey()[i], row.getValue()[i])) {
                     LOG.debug("Primary keys were updated");
                     // add delete event for the old row data
                     rows.add(row.getKey());

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/LogicalReplicationEventProcessor.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -374,7 +375,7 @@ public class LogicalReplicationEventProcessor {
 
     private boolean isPrimaryKeyChanged(Map<String, Object> oldRowDataMap, Map<String, Object> newRowDataMap, List<String> primaryKeys) {
         for (String primaryKey : primaryKeys) {
-            if (!oldRowDataMap.get(primaryKey).equals(newRowDataMap.get(primaryKey))) {
+            if (!Objects.equals(oldRowDataMap.get(primaryKey), newRowDataMap.get(primaryKey))) {
                 return true;
             }
         }

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetectorTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/resync/CascadingActionDetectorTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 import static org.opensearch.dataprepper.plugins.source.rds.model.TableMetadata.DOT_DELIMITER;
 
 @ExtendWith(MockitoExtension.class)
@@ -142,6 +143,24 @@ class CascadingActionDetectorTest {
         assertThat(progressState.getForeignKeyName(), is("foreign-key1"));
         assertThat(progressState.getUpdatedValue(), nullValue());
         assertThat(progressState.getPrimaryKeys(), is(primaryKeys));
+    }
+
+    @Test
+    void testDetectCascadingUpdates_does_not_throw_when_before_value_is_null() {
+        UpdateRowsEventData data = mock(UpdateRowsEventData.class);
+        List<Map.Entry<Serializable[], Serializable[]>> rows = List.of(Map.entry(new Serializable[]{null}, new Serializable[]{"new-value"}));
+        long timestampInMillis = Instant.now().toEpochMilli();
+        List<String> primaryKeys = List.of("primary-key");
+        when(event.getData()).thenReturn(data);
+        when(event.getHeader().getTimestamp()).thenReturn(timestampInMillis);
+        when(tableMetadata.getFullTableName()).thenReturn("test-database.parent-table1");
+        when(data.getRows()).thenReturn(rows);
+        when(tableMetadata.getColumnNames()).thenReturn(List.of("referenced-column"));
+        when(tableMetadata.getPrimaryKeys()).thenReturn(primaryKeys);
+
+        objectUnderTest.detectCascadingUpdates(event, parentTableMap, tableMetadata);
+
+        verify(sourceCoordinator).createPartition(any(ResyncPartition.class));
     }
 
     private CascadingActionDetector createObjectUnderTest() {

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -375,6 +375,43 @@ class BinlogEventListenerTest {
         assertThat(bulkActionCaptor.getValue().get(1), is(OpenSearchBulkActions.INDEX));
     }
 
+    @ParameterizedTest
+    @EnumSource(names = {"UPDATE_ROWS", "EXT_UPDATE_ROWS"})
+    void test_handleUpdateEvent_does_not_throw_when_before_value_is_null(EventType eventType) throws NoSuchFieldException, IllegalAccessException {
+        // Nullable column has null in the before-image of an UPDATE event
+        final UpdateRowsEventData data = mock(UpdateRowsEventData.class);
+        final Serializable[] oldData = new Serializable[]{1, null};
+        final Serializable[] newData = new Serializable[]{1, "new-value"};
+        final List<Map.Entry<Serializable[], Serializable[]>> rows = List.of(Map.entry(oldData, newData));
+        final long tableId = 1234L;
+        when(binlogEvent.getHeader().getEventType()).thenReturn(eventType);
+        when(binlogEvent.getData()).thenReturn(data);
+        when(data.getTableId()).thenReturn(tableId);
+        when(objectUnderTest.isValidTableId(tableId)).thenReturn(true);
+        when(data.getRows()).thenReturn(rows);
+
+        final TableMetadata tableMetadata = mock(TableMetadata.class);
+        final Map<Long, TableMetadata> tableMetadataMap = Map.of(tableId, tableMetadata);
+        Field tableMetadataMapField = BinlogEventListener.class.getDeclaredField("tableMetadataMap");
+        tableMetadataMapField.setAccessible(true);
+        tableMetadataMapField.set(objectUnderTest, tableMetadataMap);
+        when(tableMetadata.getPrimaryKeys()).thenReturn(List.of("col1"));
+        when(tableMetadata.getColumnNames()).thenReturn(List.of("col1", "col2"));
+
+        objectUnderTest.onEvent(binlogEvent);
+
+        verifyHandlerCallHelper();
+        verify(objectUnderTest).handleUpdateEvent(binlogEvent);
+
+        ArgumentCaptor<List<Serializable[]>> rowListCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<OpenSearchBulkActions>> bulkActionCaptor = ArgumentCaptor.forClass(List.class);
+        verify(objectUnderTest).handleRowChangeEvent(eq(binlogEvent), eq(tableId), rowListCaptor.capture(), bulkActionCaptor.capture(), eq(StreamEventType.UPDATE));
+
+        // No primary key change, only INDEX for the new row
+        assertThat(rowListCaptor.getValue().size(), is(1));
+        assertThat(bulkActionCaptor.getValue().get(0), is(OpenSearchBulkActions.INDEX));
+    }
+
     private BinlogEventListener createObjectUnderTest() {
         return BinlogEventListener.create(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
                 streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadingActionDetector,


### PR DESCRIPTION
### Description

When processing CDC update events (MySQL binlog `EXT_UPDATE_ROWS` or PostgreSQL logical replication), a `NullPointerException` is thrown if a nullable column has a `null` value in the before-image of the row. This occurs because the code uses `.equals()` directly on the column value without null-checking.

This change replaces unsafe `.equals()` calls with `Objects.equals()` in three locations:

1. `CascadingActionDetector.detectCascadingUpdates()` — cascade update detection filter
2. `BinlogEventListener.handleUpdateEvent()` — primary key change detection
3. `LogicalReplicationEventProcessor.isPrimaryKeyChanged()` — PK change detection (Postgres path)

### Issues Resolved

Resolves the NullPointerException observed in production:
```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "java.util.Map$Entry.getKey()[i]" is null
    at CascadingActionDetector.lambda$detectCascadingUpdates$0(CascadingActionDetector.java:99)
```

### Testing

- Added unit test for `BinlogEventListener` verifying no NPE when before-value is null
- Added unit test for `CascadingActionDetector` verifying cascade detection works with null before-values
- All existing rds-source tests pass

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO