### PR TITLE
Migrate Jira search from removed /rest/api/3/search to /rest/api/3/se…

### DIFF
--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/JiraService.java
@@ -97,17 +97,22 @@ public class JiraService {
                                                   Queue<ItemInfo> itemInfoQueue) {
         log.trace("Looking for Add/Modified tickets with a Search API call");
         StringBuilder jql = createIssueFilterCriteria(configuration, timestamp);
-        int total;
-        int startAt = 0;
+        int totalFound = 0;
+        String nextPageToken = null;
+        boolean isLast = false;
         do {
-            SearchResults searchIssues = jiraRestClient.getAllIssues(jql, startAt);
+            SearchResults searchIssues = jiraRestClient.getAllIssues(jql, nextPageToken);
             List<IssueBean> issueList = new ArrayList<>(searchIssues.getIssues());
-            total = searchIssues.getTotal();
-            startAt += searchIssues.getIssues().size();
+            totalFound += issueList.size();
+            nextPageToken = searchIssues.getNextPageToken();
+            isLast = Boolean.TRUE.equals(searchIssues.getIsLast());
             addItemsToQueue(issueList, itemInfoQueue);
-        } while (startAt < total);
-        searchResultsFoundCounter.increment(total);
-        log.info("Number of tickets found in search api call: {}", total);
+        } while (!isLast && nextPageToken != null);
+        if (!isLast && nextPageToken == null) {
+            log.warn("Jira search pagination ended unexpectedly: isLast={} but nextPageToken is null. Some results may be missing.", isLast);
+        }
+        searchResultsFoundCounter.increment(totalFound);
+        log.info("Number of tickets found in search api call: {}", totalFound);
     }
 
     /**

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/models/SearchResults.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/models/SearchResults.java
@@ -36,4 +36,10 @@ public class SearchResults {
     @JsonProperty("issues")
     private List<IssueBean> issues = null;
 
+    @JsonProperty("nextPageToken")
+    private String nextPageToken = null;
+
+    @JsonProperty("isLast")
+    private Boolean isLast = null;
+
 }

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/main/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClient.java
@@ -34,10 +34,10 @@ import static org.opensearch.dataprepper.plugins.source.jira.utils.JqlConstants.
 @Named
 public class JiraRestClient extends AtlassianRestClient {
 
-    public static final String REST_API_SEARCH = "rest/api/3/search";
+    public static final String REST_API_SEARCH = "rest/api/3/search/jql";
     public static final String REST_API_FETCH_ISSUE = "rest/api/3/issue";
     public static final String FIFTY = "50";
-    public static final String START_AT = "startAt";
+    public static final String NEXT_PAGE_TOKEN = "nextPageToken";
     public static final String MAX_RESULT = "maxResults";
     private static final String TICKET_FETCH_LATENCY_TIMER = "ticketFetchLatency";
     private static final String SEARCH_CALL_LATENCY_TIMER = "searchCallLatency";
@@ -81,20 +81,24 @@ public class JiraRestClient extends AtlassianRestClient {
     /**
      * Method to get Issues.
      *
-     * @param jql     input parameter.
-     * @param startAt the start at
-     * @return InputStream input stream
+     * @param jql           input parameter.
+     * @param nextPageToken the pagination token from previous response, or null for first page
+     * @return SearchResults search results
      */
