### PR TITLE
Fix JAVA_OPTS example in trace tuning docs

### DIFF
--- a/docs/trace_tuning.md
+++ b/docs/trace_tuning.md
@@ -29,7 +29,7 @@ Our recommendation is that set the workers based on the CPU utilization, this va
 
 ### Heap
 
-You can configure the heap of Data Prepper by setting the `JVM_OPTS` environmental variable. 
+You can configure the heap of Data Prepper by setting the `JAVA_OPTS` environmental variable. 
 
 Our recommendation is that set the heap value should be minimum `4` * `batch_size` * `otel_send_batch_size` * `maximum size of indvidual span`.
 


### PR DESCRIPTION
### Description

Hi, 

The docs currently says:

> Configure the Data Prepper heap by setting the JVM_OPTS environment variable.

I think that is wrong and needs to be JAVA_OPTS.
 
### Issues Resolved
See #1021
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
