### PR TITLE
feat(key-value): add destination_conflict_strategy for per-field merge in key-value processor

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -161,6 +161,34 @@ public interface Event extends Serializable {
     void merge(Event other, Collection<String> keys);
 
     /**
+     * Merges a map of fields into this Event, optionally under a destination key, resolving
+     * conflicts according to the supplied {@link MergeSettings}.
+     *
+     * <h2>Behavior</h2>
+     * <ul>
+     *   <li><b>Root write</b> when {@code destination} is {@code null} or empty, entries are
+     *       written to the event root and merged per-field. There is no single destination key
+     *       whose existence can be checked, so the conflict strategy collapses to its
+     *       {@link FieldConflictStrategy#isOverwrite()} flag: overwrite strategies replace
+     *       conflicting root fields, non-overwrite strategies preserve them. In particular
+     *       {@code SKIP} does not skip the write at the root, it merges while preserving existing
+     *       fields.</li>
+     *   <li><b>Destination does not exist</b> the whole map is written as the destination value.</li>
+     *   <li><b>Destination exists</b> resolved by the configured {@link FieldConflictStrategy};
+     *       see that enum for the per-strategy outcomes.</li>
+     * </ul>
+     *
+     * <p>Keys are interpreted as JSON Pointer paths (the {@code /} separator), so nested
+     * destinations such as {@code base/child} are created automatically.</p>
+     *
+     * @param destination   the destination key (JSON Pointer path), or {@code null}/empty for the root
+     * @param values        the parsed fields to merge
+     * @param mergeSettings the settings controlling conflict resolution and key handling
+     * @since 2.17
+     */
+    void mergeFields(String destination, Map<String, Object> values, MergeSettings mergeSettings);
+
+    /**
      * Generates a serialized Json string of the entire Event
      *
      * @return Json string of the event

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/FieldConflictStrategy.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/FieldConflictStrategy.java
@@ -45,9 +45,15 @@ public enum FieldConflictStrategy {
      * Merge parsed fields into the existing destination map per-field.
      * If a key conflict occurs, overwrite with the new parsed value.
      */
-    MERGE_OVERWRITE_EXISTING_KEYS("merge_overwrite_existing_keys", true);
+    MERGE_OVERWRITE_EXISTING_KEYS("merge_overwrite_existing_keys", true),
+
+    /**
+     * Sentinel for an unrecognized strategy used for testing. It is intentionally NOT user-selectable.
+     */
+    UNKNOWN("unknown", false);
 
     private static final Map<String, FieldConflictStrategy> NAMES_MAP = Arrays.stream(FieldConflictStrategy.values())
+            .filter(value -> !UNKNOWN.equals(value))
             .collect(Collectors.toMap(
                     value -> value.getOptionName().toLowerCase(),
                     value -> value

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/FieldConflictStrategy.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/FieldConflictStrategy.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Defines the conflict resolution strategy used when writing fields into an
+ * {@link Event} under a destination that already exists.
+ *
+ * @since 2.17
+ */
+public enum FieldConflictStrategy {
+
+    /**
+     * Skip writing entirely if the destination already exists.
+     */
+    SKIP("skip", false),
+
+    /**
+     * Overwrite the entire destination with the new parsed map.
+     */
+    OVERWRITE("overwrite", true),
+
+    /**
+     * Merge parsed fields into the existing destination map per-field.
+     * If a key conflict occurs, preserve the existing value.
+     */
+    MERGE_PRESERVE_EXISTING_KEYS("merge_preserve_existing_keys", false),
+
+    /**
+     * Merge parsed fields into the existing destination map per-field.
+     * If a key conflict occurs, overwrite with the new parsed value.
+     */
+    MERGE_OVERWRITE_EXISTING_KEYS("merge_overwrite_existing_keys", true);
+
+    private static final Map<String, FieldConflictStrategy> NAMES_MAP = Arrays.stream(FieldConflictStrategy.values())
+            .collect(Collectors.toMap(
+                    value -> value.getOptionName().toLowerCase(),
+                    value -> value
+            ));
+
+    private final String optionName;
+    private final boolean overwrite;
+
+    FieldConflictStrategy(final String optionName, final boolean overwrite) {
+        this.optionName = optionName;
+        this.overwrite = overwrite;
+    }
+
+    @JsonValue
+    public String getOptionName() {
+        return optionName;
+    }
+
+    /**
+     * Whether this strategy overwrites conflicting values. Applies both when replacing an entire
+     * destination and when merging per-field: {@code true} for {@link #OVERWRITE} and
+     * {@link #MERGE_OVERWRITE_EXISTING_KEYS}, {@code false} for {@link #SKIP} and
+     * {@link #MERGE_PRESERVE_EXISTING_KEYS}.
+     *
+     * @return true if conflicting values are overwritten
+     */
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    @JsonCreator
+    public static FieldConflictStrategy fromOptionName(final String optionName) {
+        if (optionName == null) {
+            return null;
+        }
+        final FieldConflictStrategy strategy = NAMES_MAP.get(optionName.toLowerCase());
+        if (strategy == null) {
+            throw new IllegalArgumentException(
+                    "Invalid destination_conflict_strategy: \"" + optionName +
+                    "\". Valid values are: " + NAMES_MAP.keySet());
+        }
+        return strategy;
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -488,6 +488,61 @@ public class JacksonEvent implements Event {
     }
 
     @Override
+    public void mergeFields(final String destination, final Map<String, Object> values, final MergeSettings mergeSettings) {
+        Objects.requireNonNull(mergeSettings, "mergeSettings must not be null");
+        final FieldConflictStrategy conflictStrategy = mergeSettings.getConflictStrategy();
+        final boolean replaceInvalidCharacters = mergeSettings.isReplaceInvalidCharacters();
+
+        // No destination. Write keys directly to the event root, merged per-field. At the root
+        // there is no destination key to test, so only the strategy's isOverwrite() flag applies.
+        if (destination == null || destination.isEmpty()) {
+            mergeFieldEntries(values, "", mergeSettings);
+            return;
+        }
+
+        // Destination doesn't exist yet. Put the whole map
+        if (!containsKey(destination)) {
+            put(destination, values, replaceInvalidCharacters);
+            return;
+        }
+
+        switch (conflictStrategy) {
+            case SKIP:
+                return;
+            case OVERWRITE:
+                put(destination, values, replaceInvalidCharacters);
+                return;
+            case MERGE_PRESERVE_EXISTING_KEYS:
+            case MERGE_OVERWRITE_EXISTING_KEYS:
+                if (!(get(destination, Object.class) instanceof Map)) {
+                    // Cannot merge into a non-map value; overwrite or leave as-is
+                    if (conflictStrategy.isOverwrite()) {
+                        put(destination, values, replaceInvalidCharacters);
+                    }
+                    return;
+                }
+                mergeFieldEntries(values, destination + "/", mergeSettings);
+                return;
+            default:
+                throw new IllegalStateException("Unexpected FieldConflictStrategy: " + conflictStrategy);
+        }
+    }
+
+    private void mergeFieldEntries(final Map<String, Object> values, final String pathPrefix, final MergeSettings mergeSettings) {
+        final FieldConflictStrategy conflictStrategy = mergeSettings.getConflictStrategy();
+        for (final Map.Entry<String, Object> entry : values.entrySet()) {
+            final String key = pathPrefix + entry.getKey();
+            if (conflictStrategy.isOverwrite() || !containsKey(key)) {
+                try {
+                    put(key, entry.getValue(), mergeSettings.isReplaceInvalidCharacters());
+                } catch (final IllegalArgumentException e) {
+                    LOG.warn("Failed to put key '{}' into event.", key, e);
+                }
+            }
+        }
+    }
+
+    @Override
     public String toJsonString() {
         return jsonNode.toString();
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/MergeSettings.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/MergeSettings.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable settings that control how a map of fields is merged into an {@link Event}
+ * via {@link Event#mergeFields(String, Map, MergeSettings)}.
+ *
+ * @since 2.17
+ */
+public class MergeSettings {
+    private final FieldConflictStrategy conflictStrategy;
+    private final boolean replaceInvalidCharacters;
+
+    /**
+     * @param conflictStrategy         the strategy used to resolve conflicts with an existing destination
+     * @param replaceInvalidCharacters flag indicating if invalid characters should be replaced when writing keys
+     */
+    public MergeSettings(final FieldConflictStrategy conflictStrategy, final boolean replaceInvalidCharacters) {
+        this.conflictStrategy = Objects.requireNonNull(conflictStrategy, "conflictStrategy must not be null");
+        this.replaceInvalidCharacters = replaceInvalidCharacters;
+    }
+
+    /**
+     * @return the conflict resolution strategy to apply when a destination field already exists
+     */
+    public FieldConflictStrategy getConflictStrategy() {
+        return conflictStrategy;
+    }
+
+    /**
+     * @return whether invalid characters should be replaced when writing keys
+     */
+    public boolean isReplaceInvalidCharacters() {
+        return replaceInvalidCharacters;
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventMergeFieldsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventMergeFieldsTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EventMergeFieldsTest {
+    private static final String EVENT_TYPE = "event";
+
+    private Event newEvent() {
+        return JacksonEvent.builder().withEventType(EVENT_TYPE).build();
+    }
+
+    private Event newEvent(final Map<String, Object> data) {
+        return JacksonEvent.builder().withEventType(EVENT_TYPE).withData(data).build();
+    }
+
+    private Map<String, Object> values() {
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+        return values;
+    }
+
+    private MergeSettings settings(final FieldConflictStrategy conflictStrategy) {
+        return new MergeSettings(conflictStrategy, false);
+    }
+
+    @Test
+    void mergeSettings_rejects_null_strategy() {
+        assertThrows(NullPointerException.class, () -> new MergeSettings(null, false));
+    }
+
+    @Test
+    void mergeFields_rejects_null_settings() {
+        final Event event = newEvent();
+        assertThrows(NullPointerException.class,
+                () -> event.mergeFields(null, values(), null));
+    }
+
+    // ---- Root writes (null / empty destination) ----
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "NULL"})
+    void write_toRoot_addsAllKeys(final String destination) {
+        final String dest = "NULL".equals(destination) ? null : destination;
+        final Event event = newEvent();
+
+        event.mergeFields(dest, values(), settings(FieldConflictStrategy.OVERWRITE));
+
+        assertThat(event.get("key1", String.class), is("value1"));
+        assertThat(event.get("key2", String.class), is("value2"));
+    }
+
+    @Test
+    void write_toRoot_withOverwriteStrategy_overwritesExistingKey() {
+        final Event event = newEvent(Map.of("key1", "original"));
+
+        event.mergeFields(null, values(), settings(FieldConflictStrategy.OVERWRITE));
+
+        assertThat(event.get("key1", String.class), is("value1"));
+        assertThat(event.get("key2", String.class), is("value2"));
+    }
+
+    @Test
+    void write_toRoot_withPreserveStrategy_keepsExistingKey() {
+        final Event event = newEvent(Map.of("key1", "original"));
+
+        event.mergeFields(null, values(), settings(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS));
+
+        assertThat(event.get("key1", String.class), is("original"));
+        assertThat(event.get("key2", String.class), is("value2"));
+    }
+
+    @Test
+    void write_toRoot_withSkipStrategy_mergesPreservingExistingKey() {
+        // At the root SKIP does not skip: it collapses to a preserve merge (isOverwrite() == false).
+        final Event event = newEvent(Map.of("key1", "original"));
+
+        event.mergeFields(null, values(), settings(FieldConflictStrategy.SKIP));
+
+        assertThat(event.get("key1", String.class), is("original"));
+        assertThat(event.get("key2", String.class), is("value2"));
+    }
+
+    @Test
+    void write_toRoot_withMergeOverwriteStrategy_overwritesExistingKey() {
+        final Event event = newEvent(Map.of("key1", "original"));
+
+        event.mergeFields(null, values(), settings(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS));
+
+        assertThat(event.get("key1", String.class), is("value1"));
+        assertThat(event.get("key2", String.class), is("value2"));
+    }
+
+    // ---- Destination does not exist yet ----
+
+    @Test
+    void write_toDestination_whenAbsent_writesWholeMap() {
+        final Event event = newEvent();
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.SKIP));
+
+        assertThat(event.get("dest/key1", String.class), is("value1"));
+        assertThat(event.get("dest/key2", String.class), is("value2"));
+    }
+
+    // ---- Destination exists ----
+
+    @Test
+    void write_toDestination_skip_leavesExisting() {
+        final Event event = newEvent(Map.of("dest", Map.of("existing", "keep")));
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.SKIP));
+
+        assertThat(event.get("dest/existing", String.class), is("keep"));
+        assertThat(event.containsKey("dest/key1"), is(false));
+    }
+
+    @Test
+    void write_toDestination_overwrite_replacesEntireValue() {
+        final Event event = newEvent(Map.of("dest", Map.of("existing", "gone")));
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.OVERWRITE));
+
+        assertThat(event.get("dest/key1", String.class), is("value1"));
+        assertThat(event.get("dest/existing", String.class), nullValue());
+    }
+
+    @Test
+    void write_toDestination_mergePreserve_keepsConflictingFields() {
+        final Map<String, Object> existing = new HashMap<>();
+        existing.put("key1", "original");
+        existing.put("existing", "keep");
+        final Event event = newEvent(Map.of("dest", existing));
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS));
+
+        assertThat(event.get("dest/key1", String.class), is("original"));
+        assertThat(event.get("dest/key2", String.class), is("value2"));
+        assertThat(event.get("dest/existing", String.class), is("keep"));
+    }
+
+    @Test
+    void write_toDestination_mergeOverwrite_overwritesConflictingFields() {
+        final Map<String, Object> existing = new HashMap<>();
+        existing.put("key1", "original");
+        existing.put("existing", "keep");
+        final Event event = newEvent(Map.of("dest", existing));
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS));
+
+        assertThat(event.get("dest/key1", String.class), is("value1"));
+        assertThat(event.get("dest/key2", String.class), is("value2"));
+        assertThat(event.get("dest/existing", String.class), is("keep"));
+    }
+
+    @Test
+    void write_toDestination_mergeOverwrite_intoNonMap_replacesValue() {
+        final Event event = newEvent(Map.of("dest", "a plain string"));
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS));
+
+        assertThat(event.get("dest/key1", String.class), is("value1"));
+        assertThat(event.get("dest/key2", String.class), is("value2"));
+    }
+
+    @Test
+    void write_toDestination_mergePreserve_intoNonMap_skipsWrite() {
+        final Event event = newEvent(Map.of("dest", "a plain string"));
+
+        event.mergeFields("dest", values(), settings(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS));
+
+        assertThat(event.get("dest", String.class), is("a plain string"));
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventMergeFieldsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventMergeFieldsTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EventMergeFieldsTest {
@@ -190,5 +191,29 @@ class EventMergeFieldsTest {
         event.mergeFields("dest", values(), settings(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS));
 
         assertThat(event.get("dest", String.class), is("a plain string"));
+    }
+
+    // ---- Per-field write failure is caught and does not abort the merge ----
+
+    @Test
+    void write_toRoot_whenKeyIsInvalid_swallowsExceptionAndWritesRemainingKeys() {
+        final Event event = newEvent();
+        final Map<String, Object> valuesWithInvalidKey = new HashMap<>();
+        valuesWithInvalidKey.put("valid_key", "value1");
+        valuesWithInvalidKey.put("invalid&key", "value2");
+
+        assertDoesNotThrow(() ->
+                event.mergeFields(null, valuesWithInvalidKey, settings(FieldConflictStrategy.OVERWRITE)));
+
+        assertThat(event.get("valid_key", String.class), is("value1"));
+        assertThat(event.toMap().containsKey("invalid&key"), is(false));
+    }
+
+    @Test
+    void write_toDestination_withUnrecognizedStrategy_throwsIllegalState() {
+        final Event event = newEvent(Map.of("dest", Map.of("existing", "keep")));
+
+        assertThrows(IllegalStateException.class,
+                () -> event.mergeFields("dest", values(), settings(FieldConflictStrategy.UNKNOWN)));
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/FieldConflictStrategyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/FieldConflictStrategyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FieldConflictStrategyTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @ParameterizedTest
+    @CsvSource({
+            "SKIP,skip",
+            "OVERWRITE,overwrite",
+            "MERGE_PRESERVE_EXISTING_KEYS,merge_preserve_existing_keys",
+            "MERGE_OVERWRITE_EXISTING_KEYS,merge_overwrite_existing_keys"
+    })
+    void getOptionName_returnsConfiguredName(final FieldConflictStrategy strategy, final String expectedName) {
+        assertThat(strategy.getOptionName(), is(expectedName));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "SKIP,false",
+            "OVERWRITE,true",
+            "MERGE_PRESERVE_EXISTING_KEYS,false",
+            "MERGE_OVERWRITE_EXISTING_KEYS,true"
+    })
+    void isOverwrite_reflectsStrategy(final FieldConflictStrategy strategy, final boolean expected) {
+        assertThat(strategy.isOverwrite(), is(expected));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "skip,SKIP",
+            "overwrite,OVERWRITE",
+            "merge_preserve_existing_keys,MERGE_PRESERVE_EXISTING_KEYS",
+            "merge_overwrite_existing_keys,MERGE_OVERWRITE_EXISTING_KEYS"
+    })
+    void fromOptionName_resolvesByName(final String optionName, final FieldConflictStrategy expected) {
+        assertThat(FieldConflictStrategy.fromOptionName(optionName), is(expected));
+    }
+
+    @Test
+    void fromOptionName_isCaseInsensitive() {
+        assertThat(FieldConflictStrategy.fromOptionName("SKIP"), is(FieldConflictStrategy.SKIP));
+        assertThat(FieldConflictStrategy.fromOptionName("Merge_Overwrite_Existing_Keys"),
+                is(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS));
+    }
+
+    @Test
+    void fromOptionName_null_returnsNull() {
+        assertThat(FieldConflictStrategy.fromOptionName(null), is(nullValue()));
+    }
+
+    @Test
+    void fromOptionName_invalid_throws() {
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> FieldConflictStrategy.fromOptionName("not_a_strategy"));
+        assertThat(exception.getMessage().contains("not_a_strategy"), is(true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FieldConflictStrategy.class)
+    void jackson_roundTrip(final FieldConflictStrategy strategy) throws Exception {
+        final String json = OBJECT_MAPPER.writeValueAsString(strategy);
+        assertThat(OBJECT_MAPPER.readValue(json, FieldConflictStrategy.class), is(strategy));
+    }
+
+    @Test
+    void jacksonDeserialize_invalidJsonString_throws() {
+        assertThrows(Exception.class,
+                () -> OBJECT_MAPPER.readValue("\"not_a_strategy\"", FieldConflictStrategy.class));
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/FieldConflictStrategyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/FieldConflictStrategyTest.java
@@ -77,10 +77,16 @@ class FieldConflictStrategyTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FieldConflictStrategy.class)
+    @EnumSource(value = FieldConflictStrategy.class, names = "UNKNOWN", mode = EnumSource.Mode.EXCLUDE)
     void jackson_roundTrip(final FieldConflictStrategy strategy) throws Exception {
         final String json = OBJECT_MAPPER.writeValueAsString(strategy);
         assertThat(OBJECT_MAPPER.readValue(json, FieldConflictStrategy.class), is(strategy));
+    }
+
+    @Test
+    void fromOptionName_unknownSentinel_isNotSelectable() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FieldConflictStrategy.fromOptionName("unknown"));
     }
 
     @Test

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -98,8 +98,15 @@ When run, the processor will parse the message into the following output:
   * While `recursive` is `true`, `remove_brackets` cannot also be `true`.
   * While `recursive` is `true`, `skip_duplicate_values` will always be `true`.
   * While `recursive` is `true`, `whitespace` will always be `"strict"`.
