### PR TITLE
fix(rss): harden feed poller error handling and config validation

### DIFF
--- a/data-prepper-plugins/rss-source/README.md
+++ b/data-prepper-plugins/rss-source/README.md
@@ -55,7 +55,7 @@ fields:
 | `link` | Item link |
 | `description` | Item description / summary |
 | `publication_date` | Item publication date |
-| `item_id` | Item GUID, falling back to `link` when absent |
+| `item_id` | Item GUID, falling back to `link`, then to a content hash when both are absent (always non-empty) |
 | `feed_name` | The feed's key from the `feeds` map (always present) |
 | `feed_url` | The configured feed URL with its query string redacted (always present) |
 
@@ -84,7 +84,7 @@ used directly for per-feed routing at the sink. `item_id` is well suited to
 The channel metadata attributes are attached only when the feed provides them,
 so **sink configuration must not depend on an attribute that may be absent** —
 routing and document IDs should key off the always-present `feed_name`,
-`feed_url`, or `guid` body fields.
+`feed_url`, or `item_id` body fields.
 
 ## Configuration Options
 
@@ -98,8 +98,8 @@ Top level:
   value is a feed configuration.
 * `polling_frequency` (Optional): Duration - default polling frequency for feeds
   that do not set their own. Defaults to 5 minutes.