-    public SearchResults getAllIssues(StringBuilder jql, int startAt) {
+    public SearchResults getAllIssues(StringBuilder jql, String nextPageToken) {
 
         String url = authConfig.getUrl() + REST_API_SEARCH;
 
-        URI uri = UriComponentsBuilder.fromHttpUrl(url)
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
                 .queryParam(MAX_RESULT, FIFTY)
-                .queryParam(START_AT, startAt)
                 .queryParam(JQL_FIELD, jql)
-                .queryParam(EXPAND_FIELD, EXPAND_VALUE)
-                .buildAndExpand().toUri();
+                .queryParam(EXPAND_FIELD, EXPAND_VALUE);
+
+        if (nextPageToken != null) {
+            builder.queryParam(NEXT_PAGE_TOKEN, nextPageToken);
+        }
+
+        URI uri = builder.buildAndExpand().toUri();
         return searchCallLatencyTimer.record(
                 () -> {
                     try {

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraIteratorTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraIteratorTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -72,8 +71,8 @@ public class JiraIteratorTest {
         assertNotNull(jiraIterator);
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         when(mockSearchResults.getIssues()).thenReturn(new ArrayList<>());
-        when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        when(mockSearchResults.getIsLast()).thenReturn(true);
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), any());
         assertFalse(jiraIterator.hasNext());
     }
 
@@ -103,8 +102,8 @@ public class JiraIteratorTest {
         IssueBean issue1 = createIssueBean(false);
         mockIssues.add(issue1);
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
-        when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        when(mockSearchResults.getIsLast()).thenReturn(true);
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), any());
 
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.setCrawlerQWaitTimeMillis(1);
@@ -132,8 +131,8 @@ public class JiraIteratorTest {
         IssueBean issue3 = createIssueBean(false);
         mockIssues.add(issue3);
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
-        when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        when(mockSearchResults.getIsLast()).thenReturn(true);
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), any());
 
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.setCrawlerQWaitTimeMillis(1);
@@ -149,8 +148,8 @@ public class JiraIteratorTest {
         jiraIterator = createObjectUnderTest();
         List<IssueBean> mockIssues = new ArrayList<>();
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
-        when(mockSearchResults.getTotal()).thenReturn(0);
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        when(mockSearchResults.getIsLast()).thenReturn(true);
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), any());
 
         jiraIterator.initialize(Instant.ofEpochSecond(0));
         jiraIterator.setCrawlerQWaitTimeMillis(1);

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
@@ -48,7 +48,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -204,9 +203,9 @@ public class JiraServiceTest {
 
         SearchResults mockSearchResults = mock(SearchResults.class);
         when(mockSearchResults.getIssues()).thenReturn(mockIssues);
-        when(mockSearchResults.getTotal()).thenReturn(mockIssues.size());
+        when(mockSearchResults.getIsLast()).thenReturn(true);
 
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), any());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
@@ -228,11 +227,19 @@ public class JiraServiceTest {
             mockIssues.add(issue1);
         }
 
-        SearchResults mockSearchResults = mock(SearchResults.class);
-        when(mockSearchResults.getIssues()).thenReturn(mockIssues);
-        when(mockSearchResults.getTotal()).thenReturn(100);
+        SearchResults firstPage = mock(SearchResults.class);
+        when(firstPage.getIssues()).thenReturn(mockIssues);
+        when(firstPage.getIsLast()).thenReturn(false);
+        when(firstPage.getNextPageToken()).thenReturn("page2-token");
 
