### PR TITLE
feat(os-s3-dlq): add codec option for JSON or NDJSON output

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
@@ -20,7 +20,7 @@ public enum DlqCodec {
     @JsonCreator
     public static DlqCodec fromOptionValue(final String option) {
         for (final DlqCodec codec : values()) {
-            if (codec.option.equalsIgnoreCase(option)) {
+            if (codec.option.equals(option)) {
                 return codec;
             }
         }

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.dlq.s3;

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.dlq.s3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum DlqCodec {
+    JSON("json"),
+    NDJSON("ndjson");
+
+    private final String option;
+
+    DlqCodec(final String option) {
+        this.option = option;
+    }
+
+    @JsonCreator
+    public static DlqCodec fromOptionValue(final String option) {
+        for (final DlqCodec codec : values()) {
+            if (codec.option.equalsIgnoreCase(option)) {
+                return codec;
+            }
+        }
+        throw new IllegalArgumentException("Unknown DLQ codec: " + option);
+    }
+
+    public String getExtension() {
+        return option;
+    }
+}

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodec.java
@@ -24,7 +24,8 @@ public enum DlqCodec {
                 return codec;
             }
         }
-        throw new IllegalArgumentException("Unknown DLQ codec: " + option);
+        throw new IllegalArgumentException(
+            "Unknown DLQ codec: " + option + ". Only json and ndjson are supported.");
     }
 
     public String getExtension() {

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -47,7 +47,7 @@ public class S3DlqWriter implements DlqWriter {
     static final String S3_DLQ_REQUEST_LATENCY = "dlqS3RequestLatency";
     static final String S3_DLQ_REQUEST_SIZE_BYTES = "dlqS3RequestSizeBytes";
     static final String DLQ_OBJECTS = "dlqObjects";
-    private static final String KEY_NAME_FORMAT = "dlq-v%s-%s-%s-%s-%s.json";
+    private static final String KEY_NAME_FORMAT = "dlq-v%s-%s-%s-%s-%s.%s";
     private static final String FULL_KEY_FORMAT = "%s%s";
 
     private static final Logger LOG = LoggerFactory.getLogger(S3DlqWriter.class);
@@ -58,6 +58,7 @@ public class S3DlqWriter implements DlqWriter {
 
     private final String bucketOwner;
     private final ObjectMapper objectMapper;
+    private final DlqCodec codec;
 
     private final Counter dlqS3RecordsSuccessCounter;
     private final Counter dlqS3RecordsFailedCounter;
@@ -83,6 +84,8 @@ public class S3DlqWriter implements DlqWriter {
         this.objectMapper = objectMapper;
         this.keyPathGenerator = new KeyPathGenerator(keyPathPrefix);
         this.bucketOwner = s3DlqWriterConfig.getBucketOwner();
+        final DlqCodec configuredCodec = s3DlqWriterConfig.getCodec();
+        this.codec = configuredCodec != null ? configuredCodec : DlqCodec.JSON;
     }
 
     @Override
@@ -143,9 +146,17 @@ public class S3DlqWriter implements DlqWriter {
 
     private String deserialize(final List<DlqObject> dlqObjects) throws IOException {
         try {
-            final Map<String, Object> output = Map.of(DLQ_OBJECTS, dlqObjects);
-
-            final String content = objectMapper.writeValueAsString(output);
+            final String content;
+            if (codec == DlqCodec.NDJSON) {
+                final StringBuilder builder = new StringBuilder();
+                for (final DlqObject dlqObject : dlqObjects) {
+                    builder.append(objectMapper.writeValueAsString(dlqObject)).append('\n');
+                }
+                content = builder.toString();
+            } else {
+                final Map<String, Object> output = Map.of(DLQ_OBJECTS, dlqObjects);
+                content = objectMapper.writeValueAsString(output);
+            }
 
             dlqS3RequestSizeBytesSummary.record(content.getBytes(StandardCharsets.UTF_8).length);
 
@@ -158,7 +169,7 @@ public class S3DlqWriter implements DlqWriter {
 
     private String buildKey(final String pipelineName, final String pluginId) {
         final String key = String.format(KEY_NAME_FORMAT, DataPrepperVersion.getCurrentVersion().getMajorVersion(),
-            pipelineName, pluginId, Instant.now(), UUID.randomUUID());
+            pipelineName, pluginId, Instant.now(), UUID.randomUUID(), codec.getExtension());
         return keyPathPrefix == null ? key : String.format(FULL_KEY_FORMAT, keyPathGenerator.generate(), key);
     }
 

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -77,6 +77,9 @@ public class S3DlqWriterConfig {
     @AwsAccountId
     private String bucketOwner;
 
+    @JsonProperty("codec")
+    private DlqCodec codec = DlqCodec.JSON;
+
     public String getBucket() {
         if (bucket.startsWith(S3_PREFIX)) {
             return bucket.substring(S3_PREFIX.length());
@@ -101,6 +104,10 @@ public class S3DlqWriterConfig {
     }
 
     public String getBucketOwner() { return bucketOwner; }
+
+    public DlqCodec getCodec() {
+        return codec;
+    }
 
     private AwsCredentialsProvider getAwsCredentialsProvider() {
 

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodecTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodecTest.java
@@ -1,6 +1,11 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
  */
 
 package org.opensearch.dataprepper.plugins.dlq.s3;

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodecTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/DlqCodecTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.dlq.s3;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class DlqCodecTest {
+    @ParameterizedTest
+    @EnumSource(DlqCodec.class)
+    void fromOptionValue_returns_expected_value(final DlqCodec dlqCodec) {
+        assertThat(DlqCodec.fromOptionValue(dlqCodec.getExtension()), equalTo(dlqCodec));
+    }
+
+    @ParameterizedTest
+    @EnumSource(DlqCodec.class)
+    void getExtension_returns_non_empty_string_for_all_types(final DlqCodec dlqCodec) {
+        assertThat(dlqCodec.getExtension(), notNullValue());
+        assertThat(dlqCodec.getExtension(), not(emptyString()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DlqCodecToKnownName.class)
+    void getExtension_returns_expected_name(final DlqCodec dlqCodec, final String expectedString) {
+        assertThat(dlqCodec.getExtension(), equalTo(expectedString));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"JSON", "Json", "NDJSON", "Ndjson", "yaml", "csv", ""})
+    void fromOptionValue_throws_for_unknown_or_mismatched_case(final String invalidOption) {
+        assertThrows(IllegalArgumentException.class, () -> DlqCodec.fromOptionValue(invalidOption));
+    }
+
+    static class DlqCodecToKnownName implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(DlqCodec.JSON, "json"),
+                    arguments(DlqCodec.NDJSON, "ndjson")
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
@@ -45,6 +45,11 @@ public class S3DlqWriterConfigTest {
         assertThat(new S3DlqWriterConfig().getLegacyMd5Checksum(), is(equalTo(false)));
     }
 
+    @Test
+    public void testDefaultCodec() {
+        assertThat(new S3DlqWriterConfig().getCodec(), is(equalTo(DlqCodec.JSON)));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"foobar", "arn:aws:es:us-west-2:123456789012:domain/bogus-domain",
         "arn:aws:iam::123456789012:group/bogus-group"})

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
@@ -168,6 +168,45 @@ public class S3DlqWriterTest {
     }
 
     @Test
+    public void testWriteWithNdjsonCodec() throws Exception {
+        when(config.getKeyPathPrefix()).thenReturn(null);
+        when(config.getS3Client()).thenReturn(s3Client);
+        when(config.getBucket()).thenReturn(bucket);
+        when(config.getBucketOwner()).thenReturn(UUID.randomUUID().toString());
+        when(config.getCodec()).thenReturn(DlqCodec.NDJSON);
+        when(dlqS3RequestTimer.recordCallable(any(Callable.class))).thenAnswer(a -> {
+            try {
+                return a.getArgument(0, Callable.class).call();
+            } catch (final Exception ex) {
+                throw ex;
+            }
+        });
+        s3DlqWriter = new S3DlqWriter(config, objectMapper, pluginMetrics);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(putObjectResponse);
+        when(mockHttpResponse.isSuccessful()).thenReturn(true);
+
+        s3DlqWriter.write(dlqObjects, pipelineName, pluginId);
+
+        final ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        final ArgumentCaptor<RequestBody> requestBodyArgumentCaptor = ArgumentCaptor.forClass(RequestBody.class);
+        verify(s3Client).putObject(putObjectRequestArgumentCaptor.capture(), requestBodyArgumentCaptor.capture());
+        final PutObjectRequest putObjectRequest = putObjectRequestArgumentCaptor.getValue();
+
+        assertThat(putObjectRequest.key(), endsWith(".ndjson"));
+
+        final String content = new String(
+            requestBodyArgumentCaptor.getValue().contentStreamProvider().newStream().readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        final String[] lines = content.split("\n");
+        assertThat(lines.length, is(equalTo(dlqObjects.size())));
+        for (final String line : lines) {
+            assertThat(line.trim().startsWith("{"), is(true));
+        }
+        verify(dlqS3RequestSuccessCounter).increment();
+        verify(dlqS3RecordsSuccessCounter).increment(dlqObjects.size());
+    }
+
+    @Test
     void write_with_empty_list_does_not_write_to_S3() throws Exception {
         when(config.getKeyPathPrefix()).thenReturn(keyPathPrefix);
         when(config.getS3Client()).thenReturn(s3Client);


### PR DESCRIPTION
## Summary
- Add `codec: json|ndjson` to the S3 DLQ writer. Default is `json`, so existing pipelines are unaffected. Similar in spirit to the `s3` sink's `codec` block, but implemented as a lightweight enum inside the DLQ writer.
- With `codec: ndjson`, each `DlqObject` is written on its own line and the S3 key extension becomes `.ndjson`, with no `{"dlqObjects":[...]}` envelope.

## Why not reuse the `OutputCodec` framework from the `s3` sink?
The existing `OutputCodec` plugin framework (`NdjsonOutputCodec`, `JsonOutputCodec`, `ParquetOutputCodec`, and so on) operates on `Event` objects. Its `Writer.writeEvent(Event)` API pulls JSON via `event.jsonBuilder()`. The DLQ writer's payload is a `DlqObject`, which is not an `Event`; it wraps arbitrary failed data plus failure metadata (`pluginId`, `pipelineName`, timestamp, cause). Plugging into `OutputCodec` would require either:
1. an adapter that repackages every `DlqObject` as a synthetic `JacksonLog` event, losing the shape consumers already rely on, or
2. changing `OutputCodec`'s contract to accept arbitrary POJOs, which is a much larger API change touching every existing codec and sink.

Note that the existing JSON path in `S3DlqWriter` does not use `OutputCodec` either. It calls `ObjectMapper.writeValueAsString(...)` directly on a plain Jackson mapper created in `S3DlqProvider`. This PR keeps that pattern and simply adds a second bare Jackson code path for NDJSON.

Both alternatives are disproportionate for a one line output shape toggle. Keeping this as a small enum inside `S3DlqWriter` preserves the existing DLQ payload shape, avoids destabilising a shared API, and leaves the door open to swap in the full `OutputCodec` machinery later if CSV or Parquet DLQs are wanted.

## Config example
```yaml
sink:
  - opensearch:
      dlq:
        s3:
          bucket: my-dlq
          codec: ndjson    # optional; defaults to json
```

## Test plan
- [x] `./gradlew :data-prepper-plugins:failures-common:test` passes on JDK 17.
- [x] Existing pipelines without `codec` still emit the legacy `.json` blob.
- [x] `codec: ndjson` produces a `.ndjson` object with one JSON record per line.
- [x] Invalid values (e.g. `codec: yaml`) fail pipeline validation.
