### PR TITLE
Stop the acknowledgement set monitor thread when stopping Data Prepper

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/AcknowledgementSetMonitorThread.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/AcknowledgementSetMonitorThread.java
@@ -9,9 +9,14 @@
 
 package org.opensearch.dataprepper.core.acknowledgements;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 
 class AcknowledgementSetMonitorThread {
+    private static final Logger LOG = LoggerFactory.getLogger(AcknowledgementSetMonitorThread.class);
+    private static final Duration STOP_JOIN_TIMEOUT = Duration.ofSeconds(5);
     private final Thread monitorThread;
     private final AcknowledgementSetMonitor acknowledgementSetMonitor;
     private final Duration delayTime;
@@ -33,6 +38,15 @@ class AcknowledgementSetMonitorThread {
 
     public void stop() {
         isStopped = true;
+        monitorThread.interrupt();
+        try {
+            monitorThread.join(STOP_JOIN_TIMEOUT.toMillis());
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (monitorThread.isAlive()) {
+            LOG.warn("The acknowledgement-monitor thread did not stop within {}.", STOP_JOIN_TIMEOUT);
+        }
     }
 
     private class Monitor implements Runnable {
@@ -43,7 +57,8 @@ class AcknowledgementSetMonitorThread {
                 try {
                     Thread.sleep(delayTime.toMillis());
                 } catch (final InterruptedException e) {
-                    throw new RuntimeException(e);
+                    Thread.currentThread().interrupt();
+                    break;
                 }
             }
         }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/core/acknowledgements/DefaultAcknowledgementSetManager.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.time.Duration;
@@ -58,6 +59,7 @@ public class DefaultAcknowledgementSetManager implements AcknowledgementSetManag
         return acknowledgementSet;
     }
 
+    @PreDestroy
     public void shutdown() {
         acknowledgementSetMonitorThread.stop();
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/AcknowledgementSetMonitorThreadTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/core/acknowledgements/AcknowledgementSetMonitorThreadTest.java
@@ -16,8 +16,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
@@ -49,5 +53,64 @@ class AcknowledgementSetMonitorThreadTest {
         verify(acknowledgementSetMonitor, atLeastOnce()).run();
 
         objectUnderTest.stop();
+    }
+
+    @Test
+    void stop_when_thread_is_sleeping_interrupts_and_stops_the_thread_promptly() {
+        delayTime = Duration.ofMinutes(5);
+        final AcknowledgementSetMonitorThread objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.start();
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    verify(acknowledgementSetMonitor, atLeastOnce()).run();
+                });
+
+        final Optional<Thread> monitorThread = findMonitorThread();
+        assertThat(monitorThread.isPresent(), equalTo(true));
+
+        final long stopStartTimeNanos = System.nanoTime();
+        objectUnderTest.stop();
+        final Duration stopDuration = Duration.ofNanos(System.nanoTime() - stopStartTimeNanos);
+
+        assertThat(stopDuration, lessThan(Duration.ofSeconds(2)));
+        assertThat(monitorThread.get().isAlive(), equalTo(false));
+    }
+
+    @Test
+    void run_when_thread_is_interrupted_exits_the_loop() {
+        delayTime = Duration.ofMinutes(5);
+        final AcknowledgementSetMonitorThread objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.start();
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    verify(acknowledgementSetMonitor, atLeastOnce()).run();
+                });
+
+        final Optional<Thread> monitorThread = findMonitorThread();
+        assertThat(monitorThread.isPresent(), equalTo(true));
+        monitorThread.get().interrupt();
+
+        await().atMost(Duration.ofSeconds(2))
+                .until(() -> !monitorThread.get().isAlive());
+    }
+
+    @Test
+    void stop_when_thread_was_never_started_returns_promptly() {
+        final AcknowledgementSetMonitorThread objectUnderTest = createObjectUnderTest();
+
+        final long stopStartTimeNanos = System.nanoTime();
+        objectUnderTest.stop();
+        final Duration stopDuration = Duration.ofNanos(System.nanoTime() - stopStartTimeNanos);
+
+        assertThat(stopDuration, lessThan(Duration.ofSeconds(2)));
+    }
+
+    private Optional<Thread> findMonitorThread() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(thread -> "acknowledgement-monitor".equals(thread.getName()))
+                .filter(Thread::isAlive)
+                .findFirst();
     }
 }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/concurrent/BackgroundThreadFactory.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/concurrent/BackgroundThreadFactory.java
@@ -1,6 +1,10 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  */
 
 package org.opensearch.dataprepper.common.concurrent;
@@ -12,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link ThreadFactory} that names threads with a prefix and
- * sets as daemon threads so that they do not interrupt shutdown.
+ * sets threads as non-daemon threads.
  * <p>
  * The thread name will be <i>namePrefix</i>-<i>threadNumber</i>.
  */


### PR DESCRIPTION
### Description

When stopping the Data Prepper Spring context, stop the AcknowledgementSet monitor thread. This will help with recycling application contexts in the same JVM.
 
This also updates the Javadocs for `BackgroundThreadFactory` to show that they are non-daemon. Whether they should be or not could be a good question, but that is the behavior.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
