### PR TITLE
Fix flaky ExportSchedulerTest await anchors

### DIFF
--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportSchedulerTest.java
@@ -164,9 +164,11 @@ public class ExportSchedulerTest {
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> exportScheduler.run());
+        // Await the last coordinator interaction of the scheduler's iteration. Awaiting an earlier one
+        // lets future.cancel interrupt the scheduler before it makes the remaining calls asserted below.
         await()
             .atMost(Duration.ofMillis(DEFAULT_GET_PARTITION_BACKOFF_MILLIS).plus(Duration.ofSeconds(2)))
-            .untilAsserted(() -> verify(coordinator, times(1)).createPartition(any()));
+            .untilAsserted(() -> verify(coordinator, times(2)).saveProgressStateForPartition(eq(globalState), any()));
 
         future.cancel(true);
 
@@ -235,9 +237,11 @@ public class ExportSchedulerTest {
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> exportScheduler.run());
+        // Await the last coordinator interaction of the scheduler's iteration. Awaiting an earlier one
+        // lets future.cancel interrupt the scheduler before it makes the remaining calls asserted below.
         await()
             .atMost(Duration.ofSeconds(2))
-            .untilAsserted(() -> verify(coordinator, times(3)).createPartition(any()));
+            .untilAsserted(() -> verify(coordinator).saveProgressStateForPartition(eq(globalState), any()));
 
         future.cancel(true);
 
@@ -301,9 +305,11 @@ public class ExportSchedulerTest {
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> exportScheduler.run());
+        // Await the last coordinator interaction of the scheduler's iteration. Awaiting an earlier one
+        // lets future.cancel interrupt the scheduler before it makes the remaining calls asserted below.
         await()
                 .atMost(Duration.ofMillis(DEFAULT_GET_PARTITION_BACKOFF_MILLIS).plus(Duration.ofSeconds(2)))
-                .untilAsserted(() -> verify(coordinator).completePartition(exportPartition));
+                .untilAsserted(() -> verify(coordinator).saveProgressStateForPartition(eq(globalState), eq(null)));
 
         future.cancel(true);
 


### PR DESCRIPTION
### Description

Three tests in `ExportSchedulerTest` await an *intermediate* coordinator interaction and then call `future.cancel(true)`. That can interrupt `ExportScheduler.run()` before it makes the remaining calls the assertions expect, so the tests fail intermittently. Observed in CI as:

```
org.mockito.exceptions.verification.TooFewActualInvocations:
coordinator.getPartition("EXPORT-...");
Wanted 3 times:
-> at ExportSchedulerTest.test_export_run(ExportSchedulerTest.java:173)
But was 2 times:
-> at ExportScheduler.run(ExportScheduler.java:79)
-> at ExportScheduler.run(ExportScheduler.java:83)
```

The two invocations CI saw are the first `getPartition` (`:79`) and the retry inside `while (globalPartition.isEmpty())` (`:83`). The third one — inside `markTotalPartitionsAsComplete` (`:172`) — never ran, because `cancel` landed after `createPartition` but before it.

This fix anchors each `await` on the **last** coordinator interaction of the scheduler's iteration, `saveProgressStateForPartition(globalState, ...)` at `ExportScheduler:181`. Every assertion in these tests happens at or before that call:

| assertion | ExportScheduler line |
|---|---|
| `exportPartitionTotalCounter.increment` | 131 |
| `saveProgressStateForPartition(globalState)` #1 | 140 |
| `saveProgressStateForPartition(exportPartition, null)` | 152 |
| `completePartition` | 159 |
| `getPartition` #3 | 172 |
| `setProgressState` #2 | 178 |
| `saveProgressStateForPartition(globalState)` #2 | **181 ← anchor** |

Three tests are affected; each awaited something too early:

- `test_export_run` — awaited `createPartition` (`:127`)
- `test_export_run_multiple_partitions` — awaited `createPartition` x3 (`:127`)
- `test_exportRun_emptyPartitionIdentifier` — awaited `completePartition` (`:159`)

The race is long-standing, not a recent regression: the `times(3)` `getPartition` assertion was added in #4553.

### Verification

Because the flake needs a contended runner, I validated the *mechanism* deterministically rather than statistically, by injecting a delay into a production call site that sits inside the race window and checking that the old anchor fails and the new one passes:

| Injected delay | Anchor | Result |
|---|---|---|
| `completePartition` (between `createPartition` and `:172`) | old (`createPartition`) | **fails** with CI's exact `wanted 3 / was 2` at `:79`,`:83` |
| `completePartition` | new | passes |
| `setProgressState` (straddles `:178`→`:181`) | `getPartition times(3)` | **fails** — `saveProgressStateForPartition` wanted 2, was 1 |
| `setProgressState` | new | passes |
| none | new | passes, 4/4 |

The middle two rows are why the anchor is the final `saveProgressStateForPartition` rather than `getPartition times(3)`: the latter still leaves a narrow window between `:172` and `:181`.

Also ran the suite unmodified 8x under CPU contention on JDK 21 with 0 failures — as expected, plain repetition does not reproduce it locally, which is why the injection-based proof above is the meaningful evidence.

### Issues Resolved

Contributes to #3481

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed with a real name per the DCO