### PR TITLE
Make more background threads daemon threads to shut down

### DIFF
--- a/data-prepper-plugins/aws-plugin/build.gradle
+++ b/data-prepper-plugins/aws-plugin/build.gradle
@@ -10,6 +10,7 @@
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:aws-plugin-api')
+    implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.awssdk:auth'

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
@@ -11,6 +11,7 @@ package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperExtensionPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -95,7 +96,8 @@ public class AwsSecretPlugin implements ExtensionPlugin {
             secretsSupplier = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER, awsCredentialsSupplier);
             this.pluginConfigPublisher = new AwsSecretsPluginConfigPublisher();
             pluginConfigValueTranslator = new AwsSecretsPluginConfigValueTranslator(secretsSupplier);
-            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                    BackgroundThreadFactory.defaultExecutorThreadFactory("aws-secrets-refresh"));
             pluginMetrics = PluginMetrics.fromNames("secrets", "aws");
             submitSecretsRefreshJobs(awsSecretPluginConfig, secretsSupplier);
         } else {

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginIT.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -105,7 +106,8 @@ class AwsSecretPluginIT {
         when(secretsManagerClient.getSecretValue(eq(getSecretValueRequest))).thenReturn(getSecretValueResponse);
         when(getSecretValueResponse.secretString()).thenReturn(UUID.randomUUID().toString());
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor)
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
                     .thenReturn(scheduledExecutorService);
             objectUnderTest = new AwsSecretPlugin(awsSecretPluginConfig);
             objectUnderTest.apply(extensionPoints);
@@ -140,7 +142,8 @@ class AwsSecretPluginIT {
         when(secretsManagerClient.getSecretValue(eq(getSecretValueRequest))).thenReturn(getSecretValueResponse);
         when(getSecretValueResponse.secretString()).thenReturn(UUID.randomUUID().toString());
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor)
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
                     .thenReturn(scheduledExecutorService);
             objectUnderTest = new AwsSecretPlugin(awsSecretPluginConfig);
             objectUnderTest.apply(extensionPoints);
@@ -184,7 +187,8 @@ class AwsSecretPluginIT {
         when(awsSecretPluginConfig.getAwsSecretManagerConfigurationMap()).thenReturn(
                 Collections.emptyMap());
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor)
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
                     .thenReturn(scheduledExecutorService);
             objectUnderTest = new AwsSecretPlugin(awsSecretPluginConfig);
             objectUnderTest.apply(extensionPoints);
@@ -203,7 +207,8 @@ class AwsSecretPluginIT {
         when(awsSecretPluginConfig.getAwsSecretManagerConfigurationMap()).thenReturn(
                 Collections.emptyMap());
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor)
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
                     .thenReturn(scheduledExecutorService);
             objectUnderTest = new AwsSecretPlugin(awsSecretPluginConfig);
             objectUnderTest.apply(extensionPoints);
@@ -222,7 +227,8 @@ class AwsSecretPluginIT {
         when(awsSecretPluginConfig.getAwsSecretManagerConfigurationMap()).thenReturn(
                 Collections.emptyMap());
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor)
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
                     .thenReturn(scheduledExecutorService);
             objectUnderTest = new AwsSecretPlugin(awsSecretPluginConfig);
             objectUnderTest.apply(extensionPoints);
@@ -240,7 +246,8 @@ class AwsSecretPluginIT {
     @Test
     void testShutdownWithNullScheduledExecutorService() {
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor)
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
                     .thenReturn(scheduledExecutorService);
             objectUnderTest = new AwsSecretPlugin(null);
             objectUnderTest.apply(extensionPoints);

--- a/data-prepper-plugins/buffer-common/build.gradle
+++ b/data-prepper-plugins/buffer-common/build.gradle
@@ -13,6 +13,7 @@ plugins {
 
 dependencies {
     implementation project(path: ':data-prepper-api')
+    implementation project(':data-prepper-plugins:common')
 }
 
 test {

--- a/data-prepper-plugins/buffer-common/src/main/java/org/opensearch/dataprepper/buffer/common/BufferAccumulator.java
+++ b/data-prepper-plugins/buffer-common/src/main/java/org/opensearch/dataprepper/buffer/common/BufferAccumulator.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.dataprepper.buffer.common;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
@@ -80,7 +81,8 @@ public class BufferAccumulator<T extends Record<?>> {
     }
 
     private boolean flushWithBackoff() throws Exception{
-        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("buffer-accumulator-flush-retry"));
         long nextDelay = INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION.toMillis();
         boolean flushedSuccessfully;
 

--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/CloudWatchLogsSink.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.cloudwatch_logs;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
@@ -105,7 +106,8 @@ public class CloudWatchLogsSink extends AbstractSink<Record<Event>> {
             dlqPushHandler = new DlqPushHandler(pluginFactory, pluginSetting, pluginMetrics, cloudWatchLogsSinkConfig.getDlq(), region, role, "cloudWatchLogs");
         }
 
-        Executor executor = Executors.newFixedThreadPool(cloudWatchLogsSinkConfig.getWorkers());
+        Executor executor = Executors.newFixedThreadPool(cloudWatchLogsSinkConfig.getWorkers(),
+                BackgroundThreadFactory.defaultExecutorThreadFactory("cloudwatch-logs-sink"));
 
         final EntityConfig entityConfig = cloudWatchLogsSinkConfig.getEntityConfig();
         final boolean dynamicEntity = entityConfig != null && entityConfig.isDynamic(expressionEvaluator);

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/concurrent/BackgroundThreadFactory.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/common/concurrent/BackgroundThreadFactory.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link ThreadFactory} that names threads with a prefix and
- * sets threads as non-daemon threads.
+ * sets threads as daemon threads so that they do not prevent JVM shutdown.
  * <p>
  * The thread name will be <i>namePrefix</i>-<i>threadNumber</i>.
  */
@@ -48,7 +48,7 @@ public class BackgroundThreadFactory implements ThreadFactory {
     public Thread newThread(final Runnable runnable) {
         final Thread thread = delegateThreadFactory.newThread(runnable);
         thread.setName(namePrefix + "-" + threadNumber.getAndIncrement());
-        thread.setDaemon(false);
+        thread.setDaemon(true);
 
         return thread;
     }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/concurrent/BackgroundThreadFactoryTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/common/concurrent/BackgroundThreadFactoryTest.java
@@ -83,9 +83,9 @@ class BackgroundThreadFactoryTest {
         }
 
         @Test
-        void newThread_sets_daemon_to_false() {
+        void newThread_sets_daemon_to_true() {
             createObjectUnderTest().newThread(runnable);
-            verify(threadFromDelegate).setDaemon(false);
+            verify(threadFromDelegate).setDaemon(true);
         }
     }
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -81,7 +82,7 @@ public class DynamoDBService {
         // A shard manager is responsible to retrieve the shard information from streams.
         shardManager = new ShardManager(dynamoDbStreamsClient, dynamoDBSourceAggregateMetrics, pluginMetrics);
         tableConfigs = sourceConfig.getTableConfigs();
-        executor = Executors.newFixedThreadPool(4);
+        executor = Executors.newFixedThreadPool(4, BackgroundThreadFactory.defaultExecutorThreadFactory("dynamodb-source"));
     }
 
     /**

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.export;
 
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -77,7 +78,8 @@ public class DataFileScheduler implements Runnable {
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.dynamoDBSourceConfig = dynamoDBSourceConfig;
 
-        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT);
+        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT,
+                BackgroundThreadFactory.defaultExecutorThreadFactory("dynamodb-source-data-file"));
 
         this.exportFileSuccessCounter = pluginMetrics.counter(EXPORT_S3_OBJECTS_PROCESSED_COUNT);
         this.activeExportS3ObjectConsumersGauge = pluginMetrics.gauge(ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE, numOfWorkers);

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.export;
 
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
@@ -86,7 +87,8 @@ public class ExportScheduler implements Runnable {
         this.exportTaskManager = new ExportTaskManager(dynamoDBClient, dynamoDBSourceAggregateMetrics);
 
         this.manifestFileReader = manifestFileReader;
-        executor = Executors.newCachedThreadPool();
+        executor = Executors.newCachedThreadPool(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("dynamodb-source-export"));
 
         exportJobSuccessCounter = pluginMetrics.counter(EXPORT_JOB_SUCCESS_COUNT);
         exportJobFailureCounter = pluginMetrics.counter(EXPORT_JOB_FAILURE_COUNT);

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamScheduler.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.stream;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
@@ -69,7 +70,8 @@ public class StreamScheduler implements Runnable {
         this.shardAcknowledgementManager = dynamoDBSourceConfig.isAcknowledgmentsEnabled() ? 
             new ShardAcknowledgementManager(acknowledgementSetManager, coordinator, dynamoDBSourceConfig, coordinator::giveUpPartition) : null;
 
-        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT);
+        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT,
+                BackgroundThreadFactory.defaultExecutorThreadFactory("dynamodb-source-stream"));
         activeChangeEventConsumers = pluginMetrics.gauge(ACTIVE_CHANGE_EVENT_CONSUMERS, new AtomicLong());
         shardsInProcessing = pluginMetrics.gauge(SHARDS_IN_PROCESSING, new AtomicLong());
     }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
@@ -31,10 +31,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
@@ -96,7 +98,8 @@ class DynamoDBServiceTest {
     private DynamoDBService createObjectUnderTest() {
 
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(eq(4))).thenReturn(executorService);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(eq(4), any(ThreadFactory.class))).thenReturn(executorService);
 
             return new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics, acknowledgementSetManager);
         }

--- a/data-prepper-plugins/encryption-plugin/build.gradle
+++ b/data-prepper-plugins/encryption-plugin/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:aws-plugin-api')
+    implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'io.micrometer:micrometer-core'

--- a/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionPlugin.java
+++ b/data-prepper-plugins/encryption-plugin/src/main/java/org/opensearch/dataprepper/plugins/encryption/EncryptionPlugin.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.dataprepper.plugins.encryption;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperExtensionPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -100,7 +101,8 @@ public class EncryptionPlugin implements ExtensionPlugin {
                                 entry -> encryptionSupplier.getEncryptedDataKeySupplier(entry.getKey())
                         ));
         if (!rotationEnabledEncryptionIdToEncryptedDataSuppliers.isEmpty()) {
-            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                    BackgroundThreadFactory.defaultExecutorThreadFactory("encryption-key-rotation"));
             rotationEnabledEncryptionIdToEncryptedDataSuppliers.forEach((encryptionId, encryptedDataKeySupplier) -> {
                 final EncryptionEngineConfiguration encryptionEngineConfiguration = encryptionEngineConfigurationMap.get(encryptionId);
                 final long jitterDelay = ThreadLocalRandom.current().nextLong(60L);

--- a/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/CheckpointRegistry.java
+++ b/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/CheckpointRegistry.java
@@ -12,6 +12,7 @@ package org.opensearch.dataprepper.plugins.source.file;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,11 +44,8 @@ public final class CheckpointRegistry {
     private final ScheduledExecutorService scheduler;
 
     public CheckpointRegistry(final Path checkpointFile, final Duration flushInterval, final Duration cleanupAfter) {
-        this(checkpointFile, flushInterval, cleanupAfter, () -> Executors.newSingleThreadScheduledExecutor(r -> {
-            final Thread thread = new Thread(r, "file-checkpoint-flush");
-            thread.setDaemon(true);
-            return thread;
-        }));
+        this(checkpointFile, flushInterval, cleanupAfter, () -> Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("file-checkpoint-flush")));
     }
 
     CheckpointRegistry(final Path checkpointFile, final Duration flushInterval, final Duration cleanupAfter,

--- a/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/DirectoryWatcher.java
+++ b/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/DirectoryWatcher.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.source.file;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -261,11 +262,8 @@ public final class DirectoryWatcher {
     }
 
     static ScheduledExecutorService createDefaultPollScheduler() {
-        return Executors.newSingleThreadScheduledExecutor(r -> {
-            final Thread thread = new Thread(r, "file-poll");
-            thread.setDaemon(true);
-            return thread;
-        });
+        return Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("file-poll"));
     }
 
     private void startPollScheduler(final boolean watchServiceActive) {

--- a/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileReaderPool.java
+++ b/data-prepper-plugins/file-source/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileReaderPool.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.source.file;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,11 +51,8 @@ public final class FileReaderPool {
                               final Duration closeInactive,
                               final FileReaderContext readerContext) {
         this(checkpointRegistry, metrics, maxActiveFiles, closeInactive, readerContext,
-                () -> Executors.newFixedThreadPool(readerThreads, r -> {
-                    final Thread thread = new Thread(r, "file-reader");
-                    thread.setDaemon(true);
-                    return thread;
-                }));
+                () -> Executors.newFixedThreadPool(readerThreads,
+                        BackgroundThreadFactory.defaultExecutorThreadFactory("file-reader")));
     }
 
     FileReaderPool(final CheckpointRegistry checkpointRegistry,
@@ -72,11 +70,8 @@ public final class FileReaderPool {
         this.pendingIdentities = ConcurrentHashMap.newKeySet();
         this.pendingQueue = new ConcurrentLinkedQueue<>();
         this.executorService = executorServiceSupplier.get();
-        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            final Thread thread = new Thread(r, "file-reader-scheduler");
-            thread.setDaemon(true);
-            return thread;
-        });
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("file-reader-scheduler"));
     }
 
     public synchronized void addFile(final FileIdentity fileIdentity, final Path path) {

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIPProcessorService.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIPProcessorService.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.geoip.extension;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.plugins.geoip.extension.api.GeoIPDatabaseReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +71,8 @@ public class GeoIPProcessorService {
         if (geoIPDatabaseManager.getNextUpdateAt().isBefore(Instant.now())) {
             LOG.info("Trying to update geoip Database readers");
             geoIPDatabaseManager.setNextUpdateAt(Instant.now().plus(maxMindConfig.getDatabaseRefreshInterval()));
-            executorService = Executors.newSingleThreadExecutor();
+            executorService = Executors.newSingleThreadExecutor(
+                    BackgroundThreadFactory.defaultExecutorThreadFactory("geoip-database-update"));
             executorService.execute(geoIPDatabaseManager::updateDatabaseReader);
             executorService.shutdown();
         }

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -11,6 +11,7 @@ import io.krakens.grok.api.GrokCompiler;
 import io.krakens.grok.api.Match;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.NOISY;
@@ -94,7 +95,8 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
                          final GrokProcessorConfig grokProcessorConfig,
                          final ExpressionEvaluator expressionEvaluator) {
         this(pluginMetrics, grokProcessorConfig, GrokCompiler.newInstance(),
-                Executors.newSingleThreadExecutor(), expressionEvaluator);
+                Executors.newSingleThreadExecutor(BackgroundThreadFactory.defaultExecutorThreadFactory("grok-processor")),
+                expressionEvaluator);
     }
 
     GrokProcessor(final PluginMetrics pluginMetrics,

--- a/data-prepper-plugins/http-common/src/main/java/org/opensearch/dataprepper/plugins/server/CreateServer.java
+++ b/data-prepper-plugins/http-common/src/main/java/org/opensearch/dataprepper/plugins/server/CreateServer.java
@@ -25,6 +25,7 @@ import org.opensearch.dataprepper.GrpcRequestExceptionHandler;
 import org.opensearch.dataprepper.HttpRequestExceptionHandler;
 import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.http.LogThrottlingRejectHandler;
 import org.opensearch.dataprepper.http.LogThrottlingStrategy;
 import org.opensearch.dataprepper.http.certificate.CertificateProviderFactory;
@@ -277,7 +278,8 @@ public class CreateServer {
         }
 
         final int threads = serverConfiguration.getThreadCount();
-        final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threads);
+        final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threads,
+                BackgroundThreadFactory.defaultExecutorThreadFactory(pipelineName + "-" + sourceName));
         sb.blockingTaskExecutor(blockingTaskExecutor, true);
         final int maxPendingRequests = serverConfiguration.getMaxPendingRequests();
         final LogThrottlingStrategy logThrottlingStrategy = new LogThrottlingStrategy(

--- a/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/BaseHttpSource.java
+++ b/data-prepper-plugins/http-source-common/src/main/java/org/opensearch/dataprepper/http/BaseHttpSource.java
@@ -8,6 +8,7 @@ import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.throttling.ThrottlingService;
 import org.opensearch.dataprepper.HttpRequestExceptionHandler;
 import org.opensearch.dataprepper.armeria.authentication.ArmeriaHttpAuthenticationProvider;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.http.certificate.CertificateProviderFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -124,7 +125,8 @@ public abstract class BaseHttpSource<T extends Record<?>> implements Source<T> {
                 sb.maxRequestLength(sourceConfig.getMaxRequestLength().getBytes());
             }
             final int threads = sourceConfig.getThreadCount();
-            final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threads);
+            final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threads,
+                    BackgroundThreadFactory.defaultExecutorThreadFactory(pipelineName + "-" + sourceName));
             sb.blockingTaskExecutor(blockingTaskExecutor, true);
             final int maxPendingRequests = sourceConfig.getMaxPendingRequests();
             final LogThrottlingStrategy logThrottlingStrategy = new LogThrottlingStrategy(

--- a/data-prepper-plugins/iceberg-source/src/main/java/org/opensearch/dataprepper/plugins/source/iceberg/IcebergService.java
+++ b/data-prepper-plugins/iceberg-source/src/main/java/org/opensearch/dataprepper/plugins/source/iceberg/IcebergService.java
@@ -14,6 +14,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -124,7 +125,8 @@ public class IcebergService {
         runnableList.add(new ChangelogWorker(
                 sourceCoordinator, sourceConfig, tables, tableConfigs, buffer, acknowledgementSetManager, eventFactory, shuffleStorage, certificate));
 
-        executor = Executors.newFixedThreadPool(runnableList.size());
+        executor = Executors.newFixedThreadPool(runnableList.size(),
+                BackgroundThreadFactory.defaultExecutorThreadFactory("iceberg-source"));
         runnableList.forEach(executor::submit);
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.plugins.kafka.common.serialization.CommonSerializationFactory;
 import org.opensearch.dataprepper.plugins.kafka.common.serialization.SerializationFactory;
+import org.opensearch.dataprepper.plugins.kafka.common.thread.KafkaPluginThreadFactory;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.producer.KafkaCustomProducer;
@@ -110,7 +111,8 @@ public class KafkaSink extends AbstractSink<Record<Event>> {
     }
 
     private void doInitializeInternal() {
-        executorService = Executors.newFixedThreadPool(totalWorkers);
+        executorService = Executors.newFixedThreadPool(totalWorkers,
+                KafkaPluginThreadFactory.defaultExecutorThreadFactory("sink"));
         sinkInitialized = Boolean.TRUE;
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
@@ -46,12 +46,14 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -201,7 +203,7 @@ public class KafkaSinkTest {
 
     @Test
     public void doInitializeNullPointerExceptionTest() {
-        when(Executors.newFixedThreadPool(totalWorkers)).thenThrow(NullPointerException.class);
+        when(Executors.newFixedThreadPool(eq(totalWorkers), any(ThreadFactory.class))).thenThrow(NullPointerException.class);
         final KafkaSink objectUnderTest = createObjectUnderTest();
         assertThrows(NullPointerException.class, () -> objectUnderTest.doInitialize());
     }

--- a/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisService.java
+++ b/data-prepper-plugins/kinesis-source/src/main/java/org/opensearch/dataprepper/plugins/kinesis/source/KinesisService.java
@@ -13,6 +13,7 @@ package org.opensearch.dataprepper.plugins.kinesis.source;
 import com.linecorp.armeria.client.retry.Backoff;
 import lombok.Getter;
 import lombok.Setter;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -115,7 +116,8 @@ public class KinesisService {
             this.applicationName = kinesisLeaseConfig.getPipelineIdentifier();
             }
         this.workerIdentifierGenerator = workerIdentifierGenerator;
-        this.executorService = Executors.newFixedThreadPool(1);
+        this.executorService = Executors.newFixedThreadPool(1,
+                BackgroundThreadFactory.defaultExecutorThreadFactory("kinesis-source-scheduler"));
         final PluginModel codecConfiguration = kinesisSourceConfig.getCodec();
         final PluginSetting codecPluginSettings = new PluginSetting(codecConfiguration.getPluginName(), codecConfiguration.getPluginSettings());
         this.codec = pluginFactory.loadPlugin(InputCodec.class, codecPluginSettings);

--- a/data-prepper-plugins/log-generator-source/build.gradle
+++ b/data-prepper-plugins/log-generator-source/build.gradle
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:blocking-buffer')
+    implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation libs.commons.lang3
 }

--- a/data-prepper-plugins/log-generator-source/src/main/java/org/opensearch/dataprepper/plugins/source/loggenerator/LogGeneratorSource.java
+++ b/data-prepper-plugins/log-generator-source/src/main/java/org/opensearch/dataprepper/plugins/source/loggenerator/LogGeneratorSource.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.loggenerator;
 
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -36,7 +37,8 @@ public class LogGeneratorSource implements Source<Record<Event>> {
     public LogGeneratorSource(final LogGeneratorSourceConfig sourceConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
         this.sourceConfig = sourceConfig;
         this.logTypeGenerator = loadLogTypeGenerator(pluginFactory);
-        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("log-generator-source"));
     }
 
     private LogTypeGenerator loadLogTypeGenerator(final PluginFactory pluginFactory) {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/ExportWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/ExportWorker.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.mongo.export;
 
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -88,7 +89,8 @@ public class ExportWorker implements Runnable {
                         final String s3PathPrefix,
                         final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics) {
         this.sourceCoordinator = sourceCoordinator;
-        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT);
+        executor = Executors.newFixedThreadPool(MAX_JOB_COUNT,
+                BackgroundThreadFactory.defaultExecutorThreadFactory("mongodb-export"));
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
         recordBufferWriter = RecordBufferWriter.create(bufferAccumulator, pluginMetrics);
         this.acknowledgementSetManager = acknowledgementSetManager;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
@@ -6,6 +6,7 @@ package org.opensearch.dataprepper.plugins.source.opensearch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
@@ -57,7 +58,9 @@ public class OpenSearchService {
                                                             final AcknowledgementSetManager acknowledgementSetManager,
                                                             final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics) {
         return new OpenSearchService(
-                searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, Executors.newSingleThreadScheduledExecutor(),
+                searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer,
+                Executors.newSingleThreadScheduledExecutor(
+                        BackgroundThreadFactory.defaultExecutorThreadFactory("opensearch-source")),
                 BufferAccumulator.create(buffer, openSearchSourceConfiguration.getSearchConfiguration().getBatchSize(), BUFFER_TIMEOUT),
                 acknowledgementSetManager, openSearchSourcePluginMetrics);
     }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
@@ -35,11 +35,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -95,7 +97,9 @@ public class OpenSearchServiceTest {
              final MockedConstruction<OpenSearchIndexPartitionCreationSupplier> mockedConstruction = mockConstruction(OpenSearchIndexPartitionCreationSupplier.class, (mock, context) -> {
                  openSearchIndexPartitionCreationSupplier = mock;
              })) {
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor).thenReturn(scheduledExecutorService);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
+                    .thenReturn(scheduledExecutorService);
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, openSearchSourceConfiguration.getSearchConfiguration().getBatchSize(), BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
             return OpenSearchService.createOpenSearchService(openSearchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager, openSearchSourcePluginMetrics);
         }

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.Counter;
 import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
 import org.opensearch.dataprepper.GrpcRequestExceptionHandler;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.http.LogThrottlingRejectHandler;
 import org.opensearch.dataprepper.http.LogThrottlingStrategy;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -170,7 +171,8 @@ public class OTelLogsSource implements Source<Record<Object>> {
             serverBuilder.connectionDrainDuration(oTelLogsSourceConfig.getConnectionDrainDuration());
         }
         final int threadCount = oTelLogsSourceConfig.getThreadCount();
-        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(threadCount);
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(threadCount,
+                BackgroundThreadFactory.defaultExecutorThreadFactory("otel-logs-source"));
         serverBuilder.blockingTaskExecutor(executor, true);
 
         if ((oTelLogsSourceConfig.enableUnframedRequests() || oTelLogsSourceConfig.getHttpPath() != null)

--- a/data-prepper-plugins/prometheus-source/src/main/java/org/opensearch/dataprepper/plugins/source/prometheus/PrometheusScrapeService.java
+++ b/data-prepper-plugins/prometheus-source/src/main/java/org/opensearch/dataprepper/plugins/source/prometheus/PrometheusScrapeService.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.dataprepper.plugins.source.prometheus;
 
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
@@ -59,11 +60,8 @@ public class PrometheusScrapeService {
         this.bufferWriteTimeoutMs = bufferWriteTimeoutMs;
         this.scraper = new ScrapeTargetScraper(config);
         this.parser = new TextExpositionParser(config.isFlattenLabels());
-        this.executor = Executors.newSingleThreadScheduledExecutor(r -> {
-            final Thread t = new Thread(r, "prometheus-scrape");
-            t.setDaemon(true);
-            return t;
-        });
+        this.executor = Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("prometheus-scrape"));
         this.scrapeRequestsCounter = pluginMetrics.counter(SCRAPE_REQUESTS_METRIC);
         this.scrapeSuccessCounter = pluginMetrics.counter(SCRAPE_SUCCESS_METRIC);
         this.scrapeFailureCounter = pluginMetrics.counter(SCRAPE_FAILURE_METRIC);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/RdsService.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.rds;
 
 import com.github.shyiko.mysql.binlog.network.SSLMode;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -161,7 +162,8 @@ public class RdsService {
             }
         }
 
-        executor = Executors.newFixedThreadPool(runnableList.size());
+        executor = Executors.newFixedThreadPool(runnableList.size(),
+                BackgroundThreadFactory.defaultExecutorThreadFactory("rds-source"));
         runnableList.forEach(executor::submit);
     }
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoader.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.source.rds.export;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -135,7 +136,8 @@ public class DataFileLoader implements Runnable {
     public void run() {
         LOG.info(SENSITIVE, "Start loading s3://{}/{}", bucket, objectKey);
 
-        final ScheduledExecutorService leaseRenewalScheduler = Executors.newSingleThreadScheduledExecutor();
+        final ScheduledExecutorService leaseRenewalScheduler = Executors.newSingleThreadScheduledExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("rds-source-lease-renewal"));
         leaseRenewalScheduler.scheduleAtFixedRate(() -> {
             try {
                 sourceCoordinator.saveProgressStateForPartition(dataFilePartition, LEASE_RENEWAL_DURATION);

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileScheduler.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -99,7 +100,8 @@ public class DataFileScheduler implements Runnable {
             recordConverter.setJoinMetadataEnricher(
                     new JoinMetadataEnricher(sourceConfig.getJoinConfig().getRelations()));
         }
-        executor = Executors.newFixedThreadPool(DATA_LOADER_MAX_JOB_COUNT);
+        executor = Executors.newFixedThreadPool(DATA_LOADER_MAX_JOB_COUNT,
+                BackgroundThreadFactory.defaultExecutorThreadFactory("rds-source-data-file"));
         this.buffer = buffer;
         this.pluginMetrics = pluginMetrics;
         this.acknowledgementSetManager = acknowledgementSetManager;

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/export/ExportScheduler.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.rds.export;
 
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
@@ -79,7 +80,8 @@ public class ExportScheduler implements Runnable {
         this.pluginMetrics = pluginMetrics;
         this.sourceCoordinator = sourceCoordinator;
         this.s3Client = s3Client;
-        this.executor = Executors.newCachedThreadPool();
+        this.executor = Executors.newCachedThreadPool(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("rds-source-export"));
         this.snapshotManager = snapshotManager;
         this.exportTaskManager = exportTaskManager;
 

--- a/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManager.java
+++ b/data-prepper-plugins/rds-source/src/main/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManager.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.rds.stream;
 
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -59,7 +60,8 @@ public class StreamCheckpointManager {
         this.acknowledgmentTimeout = acknowledgmentTimeout;
         this.engineType = engineType;
         this.pluginMetrics = pluginMetrics;
-        executorService = Executors.newSingleThreadExecutor();
+        executorService = Executors.newSingleThreadExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("rds-source-stream-checkpoint"));
 
         this.positiveAcknowledgementSets = pluginMetrics.counter(POSITIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME);
         this.negativeAcknowledgementSets = pluginMetrics.counter(NEGATIVE_ACKNOWLEDGEMENT_SET_METRIC_NAME);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/RdsServiceTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -126,7 +127,8 @@ class RdsServiceTest {
         doReturn(schemaManager).when(spyRdsService).getSchemaManager(any(), any());
 
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt())).thenReturn(executor);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(executor);
             spyRdsService.start(buffer);
         }
 
@@ -165,7 +167,8 @@ class RdsServiceTest {
              final MockedConstruction<LeaderScheduler> leaderSchedulerMockedConstruction = mockConstruction(LeaderScheduler.class,
                      (mock, context) -> s3PrefixArray[0] = (String) context.arguments().get(2));
              final MockedStatic<BackgroundThreadFactory> backgroundThreadFactoryMockedStatic = mockStatic(BackgroundThreadFactory.class)) {
-            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt())).thenReturn(executor);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(executor);
             backgroundThreadFactoryMockedStatic.when(() -> BackgroundThreadFactory.defaultExecutorThreadFactory(any())).thenReturn(threadFactory);
             spyRdsService.start(buffer);
         }
@@ -187,7 +190,8 @@ class RdsServiceTest {
 
         doReturn(schemaManager).when(spyRdsService).getSchemaManager(any(), any());
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt())).thenReturn(executor);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(executor);
             spyRdsService.start(buffer);
         }
         spyRdsService.shutdown();

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/export/DataFileLoaderTest.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -271,7 +272,9 @@ class DataFileLoaderTest {
              MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
 
             ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
-            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor).thenReturn(mockScheduler);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadScheduledExecutor(any(ThreadFactory.class)))
+                    .thenReturn(mockScheduler);
 
             readerMockedStatic.when(() -> AvroParquetReader.<GenericRecord>builder(any(InputFile.class), any())).thenReturn(builder);
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(any(Buffer.class), anyInt(), any(Duration.class))).thenReturn(bufferAccumulator);

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/BinlogEventListenerTest.java
@@ -136,7 +136,8 @@ class BinlogEventListenerTest {
         when(pipelineDescription.getPipelineName()).thenReturn("test-pipeline");
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
             executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(eventListnerExecutorService);
-            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(checkpointManagerExecutorService);
+            executorsMockedStatic.when(() -> Executors.newSingleThreadExecutor(any(ThreadFactory.class)))
+                    .thenReturn(checkpointManagerExecutorService);
             executorsMockedStatic.when(Executors::defaultThreadFactory).thenReturn(threadFactory);
             objectUnderTest = spy(createObjectUnderTest());
         }
@@ -285,7 +286,8 @@ class BinlogEventListenerTest {
         BinlogEventListener listenerWithNullDlq;
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
             executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt(), any(ThreadFactory.class))).thenReturn(eventListnerExecutorService);
-            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(checkpointManagerExecutorService);
+            executorsMockedStatic.when(() -> Executors.newSingleThreadExecutor(any(ThreadFactory.class)))
+                    .thenReturn(checkpointManagerExecutorService);
             executorsMockedStatic.when(Executors::defaultThreadFactory).thenReturn(threadFactory);
             listenerWithNullDlq = BinlogEventListener.create(streamPartition, buffer, sourceConfig, s3Prefix, pluginMetrics, binaryLogClient,
                     streamCheckpointer, acknowledgementSetManager, dbTableMetadata, cascadingActionDetector,

--- a/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManagerTest.java
+++ b/data-prepper-plugins/rds-source/src/test/java/org/opensearch/dataprepper/plugins/source/rds/stream/StreamCheckpointManagerTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -62,7 +63,9 @@ class StreamCheckpointManagerTest {
     void test_start() {
         final ExecutorService executorService = mock(ExecutorService.class);
         try (MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(executorService);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadExecutor(any(ThreadFactory.class)))
+                    .thenReturn(executorService);
 
             final StreamCheckpointManager streamCheckpointManager = createObjectUnderTest();
             streamCheckpointManager.start();
@@ -74,7 +77,9 @@ class StreamCheckpointManagerTest {
     void test_shutdown() {
         final ExecutorService executorService = mock(ExecutorService.class);
         try (MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
-            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(executorService);
+            executorsMockedStatic.when(Executors::defaultThreadFactory).thenCallRealMethod();
+            executorsMockedStatic.when(() -> Executors.newSingleThreadExecutor(any(ThreadFactory.class)))
+                    .thenReturn(executorService);
 
             final StreamCheckpointManager streamCheckpointManager = createObjectUnderTest();
             streamCheckpointManager.start();

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/S3OutputStream.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/S3OutputStream.java
@@ -10,6 +10,7 @@ package org.opensearch.dataprepper.plugins.codec.parquet;
 
 
 import org.apache.parquet.io.PositionOutputStream;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ServerSideEncryptionConfig;
 import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import org.slf4j.Logger;
@@ -118,7 +119,8 @@ public class S3OutputStream extends PositionOutputStream {
         etags = new ArrayList<>();
         open = true;
         this.defaultBucket = defaultBucket;
-        this.executorService = Executors.newSingleThreadExecutor();
+        this.executorService = Executors.newSingleThreadExecutor(
+                BackgroundThreadFactory.defaultExecutorThreadFactory("s3-sink-multipart-upload"));
         this.bucketOwnerProvider = bucketOwnerProvider;
         this.serverSideEncryptionConfig = serverSideEncryptionConfig;
     }


### PR DESCRIPTION
### Description

Migrate many plugins to use `BackgroundThreadFactory` for creating background threads. Update `BackgroundThreadFactory` to create daemon threads. Overall, the pipeline threads are the ones that determine whether Data Prepper should shut down.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