-* `overwrite_if_destination_exists` - Specify whether to overwrite existing fields if there are key conflicts when writing parsed fields to the event. 
-  * Default: `true` 
+* `destination_conflict_strategy` - Defines how a key conflict is resolved when a non-null `destination` already exists on the event. One of:
+  * `skip` - Skip the write entirely, leaving the existing destination untouched.
+  * `overwrite` - Replace the entire destination with the newly parsed map.
+  * `merge_preserve_existing_keys` - Merge the parsed fields into the existing destination map per-field, keeping the existing value on a key conflict.
+  * `merge_overwrite_existing_keys` - Merge the parsed fields into the existing destination map per-field, overwriting the existing value on a key conflict.
+  * Default: `overwrite`
+  * Cannot be set together with `overwrite_if_destination_exists`.
+
+* `overwrite_if_destination_exists` - **Deprecated.** Use `destination_conflict_strategy` instead. Specify whether to overwrite existing fields if there are key conflicts when writing parsed fields to the event. When unset, the behavior is governed by `destination_conflict_strategy` (default `overwrite`). Setting this to `false` is equivalent to `destination_conflict_strategy: skip`.
 
 * `tags_on_failure` - When a kv operation causes a runtime exception to be thrown within the processor, the operation is safely aborted without crashing the processor, and the event is tagged with the provided tags.
   * Example: if `tags_on_failure` is set to `["keyvalueprocessor_failure"]`, in the case of a runtime exception, `{"tags": ["keyvalueprocessor_failure"]}` will be added to the event's metadata.

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -11,6 +11,8 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.common.TransformOption;
+import org.opensearch.dataprepper.model.event.FieldConflictStrategy;
+import org.opensearch.dataprepper.model.event.MergeSettings;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -64,7 +66,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     private final List<String> tagsOnFailure;
     private final Character stringLiteralCharacter;
     private final String keyPrefix;
