### PR TITLE
Add failure metrics to the Kafka source

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -304,7 +304,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         updateOffsetsToCommit(topicPartition, offsetAndMetadata);
     }
 
-    void resetOffsets() {
+    private void resetOffsets() {
         // resetting offsets is similar to committing acknowledged offsets. Throttle the frequency of resets by
         // checking current time with last commit time. Same "lastCommitTime" and commit interval are used in both cases
         long currentTimeMillis = System.currentTimeMillis();

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -304,7 +304,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         updateOffsetsToCommit(topicPartition, offsetAndMetadata);
     }
 
-    private void resetOffsets() {
+    void resetOffsets() {
         // resetting offsets is similar to committing acknowledged offsets. Throttle the frequency of resets by
         // checking current time with last commit time. Same "lastCommitTime" and commit interval are used in both cases
         long currentTimeMillis = System.currentTimeMillis();
@@ -326,6 +326,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                     final long epoch = getCurrentTimeNanos();
                     ownedPartitionsEpoch.put(partition, epoch);
                 } catch (Exception e) {
+                    topicMetrics.getNumberOfOffsetResetFailures().increment();
                     LOG.error("Failed to seek to last committed offset upon negative acknowledgement {}", partition, e);
                 }
             });
@@ -381,9 +382,11 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                 consumer.commitSync(offsetsToCommit);
                 lastCommitTime = currentTimeMillis;
             } catch (final RebalanceInProgressException ex) {
+                topicMetrics.getNumberOfCommitFailures().increment();
                 LOG.error("Failed to commit offsets in topic {} due to rebalance in progress", topicName, ex);
                 return;
             } catch (Exception e) {
+                topicMetrics.getNumberOfCommitFailures().increment();
                 LOG.error("Failed to commit offsets in topic {}", topicName, e);
             }
 
@@ -541,6 +544,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                 if (e instanceof SizeOverflowException) {
                     topicMetrics.getNumberOfBufferSizeOverflows().increment();
                 } else {
+                    topicMetrics.getNumberOfBufferWriteFailures().increment();
                     LOG.debug("Error while adding record to buffer, retrying ", e);
                 }
                 try {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicConsumerMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicConsumerMetrics.java
@@ -32,6 +32,9 @@ public class KafkaTopicConsumerMetrics {
     static final String NUMBER_OF_RECORDS_COMMITTED = "numberOfRecordsCommitted";
     static final String NUMBER_OF_RECORDS_CONSUMED = "numberOfRecordsConsumed";
     static final String NUMBER_OF_BYTES_CONSUMED = "numberOfBytesConsumed";
+    static final String NUMBER_OF_COMMIT_FAILURES = "numberOfCommitFailures";
+    static final String NUMBER_OF_OFFSET_RESET_FAILURES = "numberOfOffsetResetFailures";
+    static final String NUMBER_OF_BUFFER_WRITE_FAILURES = "numberOfBufferWriteFailures";
     static final String ACTUAL_POLL_INTERVAL = "actualPollInterval";
 
     private final String topicName;
@@ -49,6 +52,9 @@ public class KafkaTopicConsumerMetrics {
     private final Counter numberOfRecordsCommitted;
     private final Counter numberOfRecordsConsumed;
     private final Counter numberOfBytesConsumed;
+    private final Counter numberOfCommitFailures;
+    private final Counter numberOfOffsetResetFailures;
+    private final Counter numberOfBufferWriteFailures;
     private final Timer timeBetweenPollCalls;
     private Instant lastPollTime;
 
@@ -69,6 +75,9 @@ public class KafkaTopicConsumerMetrics {
         this.numberOfPollAuthErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_POLL_AUTH_ERRORS, topicNameInMetrics));
         this.numberOfPositiveAcknowledgements = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_POSITIVE_ACKNOWLEDGEMENTS, topicNameInMetrics));
         this.numberOfNegativeAcknowledgements = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_NEGATIVE_ACKNOWLEDGEMENTS, topicNameInMetrics));
+        this.numberOfCommitFailures = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_COMMIT_FAILURES, topicNameInMetrics));
+        this.numberOfOffsetResetFailures = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_OFFSET_RESET_FAILURES, topicNameInMetrics));
+        this.numberOfBufferWriteFailures = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_BUFFER_WRITE_FAILURES, topicNameInMetrics));
         this.timeBetweenPollCalls = pluginMetrics.timer(getTopicMetricName(ACTUAL_POLL_INTERVAL, topicNameInMetrics));
         lastPollTime = Instant.now();
     }