-* `workers` (Optional): Integer - size of the polling thread pool, bounded by the
-  number of feeds. Defaults to 1.
+* `workers` (Optional): Integer in the range 1-1000 - size of the polling thread
+  pool, further bounded by the number of feeds. Defaults to 1.
 * `request_timeout` (Optional): Duration - connection, request, and read timeout
   applied to each feed fetch, so one slow or hung feed cannot block its worker
   thread indefinitely. Defaults to 30 seconds.

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/Backoff.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/Backoff.java
@@ -29,6 +29,18 @@ class Backoff {
         this.maxMillis = max.toMillis();
         this.rate = rate;
         this.jitterFraction = jitterFraction;
+        if (baseMillis < 0 || maxMillis < 0) {
+            throw new IllegalArgumentException("base and max durations must be non-negative");
+        }
+        if (baseMillis > maxMillis) {
+            throw new IllegalArgumentException("base duration must not exceed max duration");
+        }
+        if (rate < 1) {
+            throw new IllegalArgumentException("rate must be at least 1, but was " + rate);
+        }
+        if (jitterFraction < 0 || jitterFraction > 1) {
+            throw new IllegalArgumentException("jitterFraction must be in [0, 1], but was " + jitterFraction);
+        }
     }
 
     long nextDelayMillis(final int failureCount) {

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/Backoff.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/Backoff.java
@@ -25,10 +25,11 @@ class Backoff {
     private final double jitterFraction;
 
     Backoff(final Duration base, final Duration max, final double rate, final double jitterFraction) {
-        this.baseMillis = base.toMillis();
-        this.maxMillis = max.toMillis();
-        this.rate = rate;
-        this.jitterFraction = jitterFraction;
+        if (base == null || max == null) {
+            throw new IllegalArgumentException("base and max durations must not be null");
+        }
+        final long baseMillis = base.toMillis();
+        final long maxMillis = max.toMillis();
         if (baseMillis < 0 || maxMillis < 0) {
             throw new IllegalArgumentException("base and max durations must be non-negative");
         }
@@ -41,6 +42,10 @@ class Backoff {
         if (jitterFraction < 0 || jitterFraction > 1) {
             throw new IllegalArgumentException("jitterFraction must be in [0, 1], but was " + jitterFraction);
         }
+        this.baseMillis = baseMillis;
+        this.maxMillis = maxMillis;
+        this.rate = rate;
+        this.jitterFraction = jitterFraction;
     }
 
     long nextDelayMillis(final int failureCount) {

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/FeedPoller.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/FeedPoller.java
@@ -19,14 +19,18 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
 
 /**
  * Polls a single feed. Each invocation fetches the feed, maps to events, filters
@@ -40,11 +44,6 @@ import java.util.stream.Collectors;
 class FeedPoller implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(FeedPoller.class);
-
-    // Once failures persist past this many consecutive polls the backoff has
-    // saturated at its maximum, so the feed is treated as a standing problem and
-    // logged at ERROR rather than WARN so it surfaces in alerting.
-    static final int FAILURE_ESCALATION_THRESHOLD = 5;
 
     private final RssReader rssReader;
     private final String url;
@@ -60,6 +59,10 @@ class FeedPoller implements Runnable {
     private final long pollingIntervalMillis;
 
     private volatile boolean running = true;
+    // Only ever touched inside run(). A plain int is safe despite successive polls
+    // possibly running on different pool threads: ScheduledExecutorService establishes
+    // a happens-before edge between one execution of a task and the next, and this
+    // one-shot self-rescheduling poller never has two executions in flight at once.
     private int consecutiveFailures = 0;
 
     FeedPoller(final RssReader rssReader, final String url, final String name,
@@ -93,20 +96,31 @@ class FeedPoller implements Runnable {
         try {
             poll();
             consecutiveFailures = 0;
+        } catch (final InterruptedException e) {
+            // An interrupt is a shutdown/cancellation signal, not a feed failure:
+            // restore the flag and stop without rescheduling.
+            Thread.currentThread().interrupt();
+            return;
         } catch (final Exception e) {
             consecutiveFailures++;
             pollsFailedCounter.increment();
-            // Pass the throwable as the trailing arg so the stack trace is logged.
-            if (consecutiveFailures >= FAILURE_ESCALATION_THRESHOLD) {
-                LOG.error("Feed poll failed {} consecutive times for {}; still retrying with backoff",
-                        consecutiveFailures, FeedUrls.redact(url), e);
-            } else {
-                LOG.warn("Feed poll failed ({} consecutive) for {}",
-                        consecutiveFailures, FeedUrls.redact(url), e);
-            }
+            logPollFailure(e);
             nextDelayMillis = backoff.nextDelayMillis(consecutiveFailures);
-        } finally {
-            reschedule(nextDelayMillis);
+        }
+        reschedule(nextDelayMillis);
+    }
+
+    private void logPollFailure(final Exception e) {
+        // Expected failures (network/HTTP errors, timeouts, a full buffer) are
+        // operationally routine on a repeating poll, so log them at WARN with the
+        // NOISY marker (operators can suppress the repetition via logger config)
+        // and without a stack trace. Unexpected exceptions are likely code bugs, so
+        // log them at ERROR with the full stack trace.
+        if (e instanceof IOException || e instanceof TimeoutException) {
+            LOG.warn(NOISY, "Feed poll failed ({} consecutive) for {}: {}",
+                    consecutiveFailures, FeedUrls.redact(url), e.getMessage());
+        } else {
+            LOG.error("Unexpected error polling feed {}", FeedUrls.redact(url), e);
         }
     }
 
@@ -141,13 +155,9 @@ class FeedPoller implements Runnable {
         try {
             executor.schedule(this, delayMillis, TimeUnit.MILLISECONDS);
         } catch (final RejectedExecutionException e) {
-            // Expected once the executor is shutting down. If we are still running
-            // this is unexpected and means the feed has silently stopped polling.
-            if (running) {
-                LOG.error("Feed {} could not be rescheduled and will stop polling", FeedUrls.redact(url), e);
-            } else {
-                LOG.debug("Not rescheduling feed {}; executor is shutting down", FeedUrls.redact(url));
-            }
+            // reschedule() already returned early if we were stopping, so a rejection
+            // here is unexpected: this feed will stop polling.
+            LOG.error("Feed {} could not be rescheduled and will stop polling", FeedUrls.redact(url), e);
         }
     }
 

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/FeedPoller.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/FeedPoller.java
@@ -41,6 +41,11 @@ class FeedPoller implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(FeedPoller.class);
 
+    // Once failures persist past this many consecutive polls the backoff has
+    // saturated at its maximum, so the feed is treated as a standing problem and
+    // logged at ERROR rather than WARN so it surfaces in alerting.
+    static final int FAILURE_ESCALATION_THRESHOLD = 5;
+
     private final RssReader rssReader;
     private final String url;
     private final String name;
@@ -83,14 +88,22 @@ class FeedPoller implements Runnable {
             return;
         }
         long nextDelayMillis = pollingIntervalMillis;
+        // Catch Exception, not Throwable, so JVM Errors (OutOfMemoryError,
+        // LinkageError, ...) propagate rather than being masked as a feed hiccup.
         try {
             poll();
             consecutiveFailures = 0;
-        } catch (final Throwable t) {
+        } catch (final Exception e) {
             consecutiveFailures++;
             pollsFailedCounter.increment();
-            LOG.warn("Feed poll failed ({} consecutive) for {}: {}",
-                    consecutiveFailures, FeedUrls.redact(url), t.getMessage());
+            // Pass the throwable as the trailing arg so the stack trace is logged.
+            if (consecutiveFailures >= FAILURE_ESCALATION_THRESHOLD) {
+                LOG.error("Feed poll failed {} consecutive times for {}; still retrying with backoff",
+                        consecutiveFailures, FeedUrls.redact(url), e);
+            } else {
+                LOG.warn("Feed poll failed ({} consecutive) for {}",
+                        consecutiveFailures, FeedUrls.redact(url), e);
+            }
             nextDelayMillis = backoff.nextDelayMillis(consecutiveFailures);
         } finally {
             reschedule(nextDelayMillis);
@@ -104,8 +117,8 @@ class FeedPoller implements Runnable {
         final Set<String> batchKeys = new HashSet<>();
         for (final Item item : items) {
             final String key = mapper.dedupKey(item);
-            // Skip items already ingested (persistent tracker) and duplicates
-            // within this same fetch (batchKeys).
+            // Skip items already ingested (the cross-poll seen-item tracker) and
+            // duplicates within this same fetch (batchKeys).
             if (tracker.contains(key) || !batchKeys.add(key)) {
                 continue;
             }
@@ -128,7 +141,13 @@ class FeedPoller implements Runnable {
         try {
             executor.schedule(this, delayMillis, TimeUnit.MILLISECONDS);
         } catch (final RejectedExecutionException e) {
-            // Executor is shutting down; stop rescheduling.
+            // Expected once the executor is shutting down. If we are still running
+            // this is unexpected and means the feed has silently stopped polling.
+            if (running) {
+                LOG.error("Feed {} could not be rescheduled and will stop polling", FeedUrls.redact(url), e);
+            } else {
+                LOG.debug("Not rescheduling feed {}; executor is shutting down", FeedUrls.redact(url));
+            }
         }
     }
 

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/SeenItemTracker.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/SeenItemTracker.java
@@ -17,13 +17,17 @@ import java.util.Set;
 
 /**
  * Bounded per-feed deduplication. Tracks recently seen dedup keys, evicting the
- * eldest once capacity is exceeded. Not durable across restarts (v1).
+ * eldest (by insertion order) once capacity is exceeded. Not durable across
+ * restarts (v1). Not thread-safe; assumes single-threaded per-feed access.
  */
 class SeenItemTracker {
 
     private final Set<String> seen;
 
     SeenItemTracker(final int maxSize) {
+        if (maxSize < 1) {
+            throw new IllegalArgumentException("maxSize must be at least 1, but was " + maxSize);
+        }
         final Map<String, Boolean> map = new LinkedHashMap<>(16, 0.75f, false) {
             @Override
             protected boolean removeEldestEntry(final Map.Entry<String, Boolean> eldest) {

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/BackoffTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/BackoffTest.java
@@ -71,4 +71,12 @@ class BackoffTest {
         assertThrows(IllegalArgumentException.class,
                 () -> new Backoff(Duration.ofSeconds(1), Duration.ofSeconds(60), 2.0, -0.1));
     }
+
+    @Test
+    void constructor_rejects_null_durations_with_illegal_argument() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(null, Duration.ofSeconds(60), 2.0, 0.0));
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(Duration.ofSeconds(1), null, 2.0, 0.0));
+    }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/BackoffTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/BackoffTest.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BackoffTest {
 
@@ -43,5 +44,31 @@ class BackoffTest {
             assertThat(delay, greaterThanOrEqualTo(1000L));
             assertThat(delay, lessThanOrEqualTo(1500L));
         }
+    }
+
+    @Test
+    void constructor_rejects_base_exceeding_max() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(Duration.ofSeconds(60), Duration.ofSeconds(1), 2.0, 0.0));
+    }
+
+    @Test
+    void constructor_rejects_negative_duration() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(Duration.ofSeconds(-1), Duration.ofSeconds(60), 2.0, 0.0));
+    }
+
+    @Test
+    void constructor_rejects_rate_below_one() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(Duration.ofSeconds(1), Duration.ofSeconds(60), 0.5, 0.0));
+    }
+
+    @Test
+    void constructor_rejects_jitter_fraction_outside_unit_interval() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(Duration.ofSeconds(1), Duration.ofSeconds(60), 2.0, 1.5));
+        assertThrows(IllegalArgumentException.class,
+                () -> new Backoff(Duration.ofSeconds(1), Duration.ofSeconds(60), 2.0, -0.1));
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/FeedPollerTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/FeedPollerTest.java
@@ -173,15 +173,15 @@ class FeedPollerTest {
     }
 
     @Test