-    private final boolean normalizeKeys;
+    private final MergeSettings mergeSettings;
 
     @DataPrepperPluginConstructor
     public KeyValueProcessor(final PluginMetrics pluginMetrics,
@@ -76,8 +78,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         this.stringLiteralCharacter = keyValueProcessorConfig.getStringLiteralCharacter();
 
         tagsOnFailure = keyValueProcessorConfig.getTagsOnFailure();
-
-        this.normalizeKeys = keyValueProcessorConfig.getNormalizeKeys();
 
         if (keyValueProcessorConfig.getFieldDelimiterRegex() != null
                 && !keyValueProcessorConfig.getFieldDelimiterRegex().isEmpty()) {
@@ -197,6 +197,35 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         }
 
         keyPrefix = keyValueProcessorConfig.getPrefix() != null ? keyValueProcessorConfig.getPrefix() : "";
+
+        final FieldConflictStrategy fieldConflictStrategy = resolveFieldConflictStrategy(keyValueProcessorConfig);
+        final boolean normalizeKeys = keyValueProcessorConfig.getNormalizeKeys();
+        this.mergeSettings = new MergeSettings(fieldConflictStrategy, normalizeKeys);
+    }
+
+    private static FieldConflictStrategy resolveFieldConflictStrategy(final KeyValueProcessorConfig config) {
+        final FieldConflictStrategy conflictStrategy = config.getFieldConflictStrategy();
+        final Boolean overwriteIfDestinationExists = config.getOverwriteIfDestinationExists();
+
+        if (conflictStrategy != null && overwriteIfDestinationExists != null) {
+            throw new InvalidPluginConfigurationException(
+                    "overwrite_if_destination_exists and destination_conflict_strategy cannot both be set. " +
+                            "Use destination_conflict_strategy only.");
+        }
+
+        if (conflictStrategy != null) {
+            return conflictStrategy;
+        }
+
+        if (Boolean.FALSE.equals(overwriteIfDestinationExists)) {
+            LOG.warn("overwrite_if_destination_exists is deprecated. Use destination_conflict_strategy: skip instead.");
+            return FieldConflictStrategy.SKIP;
+        }
+
+        if (overwriteIfDestinationExists != null) {
+            LOG.warn("overwrite_if_destination_exists is deprecated. Use destination_conflict_strategy: overwrite instead.");
+        }
+        return FieldConflictStrategy.OVERWRITE;
     }
 
     private String buildRegexFromCharacters(String s) {
@@ -352,7 +381,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
             final Event recordEvent = record.getData();
 
             try {
-
                 if (keyValueProcessorConfig.getKeyValueWhen() != null && !expressionEvaluator.evaluateConditional(keyValueProcessorConfig.getKeyValueWhen(), recordEvent)) {
                     continue;
                 }
@@ -386,15 +414,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 }
 
                 final Map<String, Object> processedMap = executeConfigs(outputMap);
-
-                if (Objects.isNull(keyValueProcessorConfig.getDestination())) {
-                    writeToRoot(recordEvent, processedMap);
-                } else {
-                    if (keyValueProcessorConfig.getOverwriteIfDestinationExists() ||
-                            !recordEvent.containsKey(keyValueProcessorConfig.getDestination())) {
-                        recordEvent.put(keyValueProcessorConfig.getDestination(), processedMap, normalizeKeys);
-                    }
-                }
+                recordEvent.mergeFields(keyValueProcessorConfig.getDestination(), processedMap, mergeSettings);
             } catch (final Exception e) {
                 LOG.error(EVENT, "There was an exception while processing on Event [{}]: ", recordEvent, e);
                 recordEvent.getMetadata().addTags(tagsOnFailure);
@@ -688,15 +708,4 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         }
     }
 