@@ -173,6 +182,18 @@ public class KafkaTopicConsumerMetrics {
 
     public Counter getNumberOfPositiveAcknowledgements() {
         return numberOfPositiveAcknowledgements;
+    }
+
+    public Counter getNumberOfCommitFailures() {
+        return numberOfCommitFailures;
+    }
+
+    public Counter getNumberOfOffsetResetFailures() {
+        return numberOfOffsetResetFailures;
+    }
+
+    public Counter getNumberOfBufferWriteFailures() {
+        return numberOfBufferWriteFailures;
     }
 
     public void recordTimeBetweenPolls() {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -83,6 +83,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -176,6 +177,9 @@ public class KafkaCustomConsumerTest {
         when(topicMetrics.getNumberOfDeserializationErrors()).thenReturn(counter);
         when(topicMetrics.getNumberOfInvalidTimeStamps()).thenReturn(counter);
         when(topicMetrics.getNumberOfPollAuthErrors()).thenReturn(counter);
+        when(topicMetrics.getNumberOfCommitFailures()).thenReturn(counter);
+        when(topicMetrics.getNumberOfOffsetResetFailures()).thenReturn(counter);
+        when(topicMetrics.getNumberOfBufferWriteFailures()).thenReturn(counter);
         when(topicConfig.getThreadWaitingTime()).thenReturn(Duration.ofSeconds(1));
         when(topicConfig.getSerdeFormat()).thenReturn(MessageFormat.PLAINTEXT);
         when(topicConfig.getAutoCommit()).thenReturn(false);
@@ -875,10 +879,104 @@ public class KafkaCustomConsumerTest {
         return new ConsumerRecords(records);
     }
 
+    @ParameterizedTest
+    @MethodSource("provideExceptionsFromCommit")
+    public void testCommitOffsets_whenCommitFails_thenIncrementsCommitFailureCounter(final Exception commitException) throws Exception {
+        final Counter commitFailureCounter = mock(Counter.class);
+        when(topicMetrics.getNumberOfCommitFailures()).thenReturn(commitFailureCounter);
+
+        final String topic = topicConfig.getName();
+        final TopicPartition topicPartition = new TopicPartition(topic, testPartition);
+        when(topicConfig.getCommitInterval()).thenReturn(Duration.ofMillis(0));
+
+        consumer = createObjectUnderTest("plaintext", false);
+        consumer.onPartitionsAssigned(List.of(topicPartition));
+
+        consumerRecords = createPlainTextRecords(topic, 100L);
+        when(kafkaConsumer.poll(any(Duration.class))).thenReturn(consumerRecords);
+        consumer.consumeRecords();
+
+        doThrow(commitException).when(kafkaConsumer).commitSync(anyMap());
+
+        // onPartitionsRevoked forces a commit of the offsets gathered above
+        consumer.onPartitionsRevoked(List.of(topicPartition));
+
+        verify(commitFailureCounter).increment();
+    }
+
+    @Test
+    public void testResetOffsets_whenSeekFails_thenIncrementsOffsetResetFailureCounter() throws Exception {
+        final Counter offsetResetFailureCounter = mock(Counter.class);
+        when(topicMetrics.getNumberOfOffsetResetFailures()).thenReturn(offsetResetFailureCounter);
+
+        final String topic = topicConfig.getName();
+        when(topicConfig.getCommitInterval()).thenReturn(Duration.ofMillis(0));
+        consumerRecords = createPlainTextRecords(topic, 0L);
+        when(kafkaConsumer.poll(any(Duration.class))).thenReturn(consumerRecords);
+
+        consumer = createObjectUnderTest("plaintext", true);
+        consumer.onPartitionsAssigned(List.of(new TopicPartition(topic, testPartition)));
+        consumer.consumeRecords();
+
+        final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferRecords = buffer.read(1000);
+        for (final Record<Event> record : new ArrayList<>(bufferRecords.getKey())) {
+            record.getData().getEventHandle().release(false);
+        }
+        // Negative acknowledgement adds the partition to the set that resetOffsets() seeks
+        await().atMost(delayTime.plusMillis(5000))
+                .until(() -> consumer.getTopicMetrics().getNumberOfNegativeAcknowledgements().count() == 1.0);
+
+        doThrow(new RuntimeException("Failed to look up committed offset"))
+                .when(kafkaConsumer).committed(any(TopicPartition.class));
+
+        consumer.resetOffsets();
+
+        verify(offsetResetFailureCounter).increment();
+    }
+
+    @Test
+    public void testConsumeRecords_whenBufferWriteFails_thenIncrementsBufferWriteFailureCounter() throws Exception {
+        final Counter bufferWriteFailureCounter = mock(Counter.class);
+        when(topicMetrics.getNumberOfBufferWriteFailures()).thenReturn(bufferWriteFailureCounter);
+
+        when(topicConfig.getMaxPollInterval()).thenReturn(Duration.ofMillis(4000));
+        final String topic = topicConfig.getName();
+        consumerRecords = createPlainTextRecords(topic, 0L);
+        doAnswer((i) -> {
+            if (!paused && !resumed) {
+                throw new TimeoutException();
+            }
+            buffer.writeAll(i.getArgument(0), i.getArgument(1));
+            return null;
+        }).when(mockBuffer).writeAll(any(), anyInt());
+        doAnswer((i) -> {
+            if (paused && !resumed) {
+                return List.of();
+            }
+            return consumerRecords;
+        }).when(kafkaConsumer).poll(any(Duration.class));
+
+        consumer = createObjectUnderTestWithMockBuffer("plaintext");
+        try {
+            consumer.onPartitionsAssigned(List.of(new TopicPartition(topic, testPartition)));
+            consumer.consumeRecords();
+        } catch (Exception e) {}
+
+        verify(bufferWriteFailureCounter, atLeastOnce()).increment();
+        // A write timeout is not a size overflow, so the overflow counter must stay untouched
+        assertEquals(0.0, overflowCount);
+    }
+
     private static Stream<Arguments> provideExceptionsFromBufferWrite() {
         return Stream.of(
                 Arguments.of(new SizeOverflowException("size overflow")),
                 Arguments.of(new TimeoutException()));
+    }
+
+    private static Stream<Arguments> provideExceptionsFromCommit() {
+        return Stream.of(
+                Arguments.of(new RebalanceInProgressException("Rebalance in progress")),
+                Arguments.of(new RuntimeException("Generic commit failure")));
     }
 }
 

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -929,7 +929,9 @@ public class KafkaCustomConsumerTest {
         doThrow(new RuntimeException("Failed to look up committed offset"))
                 .when(kafkaConsumer).committed(any(TopicPartition.class));
 
-        consumer.resetOffsets();
+        final java.lang.reflect.Method method = consumer.getClass().getDeclaredMethod("resetOffsets");
+        method.setAccessible(true);
+        method.invoke(consumer);
 
         verify(offsetResetFailureCounter).increment();
     }


### PR DESCRIPTION
### Description
Three failure paths in the Kafka source are currently invisible to operators. They are written to the log and never counted:

- **Offset commit failures** (`KafkaCustomConsumer#commitOffsets`):  both the `RebalanceInProgressException` branch and the generic branch.
- **Offset reset failures** (`KafkaCustomConsumer#resetOffsets`):  the seek back to the last committed offset after a negative acknowledgement.
- **Buffer write failures**: the non-`SizeOverflowException` branch of the buffer write retry loop. This one is only logged at `debug`, so it is invisible even at default log levels. Size overflows are already counted via `numberOfBufferSizeOverflows`, but write timeouts are not.

These are the failures that lead to reprocessed records and stalled pipelines, so today an operator cannot distinguish "the pipeline is slow" from "commits are failing" without turning on debug logging.

This adds one counter for each, following the existing constant/field/initializer/getter pattern in `KafkaTopicConsumerMetrics`:

- `numberOfCommitFailures`
- `numberOfOffsetResetFailures`
- `numberOfBufferWriteFailures`

The change to `KafkaCustomConsumer` is five `increment()` calls; no control flow is altered.

**Scope.** This is the failure-handling portion of #7074 only. The other areas in that issue  the assigned-partition gauge, rebalance revoked/lost counters, poll-to-buffer latency, per-partition lag, and federated auth health  are intentionally left out. Per-partition lag multiplies series by topics × partitions and needs an opt-in decision, and the federated auth callback handler is instantiated by Kafka from the JAAS configuration with no `PluginMetrics` available, so it needs a design discussion first. Happy to follow up with those in separate PRs once there is agreement on the issue.

**Note on the tests.** The first test run failed two pre-existing tests, which turned out to be a useful signal: `topicMetrics` is a mock in `KafkaCustomConsumerTest`, so an unstubbed new getter returned `null` and the resulting NPE fired inside the `catch` block, preventing the recovery path from running. In production `topicMetrics` is always a real instance, so this was test wiring, fixed by stubbing the three getters in `setUp` alongside the existing counters. It does confirm the increments sit on paths that actually execute.

### Issues Resolved
Partially addresses #7074. Deliberately not using "Resolves", since this covers one of the five areas requested in that issue.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

On documentation: the Kafka source currently has no metrics documentation at all. There is no `## Metrics` section on the [kafka source page](https://github.com/opensearch-project/documentation-website/blob/main/_data-prepper/pipelines/configuration/sources/kafka.md) (13 of the 19 source pages have one) and none in the plugin README, so none of the existing counters are documented either. 

I would rather fix that in one pass than document only the three new ones. Need some guidance for updating the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