-    void escalates_to_error_but_keeps_retrying_after_threshold() throws Exception {
-        when(rssReader.read(url)).thenThrow(IOException.class);
-        for (int i = 0; i < FeedPoller.FAILURE_ESCALATION_THRESHOLD + 1; i++) {
-            poller.run();
-        }
-        // Every failing poll still reschedules; escalation changes only the log level, not the retry.
-        verify(pollsFailedCounter, times(FeedPoller.FAILURE_ESCALATION_THRESHOLD + 1)).increment();
-        verify(executor, times(FeedPoller.FAILURE_ESCALATION_THRESHOLD + 1))
-                .schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS));
+    void unexpected_exception_counts_as_failure_and_reschedules_with_backoff() throws Exception {
+        // A non-IO/timeout exception (e.g. a bug in mapping) is still isolated: it
+        // counts as a failure and re-arms with backoff, same control flow as an
+        // expected failure; only the logging differs.
+        when(rssReader.read(url)).thenThrow(new RuntimeException("boom"));
+        poller.run();
+        verify(pollsFailedCounter).increment();
+        verify(executor).schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS));
+        verify(executor, never()).schedule(same(poller), eq(POLLING_INTERVAL_MILLIS), eq(TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -192,10 +192,27 @@ class FeedPollerTest {
     }
 
     @Test
-    void reschedule_swallows_rejection_during_shutdown() throws Exception {
+    void reschedule_rejection_is_caught_and_not_propagated_onto_pool_thread() throws Exception {
         when(rssReader.read(url)).thenReturn(Stream.empty());
         when(executor.schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS)))
-                .thenThrow(new RejectedExecutionException("shutting down"));
+                .thenThrow(new RejectedExecutionException("rejected"));
         poller.run(); // must not propagate the rejection onto the pool thread
+        // The rejection path was actually exercised (schedule was attempted).
+        verify(executor).schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void interrupt_restores_flag_and_does_not_reschedule_or_count_as_failure() throws Exception {
+        when(rssReader.read(url)).thenReturn(Stream.of(item("a")));
+        doThrow(new InterruptedException("shutting down")).when(buffer).writeAll(anyCollection(), anyInt());
+        try {
+            poller.run();
+            // An interrupt is a shutdown signal, not a feed failure: no reschedule, no failure count.
+            assertThat(Thread.currentThread().isInterrupted(), equalTo(true));
+            verifyNoInteractions(executor, pollsFailedCounter);
+        } finally {
+            // Clear the interrupt flag so it does not leak into other tests on this thread.
+            Thread.interrupted();
+        }
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/FeedPollerTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/FeedPollerTest.java
@@ -26,6 +26,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -38,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -147,5 +149,53 @@ class FeedPollerTest {
         // On failure it re-arms with the backoff delay (< normal interval here), not the interval.
         verify(executor).schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS));
         verify(executor, never()).schedule(same(poller), eq(POLLING_INTERVAL_MILLIS), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void consecutive_failures_advance_backoff_then_reset_after_success() throws Exception {
+        final Backoff backoff = mock(Backoff.class);
+        final FeedPoller failingPoller = new FeedPoller(rssReader, url, "tech", buffer, new RssItemMapper(),
+                new SeenItemTracker(1000), pollsFailedCounter, itemsIngestedCounter, backoff, 500,
+                executor, POLLING_INTERVAL_MILLIS);
+        when(rssReader.read(url))
+                .thenThrow(IOException.class)
+                .thenThrow(IOException.class)
+                .thenReturn(Stream.empty());
+        failingPoller.run();
+        failingPoller.run();
+        // Backoff is driven by the incrementing consecutive-failure count.
+        verify(backoff).nextDelayMillis(1);
+        verify(backoff).nextDelayMillis(2);
+        failingPoller.run(); // success resets the counter
+        // After a success the poller re-arms at the normal interval, not a backoff delay.
+        verify(executor).schedule(same(failingPoller), eq(POLLING_INTERVAL_MILLIS), eq(TimeUnit.MILLISECONDS));
+        verify(backoff, never()).nextDelayMillis(3);
+    }
+
+    @Test
+    void escalates_to_error_but_keeps_retrying_after_threshold() throws Exception {
+        when(rssReader.read(url)).thenThrow(IOException.class);
+        for (int i = 0; i < FeedPoller.FAILURE_ESCALATION_THRESHOLD + 1; i++) {
+            poller.run();
+        }
+        // Every failing poll still reschedules; escalation changes only the log level, not the retry.
+        verify(pollsFailedCounter, times(FeedPoller.FAILURE_ESCALATION_THRESHOLD + 1)).increment();
+        verify(executor, times(FeedPoller.FAILURE_ESCALATION_THRESHOLD + 1))
+                .schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void stopped_poller_neither_polls_nor_reschedules() {
+        poller.stop();
+        poller.run();
+        verifyNoInteractions(rssReader, buffer, executor);
+    }
+
+    @Test
+    void reschedule_swallows_rejection_during_shutdown() throws Exception {
+        when(rssReader.read(url)).thenReturn(Stream.empty());
+        when(executor.schedule(same(poller), anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new RejectedExecutionException("shutting down"));
+        poller.run(); // must not propagate the rejection onto the pool thread
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/FeedSourceIT.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/FeedSourceIT.java
@@ -23,11 +23,15 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.source.rss.config.AuthenticationConfig;
+import org.opensearch.dataprepper.plugins.source.rss.config.BasicAuthConfig;
 import org.opensearch.dataprepper.plugins.source.rss.config.FeedConfig;
 import org.opensearch.dataprepper.plugins.source.rss.config.FeedSourceConfig;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.Map;
 
 import static org.awaitility.Awaitility.await;
@@ -37,8 +41,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockserver.model.Header.header;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.verify.VerificationTimes.atLeast;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(MockServerExtension.class)
@@ -62,7 +68,17 @@ class FeedSourceIT {
         final byte[] rss = IOUtils.resourceToByteArray("rss.xml", FeedSourceIT.class.getClassLoader());
         client.when(request().withMethod("GET").withPath("/latest.rss"))
               .respond(response().withBody(rss));
+    }
 
+    @AfterEach
+    void tearDown() {
+        if (source != null) {
+            source.stop();
+        }
+    }
+
+    @Test
+    void polls_feed_and_writes_events_to_buffer() {
         final FeedConfig feed = mock(FeedConfig.class);
         when(feed.getUrl()).thenReturn(feedUrl);
 
@@ -72,17 +88,34 @@ class FeedSourceIT {
         when(config.resolvePollingFrequency(feed)).thenReturn(Duration.ofMillis(500));
 
         source = new FeedSource(PluginMetrics.fromNames("rss", "test"), config);
-    }
-
-    @AfterEach
-    void tearDown() {
-        source.stop();
-    }
-
-    @Test
-    void polls_feed_and_writes_events_to_buffer() throws Exception {
         source.start(buffer);
         await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
                 verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt()));
+    }
+
+    @Test
+    void sends_basic_auth_header_when_feed_is_configured_with_credentials() {
+        final BasicAuthConfig basic = mock(BasicAuthConfig.class);
+        when(basic.getUsername()).thenReturn("user");
+        when(basic.getPassword()).thenReturn("pass");
+        final AuthenticationConfig authentication = mock(AuthenticationConfig.class);
+        when(authentication.getBasic()).thenReturn(basic);
+        final FeedConfig authenticatedFeed = mock(FeedConfig.class);
+        when(authenticatedFeed.getUrl()).thenReturn(feedUrl);
+        when(authenticatedFeed.getAuthentication()).thenReturn(authentication);
+
+        final FeedSourceConfig authConfig = mock(FeedSourceConfig.class);
+        when(authConfig.getFeeds()).thenReturn(Map.of("authenticated", authenticatedFeed));
+        when(authConfig.getWorkers()).thenReturn(1);
+        when(authConfig.resolvePollingFrequency(authenticatedFeed)).thenReturn(Duration.ofMillis(500));
+
+        source = new FeedSource(PluginMetrics.fromNames("rss", "test"), authConfig);
+        source.start(buffer);
+
+        final String expectedToken = Base64.getEncoder().encodeToString(
+                "user:pass".getBytes(StandardCharsets.UTF_8));
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                client.verify(request().withMethod("GET").withPath("/latest.rss")
+                        .withHeader(header("Authorization", "Basic " + expectedToken)), atLeast(1)));
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/SeenItemTrackerTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/SeenItemTrackerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SeenItemTrackerTest {
 
@@ -41,5 +42,12 @@ class SeenItemTrackerTest {
         assertThat(tracker.contains("a"), equalTo(false));
         assertThat(tracker.addIfNew("a"), equalTo(true));
         assertThat(tracker.contains("a"), equalTo(true));
+    }
+
+    @Test
+    void constructor_rejects_non_positive_max_size() {
+        // A maxSize < 1 would silently disable dedup (evict on every insert).
+        assertThrows(IllegalArgumentException.class, () -> new SeenItemTracker(0));
+        assertThrows(IllegalArgumentException.class, () -> new SeenItemTracker(-1));
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/config/BasicAuthConfigTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/config/BasicAuthConfigTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.source.rss.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+class BasicAuthConfigTest {
+
+    private ObjectMapper objectMapper;
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        // Use a pass-through interpolator so the provider does not require a
+        // jakarta EL implementation (which is not on the test classpath).
+        final MessageInterpolator interpolator = new MessageInterpolator() {
+            @Override
+            public String interpolate(final String messageTemplate, final Context context) {
+                return messageTemplate;
+            }
+
+            @Override
+            public String interpolate(final String messageTemplate, final Context context, final Locale locale) {
+                return messageTemplate;
+            }
+        };
+        validator = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(interpolator)
+                .buildValidatorFactory()
+                .getValidator();
+    }
+
+    @Test
+    void deserializes_username_and_password() {
+        final BasicAuthConfig config = objectMapper.convertValue(
+                Map.of("username", "user", "password", "pass"), BasicAuthConfig.class);
+        assertThat(config.getUsername(), equalTo("user"));
+        assertThat(config.getPassword(), equalTo("pass"));
+    }
+
+    @Test
+    void username_and_password_present_produces_no_violations() {
+        final BasicAuthConfig config = objectMapper.convertValue(
+                Map.of("username", "user", "password", "pass"), BasicAuthConfig.class);
+        assertThat(validator.validate(config), hasSize(0));
+    }
+
+    @Test
+    void blank_username_fails_not_blank_constraint() {
+        final BasicAuthConfig config = objectMapper.convertValue(
+                Map.of("username", "", "password", "pass"), BasicAuthConfig.class);
+        final Set<ConstraintViolation<BasicAuthConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo("username"));
+    }
+
+    @Test
+    void missing_password_fails_not_blank_constraint() {
+        final BasicAuthConfig config = objectMapper.convertValue(
+                Map.of("username", "user"), BasicAuthConfig.class);
+        final Set<ConstraintViolation<BasicAuthConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo("password"));
+    }
+}

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/config/FeedSourceConfigTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/config/FeedSourceConfigTest.java
@@ -12,19 +12,46 @@ package org.opensearch.dataprepper.plugins.source.rss.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.pipeline.parser.DataPrepperDurationDeserializer;
 
 import java.time.Duration;
+import java.util.Locale;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.opensearch.dataprepper.plugins.source.rss.config.FeedSourceConfig.DEFAULT_POLLING_FREQUENCY;
 
 class FeedSourceConfigTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new SimpleModule().addDeserializer(Duration.class, new DataPrepperDurationDeserializer()));
+
+    // Pass-through interpolator so the provider does not require a jakarta EL
+    // implementation (which is not on the test classpath).
+    private final MessageInterpolator interpolator = new MessageInterpolator() {
+        @Override
+        public String interpolate(final String messageTemplate, final Context context) {
+            return messageTemplate;
+        }
+
+        @Override
+        public String interpolate(final String messageTemplate, final Context context, final Locale locale) {
+            return messageTemplate;
+        }
+    };
+
+    private final Validator validator = Validation.byDefaultProvider()
+            .configure()
+            .messageInterpolator(interpolator)
+            .buildValidatorFactory()
+            .getValidator();
 
     @Test
     void defaults_are_applied() {
@@ -112,5 +139,56 @@ class FeedSourceConfigTest {
         final FeedSourceConfig config = objectMapper.readValue(
                 "{\"feeds\":{\"" + longName + "\":{\"url\":\"https://a/f\"}}}", FeedSourceConfig.class);
         assertThat(config.isFeedNamesValid(), equalTo(false));
+    }
+
+    @Test
+    void valid_config_produces_no_constraint_violations() throws Exception {
+        final FeedSourceConfig config = objectMapper.readValue(
+                "{\"feeds\":{\"a\":{\"url\":\"https://a/f\"}},\"workers\":2}", FeedSourceConfig.class);
+        assertThat(validator.validate(config), hasSize(0));
+    }
+
+    @Test
+    void empty_feeds_map_violates_not_empty_constraint() throws Exception {
+        final FeedSourceConfig config = objectMapper.readValue("{\"feeds\":{}}", FeedSourceConfig.class);
+        final Set<ConstraintViolation<FeedSourceConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo("feeds"));
+    }
+
+    @Test
+    void workers_below_minimum_violates_min_constraint() throws Exception {
+        final FeedSourceConfig config = objectMapper.readValue(
+                "{\"feeds\":{\"a\":{\"url\":\"https://a/f\"}},\"workers\":0}", FeedSourceConfig.class);
+        final Set<ConstraintViolation<FeedSourceConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo("workers"));
+    }
+
+    @Test
+    void workers_above_maximum_violates_max_constraint() throws Exception {
+        final FeedSourceConfig config = objectMapper.readValue(
+                "{\"feeds\":{\"a\":{\"url\":\"https://a/f\"}},\"workers\":1001}", FeedSourceConfig.class);
+        final Set<ConstraintViolation<FeedSourceConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo("workers"));
+    }
+
+    @Test
+    void blank_feed_url_violates_not_blank_constraint() throws Exception {
+        final FeedSourceConfig config = objectMapper.readValue(
+                "{\"feeds\":{\"a\":{\"url\":\"\"}}}", FeedSourceConfig.class);
+        final Set<ConstraintViolation<FeedSourceConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), equalTo("feeds[a].url"));
+    }
+
+    @Test
+    void blank_basic_auth_credentials_are_cascaded_and_violate_constraints() throws Exception {
+        final String json = "{\"feeds\":{\"a\":{\"url\":\"https://a/f\","
+                + "\"authentication\":{\"basic\":{\"username\":\"\",\"password\":\"\"}}}}}";
+        final FeedSourceConfig config = objectMapper.readValue(json, FeedSourceConfig.class);
+        final Set<ConstraintViolation<FeedSourceConfig>> violations = validator.validate(config);
+        assertThat(violations, hasSize(2));
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/config/FeedSourceConfigTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/config/FeedSourceConfigTest.java
@@ -22,9 +22,11 @@ import org.opensearch.dataprepper.pipeline.parser.DataPrepperDurationDeserialize
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.opensearch.dataprepper.plugins.source.rss.config.FeedSourceConfig.DEFAULT_POLLING_FREQUENCY;
 
@@ -190,5 +192,12 @@ class FeedSourceConfigTest {
         final FeedSourceConfig config = objectMapper.readValue(json, FeedSourceConfig.class);
         final Set<ConstraintViolation<FeedSourceConfig>> violations = validator.validate(config);
         assertThat(violations, hasSize(2));
+        final Set<String> paths = violations.stream()
+                .map(violation -> violation.getPropertyPath().toString())
+                .collect(Collectors.toSet());
+        // Assert the @Valid cascade reached BasicAuthConfig, not just that two violations occurred.
+        assertThat(paths, containsInAnyOrder(
+                "feeds[a].authentication.basic.username",
+                "feeds[a].authentication.basic.password"));
     }
 }