-    private void writeToRoot(final Event event, final Map<String, Object> parsedJson) {
-        for (Map.Entry<String, Object> entry : parsedJson.entrySet()) {
-            try {
-                if (keyValueProcessorConfig.getOverwriteIfDestinationExists() || !event.containsKey(entry.getKey())) {
-                    event.put(entry.getKey(), entry.getValue(), normalizeKeys);
-                }
-            } catch (IllegalArgumentException e) {
-                LOG.warn("Failed to put key: "+entry.getKey()+" value : "+entry.getValue()+" into event. ", e);
-            }
-        }
-    }
 }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.common.TransformOption;
+import org.opensearch.dataprepper.model.event.FieldConflictStrategy;
 import org.opensearch.dataprepper.model.annotations.AlsoRequired;
 import org.opensearch.dataprepper.model.annotations.ExampleValues;
 import org.opensearch.dataprepper.model.annotations.ExampleValues.Example;
@@ -227,11 +228,22 @@ public class KeyValueProcessorConfig {
             @AlsoRequired.Required(name = WHITESPACE_KEY, allowedValues = {"strict"})
     })
     private boolean recursive = false;
-    
-    @JsonProperty(value = "overwrite_if_destination_exists", defaultValue = "true")
-    @JsonPropertyDescription("Specifies whether to overwrite existing fields if there are key conflicts " +
-            "when writing parsed fields to the event. Default is <code>true</code>.")
-    private boolean overwriteIfDestinationExists = true;
+
+    @Deprecated
+    @JsonProperty(value = "overwrite_if_destination_exists")
+    @JsonPropertyDescription("Deprecated. Use <code>destination_conflict_strategy</code> instead. " +
+            "Specifies whether to overwrite existing fields if there are key conflicts " +
+            "when writing parsed fields to the event.")
+    private Boolean overwriteIfDestinationExists = null;
+
+    @JsonProperty(value = "destination_conflict_strategy")
+    @JsonPropertyDescription("Defines the conflict resolution strategy when the destination field already exists. " +
+            "Options are <code>skip</code> (skip the write entirely), " +
+            "<code>overwrite</code> (replace the entire destination), " +
+            "<code>merge_preserve_existing_keys</code> (merge per-field, keeping existing values on conflict), " +
+            "and <code>merge_overwrite_existing_keys</code> (merge per-field, overwriting existing values on conflict). " +
+            "Default is <code>overwrite</code>. Cannot be used together with <code>overwrite_if_destination_exists</code>.")
+    private FieldConflictStrategy fieldConflictStrategy = null;
 
     @JsonProperty(value = "drop_keys_with_no_value", defaultValue = "false")
     @JsonPropertyDescription("Specifies whether keys should be dropped if they have a null value. Default is <code>false</code>. " +
@@ -286,6 +298,12 @@ public class KeyValueProcessorConfig {
                 (!stringLiteralCharacter.equals("'"))))
             return false;
         return valueGrouping;
