### PR TITLE
feat(prometheus-sink): add external_labels

### DIFF
--- a/data-prepper-plugins/prometheus-sink/README.md
+++ b/data-prepper-plugins/prometheus-sink/README.md
@@ -91,7 +91,56 @@ pipeline:
 | `idle_timeout` | `60s` | Connection idle timeout. Must be between 1s and 600s. |
 | `out_of_order_time_window` | `10s` | Time window for handling out-of-order metric samples. |
 | `sanitize_names` | `true` | Whether to sanitize metric names to be Prometheus-compliant. |
+| `external_labels` | `{}` | Labels added to every time series this sink writes. See [External Labels](#external-labels). |
 | `threshold` | See below | Buffer threshold configuration. See [Threshold Configuration](#threshold-configuration). |
+
+### <a name="external-labels">External Labels</a>
+
+`external_labels` is a map of label names to label values that is added to every time series the sink
+writes. The primary use is to keep the series of each Data Prepper instance distinct when a metric
+pipeline runs on more than one instance.
+
+Labels on a time series come only from the metric's attributes, so every instance running the same
+pipeline produces series with identical labels. Prometheus, AMP, Cortex, and Mimir all deduplicate on
+series plus timestamp, so they keep one instance's sample and drop the rest without reporting an
+error. An `N`-instance deployment then reports roughly `1/N` of the true value.
+
+Give each instance a distinct value for one label to avoid the collision:
+
+```yaml
+pipeline:
+  ...
+  sink:
+    - prometheus:
+        url: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-xxxxxxxx-xxxx/api/v1/remote_write"
+        external_labels:
+          dp_instance: "replica-a"
+```
+
+Consumers then aggregate the label away to recover the true value, which is the standard Prometheus
+HA-replica pattern:
+
+```
+sum without (dp_instance) (test_log_count)
+```
+
+Values are literal strings. This sink does not interpret `${...}` in a value, so each instance which
+needs a distinct value needs its own value in configuration. To derive a label value at runtime
+instead, add it as a metric attribute before the sink, since every attribute becomes a label:
+
+```yaml
+processor:
+  - add_entries:
+      entries:
+        - key: /attributes/dp_instance
+          value_expression: "..."
+```
+
+Label names must match `[a-zA-Z_][a-zA-Z0-9_]*`. Names beginning with `__` are reserved by Prometheus,
+and `le`, `ge`, and `quantile` are reserved by the sink for histogram, exponential histogram, and
+summary series, so none of these are permitted. If an external label has the same name as a metric
+attribute, the metric attribute wins and the external label is not added to that series, which
+matches how Prometheus applies its own `external_labels`.
 
 ### <a name="threshold-configuration">Threshold Configuration</a>
 

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/configuration/PrometheusSinkConfiguration.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/configuration/PrometheusSinkConfiguration.java
@@ -17,8 +17,13 @@ import org.hibernate.validator.constraints.time.DurationMax;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.opensearch.dataprepper.aws.api.AwsConfig;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
+import org.opensearch.dataprepper.plugins.sink.prometheus.service.PrometheusTimeSeries;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import static com.linecorp.armeria.common.MediaTypeNames.X_PROTOBUF;
 
@@ -35,6 +40,9 @@ public class PrometheusSinkConfiguration {
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration DEFAULT_OUT_OF_ORDER_TIME_WINDOW = Duration.ofSeconds(10);
+
+    private static final Pattern VALID_LABEL_NAME_PATTERN = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+    private static final String RESERVED_LABEL_NAME_PREFIX = "__";
 
     @JsonProperty("aws")
     @Valid
@@ -86,6 +94,9 @@ public class PrometheusSinkConfiguration {
 
     @JsonProperty("sanitize_names")
     private boolean sanitizeNames = true;
+
+    @JsonProperty("external_labels")
+    private Map<String, String> externalLabels = Collections.emptyMap();
 
     public boolean isInsecure() {
         return insecure;
@@ -146,6 +157,25 @@ public class PrometheusSinkConfiguration {
         return idleTimeout;
     }
 
+    /**
+     * Returns the labels to add to every time series produced by this sink.
+     *
+     * @return an immutable copy of the external labels, never null
+     */
+    public Map<String, String> getExternalLabels() {
+        if (externalLabels == null || externalLabels.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(externalLabels));
+    }
+
+    private boolean isValidExternalLabelName(final String name) {
+        return name != null &&
+                VALID_LABEL_NAME_PATTERN.matcher(name).matches() &&
+                !name.startsWith(RESERVED_LABEL_NAME_PREFIX) &&
+                !PrometheusTimeSeries.RESERVED_LABEL_NAMES.contains(name);
+    }
+
     @AssertTrue(message = "url must be https when insecure is not set to true.")
     boolean isHttpsOrInsecure() {
         if (url == null) {
@@ -185,5 +215,22 @@ public class PrometheusSinkConfiguration {
             return false;
         }
         return true;
+    }
+
+    @AssertTrue(message = "external_labels names must match [a-zA-Z_][a-zA-Z0-9_]*, must not begin with \"__\", " +
+            "and must not be a name this sink adds itself (\"le\", \"ge\", or \"quantile\").")
+    boolean isValidExternalLabelNames() {
+        if (externalLabels == null) {
+            return true;
+        }
+        return externalLabels.keySet().stream().allMatch(this::isValidExternalLabelName);
+    }
+
+    @AssertTrue(message = "external_labels values must not be empty.")
+    boolean isValidExternalLabelValues() {
+        if (externalLabels == null) {
+            return true;
+        }
+        return externalLabels.values().stream().allMatch(value -> value != null && !value.isEmpty());
     }
 }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferEntry.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferEntry.java
@@ -15,14 +15,16 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.metric.Metric;
 
+import java.util.Map;
+
 public class PrometheusSinkBufferEntry implements SinkBufferEntry {
 
     final Event event;
     final PrometheusTimeSeries timeSeries;
 
-    public PrometheusSinkBufferEntry(final Event event, final boolean sanitizeNames) throws Exception {
+    public PrometheusSinkBufferEntry(final Event event, final boolean sanitizeNames, final Map<String, String> externalLabels) throws Exception {
         this.event = event;
-        timeSeries = getTimeSeriesForEvent(sanitizeNames);
+        timeSeries = getTimeSeriesForEvent(sanitizeNames, externalLabels);
     }
 
     public PrometheusTimeSeries getTimeSeries() {
@@ -44,9 +46,9 @@ public class PrometheusSinkBufferEntry implements SinkBufferEntry {
         return event;
     }
 
-    private PrometheusTimeSeries getTimeSeriesForEvent(final boolean sanitizeNames) throws Exception {
+    private PrometheusTimeSeries getTimeSeriesForEvent(final boolean sanitizeNames, final Map<String, String> externalLabels) throws Exception {
         if (event.getMetadata().getEventType().equals(EventType.METRIC.toString())) {
-            return new PrometheusTimeSeries((Metric)event, sanitizeNames);
+            return new PrometheusTimeSeries((Metric)event, sanitizeNames, externalLabels);
         }
         throw new RuntimeException("Not metric type");
     }

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkService.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.plugins.sink.prometheus.PrometheusHttpSender;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     static final String PLUGIN_NAME = "prometheus";
@@ -34,6 +35,7 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     private final PipelineDescription pipelineDescription;
     private final List<Record<Event>> dlqRecords;
     private final boolean sanitizeNames;
+    private final Map<String, String> externalLabels;
     private HeadlessPipeline dlqPipeline;
     private boolean dropIfNoDLQConfigured;
     private String pluginName;
@@ -50,6 +52,7 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
               new PrometheusSinkFlushContext(httpSender),
               sinkMetrics);
         sanitizeNames = prometheusSinkConfiguration.getSanitizeNames();
+        externalLabels = prometheusSinkConfiguration.getExternalLabels();
         this.dropIfNoDLQConfigured = false;
         this.dlqRecords = new ArrayList<>();
         this.httpSender = httpSender;
@@ -63,7 +66,7 @@ public class PrometheusSinkService extends DefaultSinkOutputStrategy {
     }
 
     public SinkBufferEntry getSinkBufferEntry(final Event event) throws Exception {
-        return new PrometheusSinkBufferEntry(event, sanitizeNames);
+        return new PrometheusSinkBufferEntry(event, sanitizeNames, externalLabels);
     }
 
     public void setDlqPipeline(HeadlessPipeline pipeline) {

--- a/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusTimeSeries.java
+++ b/data-prepper-plugins/prometheus-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusTimeSeries.java
@@ -31,8 +31,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class PrometheusTimeSeries {
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusTimeSeries.class);
@@ -55,6 +57,12 @@ public class PrometheusTimeSeries {
     private static final String PLUS_INF = "+Inf";
     private static final String RESOURCE_PREFIX = "resource_";
     private static final String SCOPE_PREFIX = "scope_";
+
+    /**
+     * The label names this sink adds to an individual time series. Remote write rejects a series which
+     * carries the same label name twice, so a configured label may not use any of these names.
+     */
+    public static final Set<String> RESERVED_LABEL_NAMES = Set.of(NAME_LABEL, QUANTILE_LABEL, LE_LABEL, GE_LABEL);
 
     private static final Map<String, String> otelToPrometheusUnitsMap = Map.ofEntries(
             Map.entry("d",    "days"),
@@ -91,7 +99,7 @@ public class PrometheusTimeSeries {
     private long baseLabelsSize;
     private int seriesSize;
 
-    public PrometheusTimeSeries(Metric metric, final boolean sanitizeNames) throws Exception {
+    public PrometheusTimeSeries(final Metric metric, final boolean sanitizeNames, final Map<String, String> externalLabels) throws Exception {
         this.sanitizeNames = sanitizeNames;
         this.metricName = sanitizeNames ? sanitizeMetricName(metric) : metric.getName();
 
@@ -106,6 +114,7 @@ public class PrometheusTimeSeries {
         // Process all attributes in one pass
         baseLabelsSize = processAttributes(metric.getAttributes(), "");
         baseLabelsSize += processResourceAndScopeAttributes(metric);
+        baseLabelsSize += processExternalLabels(externalLabels);
 
         if (metric instanceof Gauge) {
             addGaugeMetric((Gauge)metric);
@@ -164,6 +173,27 @@ public class PrometheusTimeSeries {
             }
         } catch (Exception e) {
             LOG.warn(NOISY, "Failed to get resource/scope attributes", e);
+        }
+        return size;
+    }
+
+    private long processExternalLabels(final Map<String, String> externalLabels) {
+        if (externalLabels == null || externalLabels.isEmpty()) {
+            return 0L;
+        }
+        // Remote write rejects a series with a repeated label name. Seeding with the names this class adds to
+        // individual series keeps that true even for a caller which did not validate the labels it passed in.
+        final Set<String> labelNames = new HashSet<>(RESERVED_LABEL_NAMES);
+        for (final Label label : baseLabels) {
+            labelNames.add(label.getName());
+        }
+        long size = 0L;
+        for (final Map.Entry<String, String> externalLabel : externalLabels.entrySet()) {
+            // A metric attribute wins any conflict.
+            if (!labelNames.add(externalLabel.getKey())) {
+                continue;
+            }
+            size += addLabelSanitized(externalLabel.getKey(), externalLabel.getValue());
         }
         return size;
     }

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/configuration/PrometheusSinkConfigurationTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/configuration/PrometheusSinkConfigurationTest.java
@@ -16,15 +16,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
+import org.opensearch.dataprepper.plugins.sink.prometheus.service.PrometheusTimeSeries;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
 
 import static com.linecorp.armeria.common.MediaTypeNames.X_PROTOBUF;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PrometheusSinkConfigurationTest {
@@ -299,5 +305,83 @@ public class PrometheusSinkConfigurationTest {
                     "          sts_role_arn: \"arn:aws:iam::895099425785:role/data-prepper-s3source-execution-role\"\n";
         final PrometheusSinkConfiguration prometheusSinkConfiguration = objectMapper.readValue(AWS_HTTP_SINK_YAML, PrometheusSinkConfiguration.class);
         assertFalse(prometheusSinkConfiguration.isValidAwsConfig());
+    }
+
+    @Test
+    void prometheus_sink_config_external_labels_defaults_to_empty() {
+        final PrometheusSinkConfiguration config = new PrometheusSinkConfiguration();
+        assertThat(config.getExternalLabels(), equalTo(Collections.emptyMap()));
+        assertTrue(config.isValidExternalLabelNames());
+        assertTrue(config.isValidExternalLabelValues());
+    }
+
+    @Test
+    void prometheus_sink_config_external_labels_with_literal_values_are_used_as_is() throws JsonProcessingException {
+        final PrometheusSinkConfiguration config = objectMapper.readValue(
+                externalLabelsYaml("dp_instance: \"replica-a\"\n   region: \"us-east-2\""), PrometheusSinkConfiguration.class);
+
+        assertThat(config.getExternalLabels(), equalTo(Map.of("dp_instance", "replica-a", "region", "us-east-2")));
+        assertTrue(config.isValidExternalLabelNames());
+        assertTrue(config.isValidExternalLabelValues());
+    }
+
+    @Test
+    void prometheus_sink_config_external_labels_are_not_interpreted_as_environment_variable_references()
+            throws JsonProcessingException {
+        final PrometheusSinkConfiguration config = objectMapper.readValue(
+                externalLabelsYaml("dp_instance: \"${HOSTNAME}\""), PrometheusSinkConfiguration.class);
+
+        assertThat(config.getExternalLabels(), equalTo(Map.of("dp_instance", "${HOSTNAME}")));
+    }
+
+    @Test
+    void prometheus_sink_config_external_labels_are_immutable() throws JsonProcessingException {
+        final PrometheusSinkConfiguration config = objectMapper.readValue(
+                externalLabelsYaml("dp_instance: \"replica-a\""), PrometheusSinkConfiguration.class);
+
+        assertThrows(UnsupportedOperationException.class, () -> config.getExternalLabels().put("region", "us-east-2"));
+    }
+
+    @Test
+    void prometheus_sink_config_external_labels_with_empty_value_is_invalid() throws JsonProcessingException {
+        final PrometheusSinkConfiguration config = objectMapper.readValue(
+                externalLabelsYaml("dp_instance: \"\""), PrometheusSinkConfiguration.class);
+
+        assertFalse(config.isValidExternalLabelValues());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"dp_instance", "_dp_instance", "dpInstance0"})
+    void prometheus_sink_config_external_labels_with_valid_name_is_valid(final String labelName) throws JsonProcessingException {
+        final PrometheusSinkConfiguration config = objectMapper.readValue(
+                externalLabelsYaml(labelName + ": \"replica-a\""), PrometheusSinkConfiguration.class);
+
+        assertTrue(config.isValidExternalLabelNames());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"dp-instance", "0dp_instance", "dp instance", "__name__", "__replica", "le", "ge", "quantile"})
+    void prometheus_sink_config_external_labels_with_invalid_name_is_invalid(final String labelName) throws JsonProcessingException {
+        final PrometheusSinkConfiguration config = objectMapper.readValue(
+                externalLabelsYaml("\"" + labelName + "\": \"replica-a\""), PrometheusSinkConfiguration.class);
+
+        assertFalse(config.isValidExternalLabelNames());
+    }
+
+    @Test
+    void prometheus_sink_config_external_labels_rejects_every_label_name_the_sink_adds_itself() throws JsonProcessingException {
+        for (final String reservedName : PrometheusTimeSeries.RESERVED_LABEL_NAMES) {
+            final PrometheusSinkConfiguration config = objectMapper.readValue(
+                    externalLabelsYaml("\"" + reservedName + "\": \"replica-a\""), PrometheusSinkConfiguration.class);
+
+            assertFalse(config.isValidExternalLabelNames(), reservedName + " must not be allowed as an external label");
+        }
+    }
+
+    private String externalLabelsYaml(final String labels) {
+        return " url: \"http://localhost:9090/api/v1/write\"\n" +
+                " insecure: true\n" +
+                " external_labels:\n" +
+                "   " + labels + "\n";
     }
 }

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferEntryTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferEntryTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -44,7 +45,7 @@ public class PrometheusSinkBufferEntryTest {
     private PrometheusSinkBufferEntry prometheusSinkBufferEntry;
 
     PrometheusSinkBufferEntry createObjectUnderTest(Event event)throws Exception {
-        return new PrometheusSinkBufferEntry(event, true);
+        return new PrometheusSinkBufferEntry(event, true, Collections.emptyMap());
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkBufferWriterTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Instant;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ public class PrometheusSinkBufferWriterTest {
         when(sinkConfig.getOutOfOrderTimeWindow()).thenReturn(Duration.ofSeconds(0));
         sinkFlushContext = mock(PrometheusSinkFlushContext.class);
         gauge1 = createGaugeMetric("gauge1", Instant.now(), 1.0d);
-        prometheusSinkBufferEntry = new PrometheusSinkBufferEntry(gauge1, true);
+        prometheusSinkBufferEntry = new PrometheusSinkBufferEntry(gauge1, true, Collections.emptyMap());
     }
 
     PrometheusSinkBufferWriter createObjectUnderTest() {
@@ -84,8 +85,8 @@ public class PrometheusSinkBufferWriterTest {
         // Same metric with same name but different value, only most recent one is kept
         Gauge gauge2 = createGaugeMetric("gauge2", t2, 10.0d);
         Gauge gauge3 = createGaugeMetric("gauge2", t2, 20.0d);
-        PrometheusSinkBufferEntry entry2 = new PrometheusSinkBufferEntry(gauge2, true);
-        PrometheusSinkBufferEntry entry3 = new PrometheusSinkBufferEntry(gauge3, true);
+        PrometheusSinkBufferEntry entry2 = new PrometheusSinkBufferEntry(gauge2, true, Collections.emptyMap());
+        PrometheusSinkBufferEntry entry3 = new PrometheusSinkBufferEntry(gauge3, true, Collections.emptyMap());
         prometheusSinkBufferWriter.writeToBuffer(prometheusSinkBufferEntry);
         prometheusSinkBufferWriter.writeToBuffer(entry2);
         prometheusSinkBufferWriter.writeToBuffer(entry3);
@@ -108,8 +109,8 @@ public class PrometheusSinkBufferWriterTest {
         Gauge gauge2 = createGaugeMetric("gauge1", t2, 10.0d);
         Instant t3 = t2.minusSeconds(150);
         Gauge gauge3 = createGaugeMetric("gauge1", t3, 20.0d);
-        PrometheusSinkBufferEntry entry2 = new PrometheusSinkBufferEntry(gauge2, true);
-        PrometheusSinkBufferEntry entry3 = new PrometheusSinkBufferEntry(gauge3, true);
+        PrometheusSinkBufferEntry entry2 = new PrometheusSinkBufferEntry(gauge2, true, Collections.emptyMap());
+        PrometheusSinkBufferEntry entry3 = new PrometheusSinkBufferEntry(gauge3, true, Collections.emptyMap());
         prometheusSinkBufferWriter.writeToBuffer(prometheusSinkBufferEntry);
         prometheusSinkBufferWriter.writeToBuffer(entry2);
         prometheusSinkBufferWriter.writeToBuffer(entry3);
@@ -133,8 +134,8 @@ public class PrometheusSinkBufferWriterTest {
         for (int i = 0; i < 5; i++) {
             Gauge gauge1 = createGaugeMetric("gauge_"+i, t1, 20.0d+i);
             Gauge gauge2 = createGaugeMetric("gauge_"+i, t2, 30.0d+i);
-            PrometheusSinkBufferEntry entry1 = new PrometheusSinkBufferEntry(gauge1, false);
-            PrometheusSinkBufferEntry entry2 = new PrometheusSinkBufferEntry(gauge2, false);
+            PrometheusSinkBufferEntry entry1 = new PrometheusSinkBufferEntry(gauge1, false, Collections.emptyMap());
+            PrometheusSinkBufferEntry entry2 = new PrometheusSinkBufferEntry(gauge2, false, Collections.emptyMap());
             prometheusSinkBufferWriter.writeToBuffer(entry1);
             prometheusSinkBufferWriter.writeToBuffer(entry2);
         }

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkFlushableBufferTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusSinkFlushableBufferTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PrometheusSinkFlushableBufferTest {
@@ -49,9 +50,9 @@ public class PrometheusSinkFlushableBufferTest {
     @BeforeEach
     void setUp() throws Exception {
         JacksonGauge gauge = createGaugeMetric("gauge1");
-        PrometheusSinkBufferEntry bufferEntry1 = new PrometheusSinkBufferEntry(gauge, true);
+        PrometheusSinkBufferEntry bufferEntry1 = new PrometheusSinkBufferEntry(gauge, true, Collections.emptyMap());
         gauge = createGaugeMetric("gauge2");
-        PrometheusSinkBufferEntry bufferEntry2 = new PrometheusSinkBufferEntry(gauge, true);
+        PrometheusSinkBufferEntry bufferEntry2 = new PrometheusSinkBufferEntry(gauge, true, Collections.emptyMap());
         buffer = new ArrayList<>();
         buffer.add((SinkBufferEntry)bufferEntry1);
         buffer.add((SinkBufferEntry)bufferEntry2);

--- a/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusTimeSeriesTest.java
+++ b/data-prepper-plugins/prometheus-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/prometheus/service/PrometheusTimeSeriesTest.java
@@ -10,6 +10,9 @@
 
 package org.opensearch.dataprepper.plugins.sink.prometheus.service;
 
+import com.arpnetworking.metrics.prometheus.Types.Label;
+import com.arpnetworking.metrics.prometheus.Types.TimeSeries;
+
 import org.apache.commons.lang3.RandomStringUtils;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import org.opensearch.dataprepper.model.metric.JacksonGauge;
@@ -40,6 +46,8 @@ import org.opensearch.dataprepper.model.metric.Bucket;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -128,7 +136,7 @@ public class PrometheusTimeSeriesTest {
     public void testGaugeMetricKey(String unit, String expectedUnitName) throws Exception {
         final String name = RandomStringUtils.randomAlphabetic(10);
         Gauge gauge = createGaugeMetric(name, unit);
-        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(gauge, true);
+        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(gauge, true, Collections.emptyMap());
         final String sanitizedName = PrometheusTimeSeries.sanitizeMetricName(gauge);
 
         String expectedKey1 = "__name__ "+sanitizedName+" "+TEST_ATTR_MAP_STR1+TEST_RESOURCE_MAP_STR+TEST_SCOPE_MAP_STR;
@@ -141,7 +149,7 @@ public class PrometheusTimeSeriesTest {
     public void testSumMetricKey(String unit, String expectedUnitName) throws Exception {
         final String name = RandomStringUtils.randomAlphabetic(10);
         Sum sum = createSumMetric(name, unit, true, "AGGREGATION_TEMPORALITY_CUMULATIVE");
-        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(sum, true);
+        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(sum, true, Collections.emptyMap());
         final String sanitizedName = PrometheusTimeSeries.sanitizeMetricName(sum);
 
         String expectedKey1 = "__name__ "+sanitizedName+" "+TEST_ATTR_MAP_STR1+TEST_RESOURCE_MAP_STR+TEST_SCOPE_MAP_STR;
@@ -154,7 +162,7 @@ public class PrometheusTimeSeriesTest {
     public void testSumMetricNonMonotonicKey(String unit, String expectedUnitName) throws Exception {
         final String name = RandomStringUtils.randomAlphabetic(10);
         Sum sum = createSumMetric(name, unit, false, "AGGREGATION_TEMPORALITY_DELTA");
-        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(sum, true);
+        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(sum, true, Collections.emptyMap());
         final String sanitizedName = PrometheusTimeSeries.sanitizeMetricName(sum);
 
         String expectedKey1 = "__name__ "+sanitizedName+" "+TEST_ATTR_MAP_STR1+TEST_RESOURCE_MAP_STR+TEST_SCOPE_MAP_STR;
@@ -167,7 +175,7 @@ public class PrometheusTimeSeriesTest {
     public void testSummaryMetricKey(String unit, String expectedUnitName) throws Exception {
         final String name = RandomStringUtils.randomAlphabetic(10);
         Summary summary = createSummaryMetric(name, unit);
-        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(summary, true);
+        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(summary, true, Collections.emptyMap());
         final String sanitizedName = PrometheusTimeSeries.sanitizeMetricName(summary);
 
         String expectedKey1 = "__name__ "+sanitizedName+"_count "+TEST_ATTR_MAP_STR1+TEST_RESOURCE_MAP_STR+TEST_SCOPE_MAP_STR;
@@ -180,7 +188,7 @@ public class PrometheusTimeSeriesTest {
     public void testHistogramMetricKey(String unit, String expectedUnitName) throws Exception {
         final String name = RandomStringUtils.randomAlphabetic(10);
         Histogram histogram = createHistogramMetric(name, unit);
-        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(histogram, true);
+        PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(histogram, true, Collections.emptyMap());
         final String sanitizedName = PrometheusTimeSeries.sanitizeMetricName(histogram);
 
         String expectedKey1 = "__name__ "+sanitizedName+"_count "+TEST_ATTR_MAP_STR1+TEST_RESOURCE_MAP_STR+TEST_SCOPE_MAP_STR;
@@ -218,6 +226,75 @@ public class PrometheusTimeSeriesTest {
         Sum sum = createSumMetric(name, null, true, null);
         String sanitizedName = PrometheusTimeSeries.sanitizeMetricName(sum);
         assertThat(sanitizedName, equalTo(name));
+    }
+
+    @Test
+    public void testExternalLabelsAreAddedToEveryTimeSeries() throws Exception {
+        final String name = RandomStringUtils.randomAlphabetic(10);
+        final Histogram histogram = createHistogramMetric(name, "s");
+        final PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(histogram, true, Map.of("dp_instance", "replica-a"));
+
+        assertThat(timeSeries.getTimeSeriesList().size(), greaterThan(1));
+        for (final TimeSeries series : timeSeries.getTimeSeriesList()) {
+            assertThat(getLabels(series).get("dp_instance"), equalTo("replica-a"));
+        }
+    }
+
+    @Test
+    public void testExternalLabelsDoNotOverrideMetricAttributes() throws Exception {
+        final String name = RandomStringUtils.randomAlphabetic(10);
+        final Gauge gauge = createGaugeMetric(name, "s");
+        final PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(gauge, true, Map.of("attrKey1", "externalValue"));
+
+        final TimeSeries series = timeSeries.getTimeSeriesList().get(0);
+        assertThat(getLabels(series).get("attrKey1"), equalTo("1"));
+        assertThat(series.getLabelsList().stream().filter(label -> label.getName().equals("attrKey1")).count(), equalTo(1L));
+    }
+
+    @Test
+    public void testExternalLabelsMakeTheMetricKeyUniquePerInstance() throws Exception {
+        final String name = RandomStringUtils.randomAlphabetic(10);
+        final Gauge gauge = createGaugeMetric(name, "s");
+
+        final PrometheusTimeSeries replicaA = new PrometheusTimeSeries(gauge, true, Map.of("dp_instance", "replica-a"));
+        final PrometheusTimeSeries replicaB = new PrometheusTimeSeries(gauge, true, Map.of("dp_instance", "replica-b"));
+        final PrometheusTimeSeries withoutExternalLabels = new PrometheusTimeSeries(gauge, true, Collections.emptyMap());
+
+        assertThat(replicaA.getMetricKey(), not(equalTo(replicaB.getMetricKey())));
+        assertThat(replicaA.getMetricKey(), not(equalTo(withoutExternalLabels.getMetricKey())));
+    }
+
+    @Test
+    public void testExternalLabelsNeverRepeatALabelNameTheSinkAddsItself() throws Exception {
+        final String name = RandomStringUtils.randomAlphabetic(10);
+        // An exponential histogram is the only metric which emits "ge", and it emits "le" and "__name__" too.
+        final ExponentialHistogram histogram = createExponentialHistogramMetric(name, "s");
+        final Map<String, String> reservedNames = PrometheusTimeSeries.RESERVED_LABEL_NAMES.stream()
+                .collect(Collectors.toMap(labelName -> labelName, labelName -> "externalValue"));
+
+        final PrometheusTimeSeries timeSeries = new PrometheusTimeSeries(histogram, true, reservedNames);
+
+        assertThat(timeSeries.getTimeSeriesList().size(), greaterThan(1));
+        for (final TimeSeries series : timeSeries.getTimeSeriesList()) {
+            final List<String> labelNames = series.getLabelsList().stream()
+                    .map(Label::getName).collect(Collectors.toList());
+            assertThat(labelNames.size(), equalTo(new HashSet<>(labelNames).size()));
+        }
+    }
+
+    @Test
+    public void testNullExternalLabelsAddNoLabels() throws Exception {
+        final String name = RandomStringUtils.randomAlphabetic(10);
+        final Gauge gauge = createGaugeMetric(name, "s");
+
+        final PrometheusTimeSeries withNullLabels = new PrometheusTimeSeries(gauge, true, null);
+        final PrometheusTimeSeries withEmptyLabels = new PrometheusTimeSeries(gauge, true, Collections.emptyMap());
+
+        assertThat(withNullLabels.getMetricKey(), equalTo(withEmptyLabels.getMetricKey()));
+    }
+
+    private Map<String, String> getLabels(final TimeSeries series) {
+        return series.getLabelsList().stream().collect(Collectors.toMap(Label::getName, Label::getValue));
     }
 
     private Summary createSummaryMetric(final String name, final String unit) {


### PR DESCRIPTION
### Description

Prometheus sink time series labels are drawn only from metric attributes, so every Data Prepper instance running the same pipeline emits series with identical labels. Prometheus, AMP, Cortex, and Mimir all deduplicate on series plus timestamp, so they keep one instance's sample and drop the rest without reporting an error. An N-instance deployment then reports roughly 1/N of the true value, and nothing surfaces the loss.

This adds an `external_labels` map to the sink which is applied to every time series it writes. Giving each instance a distinct value for one label keeps its series separate:

```yaml
sink:
  - prometheus:
      url: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-xxxxxxxx-xxxx/api/v1/remote_write"
      external_labels:
        dp_instance: "replica-a"
```

Consumers then aggregate the label away to recover the true value, which is the standard Prometheus HA-replica pattern:

```
sum without (dp_instance) (test_log_count)
```

Behaviour notes:

- **Values are literal strings.** I deliberately did not add `${VARIABLE}` environment substitution. `${...}` already means an event field reference elsewhere in Data Prepper (`index: "rss-${/feed_name}"`, `document_id: "${/item_id}"`, `format: "new ${message}"`), and giving the same syntax a second meaning inside one sink's config seemed likely to confuse more than it helped. Environment substitution also looks like a framework concern rather than a per-plugin one — see the follow-up below.
- **Reserved names are rejected.** Names must match `[a-zA-Z_][a-zA-Z0-9_]*`, may not begin with `__`, and may not be a name the sink adds to individual series (`le`, `ge`, `quantile`). Remote write rejects a series carrying a repeated label name, and it rejects the whole write request rather than the single series, so allowing these would be costly. The reserved set is declared once on `PrometheusTimeSeries` and that class seeds its own conflict check with it, so a duplicate label name cannot be emitted regardless of what a caller passes in.
- **A metric attribute wins any conflict** with an external label of the same name, matching how Prometheus applies its own external labels.
- **Invalid names and empty values fail bean validation**, so the pipeline refuses to start rather than quietly writing wrong data.

### Follow-ups, not in this PR

An `${{env:VAR}}` value translator at the framework level would let any plugin config read an environment variable. It fits the existing `PluginConfigValueTranslator` extension point, resolves at config load so validation still applies, and uses the `${{...}}` form which does not collide with the event-reference syntax. Happy to open that as its own issue if maintainers agree it belongs there.

Two unrelated bugs noticed while working in this area, also happy to file separately:

- `HostContext.getHostname()` returns the constant `"unknown"` whenever `InetAddress.getLocalHost()` fails, which is reachable in a container whose hostname is set but not resolvable. `OTelApmServiceMapProcessor.resolveHostId()` hashes that value under a javadoc promising "to ensure uniqueness", so every affected instance shares one host ID.
- `PrometheusTimeSeries.addExponentialHistogramMetric` reads `getPositiveOffset()` where it means `getNegativeOffset()` when computing negative bucket bounds.

### Issues Resolved

Resolves #7023

### Testing

`./gradlew :data-prepper-plugins:prometheus-sink:check` passes: 377 tests, 0 failures, 0 skipped, with checkstyle and spotless clean.

New tests:

- `PrometheusTimeSeriesTest.testExternalLabelsAreAddedToEveryTimeSeries`
- `PrometheusTimeSeriesTest.testExternalLabelsDoNotOverrideMetricAttributes` — asserts exactly one label survives a name collision
- `PrometheusTimeSeriesTest.testExternalLabelsMakeTheMetricKeyUniquePerInstance` — the regression test for the reported bug
- `PrometheusTimeSeriesTest.testExternalLabelsNeverRepeatALabelNameTheSinkAddsItself` — builds an exponential histogram, the only metric that emits `ge`, with external labels named after every reserved name, and asserts no series carries a duplicate label name
- `PrometheusSinkConfigurationTest` cases covering the empty default, immutability of the returned map, literal values, empty values, and valid and invalid label names

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
