### PR TITLE
Fix Kafka plugin integration tests

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferOTelIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferOTelIT.java
@@ -170,6 +170,12 @@ public class KafkaBufferOTelIT {
         when(topicConfig.getAutoCommit()).thenReturn(false);
         when(topicConfig.getAutoOffsetReset()).thenReturn("earliest");
         when(topicConfig.getThreadWaitingTime()).thenReturn(Duration.ofSeconds(1));
+        // Unstubbed getters yield zero-valued Kafka client settings, which break the consumer
+        when(topicConfig.getCommitInterval()).thenReturn(Duration.ofSeconds(1));
+        when(topicConfig.getFetchMaxBytes()).thenReturn(52428800L);
+        when(topicConfig.getFetchMaxWait()).thenReturn(500);
+        when(topicConfig.getFetchMinBytes()).thenReturn(1L);
+        when(topicConfig.getConnectionsMaxIdle()).thenReturn(Duration.ofMinutes(9));
         when(kafkaBufferConfig.getTopic()).thenReturn(topicConfig);
 
         EncryptionConfig encryptionConfig = mock(EncryptionConfig.class);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -167,6 +167,12 @@ public class KafkaSourceJsonTypeIT {
         when(jsonTopic.getSerdeFormat()).thenReturn(MessageFormat.JSON);
         when(jsonTopic.getAutoOffsetReset()).thenReturn("earliest");
         when(jsonTopic.getThreadWaitingTime()).thenReturn(Duration.ofSeconds(1));
+        // Unstubbed getters yield zero-valued Kafka client settings, which break the consumer
+        when(jsonTopic.getCommitInterval()).thenReturn(Duration.ofSeconds(1));
+        when(jsonTopic.getFetchMaxBytes()).thenReturn(52428800L);
+        when(jsonTopic.getFetchMaxWait()).thenReturn(500);
+        when(jsonTopic.getFetchMinBytes()).thenReturn(1L);
+        when(jsonTopic.getConnectionsMaxIdle()).thenReturn(Duration.ofMinutes(9));
         bootstrapServers = System.getProperty("tests.kafka.bootstrap_servers");
         LOG.info("Using Kafka bootstrap servers: {}", bootstrapServers);
         when(sourceConfig.getBootstrapServers()).thenReturn(Collections.singletonList(bootstrapServers));
@@ -193,6 +199,9 @@ public class KafkaSourceJsonTypeIT {
 
     @AfterEach
     void tearDown() {
+        if (kafkaSource != null) {
+            kafkaSource.stop();
+        }
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         AtomicBoolean deleted = new AtomicBoolean(false);


### PR DESCRIPTION
### Description

The Kafka plugin integration tests have failed on every run for months — all 60 of the last 60 runs of that workflow, on `main` and on pull requests. The same 8 of 25 tests fail each time, always because the test produces a record and then receives nothing:

```
KafkaSourceJsonTypeIT > TestJsonRecordsWithNullKey() FAILED
    java.lang.AssertionError: Expected: <1> but: was <0>
```

**Why it happens**

The tests build their topic configuration with Mockito mocks. For any getter the test does not stub, Mockito hands back `Duration.ZERO` rather than `null`, and `0` for numeric getters. Those values go straight into the Kafka client, so every consumer in these tests was created with:

```
connections.max.idle.ms   = 0
fetch.max.bytes           = 0
fetch.min.bytes           = 0
fetch.max.wait.ms         = 0
auto.commit.interval.ms   = 0
```

`connections.max.idle.ms = 0` is the one that breaks everything. The client drops its connection to the group coordinator the moment it goes idle, so the consumer joins the group, is disconnected, rejoins, is disconnected, and never gets a partition assigned. With no partitions it never reads a record. Nothing appears at ERROR level, because it is all ordinary INFO activity inside `poll()` — which is why this has been so hard to spot.

The existing null check in `KafkaCustomConsumerFactory` does not catch it, since `Duration.ZERO` is not `null`.

This is also why the failure cannot be traced to a single commit: each pull request that added a new consumer setting added another zero to a mock that nobody updated.

**What this changes**

Both changes are in test code only. No production code is touched.

1. Stub the five missing settings in `KafkaSourceJsonTypeIT` and `KafkaBufferOTelIT`, using Kafka's own default values.
2. Call `kafkaSource.stop()` in `KafkaSourceJsonTypeIT.tearDown()`. Without it, each test left its consumer running while the topic was deleted underneath it, and those abandoned consumers spun on reconnect attempts — one produced 286,000 warning lines in a single run.

**Results**

Verified locally against the project's own Docker Compose broker, running the same commands on `main` and on this branch:

| Test class | On `main` | With this change |
| --- | --- | --- |
| `KafkaSourceJsonTypeIT` | 5 failed | 5 passed, 32s |
| `KafkaBufferOTelIT` | 3 failed | 3 passed, 42s |

That is all 8 failing tests in the workflow. Stopping the leaked consumers also brought the source test class down from 5 minutes 13 seconds to 32 seconds.

**Not covered here**

Five other integration tests mock their configuration the same way and are missing the same settings, so they are probably affected as well. I could not verify them, because they need SASL or Confluent Schema Registry infrastructure that the local Compose setup does not provide, and the workflow does not run them:

- `KafkaSourceSaslScramIT`
- `KafkaSourceMultipleAuthTypeIT`
- `KafkaSourceSaslPlainTextIT`
- `ConfluentKafkaProducerConsumerIT`
- `ConfluentKafkaProducerConsumerWithSchemaRegistryIT`

I would rather not change tests I cannot run. Happy to include them if a maintainer can confirm the result.

One thing worth deciding separately: stubbing each new setting in every test means this breaks again the next time a consumer setting is added. Building these tests on a real configuration object instead of a mock would fix that for good. This pull request takes the smaller approach so the tests pass now — glad to follow up with the larger change if you prefer it.

### Issues Resolved
Resolves #7089

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

This is a test-only fix, so there is no user-facing documentation or javadoc to add.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