+    }
+
+    @AssertTrue(message = "overwrite_if_destination_exists and destination_conflict_strategy cannot both be set. " +
+            "Use destination_conflict_strategy only.")
+    boolean isValidDestinationConflictConfig() {
+        return overwriteIfDestinationExists == null || fieldConflictStrategy == null;
     }
 
     public String getSource() {
@@ -384,8 +402,12 @@ public class KeyValueProcessorConfig {
         return tagsOnFailure;
     }
 
-    public boolean getOverwriteIfDestinationExists() {
+    public Boolean getOverwriteIfDestinationExists() {
         return overwriteIfDestinationExists;
+    }
+
+    public FieldConflictStrategy getFieldConflictStrategy() {
+        return fieldConflictStrategy;
     }
 
     public String getKeyValueWhen() { return keyValueWhen; }

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorDestinationMergeIT.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorDestinationMergeIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.dataprepper.plugins.processor.keyvalue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.FieldConflictStrategy;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Integration test for the key_value processor's {@code destination_conflict_strategy} behavior.
+ * Unlike the unit tests, this deserializes a real {@link KeyValueProcessorConfig} from a settings
+ * map and drives a real {@link KeyValueProcessor}, exercising the config binding
+ * (YAML key -> enum -> strategy resolution -> write) end-to-end.
+ */
+class KeyValueProcessorDestinationMergeIT {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String TEST_SOURCE = "body";
+    private static final String TEST_DESTINATION = "attributes";
+
+    private KeyValueProcessor createProcessor(final Map<String, Object> extraSettings) {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put("source", TEST_SOURCE);
+        settings.put("destination", TEST_DESTINATION);
+        settings.put("field_split_characters", " ");
+        settings.put("value_split_characters", "=");
+        settings.putAll(extraSettings);
+
+        final KeyValueProcessorConfig config = OBJECT_MAPPER.convertValue(settings, KeyValueProcessorConfig.class);
+        return new KeyValueProcessor(mock(PluginMetrics.class), config, mock(ExpressionEvaluator.class));
+    }
+
+    private KeyValueProcessor createProcessor(final FieldConflictStrategy strategy) {
+        return createProcessor(Map.of("destination_conflict_strategy", strategy.getOptionName()));
+    }
+
+    private Record<Event> createEventWithExistingAttributes(final String body, final Map<String, Object> existingAttributes) {
+        final Map<String, Object> data = new HashMap<>();
+        data.put(TEST_SOURCE, body);
+        data.put(TEST_DESTINATION, existingAttributes);
+        return new Record<>(JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build());
+    }
+
+    private Record<Event> createEventWithBodyOnly(final String body) {
+        final Map<String, Object> data = new HashMap<>();
+        data.put(TEST_SOURCE, body);
+        return new Record<>(JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Event process(final KeyValueProcessor processor, final Record<Event> record) {
+        final List<Record<Event>> results =
+                (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        return results.get(0).getData();
+    }
+
+    @Test
+    void test_merge_preserve_existing_keys_merges_new_fields_without_overwriting_conflicts() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS);
+
+        final Map<String, Object> existingAttributes = new HashMap<>();
+        existingAttributes.put("cluster_name", "my-cluster");
+        existingAttributes.put("obs_body_length", 42);
+
+        final Event event = process(processor, createEventWithExistingAttributes(
+                "logtype=ws:access method=GET uri=/health", existingAttributes));
+
+        // Existing fields preserved
+        assertThat(event.get("attributes/cluster_name", Object.class), is("my-cluster"));
+        assertThat(event.get("attributes/obs_body_length", Object.class), is(42));
+
+        // New fields merged in
+        assertThat(event.get("attributes/logtype", Object.class), is("ws:access"));
+        assertThat(event.get("attributes/method", Object.class), is("GET"));
+        assertThat(event.get("attributes/uri", Object.class), is("/health"));
+    }
+
+    @Test
+    void test_merge_preserve_existing_keys_does_not_overwrite_conflicting_keys() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS);
+
+        final Map<String, Object> existingAttributes = new HashMap<>();
+        existingAttributes.put("method", "POST");  // conflicts with parsed value
+
+        final Event event = process(processor, createEventWithExistingAttributes(
+                "method=GET uri=/health", existingAttributes));
+
+        // Conflicting field NOT overwritten
+        assertThat(event.get("attributes/method", Object.class), is("POST"));
+        // Non-conflicting field merged
+        assertThat(event.get("attributes/uri", Object.class), is("/health"));
+    }
+
+    @Test
+    void test_merge_overwrite_existing_keys_overwrites_conflicting_fields() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS);
+
+        final Map<String, Object> existingAttributes = new HashMap<>();
+        existingAttributes.put("cluster_name", "my-cluster");
+        existingAttributes.put("method", "POST");  // This should be overwritten
+
+        final Event event = process(processor, createEventWithExistingAttributes(
+                "logtype=ws:access method=GET uri=/health", existingAttributes));
+
+        // Existing non-conflicting field preserved
+        assertThat(event.get("attributes/cluster_name", Object.class), is("my-cluster"));
+        // Conflicting field overwritten
+        assertThat(event.get("attributes/method", Object.class), is("GET"));
+        // New fields merged in
+        assertThat(event.get("attributes/logtype", Object.class), is("ws:access"));
+        assertThat(event.get("attributes/uri", Object.class), is("/health"));
+    }
+
+    @Test
+    void test_skip_strategy_skips_when_destination_exists() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.SKIP);
+
+        final Map<String, Object> existingAttributes = new HashMap<>();
+        existingAttributes.put("cluster_name", "my-cluster");
+
+        final Event event = process(processor, createEventWithExistingAttributes(
+                "logtype=ws:access method=GET", existingAttributes));
+
+        assertThat(event.get("attributes/cluster_name", Object.class), is("my-cluster"));
+        assertThat(event.containsKey("attributes/logtype"), is(false));
+        assertThat(event.containsKey("attributes/method"), is(false));
+    }
+
+    @Test
+    void test_overwrite_strategy_replaces_entire_destination() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.OVERWRITE);
+
+        final Map<String, Object> existingAttributes = new HashMap<>();
+        existingAttributes.put("cluster_name", "my-cluster");
+        existingAttributes.put("obs_body_length", 42);
+
+        final Event event = process(processor, createEventWithExistingAttributes(
+                "logtype=ws:access method=GET uri=/health", existingAttributes));
+
+        // Entire destination replaced - existing fields lost
+        assertThat(event.containsKey("attributes/cluster_name"), is(false));
+        assertThat(event.containsKey("attributes/obs_body_length"), is(false));
+        // New parsed fields present
+        assertThat(event.get("attributes/logtype", Object.class), is("ws:access"));
+        assertThat(event.get("attributes/method", Object.class), is("GET"));
+        assertThat(event.get("attributes/uri", Object.class), is("/health"));
+    }
+
+    @Test
+    void test_destination_does_not_exist_creates_it_regardless_of_strategy() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS);
+
+        final Event event = process(processor, createEventWithBodyOnly("key1=value1 key2=value2"));
+
+        assertThat(event.get("attributes/key1", Object.class), is("value1"));
+        assertThat(event.get("attributes/key2", Object.class), is("value2"));
+    }
+
+    @Test
+    void test_merge_preserve_on_non_map_destination_skips_write() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS);
+
+        final Map<String, Object> data = new HashMap<>();
+        data.put(TEST_SOURCE, "key1=value1 key2=value2");
+        data.put(TEST_DESTINATION, "a plain string");
+        final Event event = process(processor, new Record<>(JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build()));
+
+        assertThat(event.get(TEST_DESTINATION, Object.class), equalTo("a plain string"));
+    }
+
+    @Test
+    void test_merge_overwrite_on_non_map_destination_replaces_with_parsed_map() {
+        final KeyValueProcessor processor = createProcessor(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS);
+
+        final Map<String, Object> data = new HashMap<>();
+        data.put(TEST_SOURCE, "key1=value1 key2=value2");
+        data.put(TEST_DESTINATION, "a plain string");
+        final Event event = process(processor, new Record<>(JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build()));
+
+        assertThat(event.get("attributes/key1", Object.class), is("value1"));
+        assertThat(event.get("attributes/key2", Object.class), is("value2"));
+    }
+
+    @Test
+    void test_legacy_overwrite_false_without_strategy_resolves_to_skip_behavior() {
+        // Backward compatibility: overwrite_if_destination_exists: false should behave as SKIP
+        final KeyValueProcessor processor = createProcessor(Map.of("overwrite_if_destination_exists", false));
+
+        final Map<String, Object> existingAttributes = new HashMap<>();
+        existingAttributes.put("cluster_name", "my-cluster");
+
+        final Event event = process(processor, createEventWithExistingAttributes(
+                "logtype=ws:access method=GET", existingAttributes));
+
+        // Destination exists, legacy overwrite=false -> skip entirely (backward compatible)
+        assertThat(event.get("attributes/cluster_name", Object.class), is("my-cluster"));
+        assertThat(event.containsKey("attributes/logtype"), is(false));
+        assertThat(event.containsKey("attributes/method"), is(false));
+    }
+
+    @Test
+    void test_legacy_overwrite_true_and_strategy_together_is_rejected() {
+        // The two options are mutually exclusive and must fail fast at construction.
+        final Map<String, Object> settings = Map.of(
+                "overwrite_if_destination_exists", true,
+                "destination_conflict_strategy", FieldConflictStrategy.OVERWRITE.getOptionName());
+
+        org.junit.jupiter.api.Assertions.assertThrows(InvalidPluginConfigurationException.class,
+                () -> createProcessor(settings));
+    }
+}

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -482,6 +482,23 @@ public class KeyValueProcessorTests {
     }
 
     @Test