-        doReturn(mockSearchResults).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        SearchResults secondPage = mock(SearchResults.class);
+        when(secondPage.getIssues()).thenReturn(mockIssues);
+        when(secondPage.getIsLast()).thenReturn(true);
+        when(secondPage.getNextPageToken()).thenReturn(null);
+
+        when(jiraRestClient.getAllIssues(any(StringBuilder.class), any()))
+                .thenReturn(firstPage)
+                .thenReturn(secondPage);
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
@@ -271,7 +278,7 @@ public class JiraServiceTest {
         JiraSourceConfig jiraSourceConfig = createJiraConfiguration(BASIC, issueType, issueStatus, projectKey);
         JiraService jiraService = spy(new JiraService(jiraSourceConfig, jiraRestClient, pluginMetrics));
 
-        doThrow(RuntimeException.class).when(jiraRestClient).getAllIssues(any(StringBuilder.class), anyInt());
+        doThrow(RuntimeException.class).when(jiraRestClient).getAllIssues(any(StringBuilder.class), any());
 
         Instant timestamp = Instant.ofEpochSecond(0);
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/JiraServiceTest.java
@@ -53,6 +53,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.atlassian.rest.auth.AtlassianOauthConfig.ACCESSIBLE_RESOURCES;
 import static org.opensearch.dataprepper.plugins.source.jira.utils.Constants.BASIC;
@@ -245,6 +247,10 @@ public class JiraServiceTest {
         Queue<ItemInfo> itemInfoQueue = new ConcurrentLinkedQueue<>();
         jiraService.getJiraEntities(jiraSourceConfig, timestamp, itemInfoQueue);
         assertTrue(itemInfoQueue.size() >= 100);
+
+        // Verify pagination token was read from each page
+        verify(firstPage, times(1)).getNextPageToken();
+        verify(secondPage, times(1)).getNextPageToken();
     }
 
     @Test

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -40,6 +41,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -139,9 +141,13 @@ public class JiraRestClientTest {
         JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
         SearchResults mockSearchResults = mock(SearchResults.class);
         doReturn("http://mock-service.jira.com/").when(authConfig).getUrl();
-        doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(uriCaptor.capture(), any(Class.class));
+
         SearchResults results = jiraRestClient.getAllIssues(jql, "some-token-value");
+
         assertNotNull(results);
+        assertTrue(uriCaptor.getValue().toString().contains("nextPageToken=some-token-value"));
     }
 
     @Test

--- a/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
+++ b/data-prepper-plugins/saas-source-plugins/jira-source/src/test/java/org/opensearch/dataprepper/plugins/source/jira/rest/JiraRestClientTest.java
@@ -118,7 +118,7 @@ public class JiraRestClientTest {
         SearchResults mockSearchResults = mock(SearchResults.class);
         doReturn("http://mock-service.jira.com/").when(authConfig).getUrl();
         doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
-        SearchResults results = jiraRestClient.getAllIssues(jql, 0);
+        SearchResults results = jiraRestClient.getAllIssues(jql, null);
         assertNotNull(results);
     }
 
@@ -130,7 +130,17 @@ public class JiraRestClientTest {
         SearchResults mockSearchResults = mock(SearchResults.class);
         when(authConfig.getUrl()).thenReturn("https://example.com/");
         doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
-        SearchResults results = jiraRestClient.getAllIssues(jql, 0);
+        SearchResults results = jiraRestClient.getAllIssues(jql, null);
+        assertNotNull(results);
+    }
+
+    @Test
+    public void testGetAllIssuesWithNextPageToken() {
+        JiraRestClient jiraRestClient = new JiraRestClient(restTemplate, authConfig, pluginMetrics);
+        SearchResults mockSearchResults = mock(SearchResults.class);
+        doReturn("http://mock-service.jira.com/").when(authConfig).getUrl();
+        doReturn(new ResponseEntity<>(mockSearchResults, HttpStatus.OK)).when(restTemplate).getForEntity(any(URI.class), any(Class.class));
+        SearchResults results = jiraRestClient.getAllIssues(jql, "some-token-value");
         assertNotNull(results);
     }
 


### PR DESCRIPTION
Migrate Jira search from removed /rest/api/3/search to /rest/api/3/search/jql

Closes #7104

### Description

Atlassian permanently removed the `/rest/api/3/search` endpoint (CHANGE-2046, effective May 1, 2025). All Jira Cloud instances now return HTTP 410 GONE for this endpoint. This change migrates the Jira source plugin to the replacement `/rest/api/3/search/jql` endpoint.

Key changes:
- Updated search endpoint URL from `rest/api/3/search` to `rest/api/3/search/jql`
- Migrated from offset-based (`startAt`) to cursor-based (`nextPageToken`) pagination per the new API contract
- Added `nextPageToken` and `isLast` fields to the `SearchResults` model
- Updated pagination loop in `JiraService` to use cursor-based iteration

### Issues Resolved

Closes #7104

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