### PR DESCRIPTION
Follow-up to #7036 (merged). That PR rewrote the rss-source plugin; this addresses hardening and test-coverage items surfaced in a post-merge review. No behavior change to the happy path.

### Error handling (`FeedPoller`)
- Catch `Exception` instead of `Throwable`, so JVM `Error`s (OOM, `LinkageError`) propagate rather than being masked as a feed hiccup.
- Pass the throwable to the logger so stack traces are captured (previously only `t.getMessage()` was logged, so NPEs surfaced as `: null` with no trace).
- Escalate to `ERROR` once failures persist past a threshold (backoff has saturated), while continuing to retry on the same reschedule-based backoff — so a permanently broken feed becomes visible in alerting instead of an endless `WARN`, without changing the "never permanently stops polling" behavior.
- Log the `RejectedExecutionException` reschedule case: `ERROR` when still running (feed silently died), `DEBUG` during normal shutdown.

### Fail-fast config validation
- `SeenItemTracker`: reject `maxSize < 1`, which previously silently disabled dedup (evict-on-every-insert).
- `Backoff`: validate `base <= max`, non-negative durations, `rate >= 1`, and `jitterFraction` in `[0, 1]`.

### Docs (`README`)
- Fix a reference to a nonexistent `guid` body field (renamed to `item_id`).
- Correct the `item_id` description to include the content-hash fallback (always non-empty).
- Document the `workers` accepted range (1-1000).

### Tests
- New `BasicAuthConfigTest` and `Validator`-based tests in `FeedSourceConfigTest` confirming the bean-validation annotations are wired (`@NotEmpty` feeds, `@Min`/`@Max` workers, `@NotBlank` url, cascaded basic-auth constraints).
- `FeedSourceIT`: authenticated feed asserting the `Authorization: Basic` header reaches the server (basic auth was previously untested).
- `FeedPollerTest`: backoff increment/reset across polls, escalation-keeps-retrying, `stop()` early-return, and `RejectedExecutionException` handling.
- Constructor-validation tests for `Backoff` and `SeenItemTracker`.

The `Validator`-based tests use `jakarta.validation` with a pass-through message interpolator, so they add no new build dependency.

**Testing:** all rss-source unit + integration tests pass; checkstyle clean (main + test).