+    void testLegacyOverwriteTrue_withNoStrategy_resolvesToOverwriteBehavior() {
+        when(mockConfig.getOverwriteIfDestinationExists()).thenReturn(true);
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(null);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        final Map<String, Object> existingMap = new HashMap<>();
+        existingMap.put("existing_key", "existing_value");
+        record.getData().put("parsed_message", existingMap);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final Event event = editedRecords.get(0).getData();
+
+        assertThat(event.containsKey("parsed_message"), is(true));
+        assertThat(event.get("parsed_message/key1", Object.class), is("value1"));
+        assertThat(event.get("parsed_message/key2", Object.class), is("value2"));
+        assertThat(event.containsKey("parsed_message/existing_key"), is(false));
+    }
+
+    @Test
     void testSingleRegexFieldDelimiterKvToObjectKeyValueProcessor() {
         when(mockConfig.getFieldDelimiterRegex()).thenReturn(":_*:");
         when(mockConfig.getFieldSplitCharacters()).thenReturn(null);

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.FieldConflictStrategy;
 import org.opensearch.dataprepper.common.TransformOption;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
@@ -89,6 +90,7 @@ public class KeyValueProcessorTests {
         lenient().when(mockConfig.getRemoveBrackets()).thenReturn(defaultConfig.getRemoveBrackets());
         lenient().when(mockConfig.getRecursive()).thenReturn(defaultConfig.getRecursive());
         lenient().when(mockConfig.getOverwriteIfDestinationExists()).thenReturn(defaultConfig.getOverwriteIfDestinationExists());
+        lenient().when(mockConfig.getFieldConflictStrategy()).thenReturn(null);
         lenient().when(mockConfig.getValueGrouping()).thenReturn(false);
         lenient().when(mockConfig.getDropKeysWithNoValue()).thenReturn(false);
 
@@ -363,6 +365,120 @@ public class KeyValueProcessorTests {
 
         assertThat(event.containsKey("parsed_message"), is(true));
         assertThat(event.get("parsed_message", Object.class), is("value will not be overwritten"));
+    }
+
+    @Test
+    void testWriteToDestinationPerFieldMerge_withOverwriteDisabled_doesNotOverwriteExistingFields() {
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        final Map<String, Object> existingMap = new HashMap<>();
+        existingMap.put("key1", "existing_value");
+        existingMap.put("existing_key", "should_remain");
+        record.getData().put("parsed_message", existingMap);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final Event event = editedRecords.get(0).getData();
+
+        assertThat(event.containsKey("parsed_message"), is(true));
+        assertThat(event.get("parsed_message/key1", Object.class), is("existing_value"));
+        assertThat(event.get("parsed_message/key2", Object.class), is("value2"));
+        assertThat(event.get("parsed_message/existing_key", Object.class), is("should_remain"));
+    }
+
+    @Test
+    void testWriteToDestinationPerFieldMerge_withOverwriteEnabled_overwritesConflictingFields() {
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        final Map<String, Object> existingMap = new HashMap<>();
+        existingMap.put("key1", "existing_value");
+        existingMap.put("existing_key", "should_remain");
+        record.getData().put("parsed_message", existingMap);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final Event event = editedRecords.get(0).getData();
+
+        assertThat(event.containsKey("parsed_message"), is(true));
+        assertThat(event.get("parsed_message/key1", Object.class), is("value1"));
+        assertThat(event.get("parsed_message/key2", Object.class), is("value2"));
+        assertThat(event.get("parsed_message/existing_key", Object.class), is("should_remain"));
+    }
+
+    @Test
+    void testWriteToDestinationWithOverwriteEnabled_nonMapDestination_replacesEntireValue() {
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        record.getData().put("parsed_message", "a plain string value");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(2));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
+        assertThatKeyEquals(parsed_message, "key2", "value2");
+    }
+
+    @Test
+    void testWriteToDestination_withSkipStrategy_skipsWhenDestinationExists() {
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.SKIP);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        final Map<String, Object> existingMap = new HashMap<>();
+        existingMap.put("existing_key", "existing_value");
+        record.getData().put("parsed_message", existingMap);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final Event event = editedRecords.get(0).getData();
+
+        assertThat(event.containsKey("parsed_message"), is(true));
+        assertThat(event.get("parsed_message/existing_key", Object.class), is("existing_value"));
+        assertThat(event.containsKey("parsed_message/key1"), is(false));
+        assertThat(event.containsKey("parsed_message/key2"), is(false));
+    }
+
+    @Test
+    void testWriteToDestination_withOverwriteStrategy_replacesEntireDestination() {
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.OVERWRITE);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        final Map<String, Object> existingMap = new HashMap<>();
+        existingMap.put("existing_key", "existing_value");
+        record.getData().put("parsed_message", existingMap);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(2));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
+        assertThatKeyEquals(parsed_message, "key2", "value2");
+    }
+
+    @Test
+    void testMergePreserveExistingKeys_nonMapDestination_skipsWrite() {
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.MERGE_PRESERVE_EXISTING_KEYS);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        record.getData().put("parsed_message", "a plain string value");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final Event event = editedRecords.get(0).getData();
+
+        assertThat(event.containsKey("parsed_message"), is(true));
+        assertThat(event.get("parsed_message", Object.class), is("a plain string value"));
+    }
+
+    @Test
+    void testBothOverwriteAndStrategySetThrowsException() {
+        when(mockConfig.getOverwriteIfDestinationExists()).thenReturn(false);
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(FieldConflictStrategy.MERGE_OVERWRITE_EXISTING_KEYS);
+        assertThrows(InvalidPluginConfigurationException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void testLegacyOverwriteFalse_withNoStrategy_resolvesToSkipBehavior() {
+        when(mockConfig.getOverwriteIfDestinationExists()).thenReturn(false);
+        when(mockConfig.getFieldConflictStrategy()).thenReturn(null);
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
+        final Map<String, Object> existingMap = new HashMap<>();
+        existingMap.put("existing_key", "existing_value");
+        record.getData().put("parsed_message", existingMap);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) createObjectUnderTest().doExecute(Collections.singletonList(record));
+        final Event event = editedRecords.get(0).getData();
+
+        assertThat(event.containsKey("parsed_message"), is(true));
+        assertThat(event.get("parsed_message/existing_key", Object.class), is("existing_value"));
+        assertThat(event.containsKey("parsed_message/key1"), is(false));
+        assertThat(event.containsKey("parsed_message/key2"), is(false));
     }
 
     @Test


### PR DESCRIPTION
### Description
Add destination_conflict_strategy with skip, overwrite, merge_preserve_existing_keys, and merge_overwrite_existing_keys. The merge strategies resolve conflicts per-field on an existing destination map.

overwrite_if_destination_exists is deprecated but still honored (false -> skip, true -> overwrite); setting both options is rejected. The default stays overwrite, so existing pipelines are unaffected. The logic is extracted into a reusable EventDestinationWriter that can be used to bring this logic to other processors.
 
### Issues Resolved
Resolves #7091
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR. - Will create a PR for documentation
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
