### PR TITLE
Update BouncyCastle to 1.85.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -54,7 +54,7 @@ dependencyResolutionManagement {
             library('spring-core', 'org.springframework', 'spring-core').versionRef('spring')
             library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
             library('spring-web', 'org.springframework', 'spring-web').versionRef('spring')
-            version('bouncycastle', '1.81')
+            version('bouncycastle', '1.85')
             library('bouncycastle-bcprov', 'org.bouncycastle', 'bcprov-jdk18on').versionRef('bouncycastle')
             library('bouncycastle-bcpkix', 'org.bouncycastle', 'bcpkix-jdk18on').versionRef('bouncycastle')
             version('guava', '32.1.2-jre')


### PR DESCRIPTION
### Description

Updates BouncyCastle to 1.85.

The 1.85.2 patch exists only for some dependencies. To keep these in sync I'm updating only to 1.85.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
